### PR TITLE
Allow setting depthTest to false

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -23,7 +23,8 @@ module.exports.Component = registerComponent('material', {
     shader: { default: 'standard', oneOf: shaderNames },
     transparent: { default: false },
     opacity: { default: 1.0, min: 0.0, max: 1.0 },
-    side: { default: 'front', oneOf: ['front', 'back', 'double'] }
+    side: { default: 'front', oneOf: ['front', 'back', 'double'] },
+    depthTest: { default: true }
   },
 
   init: function () {
@@ -99,6 +100,7 @@ module.exports.Component = registerComponent('material', {
     material.side = parseSide(data.side);
     material.opacity = data.opacity;
     material.transparent = data.transparent !== false || data.opacity < 1.0;
+    material.depthTest = data.depthTest !== false;
   },
 
   /**

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -272,4 +272,13 @@ suite('material', function () {
       assert.ok(el.getObject3D('mesh').material.transparent);
     });
   });
+
+  suite('depthTest', function () {
+    test('can be set to false', function () {
+      var el = this.el;
+      assert.ok(el.getObject3D('mesh').material.depthTest);
+      el.setAttribute('material', 'depthTest: false');
+      assert.equal(el.getObject3D('mesh').material.depthTest, 0);
+    });
+  });
 });


### PR DESCRIPTION
**Description:**
Allow setting the `depthTest` property of the material component.

Fixes https://github.com/aframevr/aframe/issues/714
Relates to https://github.com/aframevr/aframe/issues/666

**Changes proposed:**
- Add `depthTest` in the list of parameters allowed with `material`.
- Apply the `depthTest` value to the material object.
