### PR TITLE
Create a `torus` primitve #155

### DIFF
--- a/docs/primitives/a-torus.md
+++ b/docs/primitives/a-torus.md
@@ -1,0 +1,28 @@
+---
+title: <a-torus>
+type: primitives
+layout: docs
+parent_section: primitives
+order: 19
+---
+
+The torus primitive creates a donut or circular tube shape. It is an entity that prescribes the [geometry](../components/geometry.md) with its geometric primitive set to `torus`.
+
+## Example
+
+```html
+<a-torus color="blue" position="0 0 0" segments-radial="50" segments-tubular="200" radius="5" tube="0.1"></a-torus>
+```
+
+## Attributes
+
+Note that the torus primitive inherits common [mesh attributes](./mesh-attributes.md).
+
+| Attribute         | Component Mapping        | Default Value |
+|-------------------|--------------------------|---------------|
+| arc               | geometry.arc             | 360           |
+| radius            | geometry.radius          | 1             |
+| radius-tubular    | geometry.radius-tubular  | 0.2           |
+| segments-radial   | geometry.segmentsRadial  | 36            |
+| segments-tubular  | geometry.segmentsTubular | 8             |
+

--- a/examples/index.html
+++ b/examples/index.html
@@ -173,6 +173,7 @@
       <li><a href="primitives-models/">Models</a></li>
       <li><a href="primitives-planes/">Planes</a></li>
       <li><a href="primitives-sky/">Sky</a></li>
+      <li><a href="primitives-torus/">Torus</a></li>
       <li><a href="primitives-video/">Video</a></li>
       <li><a href="primitives-videosphere/">Video Sphere</a></li>
     </ul>

--- a/examples/primitives-torus/index.html
+++ b/examples/primitives-torus/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Torus</title>
+  <meta name="description" content="Torus - A-Frame">
+  <script src="../../dist/aframe.js"></script>
+</head>
+<body>
+  <a-scene>
+  <a-torus id="asd"></a-torus>
+    <a-torus color="lightblue" position="0 2 -5" segments-radial="50" segments-tubular="200" radius="5"></a-torus>
+    <a-torus color="green" position="2 3 -5" segments-radial="10"></a-torus>
+    <a-torus color="green" position="-2 3 -5" segments-tubular="20"></a-torus>
+    <a-torus color="tomato" position="0 0 -5" arc="-200"></a-torus>
+    <a-torus color="coral" position="-4 0 0"></a-torus>
+    <a-torus color="yellow" rotation="90 0 0" position="3 0 0"></a-torus>
+    <a-torus color="purple" rotation="0 90 0" position="7 0 -5" radius="2" tube="0.2"> </a-torus>
+    <a-sky color="#F2F2F2"></a-sky>
+  </a-scene>
+</body>
+</html>

--- a/src/extras/primitives/index.js
+++ b/src/extras/primitives/index.js
@@ -14,5 +14,6 @@ require('./primitives/a-plane');
 require('./primitives/a-ring');
 require('./primitives/a-sky');
 require('./primitives/a-sphere');
+require('./primitives/a-torus');
 require('./primitives/a-video');
 require('./primitives/a-videosphere');

--- a/src/extras/primitives/primitives/a-torus.js
+++ b/src/extras/primitives/primitives/a-torus.js
@@ -1,0 +1,19 @@
+var getMeshMixin = require('../getMeshMixin');
+var registerPrimitive = require('../registerPrimitive');
+var utils = require('../../../utils/');
+
+registerPrimitive('a-torus', utils.extendDeep({}, getMeshMixin(), {
+  defaultAttributes: {
+    geometry: {
+      primitive: 'torus'
+    }
+  },
+
+  mappings: {
+    'radius': 'geometry.radius',
+    'radius-tubular': 'geometry.radiusTubular',
+    'segments-radial': 'geometry.segmentsRadial',
+    'segments-tubular': 'geometry.segmentsTubular',
+    'arc': 'geometry.arc'
+  }
+}));

--- a/tests/extras/a-torus.test.js
+++ b/tests/extras/a-torus.test.js
@@ -1,0 +1,36 @@
+/* global assert, suite, test, setup */
+suite('a-torus', function () {
+  var scene;
+  var torus;
+  var torus2;
+  setup(function (done) {
+    scene = document.createElement('a-scene');
+    torus = document.createElement('a-torus');
+    document.body.appendChild(scene);
+    scene.appendChild(torus);
+    torus2 = document.createElement('a-torus');
+    torus2.addEventListener('loaded', function () {
+      done();
+    });
+    torus2.setAttribute('segments-tubular', '100');
+    torus2.setAttribute('radius', '2');
+    torus2.setAttribute('radius-tubular', '0.1');
+    scene.appendChild(torus2);
+  });
+
+  test('has default position when created', function () {
+    assert.deepEqual(torus.getComputedAttribute('position'), { x: 0, y: 0, z: 0 });
+  });
+
+  test('has torus geometry', function () {
+    assert.strictEqual(torus.getAttribute('geometry').primitive, 'torus');
+  });
+
+  test('has inherited attributes on geometry', function () {
+    var geometry = torus2.getAttribute('geometry');
+    assert.strictEqual(geometry.primitive, 'torus');
+    assert.strictEqual(geometry.segmentsTubular, 100);
+    assert.strictEqual(geometry.radius, 2);
+    assert.strictEqual(geometry.radiusTubular, 0.1);
+  });
+});


### PR DESCRIPTION
Torus primitive was implemented, notice that `tube` attribute is not working yet, probably (not sure) because is not included in [geometry schema.
](https://github.com/aframevr/aframe/blob/master/src/components/geometry.js)

I´ve created a simple example:
![torus](https://cloud.githubusercontent.com/assets/2657897/13830639/437b1e5e-ebce-11e5-8a9b-88da5b47cdc8.png)

(yep, it´s a face ^^)