### PR TITLE
Revert "left-pad apocalypse (fixes #1225)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "debug": "^2.2.0",
     "deep-assign": "^2.0.0",
     "document-register-element": "dmarcos/document-register-element#8ccc532b7",
-    "left-pad": "azer/left-pad#bff80e3ef0db0bfaba7698606c4f623433d14355",
     "promise-polyfill": "^3.1.0",
     "object-assign": "^4.0.1",
     "polymerize": "^1.0.0",


### PR DESCRIPTION
**Description:** NPM just un-un-published it https://twitter.com/seldo/status/712414588281552900

**Changes proposed:**
-
-
-

This reverts commit d24a231da42dc6645301269128cb0d35617f9f17.