### PR TITLE
allow properties to define their own parse again

### DIFF
--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -65,8 +65,12 @@ function processPropertyDefinition (propDefinition) {
     return propDefinition;
   }
 
-  propDefinition.parse = propType.parse;
-  propDefinition.stringify = propType.stringify;
+  if (!propDefinition.parse) {
+    propDefinition.parse = propType.parse;
+  }
+  if (!propDefinition.stringify) {
+    propDefinition.stringify = propType.stringify;
+  }
   propDefinition.type = typeName;
   if (!('default' in propDefinition)) {
     propDefinition.default = propType.default;

--- a/tests/core/schema.test.js
+++ b/tests/core/schema.test.js
@@ -138,6 +138,19 @@ suite('schema', function () {
       var definition = processSchema({ type: 'faketype' });
       assert.equal(definition.default, 'FAKEDEFAULT');
     });
+
+    test('preserves custom parse/stringify', function () {
+      var parse = function (value) {
+        return value.split('');
+      };
+      var definition = processSchema({
+        default: 'abc',
+        parse: parse
+      });
+      assert.equal(definition.type, 'string');
+      assert.equal(definition.parse, parse);
+      assert.ok(typeof definition.stringify, 'function');
+    });
   });
 
   suite('processSchema', function () {


### PR DESCRIPTION
It got overridden by the type in the prop processing.

