### PR TITLE
move camera code to camera system (fixes #1079)

### DIFF
--- a/docs/core/AFRAME.md
+++ b/docs/core/AFRAME.md
@@ -3,7 +3,7 @@ title: AFRAME
 type: core
 layout: docs
 parent_section: core
-order: 9
+order: 10
 ---
 
 A-Frame exposes its public interface through the `window.AFRAME` browser global. This same interface is exposed if requiring with NPM (`require('aframe');`). `AFRAME` can be used to register new things and extend AFRAME's capabilities.
@@ -15,7 +15,9 @@ A-Frame exposes its public interface through the `window.AFRAME` browser global.
 | AScene            | [Scene][scene] prototype.                               |
 | components        | Object of registered components.                        |
 | registerComponent | Function to register a [component][component].          |
+| registerPrimitive | Function to register a [primitive][primitive].          |
 | registerShader    | Function to register a [shader][shader].                |
+| shaders           | Object of registered shaders.                           |
 | systems           | Object of registered systems.                           |
 | THREE             | Global [three.js][three.js] object.                     |
 | TWEEN             | Global [tween.js][tween.js] object.                     |
@@ -24,6 +26,7 @@ A-Frame exposes its public interface through the `window.AFRAME` browser global.
 
 [component]: ./component.md
 [entity]: ./entity.md
+[primitive]: ../primitives/index.md
 [scene]: ./scene.md
 [shader]: ./shaders.md
 [three.js]: http://threejs.org

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -10,9 +10,9 @@ section_order: 2
 
 A-Frame is based on an __[entity-component-system pattern](https://en.wikipedia.org/wiki/Entity_component_system)__, a pattern common in game development that emphasizes composability over inheritance:
 
-- An **entity** is a general-purpose object in the scene that, by itself, does nothing.
-- A **component** is a reusable module that is attached to an entity to provide appearance, behavior, and/or functionality.
-- A **system** manages components of its type.
+- An [entity][entity] is a general-purpose object in the scene that, by itself, does nothing.
+- A [component][component] is a reusable module that is attached to an entity to provide appearance, behavior, and/or functionality.
+- A [system][system] provide global scope, services, and management to classes of components.
 
 Components are plug-and-play for objects. They let us build complex entities with rich behavior by plugging different reusable components into the sockets on the entity. Contrast this to traditional inheritance where if we want extend an object, we would have to manually create a new class to do so.
 
@@ -49,9 +49,12 @@ From there, we can attach more and more components to add whatever appearance, b
 
 We can even attach third-party components that other people have created. If someone writes a component that enables a mesh to explode, or a component that enables the mesh to use a canvas as its material texture, we could just drop the component into our A-Frame experience and use it immediately in HTML. The entity-component-system pattern enables great flexibility and extensibility.
 
+[component]: ./component.md
 [composegif]: http://i.imgur.com/0UIZFgs.gifv
+[entity]: ./entity.md
 [geometry]: ../components/geometry.md
 [light]: ../components/light.md
 [material]: ../components/material.md
 [physics]: https://github.com/ngokevin/aframe-physics-components]
 [sound]: ../components/sound.html
+[system]: ./systems.md

--- a/docs/core/scene.md
+++ b/docs/core/scene.md
@@ -27,12 +27,14 @@ The scene inherits from the [`Entity`][entity] class so it inherits all of its p
 | Name           | Description                                                                  |
 |----------------|------------------------------------------------------------------------------|
 | behaviors      | Array of components with tick methods that will be run on every frame.       |
+| camera         | Active three.js camera.                                                      |
 | canvas         | Reference to the canvas element.                                             |
 | isMobile       | Whether or not environment is detected to be mobile.                         |
 | monoRenderer   | Instance of `THREE.WebGlRenderer`.                                           |
 | object3D       | [`THREE.Scene`][scene] object.                                               |
 | renderer       | Active renderer, one of `monoRenderer` or `stereoRenderer`.                  |
 | stereoRenderer | Renderer for VR created by passing the `monoRenderer` into `THREE.VREffect`. |
+| systems        | Instantiated [systems][systems].                                             |
 | time           | Global uptime of scene in seconds.                                           |
 
 ## Methods
@@ -93,4 +95,5 @@ function run () {
 [keyboard-shortcuts]: ../components/keyboard-shortcuts.md
 [scene]: http://threejs.org/docs/#Reference/Scenes/Scene
 [stats]: ../components/stats.md
+[systems]: ../core/systems.md
 [vr-mode-ui]: ../components/vr-mode-ui.md

--- a/docs/core/systems.md
+++ b/docs/core/systems.md
@@ -1,0 +1,54 @@
+---
+title: Systems
+type: core
+layout: docs
+parent_section: core
+order: 9
+---
+
+> Note: the systems API is new and may be unstable.
+
+Systems, of the [entity-component-system pattern][ecs], provide global scope, services, and management to classes of components. They provide public APIs (methods and properties) for classes of components as systems can be accessed through the scene element. Systems also help components interface with the global scene.
+
+For example, the camera system manages all entities with the [camera component][camera], controlling which camera is the active camera.
+
+## Registering a System
+
+Systems are registered similarly to [components][components]. If the system name matches a component name, then the component will have a reference to the system as `this.system`:
+
+```js
+AFRAME.registerSystem('my-component', {
+  // System handlers and methods.
+});
+
+AFRAME.registerComponent('my-component', {
+  init: function () {
+    console.log(this.system);
+  }
+});
+```
+
+## Methods
+
+Systems, like components, define lifecycle handlers. They can also define methods intended to be public API.
+
+| Method   | Description                                                              |
+| -------- | -------------                                                            |
+| init     | Called once when the system is initialized. Used to initialize.          |
+| pause    | Called when the scene pauses. Used to stop dynamic behavior.             |
+| play     | Called when the scene starts or resumes. Used to start dynamic behavior. |
+| tick     | If defined, will be called on every tick of the scene's render loop.     |
+
+## Accessing a System
+
+An instantiated system can be accessed through the scene:
+
+```js
+console.log(document.querySelector('a-scene').systems);
+```
+
+Registered system prototypes can be accessed through `AFRAME.systems`.
+
+[camera]: ../components/camera.md
+[components]: ./component.md
+[ecs]: ./index.md

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -30,6 +30,7 @@ var isMobile = utils.isMobile();
  * @member {object} renderer
  * @member {bool} renderStarted
  * @member {object} stereoRenderer
+ * @member {object} systems - Registered instantiated systems.
  * @member {number} time
  */
 var AScene = module.exports = registerElement('a-scene', {

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -42,12 +42,7 @@ System.prototype = {
   /**
    * Called to stop any dynamic behavior (e.g., animation, AI, events, physics).
    */
-  pause: function () { /* no-op */ },
-
-  /**
-   * Remove handler. Shuts down the system.
-   */
-  remove: function () { /* no-op */ }
+  pause: function () { /* no-op */ }
 };
 
 /**

--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -1,0 +1,115 @@
+var registerSystem = require('../core/system').registerSystem;
+
+var DEFAULT_CAMERA_ATTR = 'data-aframe-default-camera';
+
+/**
+ * Camera system. Manages which camera is active among multiple cameras in scene.
+ *
+ * @member {object} activeCameraEl - Active camera entity.
+ */
+module.exports.System = registerSystem('camera', {
+  init: function () {
+    this.activeCameraEl = null;
+    this.setupDefaultCamera();
+  },
+
+  /**
+   * Creates a default camera if user has not added one during the initial scene traversal.
+   *
+   * Default camera height is at human level (~1.8m) and back such that
+   * entities at the origin (0, 0, 0) are well-centered.
+   */
+  setupDefaultCamera: function () {
+    var sceneEl = this.sceneEl;
+    var cameraWrapperEl;
+    var defaultCameraEl;
+
+    // setTimeout in case the camera is being set dynamically with a setAttribute.
+    setTimeout(function checkForCamera () {
+      var cameraEl = sceneEl.querySelector('[camera]');
+
+      if (cameraEl && cameraEl.isEntity) {
+        sceneEl.emit('camera-ready', {cameraEl: cameraEl});
+        return;
+      }
+
+      // DOM calls to create camera.
+      cameraWrapperEl = document.createElement('a-entity');
+      cameraWrapperEl.setAttribute('position', {x: 0, y: 1.8, z: 4});
+      cameraWrapperEl.setAttribute(DEFAULT_CAMERA_ATTR, '');
+      defaultCameraEl = document.createElement('a-entity');
+      defaultCameraEl.setAttribute('camera', {'active': true});
+      defaultCameraEl.setAttribute('wasd-controls');
+      defaultCameraEl.setAttribute('look-controls');
+      cameraWrapperEl.appendChild(defaultCameraEl);
+      sceneEl.appendChild(cameraWrapperEl);
+      sceneEl.emit('camera-ready', {cameraEl: defaultCameraEl});
+    });
+  },
+
+  /**
+   * Set a different active camera.
+   * When we choose a (sort of) random scene camera as the replacement, set its `active` to
+   * true. The camera component will call `setActiveCamera` and handle passing the torch to
+   * the new camera.
+   */
+  disableActiveCamera: function () {
+    var sceneEl = this.sceneEl;
+    var sceneCameras = sceneEl.querySelectorAll('[camera]');
+    var newActiveCameraEl = sceneCameras[sceneCameras.length - 1];
+    newActiveCameraEl.setAttribute('camera', 'active', true);
+  },
+
+  /**
+   * Set active camera to be used by renderer.
+   * Removes the default camera (if present).
+   * Disables all other cameras in the scene.
+   *
+   * @param {Element} newCameraEl - Entity with camera component.
+   * @param {object} newCamera - three.js Camera object.
+   */
+  setActiveCamera: function (newCameraEl, newCamera) {
+    var cameraEl;
+    var i;
+    var sceneEl = this.sceneEl;
+    var sceneCameraEls = sceneEl.querySelectorAll('[camera]');
+
+    // Grab the default camera.
+    var defaultCameraWrapper = sceneEl.querySelector('[' + DEFAULT_CAMERA_ATTR + ']');
+    var defaultCameraEl = defaultCameraWrapper &&
+                          defaultCameraWrapper.querySelector('[camera]');
+    // Remove default camera if new camera is not the default camera.
+    if (newCameraEl !== defaultCameraEl) { removeDefaultCamera(sceneEl); }
+
+    // Make new camera active.
+    this.activeCameraEl = newCameraEl;
+    if (sceneEl.isPlaying) { newCameraEl.play(); }
+    newCameraEl.setAttribute('camera', 'active', true);
+    sceneEl.camera = newCamera;
+    sceneEl.emit('camera-set-active', {cameraEl: newCameraEl});
+
+    // Disable other cameras.
+    for (i = 0; i < sceneCameraEls.length; i++) {
+      cameraEl = sceneCameraEls[i];
+      if (newCameraEl === cameraEl) { continue; }
+      cameraEl.setAttribute('camera', 'active', false);
+      cameraEl.pause();
+    }
+  }
+});
+
+/**
+ * Remove injected default camera from scene, if present.
+ *
+ * @param {Element} sceneEl
+ */
+function removeDefaultCamera (sceneEl) {
+  var defaultCameraWrapper;
+  var camera = sceneEl.camera;
+  if (!camera) { return; }
+
+  // Remove default camera if present.
+  defaultCameraWrapper = sceneEl.querySelector('[' + DEFAULT_CAMERA_ATTR + ']');
+  if (!defaultCameraWrapper) { return; }
+  sceneEl.removeChild(defaultCameraWrapper);
+}

--- a/src/systems/index.js
+++ b/src/systems/index.js
@@ -1,1 +1,2 @@
-require('../systems/material');
+require('./camera');
+require('./material');

--- a/tests/core/a-scene.test.js
+++ b/tests/core/a-scene.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, sinon, setup, suite, teardown, test, THREE */
+/* global assert, process, sinon, setup, suite, teardown, test */
 'use strict';
 var helpers = require('../helpers');
 var AEntity = require('core/a-entity');
@@ -60,86 +60,6 @@ suite('a-scene (without renderer)', function () {
       sceneEl.reload(true);
       sinon.assert.called(AEntity.prototype.pause);
       sinon.assert.called(ANode.prototype.load);
-    });
-  });
-
-  suite('setActiveCamera', function () {
-    test('sets new active camera in three.js graph', function () {
-      var el = this.el;
-      var camera = new THREE.PerspectiveCamera(45, 2, 1, 1000);
-      el.setActiveCamera(camera);
-      assert.equal(el.camera, camera);
-    });
-
-    test('sets new active camera in entity graph', function (done) {
-      var self = this;
-      var cameraEl = document.createElement('a-entity');
-      cameraEl.setAttribute('camera', '');
-      this.el.appendChild(cameraEl);
-      process.nextTick(function () {
-        self.el.setActiveCamera(cameraEl);
-        assert.equal(self.el.camera, cameraEl.components.camera.camera);
-        done();
-      });
-    });
-  });
-
-  suite('setActiveCamera', function () {
-    test('switches active camera', function (done) {
-      var sceneEl = this.el;
-      var camera1El = document.createElement('a-entity');
-      var camera2El = document.createElement('a-entity');
-      camera1El.setAttribute('camera', 'active: false');
-      sceneEl.appendChild(camera1El);
-      camera2El.setAttribute('camera', 'active: true');
-      sceneEl.appendChild(camera2El);
-      process.nextTick(function () {
-        assert.equal(camera1El.getAttribute('camera').active, false);
-        sceneEl.setActiveCamera(camera1El);
-        assert.equal(camera1El.getAttribute('camera').active, true);
-        assert.equal(camera2El.getAttribute('camera').active, false);
-        done();
-      });
-    });
-  });
-
-  suite('removeDefaultCamera', function () {
-    test('removes the default camera', function (done) {
-      var sceneEl = this.el;
-      var defaultCamera;
-      sceneEl.setupDefaultCamera();
-      process.nextTick(function () {
-        defaultCamera = sceneEl.querySelector('[data-aframe-default-camera]');
-        assert.notEqual(defaultCamera, null);
-        // Mocks camera initialization
-        sceneEl.camera = { el: true };
-        sceneEl.removeDefaultCamera();
-        defaultCamera = sceneEl.querySelector('[data-aframe-default-camera]');
-        assert.equal(defaultCamera, null);
-        done();
-      });
-    });
-  });
-
-  suite('updateCameras', function () {
-    test('disable inactive cameras', function (done) {
-      var sceneEl = this.el;
-      var cameraEl = document.createElement('a-entity');
-      cameraEl.setAttribute('camera', 'active: false');
-      sceneEl.appendChild(cameraEl);
-
-      var camera2El = document.createElement('a-entity');
-      camera2El.setAttribute('camera', 'active: false');
-      sceneEl.appendChild(camera2El);
-
-      process.nextTick(function () {
-        cameraEl.setAttribute('camera', 'active: true');
-        camera2El.setAttribute('camera', 'active: true');
-        assert.equal(cameraEl.getAttribute('camera').active, false);
-        assert.equal(camera2El.getAttribute('camera').active, true);
-        assert.equal(camera2El.components.camera.camera, sceneEl.camera);
-        done();
-      });
     });
   });
 

--- a/tests/systems/camera.test.js
+++ b/tests/systems/camera.test.js
@@ -1,0 +1,71 @@
+/* global assert, process, setup, suite, test */
+var entityFactory = require('../helpers').entityFactory;
+
+suite('camera system', function () {
+  setup(function (done) {
+    var el = this.el = entityFactory();
+    el.addEventListener('loaded', function () {
+      done();
+    });
+  });
+
+  suite('setActiveCamera', function () {
+    test('sets new active camera on scene', function () {
+      var el = this.el;
+      el.setAttribute('camera', '');
+      assert.equal(el.sceneEl.camera, el.components.camera.camera);
+    });
+
+    test('switches active camera', function (done) {
+      var sceneEl = this.el.sceneEl;
+      var camera1El = document.createElement('a-entity');
+      var camera2El = document.createElement('a-entity');
+      camera1El.setAttribute('camera', 'active: false');
+      sceneEl.appendChild(camera1El);
+      camera2El.setAttribute('camera', 'active: true');
+      sceneEl.appendChild(camera2El);
+      process.nextTick(function () {
+        assert.notOk(camera1El.getAttribute('camera').active);
+        sceneEl.systems.camera.setActiveCamera(camera1El, camera1El.components.camera.camera);
+        assert.ok(camera1El.getAttribute('camera').active);
+        assert.notOk(camera2El.getAttribute('camera').active);
+        done();
+      });
+    });
+
+    test('disable inactive cameras', function (done) {
+      var sceneEl = this.el.sceneEl;
+      var cameraEl = document.createElement('a-entity');
+      cameraEl.setAttribute('camera', 'active: false');
+      sceneEl.appendChild(cameraEl);
+
+      var camera2El = document.createElement('a-entity');
+      camera2El.setAttribute('camera', 'active: false');
+      sceneEl.appendChild(camera2El);
+
+      process.nextTick(function () {
+        cameraEl.setAttribute('camera', 'active: true');
+        camera2El.setAttribute('camera', 'active: true');
+        assert.notOk(cameraEl.getAttribute('camera').active);
+        assert.ok(camera2El.getAttribute('camera').active, true);
+        assert.equal(camera2El.components.camera.camera, sceneEl.camera);
+        done();
+      });
+    });
+
+    test('removes the default camera', function (done) {
+      var cameraEl2 = document.createElement('a-entity');
+      var sceneEl = this.el.sceneEl;
+      cameraEl2.setAttribute('camera', 'active: true');
+      process.nextTick(function () {
+        assert.ok(sceneEl.querySelector('[data-aframe-default-camera]'));
+        sceneEl.appendChild(cameraEl2);
+        // Need to setTimeout to wait for scene to remove element.
+        setTimeout(function () {
+          assert.notOk(sceneEl.querySelector('[data-aframe-default-camera]'));
+          done();
+        });
+      });
+    });
+  });
+});

--- a/tests/systems/material.test.js
+++ b/tests/systems/material.test.js
@@ -1,12 +1,12 @@
 /* global assert, process, setup, suite, test */
 var entityFactory = require('../helpers').entityFactory;
 
-suite('material', function () {
+suite('material system', function () {
   'use strict';
 
   setup(function (done) {
-    this.el = entityFactory();
-    process.nextTick(function () {
+    var el = this.el = entityFactory();
+    el.addEventListener('loaded', function () {
       done();
     });
   });


### PR DESCRIPTION
Before starting feature work and perf work, wanted to finish up some refactoring debt.

Changes proposed:
- Migrate camera code from scene to systems.
- Document systems API.
- Remove `System.remove()` stubbed handler. Not sure how a system would get removed and how it would differ from `System.pause()`.
