### PR TITLE
Fixed error of function handleVideoTextureLoaded @ texture.js:103

### DIFF
--- a/src/utils/texture.js
+++ b/src/utils/texture.js
@@ -64,6 +64,7 @@ function loadVideo (material, data, src) {
   var hash;
   var texture;
   var videoEl;
+  var videoTextureResult;
 
   if (typeof src !== 'string') {
     // Check cache before creating texture.
@@ -92,13 +93,18 @@ function loadVideo (material, data, src) {
   texture = new THREE.VideoTexture(videoEl);
   texture.minFilter = THREE.LinearFilter;
 
-  // Cache as promise to be consistent with image texture caching.
-  textureCache[hash] = Promise.resolve([texture, videoEl]);
-  handleVideoTextureLoaded([texture, videoEl]);
+  videoTextureResult = {
+    texture: texture,
+    videoEl: videoEl
+  };
 
-  function handleVideoTextureLoaded (item) {
-    texture = item[0];
-    videoEl = item[1];
+  // Cache as promise to be consistent with image texture caching.
+  textureCache[hash] = Promise.resolve(videoTextureResult);
+  handleVideoTextureLoaded(videoTextureResult);
+
+  function handleVideoTextureLoaded (res) {
+    texture = res.texture;
+    videoEl = res.videoEl;
     updateMaterial(material, texture);
     el.emit(EVENTS.TEXTURE_LOADED, { element: videoEl, src: src });
     videoEl.addEventListener('loadeddata', function () {

--- a/src/utils/texture.js
+++ b/src/utils/texture.js
@@ -93,10 +93,12 @@ function loadVideo (material, data, src) {
   texture.minFilter = THREE.LinearFilter;
 
   // Cache as promise to be consistent with image texture caching.
-  textureCache[calculateVideoCacheHash(videoEl)] = Promise.resolve(texture, videoEl);
-  handleVideoTextureLoaded(texture, videoEl);
+  textureCache[hash] = Promise.resolve([texture, videoEl]);
+  handleVideoTextureLoaded([texture, videoEl]);
 
-  function handleVideoTextureLoaded (texture, videoEl) {
+  function handleVideoTextureLoaded (item) {
+    texture = item[0];
+    videoEl = item[1];
     updateMaterial(material, texture);
     el.emit(EVENTS.TEXTURE_LOADED, { element: videoEl, src: src });
     videoEl.addEventListener('loadeddata', function () {


### PR DESCRIPTION
There was an error in handleVideoTextureLoaded if no video element exist.

![error](http://cl.meowyo.com/fVCg/Image%202016-03-24%20at%2011.06.29%20AM.png)
![code](http://cl.meowyo.com/fVLc/Image%202016-03-24%20at%2011.06.53%20AM.png)

Now it only emits/adds event lister if videoEl exits.

This still works with multiple videos and entities.
[Here is a reference video (please use webkit based browser)](http://cl.meowyo.com/fVRi)