### PR TITLE
entity play on attach (fixes #1011)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -61,6 +61,7 @@ var proto = Object.create(ANode.prototype, {
       this.addToParent();
       if (!this.isScene) {
         this.load();
+        if (!this.parentNode.paused) { this.play(); }
       }
     }
   },

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -69,16 +69,29 @@ suite('a-entity', function () {
     });
 
     test('waits for children to load', function (done) {
+      var scene = document.createElement('a-scene');
       var entity = document.createElement('a-entity');
       var entityChild1 = document.createElement('a-entity');
       var entityChild2 = document.createElement('a-entity');
       entity.appendChild(entityChild1);
       entity.appendChild(entityChild2);
-      document.body.appendChild(entity);
+      scene.appendChild(entity);
+      document.body.appendChild(scene);
 
       entity.addEventListener('loaded', function () {
         assert.ok(entityChild1.hasLoaded);
         assert.ok(entityChild2.hasLoaded);
+        done();
+      });
+    });
+
+    test('plays when entity is attached after scene load', function (done) {
+      var el = document.createElement('a-entity');
+      this.sinon.spy(AEntity.prototype, 'play');
+
+      this.el.sceneEl.appendChild(el);
+      el.addEventListener('loaded', function () {
+        sinon.assert.called(AEntity.prototype.play);
         done();
       });
     });
@@ -508,6 +521,7 @@ suite('a-entity component lifecycle management', function () {
   test('calls play on entity play', function () {
     var el = this.el;
     var TestComponent = this.TestComponent.prototype;
+    this.el.pause();
 
     this.sinon.spy(TestComponent, 'play');
     el.setAttribute('test', '');


### PR DESCRIPTION
At the moment, entities only play since the scene calls play. We need to call play when an entity is attached after the scene is already running.

- [x] tests