### PR TITLE
add example of single-page-app world traversal approach

### DIFF
--- a/examples/images/index.html
+++ b/examples/images/index.html
@@ -9,9 +9,9 @@
   <body>
     <vr-scene>
       <vr-object position="0 0 10" camera controls="mouselook: true; locomotion: true"></vr-object>
-      <vr-image position="0 0 0" width="16" height="4.5" url="mozvr-office-1.jpg"></vr-image>
-      <vr-image position="-4 2 2" width="14" height="9" scale="0.4 0.4 0.4" url="mozvr-office-2.jpg"></vr-image>
-      <vr-image position="4 -1 5" width="12" height="8" scale="0.3 0.3 0.3" url="mozvr-office-3.jpg"></vr-image>
+      <vr-image position="0 0 0" width="16" height="4.5" url="/examples/images/mozvr-office-1.jpg"></vr-image>
+      <vr-image position="-4 2 2" width="14" height="9" scale="0.4 0.4 0.4" url="/examples/images/mozvr-office-2.jpg"></vr-image>
+      <vr-image position="4 -1 5" width="12" height="8" scale="0.3 0.3 0.3" url="/examples/images/mozvr-office-3.jpg"></vr-image>
       <vr-image position="5 1.5 5" width="12" height="8" scale="0.2 0.2 0.2" color="aqua"></vr-image>
     </vr-scene>
   </body>

--- a/examples/legos/index.html
+++ b/examples/legos/index.html
@@ -20,26 +20,28 @@
       <vr-lego color="blue" position="3 -4.25 0" rotation="45 -45 0"></vr-lego>
     </vr-scene>
 
-    <template is="vr-template" element="vr-lego" color="red">
-      <vr-lego-block color="${color}">
-        <vr-lego-stud position="-2.25 2 -0.5" color="${color}"></vr-lego-stud>
-        <vr-lego-stud position="-.5 2 -0.5" color="${color}"></vr-lego-stud>
-        <vr-lego-stud position="1.25 2 -0.5" color="${color}"></vr-lego-stud>
-        <vr-lego-stud position="3 2 -0.5" color="${color}"></vr-lego-stud>
+    <vr-templates>
+      <template is="vr-template" element="vr-lego" color="red">
+        <vr-lego-block color="${color}">
+          <vr-lego-stud position="-2.25 2 -0.5" color="${color}"></vr-lego-stud>
+          <vr-lego-stud position="-.5 2 -0.5" color="${color}"></vr-lego-stud>
+          <vr-lego-stud position="1.25 2 -0.5" color="${color}"></vr-lego-stud>
+          <vr-lego-stud position="3 2 -0.5" color="${color}"></vr-lego-stud>
 
-        <vr-lego-stud position="-2.25 2 1.5" color="${color}"></vr-lego-stud>
-        <vr-lego-stud position="-0.5 2 1.5" color="${color}"></vr-lego-stud>
-        <vr-lego-stud position="1.25 2 1.5" color="${color}"></vr-lego-stud>
-        <vr-lego-stud position="3 2 1.5" color="${color}"></vr-lego-stud>
-      </vr-lego-block>
-    </template>
+          <vr-lego-stud position="-2.25 2 1.5" color="${color}"></vr-lego-stud>
+          <vr-lego-stud position="-0.5 2 1.5" color="${color}"></vr-lego-stud>
+          <vr-lego-stud position="1.25 2 1.5" color="${color}"></vr-lego-stud>
+          <vr-lego-stud position="3 2 1.5" color="${color}"></vr-lego-stud>
+        </vr-lego-block>
+      </template>
 
-    <template is="vr-template" element="vr-lego-block" color="red">
-      <vr-cube width="8.5" height="3" depth="5" color="${color}"></vr-cube>
-    </template>
+      <template is="vr-template" element="vr-lego-block" color="red">
+        <vr-cube width="8.5" height="3" depth="5" color="${color}"></vr-cube>
+      </template>
 
