### PR TITLE
Fix iOS viewport issue (Fixes #1122)

### DIFF
--- a/src/core/scene/metaTags.js
+++ b/src/core/scene/metaTags.js
@@ -25,7 +25,7 @@ function injectMetaTags () {
   meta = document.createElement('meta');
   meta.name = 'viewport';
   meta.content =
-    'width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no';
+    'width=device-width,initial-scale=1,shrink-to-fit=no,user-scalable=no,maximum-scale=1';
   headEl.appendChild(meta);
   metaTags.push(meta);
 


### PR DESCRIPTION
Changes proposed:
- Add maximum-scale=1 to fix iOS viewport scaling (Fixes #1122)

Before:
![before fix](http://i.imgur.com/HDZyyM7.jpg)

After:
![after fix](http://i.imgur.com/kzKtZ1D.jpg)

I tested this in the Xcode iOS simulator and an iPhone 6, did not get a chance to test a 6S or newer devices.