### PR TITLE
use THREE.Cache for in-memory asset caching (fixes #772)

### DIFF
--- a/src/lib/three.js
+++ b/src/lib/three.js
@@ -13,6 +13,11 @@ if (THREE.ImageLoader) {
   THREE.ImageLoader.prototype.crossOrigin = '';
 }
 
+// In-memory caching for XHRs (for images, audio files, textures, etc.).
+if (THREE.Cache) {
+  THREE.Cache.enabled = true;
+}
+
 // TODO: Eventually include these only if they are needed by a component.
 require('../../node_modules/three-dev/examples/js/loaders/OBJLoader');  // THREE.OBJLoader
 require('../../node_modules/three-dev/examples/js/loaders/MTLLoader');  // THREE.MTLLoader


### PR DESCRIPTION
Interestingly, because of how entities loads assets asynchronously, this doesn't improve the case of a scene that requests multiple images that share the same URL on page load. Example: [http://localhost:9000/examples/showcase-spheres-and-fog/](http://localhost:9000/examples/showcase-spheres-and-fog/)

But if you add a new entity with an asset that has already been loaded (and cached), then a cache hit does in fact happen, and it's served from the in-memory cache.

If the nodes and their assets were loaded sequentially, all subsequent requests would be cache hits. But that's not how things work.

So this isn't a huge improvement, but it'll help in some cases.
