### PR TITLE
Move browserify dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,21 +21,21 @@
   "repository": "aframevr/aframe",
   "license": "MIT",
   "devDependencies": {
-    "browserify": "^11.0.1",
-    "browserify-css": "^0.8.2",
     "budo": "^7.0.2",
     "exorcist": "^0.4.0",
     "gh-pages": "^0.4.0",
     "html-minifier": "^0.8.0",
     "husky": "^0.10.1",
-    "polymerize": "^1.0.0",
     "replace": "^0.3.0",
     "semistandard": "^7.0.2",
     "snazzy": "^2.0.1",
     "uglifyjs": "^2.4.10"
   },
   "dependencies": {
-    "aframe-core": "^0.1.1"
+    "aframe-core": "^0.1.1",
+		"browserify": "^11.0.1",
+    "browserify-css": "^0.8.2",
+		"polymerize": "^1.0.0"
   },
   "link": true,
   "browserify": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "dependencies": {
     "aframe-core": "^0.1.1",
-		"browserify": "^11.0.1",
+    "browserify": "^11.0.1",
     "browserify-css": "^0.8.2",
-		"polymerize": "^1.0.0"
+    "polymerize": "^1.0.0"
   },
   "link": true,
   "browserify": {


### PR DESCRIPTION
As discussed in #347, I moved some of the browserify-specific dependencies so they're properly installed during a bundling process. 