### PR TITLE
use hyphens instead of camelBack casing for component properties

### DIFF
--- a/core/templates/vr-cylinder.html
+++ b/core/templates/vr-cylinder.html
@@ -14,11 +14,11 @@
   <vr-object geometry="primitive: cylinder;
                        radius: ${radius};
                        height: ${height};
-                       segmentsRadius: ${segments-radius};
-                       segmentsHeight: ${segments-height};
-                       thetaStart: ${theta-start};
-                       thetaLength: ${theta-length};
-                       openEnded: ${open-ended}"
+                       segments-radius: ${segments-radius};
+                       segments-height: ${segments-height};
+                       theta-start: ${theta-start};
+                       theta-length: ${theta-length};
+                       open-ended: ${open-ended}"
              material="color: ${color};
                        metalness: ${metalness};
                        roughness: ${roughness};

--- a/core/templates/vr-sphere.html
+++ b/core/templates/vr-sphere.html
@@ -11,10 +11,10 @@
           url="">
   <vr-object geometry="primitive: sphere;
                        radius: ${radius};
-                       segmentsWidth: ${segments-width};
-                       segmentsHeight: ${segments-height};
-                       thetaStart: ${theta-start};
-                       thetaLength: ${theta-length}"
+                       segments-width: ${segments-width};
+                       segments-height: ${segments-height};
+                       theta-start: ${theta-start};
+                       theta-length: ${theta-length}"
              material="color: ${color};
                        metalness: ${metalness};
                        roughness: ${roughness};


### PR DESCRIPTION
see MozVR/aframe-core#316
