### PR TITLE
Settings on look-controls to configure mouse movement

### DIFF
--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -22,9 +22,11 @@ The look-controls component is usually used alongside the [camera component][com
 
 ## Properties
 
-| Property  | Description                        | Default Value |
-|-----------|-----------------------------------------------------
-| enabled   | Whether look controls are enabled. | true          |
+| Property              | Description                                 | Default Value |
+|-----------------------|--------------------------------------------------------------
+| enabled               | Whether look controls are enabled.          | true          |
+| reverseMouseMovement  | Enable for a "drag feel" to mouse movement. | false         |
+| mouseMovementSpeed    | Speed when looking with mouse (careful!)    | 0.002         |
 
 ## Caveats
 

--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -8,7 +8,9 @@ module.exports.Component = registerComponent('look-controls', {
   dependencies: ['position', 'rotation'],
 
   schema: {
-    enabled: { default: true }
+    enabled: { default: true },
+    reverseMouseMovement: { default: false },
+    mouseMovementSpeed: { default: 0.002 }
   },
 
   init: function () {
@@ -203,8 +205,13 @@ module.exports.Component = registerComponent('look-controls', {
     }
     this.previousMouseEvent = event;
 
-    yawObject.rotation.y -= movementX * 0.002;
-    pitchObject.rotation.x -= movementY * 0.002;
+    if (this.data.reverseMouseMovement) {
+      movementX *= -1;
+      movementY *= -1;
+    }
+
+    yawObject.rotation.y -= movementX * this.data.mouseMovementSpeed;
+    pitchObject.rotation.x -= movementY * this.data.mouseMovementSpeed;
     pitchObject.rotation.x = Math.max(-PI_2, Math.min(PI_2, pitchObject.rotation.x));
   },
 


### PR DESCRIPTION
A client recently complained that mouse movement in A-Frame felt wrong compared to ie. mouse movement in YouTube's and Facebook's 360 videos. He want to "drag" the canvas around with the mouse, rather than to "push" it. He also wanted a slightly faster movement for the mouse, as he felt the experience was a bit "sluggish" with the default setting.

Changes proposed:
- Add a property called reverseMouseMovement to the look-controls component with a default of false. When set to true, mouse movement will work reversed.
- Add a property called mouseMovementSpeed to the look-controls component with a default of 0.002 - the current hardcoded setting.

I was unable to find any tests that covers the look-controls component, so I have not included any tests for my change.
