### PR TITLE
fix component double-parsing (fixes #912)

### DIFF
--- a/src/components/look-at.js
+++ b/src/components/look-at.js
@@ -26,7 +26,23 @@ var isCoordinate = coordinates.isCoordinate;
  * @member {object} vector - Helper vector to do matrix transformations.
  */
 module.exports.Component = registerComponent('look-at', {
-  schema: { default: '' },
+  schema: {
+    default: '',
+
+    parse: function (value) {
+      if (isCoordinate(value) || typeof value === 'object') {
+        return coordinates.parse(value);
+      }
+      return value;
+    },
+
+    stringify: function (data) {
+      if (typeof data === 'object') {
+        return coordinates.stringify(data);
+      }
+      return data;
+    }
+  },
 
   init: function () {
     this.target3D = null;
@@ -76,17 +92,6 @@ module.exports.Component = registerComponent('look-at', {
     if (target3D) {
       return this.el.object3D.lookAt(this.vector.setFromMatrixPosition(target3D.matrixWorld));
     }
-  },
-
-  parse: function (value) {
-    if (isCoordinate(value) || typeof value === 'object') {
-      return coordinates.parse(value);
-    }
-    return value;
-  },
-
-  stringify: function (data) {
-    return coordinates.stringify(data);
   },
 
   beginTracking: function (targetEl) {

--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -418,6 +418,7 @@ function getAnimationValues (el, attribute, dataFrom, dataTo, currentValue) {
     from[attribute] = parseProperty(from[attribute], schema[componentPropName]);
     to[attribute] = parseProperty(dataTo, schema[componentPropName]);
     partialSetAttribute = function (value) {
+      if (!(attribute in value)) { return; }
       el.setAttribute(componentName, componentPropName, value[attribute]);
     };
   }

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -360,24 +360,16 @@ var proto = Object.create(ANode.prototype, {
   },
 
   /**
-   * If `attr` is a component name and `componentProp` is not defined, removeAttribute removes
-   * the entire component from the entity.
-   *
-   * If `attr` is a component name and `componentProp` is defined, removeAttribute removes a
-   * single property from the component.
+   * If `attr` is a component name, removeAttribute detaches the component from the
+   * entity.
    *
    * @param {string} attr - Attribute name, which could also be a component name.
-   * @param {string} componentProp - Component property name.
    */
   removeAttribute: {
-    value: function (attr, componentProp) {
+    value: function (attr) {
       var component = components[attr];
       if (component) {
-        if (componentProp) {
-          this.setAttribute(attr, componentProp, undefined);
-        } else {
-          this.setEntityAttribute(attr, undefined, null);
-        }
+        this.setEntityAttribute(attr, undefined, null);
       }
       HTMLElement.prototype.removeAttribute.call(this, attr);
     }

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -11,7 +11,7 @@ registerPropertyType('int', 0, intParse);
 registerPropertyType('number', 0, numberParse);
 registerPropertyType('selector', '', selectorParse, selectorStringify);
 registerPropertyType('string', '', defaultParse, defaultStringify);
-registerPropertyType('vec3', { x: 0, y: 0, z: 0 }, coordinates.parse, coordinates.stringify);
+registerPropertyType('vec3', { x: 0, y: 0, z: 0 }, vec3Parse, coordinates.stringify);
 
 /**
  * Register a parser for re-use such that when someone uses `type` in the schema,
@@ -42,6 +42,7 @@ function defaultParse (value) {
 }
 
 function defaultStringify (value) {
+  if (value === null) { return 'null'; }
   return value.toString();
 }
 
@@ -67,4 +68,8 @@ function selectorStringify (el) {
   // Currently no way to infer the selector used for this component.
   if (el) { return '#' + el.getAttribute('id'); }
   return '';
+}
+
+function vec3Parse (value) {
+  return coordinates.parse(value, this.default);
 }

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -10,30 +10,22 @@ module.exports.regex = regex;
  * @param {string} defaults - fallback value.
  * @returns {object} An object with keys [x, y, z].
  */
-function parse (value, defaultCoordinate) {
+function parse (value, defaultVec3) {
   var coordinate;
 
   if (value && typeof value === 'object') {
     return vec3ParseFloat(value);
   }
 
-  if (!defaultCoordinate && this.schema) {
-    if ('default' in this.schema) {
-      defaultCoordinate = this.schema.default;
-    } else {
-      defaultCoordinate = this.schema;
-    }
-  }
-
   if (typeof value !== 'string' || value === null) {
-    return defaultCoordinate;
+    return defaultVec3;
   }
 
   coordinate = value.trim().replace(/\s+/g, ' ').split(' ');
   return vec3ParseFloat({
-    x: coordinate[0] || defaultCoordinate.x,
-    y: coordinate[1] || defaultCoordinate.y,
-    z: coordinate[2] || defaultCoordinate.z
+    x: coordinate[0] || defaultVec3.x,
+    y: coordinate[1] || defaultVec3.y,
+    z: coordinate[2] || defaultVec3.z
   });
 }
 module.exports.parse = parse;

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -355,15 +355,6 @@ suite('a-entity', function () {
       el.removeAttribute('material');
       assert.notOk(el.components.material);
     });
-
-    test('can remove a component attribute', function () {
-      var el = this.el;
-      el.setAttribute('material', 'color: #F0F; transparent: true');
-      assert.ok(el.getAttribute('material', 'transparent'));
-      el.removeAttribute('material', 'transparent');
-      assert.notOk(el.getAttribute('material', 'transparent'));
-      assert.equal(el.getAttribute('material', 'color', '#F0F'));
-    });
   });
 
   suite('initComponent', function () {

--- a/tests/core/schema.test.js
+++ b/tests/core/schema.test.js
@@ -148,7 +148,7 @@ suite('schema', function () {
         parse: parse
       });
       assert.equal(definition.type, 'string');
-      assert.equal(definition.parse, parse);
+      assert.shallowDeepEqual(definition.parse('def'), parse('def'));
       assert.ok(typeof definition.stringify, 'function');
     });
   });

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -29,15 +29,6 @@ suite('utils.coordinates', function () {
                               { x: 1, y: 2, z: -3 });
     });
 
-    test('can return schema values', function () {
-      var obj = new Obj();
-      assert.shallowDeepEqual(coordinates.parse.call(obj, '1 2'),
-                              { x: 1, y: 2, z: -3 });
-      function Obj () {
-        this.schema = { z: -3 };
-      }
-    });
-
     test('returns already-parsed object', function () {
       assert.shallowDeepEqual(coordinates.parse({ x: 1, y: 2, z: -3 }),
                               { x: 1, y: 2, z: -3 });


### PR DESCRIPTION
This is blocking adding a property type for assets and the model work:

- Need to change Component to not call `parse` before doing `buildData` since that already does schema parsing. We used to call it because we needed the `style-attr`-parsing. Since we only need that, I changed `buildData` to do `style-attr` parsing for multi-prop schemas.
- Simplified Component.parse/Component.stringify to use the schema functions since it was doing the same thing the schema already handles.
- Bind property parse/stringify to component prop definition to give vec3 parser access to default value