### PR TITLE
Animation.stop() should consider fill value (#1168)

### DIFF
--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -215,7 +215,9 @@ module.exports.AAnimation = registerElement('a-animation', {
         if (!tween) { return; }
         tween.stop();
         this.isRunning = false;
-        this.partialSetAttribute(this.initialValue);
+        if ([FILLS.backwards, FILLS.none].indexOf(this.data.fill) !== -1) {
+          this.partialSetAttribute(this.initialValue);
+        }
         this.emit('animationstop');
       },
       writable: true

--- a/tests/core/a-animation.test.js
+++ b/tests/core/a-animation.test.js
@@ -362,8 +362,7 @@ suite('a-animation', function () {
     });
 
     test('gets correct values coordinate component with no `from`', function () {
-      var values = getAnimationValues(this.el, 'position', undefined, '4 5 6',
-                                      { x: 0, y: 0, z: 0 });
+      var values = getAnimationValues(this.el, 'position', undefined, '4 5 6', { x: 0, y: 0, z: 0 });
       assert.shallowDeepEqual(values.from, { x: 0, y: 0, z: 0 });
       assert.shallowDeepEqual(values.to, { x: 4, y: 5, z: 6 });
     });
@@ -397,6 +396,100 @@ suite('a-animation', function () {
         animationEl.stop();
         assert.notOk(animationEl.isRunning);
         done();
+      });
+    });
+
+    suite('considers fill value', function () {
+      test('default', function (done) {
+        setupAnimation({
+          attribute: 'position',
+          dur: 5000,
+          from: '0 0 0',
+          to: '10 10 10'
+        }, function (el, animationEl, startTime) {
+          animationEl.tween.update(startTime + 500);
+          animationEl.stop();
+          var position = el.getAttribute('position');
+          ['x', 'y', 'z'].forEach(function (axis) {
+            assert.isAbove(position[axis], 0);
+            assert.isBelow(position[axis], 10);
+          });
+          done();
+        });
+      });
+
+      test('backwards', function (done) {
+        setupAnimation({
+          attribute: 'position',
+          dur: 5000,
+          from: '0 0 0',
+          to: '10 10 10',
+          fill: 'backwards'
+        }, function (el, animationEl, startTime) {
+          animationEl.tween.update(startTime + 500);
+          animationEl.stop();
+          var position = el.getAttribute('position');
+          ['x', 'y', 'z'].forEach(function (axis) {
+            assert.equal(position[axis], 0);
+          });
+          done();
+        });
+      });
+
+      test('both', function (done) {
+        setupAnimation({
+          attribute: 'position',
+          dur: 5000,
+          from: '0 0 0',
+          to: '10 10 10',
+          fill: 'both'
+        }, function (el, animationEl, startTime) {
+          animationEl.tween.update(startTime + 500);
+          animationEl.stop();
+          var position = el.getAttribute('position');
+          ['x', 'y', 'z'].forEach(function (axis) {
+            assert.isAbove(position[axis], 0);
+            assert.isBelow(position[axis], 10);
+          });
+          done();
+        });
+      });
+
+      test('forwards', function (done) {
+        setupAnimation({
+          attribute: 'position',
+          dur: 5000,
+          from: '0 0 0',
+          to: '10 10 10',
+          fill: 'forwards'
+        }, function (el, animationEl, startTime) {
+          animationEl.tween.update(startTime + 500);
+          animationEl.stop();
+          var position = el.getAttribute('position');
+          ['x', 'y', 'z'].forEach(function (axis) {
+            assert.isAbove(position[axis], 0);
+            assert.isBelow(position[axis], 10);
+          });
+          done();
+        });
+      });
+
+      test('none', function (done) {
+        setupAnimation({
+          attribute: 'position',
+          dur: 5000,
+          from: '0 0 0',
+          to: '10 10 10',
+          fill: 'none'
+        }, function (el, animationEl, startTime) {
+          animationEl.tween.update(startTime + 500);
+          animationEl.stop();
+          var position = el.getAttribute('position');
+          ['x', 'y', 'z'].forEach(function (axis) {
+            assert.equal(position[axis], 0);
+          });
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
#### When animation.stop() it´s called, the animation value considers fill value

- **backwards**: : When animation is stopped set the starting value to the initial value.
- **both**: Animation value is saved when stopped.
- **forwards**: Animation value is saved when stopped.
- **none**: When animation is stopped set the starting value to the initial value.