### PR TITLE
Fix for #692. Iterate up to a parent when matching subobject.

### DIFF
--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -66,11 +66,26 @@ module.exports.Component = registerComponent('raycaster', {
     var intersectedObjs = this.intersect(scene.children);
     for (var i = 0; i < intersectedObjs.length; ++i) {
       intersectedObj = intersectedObjs[i];
+
+      while (
+        (intersectedObj.object.parent) &&
+        (intersectedObj.object.el === undefined)
+      ) {
+        intersectedObj.object = intersectedObj.object.parent;
+      }
+
       // If the intersected object is the cursor itself
       // or the object is further than the max distance
-      if (intersectedObj.object.el === undefined) { continue; }
-      if (intersectedObj.object.el === cursorEl) { continue; }
-      if (!intersectedObj.object.visible) { continue; }
+
+      if (intersectedObj.object.el === undefined) {
+        continue;
+      }
+      if (intersectedObj.object.el === cursorEl) {
+        continue;
+      }
+      if (!intersectedObj.object.visible) {
+        continue;
+      }
       return intersectedObj;
     }
     return null;

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -67,25 +67,16 @@ module.exports.Component = registerComponent('raycaster', {
     for (var i = 0; i < intersectedObjs.length; ++i) {
       intersectedObj = intersectedObjs[i];
 
-      while (
-        (intersectedObj.object.parent) &&
-        (intersectedObj.object.el === undefined)
-      ) {
+      while (intersectedObj.object.parent && intersectedObj.object.el === undefined) {
         intersectedObj.object = intersectedObj.object.parent;
       }
 
       // If the intersected object is the cursor itself
       // or the object is further than the max distance
 
-      if (intersectedObj.object.el === undefined) {
-        continue;
-      }
-      if (intersectedObj.object.el === cursorEl) {
-        continue;
-      }
-      if (!intersectedObj.object.visible) {
-        continue;
-      }
+      if (intersectedObj.object.el === undefined) { continue; }
+      if (intersectedObj.object.el === cursorEl) { continue; }
+      if (!intersectedObj.object.visible) { continue; }
       return intersectedObj;
     }
     return null;


### PR DESCRIPTION
Changes proposed:
- Iterate up object tree to the element that is attached to the dom.
