### PR TITLE
Add modelloaded event.

### DIFF
--- a/src/components/collada-model.js
+++ b/src/components/collada-model.js
@@ -25,6 +25,7 @@ module.exports.Component = registerComponent('collada-model', {
     loader.load(src, function (colladaModel) {
       self.model = colladaModel.scene;
       el.setObject3D('mesh', self.model);
+      el.emit('model-loaded', {format: 'collada', model: self.model});
     });
   },
 


### PR DESCRIPTION
Helpful to know when model assets have finished loading.

For example, to get @ngokevin's shadow component working with .OBJ models:

```javascript

module.exports = {
  schema: {
    cast:     { default: false },
    receive:  { default: false }
  },

  init: function () {
    this.update();
    this.el.addEventListener('modelloaded', () => this.update());
  },

  update: function (previousData) {
    var data = this.data;
    // Applied recursively to support imported models.
    this.el.object3D.traverse(function(node) {
      if (node instanceof THREE.Mesh) {
        node.castShadow = data.cast;
        node.receiveShadow = data.receive;
      }
    });
  },

  tick: function () {}
}
```

