### PR TITLE
Fix Budo live-reload on mobile

### DIFF
--- a/scripts/budo.js
+++ b/scripts/budo.js
@@ -25,6 +25,7 @@ app
 .live()
 .on('watch', function (eventType, fn) {
   if (eventType !== 'change' && eventType !== 'add') { return; }
+
   if (path.extname(fn) === '.css') {
     // We want to trigger a reload of the entire document, since
     // browserify-css injects CSS into the page.

--- a/scripts/budo.js
+++ b/scripts/budo.js
@@ -16,17 +16,15 @@ var app = budo('./index.js:build/aframe.js', {
   debug: process.env.NODE_ENVIRONMENT !== 'production',
   verbose: true,
   stream: process.stdout,  // log to stdout
-  host: '0.0.0.0',
   port: 9000,
   browserifyArgs: '-s AFRAME'.split(' ')
 });
 
 app
 .watch('**/*.{css,js,html}')
-// .live()
+.live()
 .on('watch', function (eventType, fn) {
   if (eventType !== 'change' && eventType !== 'add') { return; }
-
   if (path.extname(fn) === '.css') {
     // We want to trigger a reload of the entire document, since
     // browserify-css injects CSS into the page.


### PR DESCRIPTION
This PR introduces these changes:

- Removes the `host` field from budo options. This will make budo resolve to the internal IP, and log that instead of `0.0.0.0`. Now it looks like this:  
<img width="455" alt="screen shot 2015-12-17 at 11 06 48 am" src="https://cloud.githubusercontent.com/assets/1383811/11874674/f27374c2-a4ae-11e5-80bd-510541be832b.png">
- The above change will fix LiveReload when you hit the IP on mobile devices. This seems like a bug with budo, I opened an issue here: https://github.com/mattdesl/budo/issues/118
- I have un-commented the `live()` feature since it now works on mobile. I'm not sure whether you had this commented intentionally (some devs prefer not to use it; my scripts sometimes include a `--live` option to toggle this).

Some other small things that could change with the build script:

- `browserify-css` should now emit file events (https://github.com/cheton/browserify-css/issues/20), so it should be picked up by watchify and trigger a hard live-reload. However it seems like all the browserify-css stuff is legacy, I am not seeing much CSS in this repo.
- The HTML inside `examples/` are not live-reloading
- The `browserifyArgs` option can be replaced by a `browserify: { ... }` options object for code clarity