-    <template is="vr-template" element="vr-lego-stud" color="red">
-      <vr-cylinder height="0.5" radius="0.5" color="${color}"></vr-cylinder>
-    </template>
+      <template is="vr-template" element="vr-lego-stud" color="red">
+        <vr-cylinder height="0.5" radius="0.5" color="${color}"></vr-cylinder>
+      </template>
+    </vr-templates>
   </body>
 </html>

--- a/examples/worldTraversal/index.html
+++ b/examples/worldTraversal/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single-Page App</title>
+    <meta name="description" content="Single-Page App — vr-components">
+    <script src="../../build/vr-components.js"></script>
+  </head>
+  <body>
+    <vr-assets></vr-assets>
+    <vr-scene>
+      <vr-object camera="fov: 45" position="0 0 20" controls="mouselook: true; locomotion: true"></vr-object>
+    </vr-scene>
+    <vr-templates></vr-templates>
+    <main></main>
+    <script>
+      (function () {
+        var counter = 0;
+        var worlds = [
+          '../cubes/',
+          // '../images/',
+          '../legos/',
+          '../panoExplorer/',
+          '../spheres/',
+        ];
+        var main = document.querySelector('main');
+
+        function injectAsHTML (el) {
+          // Reuse the elements and actually use new camera.
+          var temp = document.createElement('template');
+          var div = document.createElement('div');
+          div.className = el.className;
+          div.innerHTML = el.innerHTML;
+          temp.appendChild(div);
+
+          // TODO: Load external templates!
+
+          // var templates = document.querySelectorAll('template[is="vr-template"]');
+          // Array.prototype.forEach.call(templates, function (template) {
+          //   template.parentNode.removeChild(template);
+          // });
+
+          ['vr-assets', 'vr-scene', 'vr-templates'].forEach(function (selector) {
+            replaceHTML(temp.querySelector(selector), document.querySelector(selector));
+          });
+
+          // var currentMainEl = document.querySelector('main');
+          // if (currentMainEl) {
+          //   currentMainEl.innerHTML = temp.innerHTML;
+          // }
+
+          // var templates = fragment.querySelectorAll('template[is="vr-template"]');
+          // Array.prototype.forEach.call(templates, function (template) {
+          //   main(template);
+          // });
+        }
+
+        function replaceHTML (srcEl, destEl) {
+          if (!srcEl || !destEl) { return; }
+          destEl.innerHTML = srcEl.innerHTML;
+          srcEl.parentNode.removeChild(srcEl);
+        }
+
+        function loadWorld (idx) {
+          // Could just use `XMLHttpRequest` directly, but THREE's `XHRLoader`
+          // does nice caching.
+          var loader = new vrComponents.VRMarkup.THREE.XHRLoader();
+          loader.setCrossOrigin('');
+          loader.setResponseType('document');
+          loader.load(worlds[idx], function (res) {
+            injectAsHTML(res.body);
+          }, function () {}, function (res) {
+            throw new Error('Could not load "' + worlds[idx] + '": ' + res.statusText);
+            console.error(res);
+          });
+        }
+
+        loadWorld(counter);
+
+        window.addEventListener('keydown', function (e) {
+          if (e.keyCode === 37) {
+            counter--;
+          }
+          if (e.keyCode === 39) {
+            counter++;
+          }
+          if (e.keyCode === 37 || e.keyCode === 39) {
+            if (counter < 0) {
+              counter = worlds.length - 1;
+            }
+            if (counter >= worlds.length) {
+              counter = 0;
+            }
+            loadWorld(counter);
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
original `aframe-core` PR: MozVR/aframe-core#264

<hr>

next step would be to construct this from templates:

``` html
<vr-cards>
  <vr-card active href="../cubes"></vr-card>
  <vr-card href="../cubes/"></vr-card>
  <vr-card href="../images/"></vr-card>
  <vr-card href="../legos/"></vr-card>
  <vr-card href="../panoExplorer/"></vr-card>
  <vr-card href="../spheres/"></vr-card>
</vr-cards>
```
