### PR TITLE
Add fit-texture component

### DIFF
--- a/examples/primitives-images/index.html
+++ b/examples/primitives-images/index.html
@@ -14,19 +14,27 @@
         <img id="office3" src="mozvr-office-3.jpg">
       </a-assets>
 
-      <a-image position="-4 -7 -20" width="16" height="4.5" src="#office1"></a-image>
-      <a-image position="10 10 -20" width="14" height="9" scale="0.4 0.4 0.4" src="#office2"></a-image>
-      <a-image position="-6 6 -4" width="14" height="9" scale="0.4 0.4 0.4" src="#office2"></a-image>
-      <a-image position="-2 -5 -10" width="14" height="9" scale="0.4 0.4 0.4" src="#office2"></a-image>
-      <a-image position="-15 -1 -1" width="12" height="8" scale="0.5 0.5 0.5" src="#office3"></a-image>
-      <a-image position="5 -2 -3" width="12" height="8" scale="0.3 0.3 0.3" src="#office3"></a-image>
+      <!--You can define the width (in meters). The height will be set automatically to fit the image properly.  -->
+      <a-image position="-4 -7 -20" width="16" src="#office1"></a-image>
+
+      <!-- Same applies to height: -->
+      <a-image position="10 10 -20" height="6" src="#office2"></a-image>
+
+      <!-- You don't have to use width/height, the image will use default dimensions, you can later scale it via `scale` if you like: -->
+      <a-image position="-6 6 -4" src="#office2"></a-image>
+      <a-image position="-2 -5 -10" src="#office2" scale="8 8 8"></a-image>
+      <a-image position="-15 -1 -1" src="#office3" scale="8 8 8"></a-image>
+
+
+      <!-- If you want to have complete control over the a-image's dimensions you can set `fit-texture="false", like so:` -->
+      <a-image position="5 -2 -3" width="0.5" height="5" fit-texture="false" src="#office3"></a-image>
 
       <!-- hide a-image element until the texture has actually been loaded, then transition inside the camera view -->
-      <a-image id="eventImage" opacity="0.0" position="0 1 -50" width="16" height="4.5" src="https://upload.wikimedia.org/wikipedia/commons/5/5e/Big_Wood,_N2.JPG">
+      <a-image id="eventImage" opacity="0.0" width="5" position="0 5 -50" src="https://upload.wikimedia.org/wikipedia/commons/5/5e/Big_Wood,_N2.JPG">
 
         <a-animation begin="material-texture-loaded" attribute="opacity" to="1.0" dur="2000"> </a-animation>
         <a-animation begin="material-texture-loaded" attribute="rotation" from="180 0 0" to="0 0 0" dur="2500"> </a-animation>
-        <a-animation begin="material-texture-loaded" attribute="position" to="0 1 -8" dur="3000"> </a-animation>
+        <a-animation begin="material-texture-loaded" attribute="position" to="0 5 -8" dur="3000"> </a-animation>
 
       </a-image>
 

--- a/src/components/fit-texture.js
+++ b/src/components/fit-texture.js
@@ -33,7 +33,7 @@ module.exports.Component = registerComponent('fit-texture', {
     var widthHeightRatio = this.texture.image.height / this.texture.image.width;
 
     if (geometry.width && geometry.height) {
-      console.warn('Using `fit-texture` component on an element with both width and height. Keeping width and changing height to fit the texture.');
+      console.warn('Using `fit-texture` component on an element with both width and height. Therefore keeping width and changing height to fit the texture. If you want to manually set both width and height, set `fit-texture="false"`. ');
     }
     if (geometry.width) {
       el.setAttribute('height', geometry.width * widthHeightRatio);

--- a/src/components/fit-texture.js
+++ b/src/components/fit-texture.js
@@ -1,0 +1,49 @@
+var registerComponent = require('../core/component').registerComponent;
+
+/**
+ * Visibility component.
+ */
+module.exports.Component = registerComponent('fit-texture', {
+  dependencies: ['geometry'],
+  schema: {
+    type: 'boolean',
+    default: true
+  },
+
+  update: function () {
+    if (this.data === false) return;
+
+    var el = this.el;
+    var self = this;
+    if (self.texture) {
+      // If texture has already been loaded, and `fit-texture` was reset.
+      self.applyTransformation();
+    } else {
+      el.addEventListener('material-texture-loaded', function (e) {
+        // TODO: It's probably better to set the texture via material.js/texture.js
+        // instead of here, so all components could benefit from this info.
+        self.texture = e.detail.texture;
+        self.applyTransformation();
+      });
+    }
+  },
+  applyTransformation: function () {
+    var el = this.el;
+    var geometry = el.getAttribute('geometry');
+    var widthHeightRatio = this.texture.image.height / this.texture.image.width;
+
+    if (geometry.width && geometry.height) {
+      console.warn('Using `fit-texture` component on an element with both width and height. Keeping width and changing height to fit the texture.');
+    }
+    if (geometry.width) {
+      el.setAttribute('height', geometry.width * widthHeightRatio);
+    } else if (geometry.height) {
+      el.setAttribute('width', geometry.height / widthHeightRatio);
+    } else {
+      // Neither width nor height is set.
+      var tempWidth = 2;
+      el.setAttribute('width', '' + tempWidth);
+      el.setAttribute('height', tempWidth * widthHeightRatio);
+    }
+  }
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,6 +14,7 @@ require('./scale');
 require('./sound');
 require('./visible');
 require('./wasd-controls');
+require('./fit-texture');
 
 require('./scene/canvas');
 require('./scene/fog');

--- a/src/extras/primitives/primitives/a-image.js
+++ b/src/extras/primitives/primitives/a-image.js
@@ -12,7 +12,8 @@ registerPrimitive('a-image', utils.extendDeep({}, meshMixin(), {
       shader: 'flat',
       side: 'double',
       transparent: true
-    }
+    },
+    'fit-texture': true
   },
 
   mappings: {


### PR DESCRIPTION
I propose adding a `fit-texture` component, that automatically scales planes with textures (eg. `a-image`) to fit the image texture without distortions.

Right now, the user has to manually set the width and height if they don't want the image to appear stretched. This is not ergonomic or intuitive, as newcomers to aframe would possibly expect the behaviour of standard html `img` elements, that display images undistorted. Even with the knowledge, it's not really efficient to set dimensions by hand.

The `fit-texture` should be applied to `a-image` by default and can optionally set to other `a-entitites` and may be disabled on `a-image`'s by setting`fit-texture="false"`.
It is possible to set only one side (width or height), and the component will scale the other one accordingly.
If both sides are set, the component will use `width` as base side and emit a warning that it doesn't make sense to set width and height, unless you set `fit-texture="false"`.

I kept thinking wether it is necessary to merge this component into master or not. But I think it adds much needed comfort to use image textures in aframe. Take a look at `examples/primitives/images`!
In future, we might want to approach this differently, but at the moment I thought I'd leave this here for you to discuss/decide :)