### PR TITLE
Add .npmignore to stop npm install from downloading tests and examples (fixes #250)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+tests
+examples


### PR DESCRIPTION
Added a .npmignore that stops `npm install` from downloading the tests and examples folders. Do we still want tests cloned via npm? Do most users embedding A-Frame in their project use the tests? Is there anything besides examples that we want ignored? I suppose the ignoring may be able to be done within the package.json instead.

Note: this does not stop `git clone` from grabbing tests and examples.