### PR TITLE
Fix WASD controls enabled on aframe-logo example

### DIFF
--- a/examples/animation-aframe-logo/index.html
+++ b/examples/animation-aframe-logo/index.html
@@ -12,7 +12,7 @@
       <!-- Quasi-isometric camera -->
       <a-entity>
         <a-animation attribute="position" from="0 5 0" to="0 0 0" dur="4000" easing="ease-out"></a-animation>
-        <a-camera id="camera" near="1000" far="4000" position="0 880 1290" fov="2.2" cursor-visible="false" rotation="-34 0 0" wasd- controls-enabled="false" look-controls-enabled="false"></a-camera>
+        <a-camera id="camera" near="1000" far="4000" position="0 880 1290" fov="2.2" cursor-visible="false" rotation="-34 0 0" wasd-controls-enabled="false" look-controls-enabled="false"></a-camera>
       </a-entity>
 
       <a-entity id="logo" rotation="0 45 0">


### PR DESCRIPTION
There was a space in the `wasd- controls-enabled` attribute which ended up evaluating to `wasd-="" controls-enabled="false"` which isn't valid.