### PR TITLE
Removing function binds

### DIFF
--- a/examples/stress-entities/index.html
+++ b/examples/stress-entities/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Stress Test - Large Number of Entities</title>
+    <meta name="description" content="Stress Test - Large Number of Entities - A-Frame">
+    <script src="../../dist/aframe.js"></script>
+    <style>
+      body { background-color: black; }
+      .stats {
+        position: fixed;
+        text-align: center;
+        top: 200px;
+        right: calc(50% - 225px);
+        left: calc(50% - 225px);
+        width: 450px;
+        height: 75px;
+        color: white;
+        padding: 20px;
+        font-size: 20pt;
+        font-family: Helvetica;
+        font-weight: medium;
+        line-height: 1.6em;
+        background-color: #EF2D5E;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="stats"></div>
+    <a-scene stats="true">
+      <a-assets>
+        <a-mixin id="cube" geometry="primitive: box; height: 16; width: 16; depth: 16;"
+                 material="color: #167341; roughness: 1.0; metalness: 0.2;"></a-mixin>
+      </a-assets>
+      <a-entity position="0 20 0">
+        <a-entity camera="active:true" rotation="0 0 0" position="0 0 0"></a-entity>
+      </a-entity>
+    </a-scene>
+    <script>
+      var cubeEl;
+      var sceneEl = document.querySelector('a-scene');
+      sceneEl.addEventListener('renderstart', function() { 
+        var statsEl = document.querySelector('.stats');
+        statsEl.innerHTML = cubesNum + " entities rendered</br> The scene took " + window.performance.getEntriesByName('render-started')[0].startTime.toFixed(2) + " ms to load";
+      });
+      var x = -90;
+      var z = -10;
+      var cubesNum = 0;
+      var innerHTML = '';
+      var parentEl = document.createElement('a-entity');
+      for (var i = 0; i < 400; i+=1) {
+        for (var j = 0; j < 10; j+=1) {
+          cubeEl = document.createElement('a-entity');
+          cubeEl.setAttribute('mixin', 'cube');
+          cubeEl.setAttribute('position', { x: x, y: 0, z: z});
+          x += 20;
+          cubesNum += 1;
+          sceneEl.appendChild(cubeEl);
+        }
+        x = -90;
+        z -= 20;
+      }
+    </script>
+  </body>
+</html>

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -246,6 +246,9 @@ var AScene = module.exports = registerElement('a-scene', {
 
           // Kick off render loop.
           if (this.renderer) {
+            if (window.performance) {
+              window.performance.mark('render-started');
+            }
             this.render();
             this.renderStarted = true;
             this.emit('renderstart');

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -39,8 +39,8 @@ module.exports.process = function (schema) {
  * Inject default value, parser, stringifier for single property.
  */
 function processPropertyDefinition (propDefinition) {
-  var propType;
   var defaultVal = propDefinition.default;
+  var propType;
   var typeName = propDefinition.type;
 
   // Type inference.
@@ -66,12 +66,8 @@ function processPropertyDefinition (propDefinition) {
   }
 
   // Fill in parse and stringify using property types.
-  if (!propDefinition.parse) {
-    propDefinition.parse = propType.parse;
-  }
-  if (!propDefinition.stringify) {
-    propDefinition.stringify = propType.stringify;
-  }
+  propDefinition.parse = propDefinition.parse || propType.parse;
+  propDefinition.stringify = propDefinition.stringify || propType.stringify;
 
   // Fill in type name.
   propDefinition.type = typeName;
@@ -80,10 +76,6 @@ function processPropertyDefinition (propDefinition) {
   if (!('default' in propDefinition)) {
     propDefinition.default = propType.default;
   }
-
-  // Bind parse and stringify to the property definition.
-  propDefinition.parse = propDefinition.parse.bind(propDefinition);
-  propDefinition.stringify = propDefinition.stringify.bind(propDefinition);
 
   return propDefinition;
 }
@@ -110,7 +102,7 @@ module.exports.parseProperties = function (propData, schema, getPartialData, sil
     }
   });
 
-  propNames.forEach(function (propName) {
+  propNames.forEach(function parse (propName) {
     var propDefinition = schema[propName];
     var propValue = propData[propName];
 


### PR DESCRIPTION
Functions bound with the method .bind are slow. there was a very big overhead when parsing/stringifying component properties. It was specially noticeable at startup when all the components are initialized. With these changes scenes load twice as fast. In the included stress test loading time for 4000 entities prior to this patch was 8s on my computer. This patch improves it to 4s