### PR TITLE
block render loop on assets (fixes #873, #367, #779)

### DIFF
--- a/examples/model/index.html
+++ b/examples/model/index.html
@@ -8,16 +8,21 @@
   </head>
   <body>
     <a-scene stats="true">
-      <a-entity position="0 0 15">
-        <a-entity camera look-controls wasd-controls></a-entity>
-      </a-entity>
+      <a-assets>
+        <a-asset-item id="crate-obj" src="models/crate/crate.obj"></a-asset-item>
+        <a-asset-item id="crate-mtl" src="models/crate/crate.mtl"></a-asset-item>
+        <a-asset-item id="monster" src="models/monster.dae"></a-asset-item>
+      </a-assets>
 
       <a-entity collada-model="url(models/monster.dae)"
                 material="color: green" scale="0.25 0.25 0.25"
                 position="-10 -3 1"></a-entity>
       <a-entity obj-model="obj: url(models/crate/crate.obj); mtl: url(models/crate/crate.mtl)"
                 position="5 -3 5"
-                rotation="0 45 0"></a-entity>
+
+      <a-entity position="0 0 15">
+        <a-entity camera look-controls wasd-controls></a-entity>
+      </a-entity>
     </a-scene>
   </body>
 </html>

--- a/examples/video/index.html
+++ b/examples/video/index.html
@@ -9,11 +9,11 @@
   <body>
     <a-scene stats="true">
       <a-assets>
-        <video id="videoParis"
+        <video id="videoParis" preload="auto"
                src="https://ucarecdn.com/4130c599-445f-4e76-9052-49978e972641/"
                width="160" height="90" autoplay loop="true"
                crossOrigin="anonymous"></video>
-        <video id="videoHypercube"
+        <video id="videoHypercube" preload="auto"
                src="https://ucarecdn.com/210dd043-dcd3-446d-9b36-ad19471f6273/"
                width="160" height="90" autoplay loop="true"
                crossOrigin="anonymous"></video>

--- a/examples/videosphere/index.html
+++ b/examples/videosphere/index.html
@@ -9,7 +9,7 @@
   <body>
     <a-scene stats="true">
       <a-assets>
-        <video id="lego"
+        <video id="lego" preload="true"
                src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/t-197/walking_the_dog_360_video_short.webm"
                width="360" height="360" autoplay loop="true"
                crossOrigin="anonymous"></video>

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -1,15 +1,126 @@
 var ANode = require('./a-node');
+var debug = require('../utils/debug');
 var registerElement = require('./a-register-element').registerElement;
+var THREE = require('../lib/three');
+
+var xhrLoader = new THREE.XHRLoader();
+var warn = debug('core:a-assets:warn');
 
 /**
- * TODO: Block on assets before loading.
+ * Asset manager.
  */
 module.exports = registerElement('a-assets', {
   prototype: Object.create(ANode.prototype, {
+    createdCallback: {
+      value: function () {
+        this.isAssets = true;
+      }
+    },
+
+    attachedCallback: {
+      value: function () {
+        var self = this;
+        var loaded = [];
+        var audios = this.querySelectorAll('audio');
+        var imgs = this.querySelectorAll('img');
+        var timeout = parseInt(this.getAttribute('timeout'), 10) || 3000;
+        var videos = this.querySelectorAll('video');
+
+        // Wait for <img>s.
+        for (var i = 0; i < imgs.length; i++) {
+          loaded.push(new Promise(function (resolve, reject) {
+            var img = imgs[i];
+            img.onload = resolve;
+            img.onerror = reject;
+          }));
+        }
+
+        // Wait for <audio>s.
+        for (i = 0; i < audios.length; i++) {
+          loaded.push(mediaElementLoaded(audios[i]));
+        }
+
+        // Wait for <video>s.
+        for (i = 0; i < videos.length; i++) {
+          loaded.push(mediaElementLoaded(videos[i]));
+        }
+
+        // Trigger loaded for scene to start rendering.
+        Promise.all(loaded).then(this.load.bind(this));
+
+        setTimeout(function () {
+          if (self.hasLoaded) { return; }
+          warn('Asset loading timed out in ', timeout, 'ms');
+          self.emit('timeout');
+          self.load();
+        }, timeout);
+      }
+    },
+
     load: {
       value: function () {
-        ANode.prototype.load.call(this);
+        ANode.prototype.load.call(this, null, function waitOnFilter (el) {
+          return el.isAssetItem && el.hasAttribute('src');
+        });
       }
     }
   })
 });
+
+registerElement('a-asset-item', {
+  prototype: Object.create(ANode.prototype, {
+    createdCallback: {
+      value: function () {
+        this.data = null;
+        this.isAssetItem = true;
+      }
+    },
+
+    attachedCallback: {
+      value: function () {
+        var self = this;
+        var src = this.getAttribute('src');
+
+        xhrLoader.load(src, function (textResponse) {
+          self.data = textResponse;
+          ANode.prototype.load.call(self);
+        });
+      }
+    }
+  })
+});
+
+/**
+ * Create a Promise that resolves once the media element has finished buffering.
+ *
+ * @param {Element} el - HTMLMediaElement.
+ * @returns {Promise}
+ */
+function mediaElementLoaded (el) {
+  if (!el.hasAttribute('autoplay') && el.getAttribute('preload') !== 'auto') {
+    return;
+  }
+
+  // If media specifies autoplay or preload, wait until media is completely buffered.
+  return new Promise(function (resolve, reject) {
+    if (el.readyState === 4) { return resolve(); }  // Already loaded.
+    if (el.error) { return reject(); }  // Error.
+
+    el.addEventListener('loadeddata', checkProgress, false);
+    el.addEventListener('progress', checkProgress, false);
+    el.addEventListener('error', reject, false);
+
+    function checkProgress () {
+      // Add up the seconds buffered.
+      var secondsBuffered = 0;
+      for (var i = 0; i < el.buffered.length; i++) {
+        secondsBuffered += el.buffered.end(i) - el.buffered.start(i);
+      }
+
+      // Compare seconds buffered to media duration.
+      if (secondsBuffered >= el.duration) {
+        resolve();
+      }
+    }
+  });
+}

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -191,9 +191,6 @@ var proto = Object.create(ANode.prototype, {
         attach();
         return;
       }
-      // If the parent isn't an `ANode` but eventually it will be
-      // when a templated element is created, we want to attach
-      // this element to the parent then.
       parent.addEventListener('nodeready', attach);
       function attach () {
         // To prevent an object to attach itself multiple times to the parent.

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -22,7 +22,6 @@ module.exports = registerElement('a-node', {
     attachedCallback: {
       value: function () {
         var mixins = this.getAttribute('mixin');
-
         this.sceneEl = this.closest('a-scene');
         this.emit('nodeready', {}, false);
         if (mixins) { this.updateMixins(mixins); }
@@ -68,7 +67,7 @@ module.exports = registerElement('a-node', {
         var childrenLoaded;
         var self = this;
 
-        if (self.hasLoaded) { return; }
+        if (this.hasLoaded) { return; }
 
         // Default to waiting for all nodes.
         childFilter = childFilter || function (el) { return el.isNode; };
@@ -77,6 +76,7 @@ module.exports = registerElement('a-node', {
         children = this.getChildren();
         childrenLoaded = children.filter(childFilter).map(function (child) {
           return new Promise(function waitForLoaded (resolve) {
+            if (child.hasLoaded) { return resolve(); }
             child.addEventListener('loaded', resolve);
           });
         });

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -248,8 +248,8 @@ var AScene = module.exports = registerElement('a-scene', {
         var canvas = this.canvas;
         var size;
 
-        // Possible camera not injected yet.
-        if (!camera) { return; }
+        // Possible camera or canvas not injected yet.
+        if (!camera || !canvas) { return; }
 
         // Update canvas.
         if (!isMobile) {
@@ -362,25 +362,29 @@ var AScene = module.exports = registerElement('a-scene', {
      */
     play: {
       value: function () {
+        var self = this;
+
         if (this.renderStarted) {
           AEntity.prototype.play.call(this);
           return;
         }
 
         this.addEventListener('loaded', function () {
-          var self = this;
           if (this.renderStarted) { return; }
 
-          AEntity.prototype.play.call(self);
-          self.resize();
+          AEntity.prototype.play.call(this);
+          this.resize();
 
           // Kick off render loop.
-          self.render();
-          self.renderStarted = true;
-          self.emit('renderstart');
+          this.render();
+          this.renderStarted = true;
+          this.emit('renderstart');
         });
 
-        AEntity.prototype.load.call(this);
+        // setTimeout to wait for all nodes to attach and run their callbacks.
+        setTimeout(function () {
+          AEntity.prototype.load.call(self);
+        });
       }
     },
 

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -1,0 +1,86 @@
+/* global assert, setup, suite, test */
+
+suite('a-assets', function () {
+  setup(function () {
+    var el = this.el = document.createElement('a-assets');
+    var scene = this.scene = document.createElement('a-scene');
+    scene.appendChild(el);
+  });
+
+  test('loads if no assets', function (done) {
+    var scene = this.scene;
+    scene.addEventListener('loaded', function () {
+      done();
+    });
+    document.body.appendChild(scene);
+  });
+
+  test('waits for images to load', function (done) {
+    var el = this.el;
+    var scene = this.scene;
+
+    // Create image.
+    var img = document.createElement('img');
+    img.setAttribute('src', '');
+    el.appendChild(img);
+
+    scene.addEventListener('loaded', function () {
+      done();
+    });
+
+    // Load image.
+    document.body.appendChild(scene);
+    process.nextTick(function () {
+      img.onload();
+    });
+  });
+
+  test('does not wait for media element without preload attribute', function (done) {
+    var el = this.el;
+    var scene = this.scene;
+
+    // Create audio.
+    var audio = document.createElement('audio');
+    audio.setAttribute('src', '');
+    el.appendChild(audio);
+
+    scene.addEventListener('loaded', function () {
+      done();
+    });
+
+    document.body.appendChild(scene);
+  });
+
+  test('does not wait for random element', function (done) {
+    var el = this.el;
+    var scene = this.scene;
+
+    var div = document.createElement('div');
+    el.appendChild(div);
+
+    scene.addEventListener('loaded', function () {
+      done();
+    });
+
+    document.body.appendChild(scene);
+  });
+
+  test('calls load when timing out', function (done) {
+    var el = this.el;
+    var scene = this.scene;
+    var img = document.createElement('img');
+
+    el.setAttribute('timeout', 50);
+    img.setAttribute('src', '');
+    el.appendChild(img);
+
+    el.addEventListener('timeout', function () {
+      el.addEventListener('loaded', function () {
+        assert.ok(el.hasLoaded);
+        done();
+      });
+    });
+
+    document.body.appendChild(scene);
+  });
+});


### PR DESCRIPTION
- Currently waits for img (or anything with `src`) to load, and video/audio to load if they had preload or autoplay. 
- Configurable timeout, defaults to 3 seconds. After timeout, assets will no longer block
- https://github.com/aframevr/aframe/pull/913 will follow to get blocking on models since we need to allow models to specify selector to asset.