### PR TITLE
support `theta-start` and `theta-length` in templates

### DIFF
--- a/core/templates/vr-cylinder.html
+++ b/core/templates/vr-cylinder.html
@@ -4,6 +4,8 @@
           height="1"
           segments-radius="36"
           segments-height="4"
+          theta-start="0"
+          theta-length="6.3"
           open-ended="false"
           color="gray"
           metallic="0.0"
@@ -14,6 +16,8 @@
                        height: ${height};
                        segmentsRadius: ${segments-radius};
                        segmentsHeight: ${segments-height};
+                       thetaStart: ${theta-start};
+                       thetaLength: ${theta-length};
                        openEnded: ${open-ended}"
              material="color: ${color};
                        metallic: ${metallic};

--- a/core/templates/vr-sphere.html
+++ b/core/templates/vr-sphere.html
@@ -3,6 +3,8 @@
           radius="5"
           segments-width="36"
           segments-height="18"
+          theta-start="0"
+          theta-length="6.3"
           color="gray"
           metallic="0.0"
           roughness="0.5"
@@ -10,7 +12,9 @@
   <vr-object geometry="primitive: sphere;
                        radius: ${radius};
                        segmentsWidth: ${segments-width};
-                       segmentsHeight: ${segments-height}"
+                       segmentsHeight: ${segments-height};
+                       thetaStart: ${theta-start};
+                       thetaLength: ${theta-length}"
              material="color: ${color};
                        metallic: ${metallic};
                        roughness: ${roughness};


### PR DESCRIPTION
per MozVR/aframe-core#318
