### PR TITLE
removed unnecessary parameter from vec2 primitave

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -16,7 +16,7 @@ registerPropertyType('selectorAll', '', selectorAllParse, selectorAllStringify);
 registerPropertyType('src', '', srcParse);
 registerPropertyType('string', '', defaultParse, defaultStringify);
 registerPropertyType('time', 0, intParse);
-registerPropertyType('vec2', { x: 0, y: 0, z: 0 }, vecParse, coordinates.stringify);
+registerPropertyType('vec2', { x: 0, y: 0 }, vecParse, coordinates.stringify);
 registerPropertyType('vec3', { x: 0, y: 0, z: 0 }, vecParse, coordinates.stringify);
 registerPropertyType('vec4', { x: 0, y: 0, z: 0, w: 0 }, vecParse, coordinates.stringify);
 


### PR DESCRIPTION
vec2 only showed up in 4 places in the repo, two were commented out examples and the other two were the switch where Vector2 is created with threejs in src/core/shader and the other is where vec2 is initialized in src/core/propertyType.

I installed and ran aframe after I made changes and opened up a few of the boiler plates and showcase (figuring lightroom would have plenty of shaders in it).

@larouxn also tested saying: "Cloned it myself. Ran the npm test tests, started the server, and checked out a few examples. No errors anywhere as far as I can tell."