### PR TITLE
fix scene default component double init (fixes #1059)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -9,6 +9,7 @@ var processSchema = schema.process;
 var isSingleProp = schema.isSingleProperty;
 var stringifyProperties = schema.stringifyProperties;
 var stringifyProperty = schema.stringifyProperty;
+
 var components = module.exports.components = {}; // Keep track of registered components.
 
 /**
@@ -212,7 +213,9 @@ module.exports.registerComponent = function (name, definition) {
   });
 
   if (components[name]) {
-    throw new Error('The component ' + name + ' has been already registered');
+    throw new Error('The component `' + name + '` has been already registered. ' +
+                    'Check that you are not loading two versions of the same component ' +
+                    'or two different components of the same name.');
   }
   NewComponent = function (el) {
     Component.call(this, el);

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -536,7 +536,11 @@ suite('a-entity component lifecycle management', function () {
 suite('a-entity component dependency management', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
-    components.test = undefined;
+    var componentNames = ['codependency', 'dependency', 'nested-dependency', 'test'];
+    componentNames.forEach(function clearComponent (componentName) {
+      components[componentName] = undefined;
+    });
+
     this.TestComponent = registerComponent('test', extend({}, TestComponent, {
       dependencies: ['dependency', 'codependency']
     }));
@@ -558,5 +562,11 @@ suite('a-entity component dependency management', function () {
     assert.ok('dependency' in el.components);
     assert.ok('codependency' in el.components);
     assert.ok('nested-dependency' in el.components);
+  });
+
+  test('only initializes each component once', function () {
+    var spy = this.sinon.spy(this.DependencyComponent.prototype, 'init');
+    this.el.setAttribute('test', '');
+    assert.equal(spy.callCount, 1);
   });
 });

--- a/tests/core/a-scene.test.js
+++ b/tests/core/a-scene.test.js
@@ -17,7 +17,6 @@ suite('a-scene (without renderer)', function () {
   setup(function () {
     var el;
     el = this.el = document.createElement('a-scene');
-    el.setAttribute('canvas', '');
     document.body.appendChild(el);
   });
 


### PR DESCRIPTION
Had to move the component-already-initialized check closer to the component initialization. I think because several components are trying to initialize the same component (on top of the scene setAttribute call) at the same time.