### PR TITLE
add timedelta built-in uniform type

### DIFF
--- a/docs/core/shaders.md
+++ b/docs/core/shaders.md
@@ -110,14 +110,15 @@ AFRAME.registerShader('hello-world-shader', {
 
 #### Shader Uniform and Attribute Types
 
-| Type     | Description                                                                                                                                                              |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| color    | Built-in convenience (vec3) uniform type. Will take colors in multiple formats and automatically convert them to vec3 format (e.g., 'red' -> `THREE.Vector3(1, 0, 0)`)   |
-| number   | Maps to GLSL `float`.                                                                                                                                                    |
-| time     | Built-in convenience (float) uniform type. If specified, the material component will continuously update the shader with the global scene time.                          |
-| vec2     | Maps to GLSL `vec2`.                                                                                                                                                     |
-| vec3     | Maps to GLSL `vec3`.                                                                                                                                                     |
-| vec4     | Maps to GLSL `vec4`.                                                                                                                                                     |
+| Type      | Description                                                                                                                                                              |
+| --------  | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| color     | Takes colors in multiple formats and automatically convert them to a `vec3` (e.g., 'red' -> `THREE.Vector3(1, 0, 0)`).                                                   |
+| number    | Maps to GLSL `float`.                                                                                                                                                    |
+| time      | Built-in `int` uniform type. If specified, the material component will continuously update the shader with the global scene time.                                        |
+| timeDelta | Built-in `int` uniform type. If specified, the material component will continuously update the shader with the global scene time delta.                                  |
+| vec2      | Maps to GLSL `vec2`.                                                                                                                                                     |
+| vec3      | Maps to GLSL `vec3`.                                                                                                                                                     |
+| vec4      | Maps to GLSL `vec4`.                                                                                                                                                     |
 
 #### Standard Component Properties
 

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -10,6 +10,9 @@ var diff = utils.diff;
 var registerComponent = component.registerComponent;
 var shaders = shader.shaders;
 var shaderNames = shader.shaderNames;
+var TYPE_TIME = 'time';
+var TYPE_TIME_DELTA = 'timeDelta';
+var TICK_TYPES = [TYPE_TIME, TYPE_TIME_DELTA];
 
 /**
  * Material component.
@@ -27,6 +30,9 @@ module.exports.Component = registerComponent('material', {
     depthTest: { default: true }
   },
 
+  /**
+   * Init handler that can be overridden to provide a custom three.js material.
+   */
   init: function () {
     this.material = null;
   },
@@ -43,10 +49,13 @@ module.exports.Component = registerComponent('material', {
     if (!this.shader || dataDiff.shader) {
       this.updateShader(data.shader);
     }
-    this.shader.update(this.data);
-    this.updateMaterial();
+    this.shader.update(data);
+    updateBaseMaterial(this.material, data);
   },
 
+  /**
+   * Update schema (handler) based on `shader` property, if necessary.
+   */
   updateSchema: function (data) {
     var newShader = data.shader;
     var currentShader = this.data && this.data.shader;
@@ -55,31 +64,50 @@ module.exports.Component = registerComponent('material', {
     if (!schema) { error('Unknown shader schema ' + shader); }
     if (currentShader && newShader === currentShader) { return; }
     this.extendSchema(schema);
-    this.updateBehavior();
+    this.updateTick();
   },
 
-  updateBehavior: function () {
+  /**
+   * Update tick handler that continuously updates certain shader uniforms if the shader
+   * specifies certain uniform types like `time`.
+   */
+  updateTick: function () {
+    var needsTick = false;
     var scene = this.el.sceneEl;
     var schema = this.schema;
     var self = this;
-    var tickProperties = {};
-    var tick = function (time, delta) {
-      var keys = Object.keys(tickProperties);
-      keys.forEach(update);
-      function update (key) { tickProperties[key] = time; }
+    var tickProperties = {}; // Map of property name to property value.
+    var tickPropertiesTypes = {}; // Map of property name to property type.
+
+    // Tick function that updates shader uniforms.
+    function tick (time, timeDelta) {
+      Object.keys(tickPropertiesTypes).forEach(function updateShader (key) {
+        if (tickPropertiesTypes[key] === TYPE_TIME) {
+          tickProperties[key] = time;
+        }
+        if (tickPropertiesTypes[key] === TYPE_TIME_DELTA) {
+          tickProperties[key] = timeDelta;
+        }
+      });
       self.shader.update(tickProperties);
-    };
-    var keys = Object.keys(schema);
-    keys.forEach(function (key) {
-      if (schema[key].type === 'time') {
-        self.tick = tick;
-        tickProperties[key] = true;
-        scene.addBehavior(self);
-      }
-    });
-    if (Object.keys(tickProperties).length === 0) {
-      scene.removeBehavior(this);
     }
+
+    // Determine whether tick is needed.
+    Object.keys(schema).forEach(function markTickProperties (key) {
+      if (TICK_TYPES.indexOf(schema[key].type) === -1) { return; }
+      tickPropertiesTypes[key] = schema[key].type; // Mark as needing to pass into shader.
+      needsTick = true;
+    });
+
+    // Add tick if needed.
+    if (needsTick) {
+      self.tick = tick;
+      scene.addBehavior(this);
+      return;
+    }
+    // Remove tick if no longer needed.
+    self.tick = null;
+    scene.removeBehavior(this);
   },
 
   updateShader: function (shaderName) {
@@ -92,15 +120,6 @@ module.exports.Component = registerComponent('material', {
     material = this.shader.init(data);
     this.setMaterial(material);
     this.updateSchema(data);
-  },
-
-  updateMaterial: function () {
-    var data = this.data;
-    var material = this.material;
-    material.side = parseSide(data.side);
-    material.opacity = data.opacity;
-    material.transparent = data.transparent !== false || data.opacity < 1.0;
-    material.depthTest = data.depthTest !== false;
   },
 
   /**
@@ -129,6 +148,19 @@ module.exports.Component = registerComponent('material', {
     system.registerMaterial(material);
   }
 });
+
+/**
+ * Update material base properties.
+ *
+ * @param material {object} - three.js material.
+ * @param data {object} - Component data.
+ */
+function updateBaseMaterial (material, data) {
+  material.depthTest = data.depthTest;
+  material.side = parseSide(data.side);
+  material.opacity = data.opacity;
+  material.transparent = data.transparent !== false || data.opacity < 1.0;
+}
 
 /**
  * Returns a three.js constant determining which material face sides to render

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -16,6 +16,7 @@ registerPropertyType('selectorAll', '', selectorAllParse, selectorAllStringify);
 registerPropertyType('src', '', srcParse);
 registerPropertyType('string', '', defaultParse, defaultStringify);
 registerPropertyType('time', 0, intParse);
+registerPropertyType('timeDelta', 0, intParse);
 registerPropertyType('vec2', { x: 0, y: 0 }, vecParse, coordinates.stringify);
 registerPropertyType('vec3', { x: 0, y: 0, z: 0 }, vecParse, coordinates.stringify);
 registerPropertyType('vec4', { x: 0, y: 0, z: 0, w: 0 }, vecParse, coordinates.stringify);

--- a/src/core/shader.js
+++ b/src/core/shader.js
@@ -60,9 +60,7 @@ Shader.prototype = {
     var self = this;
     var variables = {};
     var schema = this.schema;
-    var squemaKeys = Object.keys(schema);
-    squemaKeys.forEach(processSquema);
-    function processSquema (key) {
+    Object.keys(schema).forEach(function processSchema (key) {
       if (schema[key].is !== type) { return; }
       var varType = propertyToThreeMapping[schema[key].type];
       var varValue = schema[key].parse(data[key] || schema[key].default);
@@ -70,7 +68,7 @@ Shader.prototype = {
         type: varType,
         value: self.parseValue(schema[key].type, varValue)
       };
-    }
+    });
     return variables;
   },
 
@@ -88,15 +86,13 @@ Shader.prototype = {
   updateVariables: function (data, type) {
     var self = this;
     var variables = type === 'uniform' ? this.uniforms : this.attributes;
-    var dataKeys = Object.keys(data);
     var schema = this.schema;
-    dataKeys.forEach(processData);
-    function processData (key) {
+    Object.keys(data).forEach(function processData (key) {
       if (!schema[key] || schema[key].is !== type) { return; }
       if (variables[key].value === data[key]) { return; }
       variables[key].value = self.parseValue(schema[key].type, data[key]);
       variables[key].needsUpdate = true;
-    }
+    });
   },
 
   parseValue: function (type, value) {

--- a/tests/core/shader.test.js
+++ b/tests/core/shader.test.js
@@ -1,0 +1,26 @@
+/* global assert, process, suite, test, setup */
+'use strict';
+var registerShader = require('core/shader').registerShader;
+var shaders = require('core/shader').shaders;
+var shaderNames = require('core/shader').shaderNames;
+
+suite('Shader', function () {
+  test('standard shaders registered', function () {
+    assert.ok('flat' in shaders);
+    assert.ok('standard' in shaders);
+    assert.notEqual(shaderNames.indexOf('flat'), -1);
+    assert.notEqual(shaderNames.indexOf('standard'), -1);
+  });
+
+  suite('registerShader', function () {
+    setup(function () {
+      delete shaders.test;
+    });
+
+    test('can register shaders', function () {
+      registerShader('test', {});
+      assert.ok('test' in shaders);
+      assert.notEqual(shaderNames.indexOf('test'), -1);
+    });
+  });
+});


### PR DESCRIPTION
Getting acquainted with the material/shader code. ShaderToy has a `iTimeDelta` uniform type that might be useful to have in A-Frame.

Changes proposed:
- Add built-in `timeDelta` uniform type.
- Add tests for `material.updateTick` and shader registration
- Move `material.updateMaterial` out of prototype
- Fix typo `squema`
- Rename `material.updateBehavior` to `material.updateTick`

