### PR TITLE
trim jsdocs that belong to and are in the docs

### DIFF
--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -10,38 +10,6 @@ var warn = debug('components:geometry:warn');
 
 /**
  * Geometry component. Combined with material component to make a mesh in 3D object.
- *
- * @param {number} [arc=360] -
- *   Used by torus. A central angle that determines arc length of the torus. In degrees.
- * @param {number} [depth=2] - Used by box. Depth of the sides on the Z axis.
- * @param {number} [height=2] -
- *   Used by box, cylinder, plane. Height of the sides on the Y axis.
- * @param {bool} [openEnded=false] - Used by cylinder.
- * @param {number} [p=2] - Used by torusKnot. Coprime of q.
- * @param {number} [primitive=null] - type of shape (e.g., box, sphere).
- * @param {number} [q=3] - Used by torusKnot. Coprime of p.
- * @param {number} [radius=1] - Used by circle, cylinder, ring, sphere, torus, torusKnot.
- * @param {number} [radiusBottom=1] - Used by cylinder.
- * @param {number} [radiusInner=0.8] - Used by ring.
- * @param {number} [radiusOuter=1.2] - Used by ring.
- * @param {number} [radiusTop=1] - Used by cylinder.
- * @param {number} [radiusTube=0.2] - Used by torus. Tube radius.
- * @param {number} [scaleHeight=1] - Used by torusKnot.
- * @param {number} [segments=8] - Used by circle. Number of segments.
- * @param {number} [segmentsHeight=18] - Used by cylinder, sphere. Number of segments.
- * @param {number} [segmentsPhi=8] - Used by ring.
- * @param {number} [segmentsRadial=36] - Used by cylinder. Number of segments.
- * @param {number} [segmentsTheta=8] -
- *   Used by ring. Number of segments. A higher number means the ring will be more round.
- *   Minimum is 3.
- * @param {number} [segmentsTubular=8] - Used by torus, torusKnot. Number of segments.
- * @param {number} [segmentsWidth=36] - Used by sphere.
- * @param {number} [thetaLength=360] - Used by circle, cylinder, ring. In degrees.
- * @param {number} [thetaStart=0] - Used by circle, cylinder, ring. In degrees.
- * @param {string} translate -
- *   Defined as a coordinate (e.g., `-1 0 5`) that translates geometry vertices. Useful for
- *   effectively changing the pivot point.
- * @param {number} [width=2] - Used by box, plane.
  */
 module.exports.Component = registerComponent('geometry', {
   schema: {

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -8,21 +8,6 @@ var warn = debug('components:light:warn');
 
 /**
  * Light component.
- *
- * @namespace light
- * @param {number} [angle=60] - maximum extent of light from its direction,
-          in degrees. For spot lights.
- * @param {string} [color=#FFF] - light color. For every light.
- * @param {number} [decay=1] - amount the light dims along the distance of the
-          light. For point and spot lights.
- * @param {number} [exponent=10.0] - rapidity of falloff of light from its
-          target direction. For spot lights.
- * @param {string} [groundColor=#FFF] - ground light color. For hemisphere
-          lights.
- * @param {number} [intensity=1.0] - light strength. For every light except
-          ambient.
- * @param {string} [type=directional] - light type (ambient, directional,
-          hemisphere, point, spot).
  */
 module.exports.Component = registerComponent('light', {
   schema: {

--- a/src/components/look-at.js
+++ b/src/components/look-at.js
@@ -8,31 +8,23 @@ var isCoordinate = coordinates.isCoordinate;
 
 /**
  * Look-at component.
+ *
  * Modifies rotation to either track another entity OR do a one-time turn towards a position
  * vector.
  *
  * If tracking an object via setting the component value via a selector, look-at will register
  * a behavior to the scene to update rotation on every tick.
- *
- * Examples:
- *
- * look-at="#the-mirror"
- * look-at="0 5 -2"
- *
- * @param Look-at either takes a target selector pointing to another object or a
- *        position.
- * @member {object} target3D - object3D of targeted element that look-at is currently
-           tracking.
- * @member {object} vector - Helper vector to do matrix transformations.
  */
 module.exports.Component = registerComponent('look-at', {
   schema: {
     default: '',
 
     parse: function (value) {
+      // A static position to look at.
       if (isCoordinate(value) || typeof value === 'object') {
         return coordinates.parse(value);
       }
+      // A selector to a target entity.
       return value;
     },
 

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -14,10 +14,9 @@ var shaderNames = shader.shaderNames;
 /**
  * Material component.
  *
- * @namespace material
- * @param {string} shader - Determines how material is shaded. Defaults to `standard`,
- *         three.js's implementation of PBR. Another option is `flat` where we use
- *         MeshBasicMaterial.
+ * @member {object} shader - Determines how material is shaded. Defaults to `standard`,
+ *         three.js's implementation of PBR. Another standard shading model is `flat` which
+ *         uses MeshBasicMaterial.
  */
 module.exports.Component = registerComponent('material', {
   schema: {

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -7,11 +7,6 @@ var warn = debug('components:sound:warn');
 
 /**
  * Sound component.
- *
- * @param {bool} [autoplay=false]
- * @param {string} on
- * @param {bool} [loop=false]
- * @param {number} [volume=1]
  */
 module.exports.Component = registerComponent('sound', {
   schema: {

--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -4,23 +4,7 @@ var THREE = require('../lib/three');
 var MAX_DELTA = 0.2;
 
 /**
- * WASD component.
- *
- * Control your entities with the WASD keys.
- *
- * @namespace wasd-controls
- * @param {number} [easing=20] - How fast the movement decelerates. If you hold the
- * keys the entity moves and if you release it will stop. Easing simulates friction.
- * @param {number} [acceleration=65] - Determines the acceleration given
- * to the entity when pressing the keys.
- * @param {bool} [enabled=true] - To completely enable or disable the controls
- * @param {bool} [fly=false] - Determines if the direction of the movement sticks
- * to the plane where the entity started off or if there are 6 degrees of
- * freedom as a diver underwater or a plane flying.
- * @param {string} [wsAxis='z'] - The axis that the W and S keys operate on
- * @param {string} [adAxis='x'] - The axis that the A and D keys operate on
- * @param {bool} [wsInverted=false] - WS Axis is inverted
- * @param {bool} [adInverted=false] - AD Axis is inverted
+ * WASD component to control entities using WASD keys.
  */
 module.exports.Component = registerComponent('wasd-controls', {
   schema: {

--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -17,37 +17,9 @@ var isCoordinate = coordinates.isCoordinate;
  * Animation element that applies Tween animation to parent element (entity).
  * Takes after the Web Animations spec.
  *
- * @namespace <a-animation>
- * @param {string} attribute -
- *   Entity attribute to animate. Can be a component name (e.g., `position`) if the component
- *   is set via a single value. Or can be a dot-separated componentName.componentProp to
- *   animate a single component property (e.g., `light.intensity`, `material.opacity`).
- * @param {number|string} begin -
- *   Either milliseconds to delay or an event name to wait upon before starting animation.
- * @param {string} direction -
- *   Direction of the animation between from and to.
- *     - alternate: Even iterations played as specified, odd iterations played in reverse
- *                direction from way specified.
- *     - alternate-reverse: Even iterations are played in the reverse direction from way
- *                        specified, odd iterations played as specified.
- *     - normal: All iterations are played as specified.
- *     - reverse: All iterations are played in reverse direction from way specified.
- * @param {number} dur - How long to run the animation in milliseconds.
- * @param {string} easing -
- *   Easing function of animation (e.g., ease, ease-in, ease-in-out, ease-out, linear).
- * @param {string} [fill=forwards] -
- *   Determines effect of animation when not in play.
- *     - backwards: Before animation, set initial value to `from`.
- *     - both: Before animation, backwards fill. After animation, forwards fill.
- *     - forwards: After animation, value will stay at `to`.
- *     - none: Animation has no effect when not in play.
- * @param {number} from - Start value. Defaults to the entity's current value for that attr.
- * @param {number|string} repeat -
- *   How the animation should repeat (e.g., a number or `indefinite`).
- * @param {number} to - End value.
- * @member {number} count -
- *   Decrementing counter for how many cycles of animations left to run.
- * @member {Element} el - Entity which the animation is modifying to.
+ * @member {number} count - Decrementing counter for how many cycles of animations left to
+ *         run.
+ * @member {Element} el - Entity which the animation is modifying.
  * @member initialValue - Value before animation started. Used to restore state.
  * @member {bool} isRunning - Whether animation is currently running.
  * @member {function} partialSetAttribute -

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -7,7 +7,7 @@ var xhrLoader = new THREE.XHRLoader();
 var warn = debug('core:a-assets:warn');
 
 /**
- * Asset manager.
+ * Asset management system. Handles blocking on asset loading.
  */
 module.exports = registerElement('a-assets', {
   prototype: Object.create(ANode.prototype, {

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -17,7 +17,6 @@ var styleParser = utils.styleParser;
  *
  * To be able to take components, the scene element inherits from the entity definition.
  *
- * @namespace Entity
  * @member {object} components - entity's currently initialized components.
  * @member {object} object3D - three.js object.
  * @member {array} states

--- a/src/core/a-mixin.js
+++ b/src/core/a-mixin.js
@@ -3,40 +3,37 @@ var AComponents = require('./component').components;
 var ANode = require('./a-node');
 var registerElement = require('./a-register-element').registerElement;
 
-module.exports = registerElement(
-  'a-mixin',
-  {
-    prototype: Object.create(
-      ANode.prototype,
-      {
-        attachedCallback: {
-          value: function () {
-            this.load();
-          },
-          writable: window.debug
+module.exports = registerElement('a-mixin', {
+  prototype: Object.create(
+    ANode.prototype,
+    {
+      attachedCallback: {
+        value: function () {
+          this.load();
         },
+        writable: window.debug
+      },
 
-        setAttribute: {
-          value: function (attr, value) {
-            var component = AComponents[attr];
-            if (component && typeof value === 'object') {
-              value = component.stringify(value);
-            }
-            HTMLElement.prototype.setAttribute.call(this, attr, value);
-          },
-          writable: window.debug
+      setAttribute: {
+        value: function (attr, value) {
+          var component = AComponents[attr];
+          if (component && typeof value === 'object') {
+            value = component.stringify(value);
+          }
+          HTMLElement.prototype.setAttribute.call(this, attr, value);
         },
+        writable: window.debug
+      },
 
-        getAttribute: {
-          value: function (attr) {
-            var component = AComponents[attr];
-            var value = HTMLElement.prototype.getAttribute.call(this, attr);
-            if (!component || typeof value !== 'string') { return value; }
-            return component.parse(value);
-          },
-          writable: window.debug
-        }
+      getAttribute: {
+        value: function (attr) {
+          var component = AComponents[attr];
+          var value = HTMLElement.prototype.getAttribute.call(this, attr);
+          if (!component || typeof value !== 'string') { return value; }
+          return component.parse(value);
+        },
+        writable: window.debug
       }
-    )
-  }
-);
+    }
+  )
+});

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -4,14 +4,12 @@ var systems = module.exports.systems = {};  // Keep track of registered componen
 /**
  * System class definition.
  *
- * Systems are pieces of data and logic that are associated to one particular
- * component. They're global to all the instantiated components of that type
- * and provide an API for them to use. An example would be a physics component
- * that would contain a physics system that oversees all the entities and
- * calculate the necessary updates based on the entities interactions.
+ * Systems provide global scope and services to a group of instantiated components of the.
+ * same class. For example, a physics component that creates a physics world that oversees
+ * all entities with a physics or rigid body component.
  *
- * @namespace System
- * @member {Element} sceneEl - Handle to the scene element where the system applies to.
+ * @member {string} name - Name that system is registered under.
+ * @member {Element} sceneEl - Handle to the scene element where system applies to.
  */
 var System = module.exports.System = function () {
   var component = components && components.components[this.name];
@@ -47,7 +45,7 @@ System.prototype = {
   pause: function () { /* no-op */ },
 
   /**
-   * Remove handler. Shuts down the system
+   * Remove handler. Shuts down the system.
    */
   remove: function () { /* no-op */ }
 };


### PR DESCRIPTION
Changes proposed:
- Remove comments that are "user"-facing rather than maintainer-facing.
- User-facing docs exist in one place, in docs/, as source of truth.
- Consistent indent on a-mixin prototype
- No actual code changes
- Don't use "ATnamespace" since we don't do auto-generation of docs

