### PR TITLE
move polymerize from devDep to dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "document-register-element": "^0.5.2",
     "es6-promise": "^3.0.2",
     "object-assign": "^4.0.1",
+    "polymerize": "^1.0.0",
     "present": "0.0.6",
     "request-interval": "^1.0.0",
     "style-attr": "^1.0.1",
@@ -37,7 +38,6 @@
   },
   "devDependencies": {
     "browserify": "^11.0.1",
-    "browserify-css": "^0.8.2",
     "browserify-derequire": "^0.9.4",
     "budo": "^7.1.0",
     "chai-shallow-deep-equal": "^1.3.0",
@@ -59,7 +59,6 @@
     "mozilla-download": "^1.0.5",
     "ncp": "2.0.0",
     "open": "0.0.5",
-    "polymerize": "^1.0.0",
     "replace": "^0.3.0",
     "rimraf": "2.5.0",
     "semistandard": "^7.0.2",


### PR DESCRIPTION
Had troubles requiring `aframe` with Browserify in another project without it since it wasn't installed as a dependency. Even though it isn't needed, it's defined in the package.json as a transform since it will try to run.