### PR TITLE
Fix cursor example

### DIFF
--- a/examples/test-cursor/index.html
+++ b/examples/test-cursor/index.html
@@ -73,7 +73,7 @@
 
         // If you want to respond to mouse events, this is how. Otherwise,
         // if you just want a working cursor, you don't need any of this.
-        var cubes = document.querySelectorAll('a-entity[mixin=cube]');
+        var cubes = document.querySelectorAll('a-entity[mixin*=cube]');
         var i;
         for (i = 0; i < cubes.length; ++i) {
           cubes[i].addEventListener('click', function () {


### PR DESCRIPTION
- Fix query selector to match all cubes, by using wildcard (*)
- Also upgrade to using a-camera and a-cursor tags, instead of depreciated attributes

