### PR TITLE
pause sound only if sound is playing

### DIFF
--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -119,7 +119,7 @@ module.exports.Component = registerComponent('sound', {
   },
 
   pause: function () {
-    if (!this.sound.source.buffer) { return; }
+    if (!this.sound.source.buffer || !this.sound.isPlaying) { return; }
     this.sound.pause();
   }
 });


### PR DESCRIPTION
**Description:**
When destroying a sound component, we pause the sound which throws an error when the sound is not playing.
**Changes proposed:**
-Check if sound is playing before attempting to pause.
