### PR TITLE
allow uppercase letters (i.e., camelback casing) in attribute names for templates

### DIFF
--- a/core/lib/utils.js
+++ b/core/lib/utils.js
@@ -80,8 +80,11 @@ module.exports.format = (function () {
     if (!(args instanceof Array || args instanceof Object)) {
       args = Array.prototype.slice.call(arguments, 1);
     }
+    Object.keys(args).forEach(function (key) {
+      args[String(key).toLowerCase()] = args[key];
+    });
     return s.replace(re, function (_, name, rhs, defaultVal) {
-      var val = args[name];
+      var val = args[name.toLowerCase()];
 
       if (typeof val === 'undefined') {
         return (defaultVal || '?').trim().replace(/^["']|["']$/g, '');


### PR DESCRIPTION
I want to just start using dashes in attribute names and data in components
