### PR TITLE
fix wakelock on Android

### DIFF
--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -168,8 +168,8 @@ var AScene = module.exports = registerElement('a-scene', {
           if (!fsElement) {
             this.showUI();
             this.setMonoRenderer();
+            if (this.wakelock) { this.wakelock.release(); }
           }
-          if (this.wakelock) { this.wakelock.release(); }
         }
         document.addEventListener('mozfullscreenchange',
                                   fullscreenChange.bind(this));


### PR DESCRIPTION
Wakelock worked fine in WebKit on iOS because we never entered fullscreen (because WebKit doesn't support the Fullscreen API, heh).

Wakelock never worked on Android because we would (1) enable Wakelock, (2) enter fullscreen, (3) fullscreen event listener gets called, and (4) Wakelock is accidentally disabled.
