### PR TITLE
Windows cmd.exe does not have command substitution and standard-reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .cache
 build
+firefox/
 gh-pages/
 karma.conf.js
 node_modules

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist": "mkdirp dist/ && npm run browserify -s -- --debug | exorcist dist/aframe.js.map > dist/aframe.js && uglifyjs dist/aframe.js -c warnings=false -m -o dist/aframe.min.js",
     "gh-pages": "npm run ghpages",
     "ghpages": "node ./scripts/gh-pages",
-    "lint": "semistandard -v $(git ls-files '*.js') | standard-reporter --stylish",
+    "lint": "semistandard -v | snazzy",
     "precommit": "npm run lint",
     "preghpages": "npm run dist && rimraf gh-pages && mkdirp gh-pages && cp -r {.nojekyll,dist,lib,examples,index.html,style} gh-pages/. 2>/dev/null || : && git checkout dist/ && replace 'build/aframe.js' 'dist/aframe.min.js' gh-pages/ -r --silent",
     "release:bump": "npm run dist && git commit -am 'bump dist' && npm version patch --preminor",
@@ -64,7 +64,7 @@
     "semistandard": "^7.0.2",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
-    "standard-reporter": "^1.0.5",
+    "snazzy" : "^3.0.0",
     "uglifyjs": "^2.4.10"
   },
   "link": true,

--- a/scripts/budo.js
+++ b/scripts/budo.js
@@ -45,5 +45,5 @@ var opts = {
 
 var app = budo(consts.ENTRY + ':' + consts.BUILD, opts);
 app.on('update', function () {
-  execCmd('semistandard -v $(git ls-files "*.js") | standard-reporter --stylish');
+  execCmd('semistandard -v | snazzy');
 });


### PR DESCRIPTION
**Description:**

Fix linter on Windows

**Changes proposed:**
Removes the explicit list of files passed to the linter via command substitution. The feature is not available on cmd.exe. Non git tracked files will be parsed by the linter. We need to find an alternative to reduce noise but in the short term is better to have a linter working on Windows.
It also replaces standard-reporter with snazzy. standard-reporter fails silently and snazzy that was broken on Windows in the past seems to be working now.

@cvan 