### PR TITLE
fix data building for single-prop components, test Component.buildData (fixes #838)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -37,18 +37,18 @@ var components = module.exports.components = {};  // Keep track of registered co
  * @member {function} stringify
  */
 var Component = module.exports.Component = function (el) {
-  var rawData = HTMLElement.prototype.getAttribute.call(el, this.name);
+  var name = this.name;
+  var rawData = HTMLElement.prototype.getAttribute.call(el, name);
   var scene;
 
   this.el = el;
-  this.data = {};
-  this.buildData(this.parse(rawData));
+  this.data = buildData(el, name, this.schema, this.parse(rawData));
   this.init();
   this.update();
 
   // Set up tick behavior.
   if (this.tick) {
-    scene = this.el.isScene ? this.el : this.el.sceneEl;
+    scene = el.isScene ? el : el.sceneEl;
     scene.addBehavior(this);
   }
 };
@@ -164,69 +164,23 @@ Component.prototype = {
    * @param {string} value - HTML attribute value.
    */
   updateProperties: function (value) {
-    var isSinglePropSchema = isSingleProp(this.schema);
+    var el = this.el;
+    var schema = this.schema;
+    var isSinglePropSchema = isSingleProp(schema);
     var previousData = extendProperties({}, this.data, isSinglePropSchema);
-    this.buildData(this.parse(value));
+
+    this.data = buildData(el, this.name, schema, this.parse(value));
 
     // Don't update if properties haven't changed
     if (!isSinglePropSchema && utils.deepEqual(previousData, this.data)) { return; }
 
     this.update(previousData);
 
-    this.el.emit('componentchanged', {
+    el.emit('componentchanged', {
       name: this.name,
       newData: this.getData(),
       oldData: previousData
     });
-  },
-
-  /**
-   * Builds component data from the current state of the entity, ultimately
-   * updating this.data.
-   *
-   * If the component was detached completely, set data to null.
-   *
-   * Precedence:
-   * 1. Defaults data
-   * 2. Mixin data.
-   * 3. Attribute data.
-   *
-   * Finally coerce the data to the types of the defaults.
-   */
-  buildData: function (newData) {
-    var self = this;
-    var data = {};
-    var schema = self.schema;
-    var isSinglePropSchema = isSingleProp(schema);
-    var el = self.el;
-    var mixinEls = el.mixinEls;
-    var name = self.name;
-
-    // 1. Default values (lowest precendence).
-    if (isSinglePropSchema) {
-      data = schema.default;
-    } else {
-      Object.keys(schema).forEach(function applyDefault (key) {
-        data[key] = schema[key].default;
-      });
-    }
-
-    // 2. Mixin values.
-    mixinEls.forEach(applyMixin);
-    function applyMixin (mixinEl) {
-      var mixinData = mixinEl.getAttribute(name);
-      extendProperties(data, mixinData, isSinglePropSchema);
-    }
-
-    // 3. Attribute values (highest precendence).
-    data = extendProperties(data, newData, isSinglePropSchema);
-
-    // Parse and coerce using the schema.
-    if (isSinglePropSchema) {
-      this.data = parseProperty(data, schema);
-    } else {
-      this.data = parseProperties(data, schema);
-    }
   }
 };
 
@@ -270,6 +224,53 @@ module.exports.registerComponent = function (name, definition) {
 };
 
 /**
+ * Builds component data from the current state of the entity, ultimately
+ * updating this.data.
+ *
+ * If the component was detached completely, set data to null.
+ *
+ * Precedence:
+ * 1. Defaults data
+ * 2. Mixin data.
+ * 3. Attribute data.
+ *
+ * Finally coerce the data to the types of the defaults.
+ */
+function buildData (el, name, schema, newData) {
+  var data = {};
+  var isSinglePropSchema = isSingleProp(schema);
+  var mixinEls = el.mixinEls;
+
+  // 1. Default values (lowest precendence).
+  if (isSinglePropSchema) {
+    data = schema.default;
+  } else {
+    Object.keys(schema).forEach(function applyDefault (key) {
+      data[key] = schema[key].default;
+    });
+  }
+
+  // 2. Mixin values.
+  mixinEls.forEach(applyMixin);
+  function applyMixin (mixinEl) {
+    var mixinData = mixinEl.getAttribute(name);
+    if (mixinData) {
+      data = extendProperties(data, mixinData, isSinglePropSchema);
+    }
+  }
+
+  // 3. Attribute values (highest precendence).
+  data = extendProperties(data, newData, isSinglePropSchema);
+
+  // Parse and coerce using the schema.
+  if (isSinglePropSchema) {
+    return parseProperty(data, schema);
+  }
+  return parseProperties(data, schema);
+}
+module.exports.buildData = buildData;
+
+/**
  * Deserializes style-like string into an object of properties.
  *
  * @param {string} value - HTML attribute value.
@@ -303,7 +304,10 @@ function objectStringify (data) {
 */
 function extendProperties (dest, source, isSinglePropSchema) {
   if (isSinglePropSchema) {
-    if (source === undefined) { return dest; }
+    if (source === undefined ||
+        (typeof source === 'object' && Object.keys(source).length === 0)) {
+      return dest;
+    }
     return source;
   }
   return utils.extend(dest, source);

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -1,10 +1,12 @@
 /* global assert, process, suite, test */
 'use strict';
+var buildData = require('core/component').buildData;
 var components = require('index').components;
 var helpers = require('../helpers');
 var registerComponent = require('index').registerComponent;
+var processSchema = require('core/schema').process;
 
-var cloneComponent = {
+var CloneComponent = {
   init: function () {
     var object3D = this.el.object3D;
     var clone = object3D.clone();
@@ -14,7 +16,7 @@ var cloneComponent = {
 };
 var entityFactory = helpers.entityFactory;
 
-suite('component', function () {
+suite('Component', function () {
   suite('standard components', function () {
     test('are registered', function () {
       assert.ok('geometry' in components);
@@ -26,16 +28,106 @@ suite('component', function () {
     });
   });
 
+  suite('buildData', function () {
+    test('uses default values', function () {
+      var schema = processSchema({
+        color: { default: 'blue' },
+        size: { default: 5 }
+      });
+      var el = document.createElement('a-entity');
+      var data = buildData(el, 'dummy', schema, {});
+      assert.equal(data.color, 'blue');
+      assert.equal(data.size, 5);
+    });
+
+    test('uses default values for single-property schema', function () {
+      var schema = processSchema({
+        default: 'blue'
+      });
+      var el = document.createElement('a-entity');
+      var data = buildData(el, 'dummy', schema, {});
+      assert.equal(data, 'blue');
+    });
+
+    test('uses mixin values', function () {
+      var data;
+      var TestComponent = registerComponent('dummy', {
+        schema: {
+          color: { default: 'red' },
+          size: { default: 5 }
+        }
+      });
+      var el = document.createElement('a-entity');
+      var mixinEl = document.createElement('a-mixin');
+
+      mixinEl.setAttribute('dummy', 'color: blue; size: 10');
+      el.mixinEls = [mixinEl];
+      data = buildData(el, 'dummy', TestComponent.prototype.schema, {});
+      assert.equal(data.color, 'blue');
+      assert.equal(data.size, 10);
+    });
+
+    test('uses mixin values for single-property schema', function () {
+      var data;
+      var TestComponent = registerComponent('dummy', {
+        schema: {
+          default: 'red'
+        }
+      });
+      var el = document.createElement('a-entity');
+      var mixinEl = document.createElement('a-mixin');
+      mixinEl.setAttribute('dummy', 'blue');
+      el.mixinEls = [mixinEl];
+      data = buildData(el, 'dummy', TestComponent.prototype.schema, {});
+      assert.equal(data, 'blue');
+    });
+
+    test('uses defined values', function () {
+      var data;
+      var TestComponent = registerComponent('dummy', {
+        schema: {
+          color: { default: 'red' },
+          size: { default: 5 }
+        }
+      });
+      var el = document.createElement('a-entity');
+      var mixinEl = document.createElement('a-mixin');
+
+      mixinEl.setAttribute('dummy', 'color: blue; size: 10');
+      el.mixinEls = [mixinEl];
+      data = buildData(el, 'dummy', TestComponent.prototype.schema, {
+        color: 'green', size: 20
+      });
+      assert.equal(data.color, 'green');
+      assert.equal(data.size, 20);
+    });
+
+    test('uses defined values for single-property schema', function () {
+      var data;
+      var TestComponent = registerComponent('dummy', {
+        schema: {
+          default: 'red'
+        }
+      });
+      var el = document.createElement('a-entity');
+      var mixinEl = document.createElement('a-mixin');
+      mixinEl.setAttribute('dummy', 'blue');
+      el.mixinEls = [mixinEl];
+      data = buildData(el, 'dummy', TestComponent.prototype.schema, 'green');
+      assert.equal(data, 'green');
+    });
+  });
+
   suite('third-party components', function () {
     test('can be registered', function () {
       assert.notOk('clone' in components);
-      registerComponent('clone', cloneComponent);
+      registerComponent('clone', CloneComponent);
       assert.ok('clone' in components);
     });
 
     test('can change behavior of entity', function (done) {
       var el = entityFactory();
-      registerComponent('clone', cloneComponent);
+      registerComponent('clone', CloneComponent);
 
       el.addEventListener('loaded', function () {
         assert.notOk('clone' in el.components);


### PR DESCRIPTION
- Fixes mixins for single-prop components.
- Fixes default values for single-prop components that don't define data.
- Isolate and unit test component data building logic.