### PR TITLE
release AudioContext and remove listener, sound from scene when remove sound component

### DIFF
--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -71,6 +71,9 @@ module.exports.Component = registerComponent('sound', {
 
   remove: function () {
     this.el.removeObject3D('sound');
+    this.sound.remove();
+    this.listener.remove();
+    this.listener.context.close();
   },
 
   /**


### PR DESCRIPTION
`this.listener.context.close()` is all that's needed to free up the Audio Context and allow more sounds to be loaded when loading and removing sounds dynamically.

Seems like we want to remove the sound and listener from the scene as well to free resources. Does this happen automagically?