### PR TITLE
Setting on look-controls to allow vertical touch movement

### DIFF
--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -22,9 +22,10 @@ The look-controls component is usually used alongside the [camera component][com
 
 ## Properties
 
-| Property  | Description                        | Default Value |
-|-----------|-----------------------------------------------------
-| enabled   | Whether look controls are enabled. | true          |
+| Property                    | Description                                 | Default Value |
+|-----------------------------|--------------------------------------------------------------
+| enabled                     | Whether look controls are enabled.          | true          |
+| allowVerticalTouchMovement  | Whether vertical touch movement is allowed. | false         |
 
 ## Caveats
 

--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -8,7 +8,8 @@ module.exports.Component = registerComponent('look-controls', {
   dependencies: ['position', 'rotation'],
 
   schema: {
-    enabled: { default: true }
+    enabled: { default: true },
+    allowVerticalTouchMovement: { default: false }
   },
 
   init: function () {
@@ -227,13 +228,22 @@ module.exports.Component = registerComponent('look-controls', {
   },
 
   onTouchMove: function (e) {
+    if (!this.touchStarted) { return; }
+
+    if (this.data.allowVerticalTouchMovement) {
+      var deltaX;
+      var pitchObject = this.pitchObject;
+      deltaX = 2 * Math.PI * (e.touches[0].pageY - this.touchStart.y) /
+              this.el.sceneEl.canvas.clientHeight;
+      pitchObject.rotation.x -= deltaX * 0.5;
+    }
+
     var deltaY;
     var yawObject = this.yawObject;
-    if (!this.touchStarted) { return; }
     deltaY = 2 * Math.PI * (e.touches[0].pageX - this.touchStart.x) /
             this.el.sceneEl.canvas.clientWidth;
-    // Limits touch orientaion to to yaw (y axis)
     yawObject.rotation.y -= deltaY * 0.5;
+
     this.touchStart = {
       x: e.touches[0].pageX,
       y: e.touches[0].pageY


### PR DESCRIPTION
A client recently complained that you could only move horizontally, not vertically, with touch. I see a comment about explicitly only allowing horizontal touch movement, but I don't understand why.

Changes proposed:
- Add a property called allowVerticalTouchMovement to the look-controls component.
- allowVerticalTouchMovement defaults to false.
- When explicitly set to true, vertical touch movement will also work.

I'd be happy to submit another PR where vertical movement is always allowed, but I didn't want to break the defaults when there might be a good reason for it being as it is.

I was unable to find any tests that covers the look-controls component, so I have not included any tests for my change.

