### PR TITLE
add three.js stats to rstats (fixes #1114)

### DIFF
--- a/src/components/scene/stats.js
+++ b/src/components/scene/stats.js
@@ -1,7 +1,9 @@
 var registerComponent = require('../../core/component').registerComponent;
 var RStats = require('../../../vendor/rStats');
+require('../../../vendor/rStats.extras');
 
 var HIDDEN_CLASS = 'a-hidden';
+var ThreeStats = window.ThreeStats;
 
 /**
  * Stats appended to document.body by RStats.
@@ -9,8 +11,9 @@ var HIDDEN_CLASS = 'a-hidden';
 module.exports.Component = registerComponent('stats', {
   init: function () {
     var scene = this.el;
+    var threeStats = new ThreeStats(scene.renderer);
 
-    this.stats = createStats();
+    this.stats = createStats(threeStats);
     this.statsEl = document.querySelector('.rs-base');
 
     this.hideBound = this.hide.bind(this);
@@ -42,14 +45,17 @@ module.exports.Component = registerComponent('stats', {
   }
 });
 
-function createStats () {
+function createStats (threeStats) {
   return new RStats({
     css: [],  // Our stylesheet is injected from `src/index.js`.
     values: {
-      fps: { caption: 'fps', below: 30 }
+      fps: {caption: 'fps', below: 30}
     },
     groups: [
-      { caption: 'Framerate', values: [ 'fps', 'raf' ] }
+      {caption: 'Framerate', values: ['fps', 'raf']}
+    ],
+    plugins: [
+      threeStats
     ]
   });
 }

--- a/src/style/rStats.css
+++ b/src/style/rStats.css
@@ -1,80 +1,72 @@
 .rs-base {
-  position: absolute;
-  z-index: 10000;
-  padding: 10px;
-  background-color: #ed134a;
-  width: 300px;
-  font: 300 10px monospace;
+  background-color: #EF2D5E;
+  border-radius: 0;
+  font: 10px monospace;
   left: 5px;
-  top: 5px;
+  line-height: 1.2em;
+  opacity: 0.75;
   overflow: hidden;
-  opacity: 0.85;
+  padding: 10px;
+  position: fixed;
+  top: 5px;
+  width: 300px;
+  z-index: 10000;
 }
 
-.rs-base h1 {
-  margin: 0;
-  padding: 0;
-  font-size: 1.4em;
-  font-weight: 300;
-  margin-bottom: 5px;
-  color: #111;
-  cursor: pointer;
-}
-
-.rs-base div.rs-group {
-  margin-bottom: 10px;
-}
-
-.rs-base div.rs-group:last-child {
-  margin-bottom: 0;
-}
-
-.rs-base div.rs-group.hidden {
+.rs-base.hidden {
   display: none;
 }
 
-.rs-base div.rs-fraction {
-  position: relative;
-  margin-bottom: 5px;
-}
-
-.rs-base div.rs-fraction p {
-  width: 70px;
-  text-align: right;
-  margin: 0;
+.rs-base h1 {
+  color: #fff;
+  cursor: pointer;
+  font-size: 1.4em;
+  font-weight: 300;
+  margin: 0 0 5px;
   padding: 0;
 }
 
-.rs-base div.rs-legend {
-  position: absolute;
-  line-height: 1em;
+.rs-group {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+  margin-bottom: 5px;
 }
 
-.rs-base div.rs-counter-base {
-  position: relative;
-  margin: 4px 0;
-  height: 1em;
+.rs-counter-base {
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: flex;
+  height: 10px;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  margin: 2px 0;
 }
 
-.rs-base span.rs-counter-id {
-  position: absolute;
-  left: 0;
-  top: 0;
+.rs-counter-id {
+  font-weight: 300;
+  -webkit-box-ordinal-group: 0;
+  -webkit-order: 0;
+  order: 0;
+  width: 50px;
 }
 
-.rs-base div.rs-counter-value {
-  position: absolute;
-  left: 40px;
-  width: 30px;
-  height: 1em;
-  top: 0;
+.rs-counter-value {
+  font-weight: 300;
+  -webkit-box-ordinal-group: 1;
+  -webkit-order: 1;
+  order: 1;
   text-align: right;
+  width: 25px;
 }
 
-.rs-base canvas.rs-canvas {
-  position: absolute;
-  right: 0;
-  top: 2px;
+.rs-canvas {
+  -webkit-box-ordinal-group: 2;
+  -webkit-order: 2;
+  order: 2;
 }
 
 @media (min-width: 480px) {

--- a/vendor/rStats.extras.js
+++ b/vendor/rStats.extras.js
@@ -1,0 +1,263 @@
+window.glStats = function () {
+
+    var _rS = null;
+
+    var _totalDrawArraysCalls = 0,
+        _totalDrawElementsCalls = 0,
+        _totalUseProgramCalls = 0,
+        _totalFaces = 0,
+        _totalVertices = 0,
+        _totalPoints = 0,
+        _totalBindTexures = 0;
+
+    function _h ( f, c ) {
+        return function () {
+            c.apply( this, arguments );
+            f.apply( this, arguments );
+        };
+    }
+
+    WebGLRenderingContext.prototype.drawArrays = _h( WebGLRenderingContext.prototype.drawArrays, function () {
+        _totalDrawArraysCalls++;
+        if ( arguments[ 0 ] == this.POINTS ) _totalPoints += arguments[ 2 ];
+        else _totalVertices += arguments[ 2 ];
+    } );
+
+    WebGLRenderingContext.prototype.drawElements = _h( WebGLRenderingContext.prototype.drawElements, function () {
+        _totalDrawElementsCalls++;
+        _totalFaces += arguments[ 1 ] / 3;
+        _totalVertices += arguments[ 1 ];
+    } );
+
+    WebGLRenderingContext.prototype.useProgram = _h( WebGLRenderingContext.prototype.useProgram, function () {
+        _totalUseProgramCalls++;
+    } );
+
+    WebGLRenderingContext.prototype.bindTexture = _h( WebGLRenderingContext.prototype.bindTexture, function () {
+        _totalBindTexures++;
+    } );
+
+    var _values = {
+        allcalls: {
+            over: 3000,
+            caption: 'Calls (hook)'
+        },
+        drawelements: {
+            caption: 'drawElements (hook)'
+        },
+        drawarrays: {
+            caption: 'drawArrays (hook)'
+        }
+    };
+
+    var _groups = [ {
+        caption: 'WebGL',
+        values: [ 'allcalls', 'drawelements', 'drawarrays', 'useprogram', 'bindtexture', 'glfaces', 'glvertices', 'glpoints' ]
+    } ];
+
+    var _fractions = [ {
+        base: 'allcalls',
+        steps: [ 'drawelements', 'drawarrays' ]
+    } ];
+
+    function _update () {
+        _rS( 'allcalls' ).set( _totalDrawArraysCalls + _totalDrawElementsCalls );
+        _rS( 'drawElements' ).set( _totalDrawElementsCalls );
+        _rS( 'drawArrays' ).set( _totalDrawArraysCalls );
+        _rS( 'bindTexture' ).set( _totalBindTexures );
+        _rS( 'useProgram' ).set( _totalUseProgramCalls );
+        _rS( 'glfaces' ).set( _totalFaces );
+        _rS( 'glvertices' ).set( _totalVertices );
+        _rS( 'glpoints' ).set( _totalPoints );
+    }
+
+    function _start () {
+        _totalDrawArraysCalls = 0;
+        _totalDrawElementsCalls = 0;
+        _totalUseProgramCalls = 0;
+        _totalFaces = 0;
+        _totalVertices = 0;
+        _totalPoints = 0;
+        _totalBindTexures = 0;
+    }
+
+    function _end () {}
+
+    function _attach ( r ) {
+        _rS = r;
+    }
+
+    return {
+        update: _update,
+        start: _start,
+        end: _end,
+        attach: _attach,
+        values: _values,
+        groups: _groups,
+        fractions: _fractions
+    };
+
+};
+
+window.threeStats = function ( renderer ) {
+
+    var _rS = null;
+
+    var _values = {
+        'renderer.info.memory.geometries': {
+            caption: 'Geometries'
+        },
+        'renderer.info.memory.textures': {
+            caption: 'Textures'
+        },
+        'renderer.info.memory.programs': {
+            caption: 'Programs'
+        },
+        'renderer.info.render.calls': {
+            caption: 'Calls'
+        },
+        'renderer.info.render.faces': {
+            caption: 'Faces',
+            over: 1000
+        },
+        'renderer.info.render.points': {
+            caption: 'Points'
+        },
+        'renderer.info.render.vertices': {
+            caption: 'Vertices'
+        }
+    };
+
+    var _groups = [ {
+        caption: 'three.js - Memory',
+        values: [ 'renderer.info.memory.geometries', 'renderer.info.memory.programs', 'renderer.info.memory.textures' ]
+    }, {
+        caption: 'three.js - Render',
+        values: [ 'renderer.info.render.calls', 'renderer.info.render.faces', 'renderer.info.render.points', 'renderer.info.render.vertices' ]
+    } ];
+
+    var _fractions = [];
+
+    function _update () {
+
+        _rS( 'renderer.info.memory.geometries' ).set( renderer.info.memory.geometries );
+        _rS( 'renderer.info.memory.programs' ).set( renderer.info.memory.programs );
+        _rS( 'renderer.info.memory.textures' ).set( renderer.info.memory.textures );
+        _rS( 'renderer.info.render.calls' ).set( renderer.info.render.calls );
+        _rS( 'renderer.info.render.faces' ).set( renderer.info.render.faces );
+        _rS( 'renderer.info.render.points' ).set( renderer.info.render.points );
+        _rS( 'renderer.info.render.vertices' ).set( renderer.info.render.vertices );
+
+    }
+
+    function _start () {}
+
+    function _end () {}
+
+    function _attach ( r ) {
+        _rS = r;
+    }
+
+    return {
+        update: _update,
+        start: _start,
+        end: _end,
+        attach: _attach,
+        values: _values,
+        groups: _groups,
+        fractions: _fractions
+    };
+
+};
+
+/*
+ *   From https://github.com/paulirish/memory-stats.js
+ */
+
+window.BrowserStats = function () {
+
+    var _rS = null;
+
+    var _usedJSHeapSize = 0,
+        _totalJSHeapSize = 0;
+
+    if ( window.performance && !performance.memory ) {
+        performance.memory = {
+            usedJSHeapSize: 0,
+            totalJSHeapSize: 0
+        };
+    }
+
+    if ( performance.memory.totalJSHeapSize === 0 ) {
+        console.warn( 'totalJSHeapSize === 0... performance.memory is only available in Chrome .' );
+    }
+
+    var _values = {
+        memory: {
+            caption: 'Used Memory',
+            average: true,
+            avgMs: 1000,
+            over: 22
+        },
+        total: {
+            caption: 'Total Memory'
+        }
+    };
+
+    var _groups = [ {
+        caption: 'Browser',
+        values: [ 'memory', 'total' ]
+    } ];
+
+    var _fractions = [ {
+        base: 'total',
+        steps: [ 'memory' ]
+    } ];
+
+    var log1024 = Math.log( 1024 );
+
+    function _size ( v ) {
+
+        var precision = 100; //Math.pow(10, 2);
+        var i = Math.floor( Math.log( v ) / log1024 );
+        return Math.round( v * precision / Math.pow( 1024, i ) ) / precision; // + ' ' + sizes[i];
+
+    }
+
+    function _update () {
+        _usedJSHeapSize = _size( performance.memory.usedJSHeapSize );
+        _totalJSHeapSize = _size( performance.memory.totalJSHeapSize );
+
+        _rS( 'memory' ).set( _usedJSHeapSize );
+        _rS( 'total' ).set( _totalJSHeapSize );
+    }
+
+    function _start () {
+        _usedJSHeapSize = 0;
+    }
+
+    function _end () {}
+
+    function _attach ( r ) {
+        _rS = r;
+    }
+
+    return {
+        update: _update,
+        start: _start,
+        end: _end,
+        attach: _attach,
+        values: _values,
+        groups: _groups,
+        fractions: _fractions
+    };
+
+};
+
+if (typeof module === 'object') {
+  module.exports = {
+    glStats: window.glStats,
+    threeStats: window.threeStats,
+    BrowserStats: window.BrowserStats
+  };
+}


### PR DESCRIPTION
<img width="771" alt="screen shot 2016-03-22 at 1 43 34 pm" src="https://cloud.githubusercontent.com/assets/674727/13967488/9c95dd34-f034-11e5-8684-a43222135fe2.png">

**Description:** Add more stats to profile three.js perf

**Changes proposed:**
- Restore CSS changes.
- Add three stats
- I modified the vendor/rStats.extras.js only to capitalize "Memory" and "Render"
