### PR TITLE
add texture object to material-texture-loaded event detail

### DIFF
--- a/src/utils/texture.js
+++ b/src/utils/texture.js
@@ -135,7 +135,7 @@ function loadImage (material, data, src) {
   var el = this.el;
   texturePromises[src] = loadImageTexture(material, src, data.repeat);
   texturePromises[src].then(emitEvent);
-  function emitEvent () { el.emit('material-texture-loaded', {src: src}); }
+  function emitEvent (texture) { el.emit('material-texture-loaded', {src: src, texture: texture}); }
 }
 
 function loadVideo (material, data, src) {


### PR DESCRIPTION
Enabling manipulations of objects based on loaded texture, like actual/native image width and height.

You could do stuff like:

```.html
<a-image id="testimg" width="10" src="test.png"> </a-image>
```
to set the base width of the image, and then:

```.js
var testimg = document.getDocumentById('testimg')
testimg.addEventListener('material-texture-loaded', function (e) {
  var widthHeightRatio = e.detail.texture.image.height / e.detail.texture.image.width
  var width = testimg.getAttribute('width')
  testimg.setAttribute('height', width * widthHeightRatio)
});
```

To dynamically set the height to fit the image texture.
I am testing this behaviour in a component called `fit-texture` to make `a-images` etc. automatically fit the image texture once it's loaded, without explicitly setting `width` and `height`.

Btw: We need a way to let the user to use image textures without them having knowledge about the actual dimensions of an image to look good when rendering. The example above is a bit hacky my taste, but works until we have a better solution.

Either way, It's useful to have the texture in the event detail.
