### PR TITLE
fix coordinate (non-string) components (attributes) with templates

### DIFF
--- a/core/lib/register-template.js
+++ b/core/lib/register-template.js
@@ -52,7 +52,14 @@ module.exports = function (tagName) {
               if (!template) { return; }
 
               // Use the defaults defined on the original `<template is="vr-template">`.
-              var templateAttrs = utils.mergeAttrs(template.attributes, this.attributes);
+              var templateAttrs = utils.mergeAttrs(template, this);
+              Object.keys(templateAttrs).filter(function (key) {
+                var value = templateAttrs[key];
+                var component = this.components[key];
+                if (component && typeof value === 'object') {
+                  templateAttrs[key] = component.stringifyAttributes(value);
+                }
+              }, this);
 
               this.root = utils.$$(this.children).filter(function (el) {
                 return el.tagName.toLowerCase() === 'vr-root';

--- a/core/lib/utils.js
+++ b/core/lib/utils.js
@@ -42,14 +42,16 @@ var forEach = module.exports.forEach = function (arr, fn) {
 /**
  * Merges attributes à la `Object.assign`.
  *
- * @param {...Array|NamedNodeMap} attrs Parent from which to query.
+ * @param {...Array|NamedNodeMap} els Parent element from which to query.
  * @returns {Array} Array of merged attributes.
  */
 module.exports.mergeAttrs = function () {
   var mergedAttrs = {};
-  forEach(arguments, function (attrs) {
-    forEach(attrs, function (attr) {
-      mergedAttrs[attr.name] = attr.value;
+  forEach(arguments, function (el) {
+    forEach(el.attributes, function (attr) {
+      // NOTE: We use `getAttribute` instead of `attr.value` so our wrapper
+      // for coordinate objects gets used.
+      mergedAttrs[attr.name] = el.getAttribute(attr.name);
     });
   });
   return mergedAttrs;


### PR DESCRIPTION
This is to fix @jcarpenter's issues with using

``` js
el.setAttribute('position', {x: xPos});
```

in his Pano Explorer example. There were two issues:
1. I was not using `<vr-object>`'s wrapped custom `getAttribute`, so the values were not coming back as objects (i.e., in the form of `{x: 0, y: 0, z: 0}`).
2. When I was merging the attributes, I was using the raw attribute `value` property from `this.attributes` instead of the stringified versions of the attribute values (from `component.stringifyAttributes`).
