### PR TITLE
don't default mesh primitives to gray (fixes #1058)

### DIFF
--- a/src/extras/primitives/meshMixin.js
+++ b/src/extras/primitives/meshMixin.js
@@ -4,9 +4,7 @@
 module.exports = function getMeshMixin () {
   return {
     defaultAttributes: {
-      material: {
-        color: 'gray'
-      }
+      material: { }
     },
 
     mappings: {


### PR DESCRIPTION
- Previously caused confusion if you try to apply a texture and the texture looks dark.