### PR TITLE
Properly detach animations by removing event listeners

### DIFF
--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -102,6 +102,7 @@ module.exports.AAnimation = registerElement('a-animation', {
 
     detachedCallback: {
       value: function () {
+        this.removeEventListeners(this.evt);
         if (!this.isRunning) { return; }
         this.stop();
       }


### PR DESCRIPTION
Detaching an animation from the DOM kept the event handlers registered, resulting in the animation still being triggered even if it had no DOM parent.