### PR TITLE
Make look-controls passive when not in use

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -111,6 +111,9 @@ module.exports.Component = registerComponent('look-controls', {
     var hmdEuler = new THREE.Euler();
     hmdEuler.order = 'YXZ';
     return function () {
+      if (!this.mouseDown && this.dolly.quaternion.equals(this.zeroQuaternion)) {
+        return;
+      }
       var pitchObject = this.pitchObject;
       var yawObject = this.yawObject;
       var hmdQuaternion = this.calculateHMDQuaternion();


### PR DESCRIPTION
Fixes #975.

More comments there. Issue is that `gamepad-controls` and `look-controls` are incompatible on the dev branch, and it's not something I can work around within my component.

I could also package my own fork of `look-controls` *into* `gamepad-controls`, and that would be fine, or not sure if you all want to embed gamepad support officially into A-Frame?

In any case though, it would take some change like this (where both controls are passive when inactive), or else the two controls need to be aware of one another, which gets messier.