### PR TITLE
API to merge entity meshes to reduce the number of draw calls

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -152,7 +152,6 @@
       <li><a href="test-mixin/">Mixin</a></li>
       <li><a href="test-model/">Model</a></li>
       <li><a href="test-opacity/">Opacity</a></li>
-      <li><a href="test-panoexplorer/">Pano Explorer</a></li>
       <li><a href="test-physical/">Physically-Based Materials</a></li>
       <li><a href="test-pivot/">Pivot</a></li>
       <li><a href="test-raycaster/">Raycaster</a></li>

--- a/examples/test-merge-geometry/index.html
+++ b/examples/test-merge-geometry/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Merge Geometries Test</title>
+    <meta name="description" content="Merge Geometry - A-Frame">
+    <script src="../../dist/aframe.js"></script>
+    <style>
+      body { background-color: black; }
+    </style>
+  </head>
+  <body>
+    <div class="stats"></div>
+    <a-scene stats="true">
+      <a-assets>
+        <a-mixin id="cube"
+                 geometry="primitive: box; height: 16; width: 16; depth: 16; mergeTo: #boxes; skipCache: true; buffer: false;"
+                 material="color: #167341; roughness: 1.0; metalness: 0.2;"></a-mixin>
+      </a-assets>
+      <a-entity position="0 20 0">
+        <a-entity camera wasd-controls look-controls></a-entity>
+      </a-entity>
+      <a-entity id="boxes" material="color: #167341; roughness: 1.0; metalness: 0.2;"></a-entity>
+    </a-scene>
+    <script>
+      var cubeEl;
+      var sceneEl = document.querySelector('a-scene');
+      var xStartPos = -90
+      var zStartPos = -10;
+      var xPos;
+      var zPos;
+      var xMargin = 20;
+      var zMargin = -20;
+      var cubesNum = 200;
+      var rootEl;
+      var x;
+      zPos = zStartPos;
+      for (var i = 0; i < cubesNum; i += 1) {
+        xPos = xStartPos;
+        for (var j = 0; j < 10; j += 1) {
+          cubeEl = document.createElement('a-entity');
+          cubeEl.setAttribute('mixin', 'cube');
+          cubeEl.setAttribute('position', { x: xPos, y: 0, z: zPos});
+          xPos += xMargin;
+          sceneEl.appendChild(cubeEl);
+        }
+        zPos += zMargin;
+      }
+    </script>
+  </body>
+</html>

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -267,10 +267,10 @@ module.exports.registerComponent = function (name, definition) {
   components[name] = {
     Component: NewComponent,
     dependencies: NewComponent.prototype.dependencies,
-    parse: NewComponent.prototype.parse.bind(NewComponent.prototype),
-    parseAttrValueForCache: NewComponent.prototype.parseAttrValueForCache.bind(NewComponent.prototype),
+    parse: NewComponent.prototype.parse,
+    parseAttrValueForCache: NewComponent.prototype.parseAttrValueForCache,
     schema: utils.extend(processSchema(NewComponent.prototype.schema)),
-    stringify: NewComponent.prototype.stringify.bind(NewComponent.prototype),
+    stringify: NewComponent.prototype.stringify,
     type: NewComponent.prototype.type
   };
   return NewComponent;

--- a/src/systems/geometry.js
+++ b/src/systems/geometry.js
@@ -59,9 +59,13 @@ module.exports.System = registerSystem('geometry', {
     var cache = this.cache;
     var cacheCount = this.cacheCount;
     var geometry;
-    var hash = this.hash(data);
+    var hash;
 
-    if (!cache[hash] || data.skipCache) { return; }
+    if (data.skipCache) { return; }
+
+    hash = this.hash(data);
+
+    if (!cache[hash]) { return; }
 
     decrementCacheCount(cacheCount, hash);
 

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -9,7 +9,7 @@ var degToRad = require('index').THREE.Math.degToRad;
 suite('geometry', function () {
   setup(function (done) {
     var el = this.el = helpers.entityFactory();
-    el.setAttribute('geometry', 'buffer: false; primitive: box');
+    el.setAttribute('geometry', 'buffer: false; primitive: box;');
     el.addEventListener('loaded', function () {
       done();
     });
@@ -52,6 +52,35 @@ suite('geometry', function () {
       assert.notOk(disposeSpy.called);
       el.setAttribute('geometry', 'primitive: sphere');
       assert.ok(disposeSpy.called);
+    });
+  });
+
+  suite('merge geometries', function () {
+    setup(function (done) {
+      var self = this;
+      var targetEl = this.targetEl = helpers.entityFactory();
+      targetEl.setAttribute('geometry', 'buffer: false; primitive: box;');
+      targetEl.addEventListener('loaded', function () {
+        var sourceEl = self.sourceEl = document.createElement('a-entity');
+        targetEl.sceneEl.appendChild(sourceEl);
+        sourceEl.addEventListener('loaded', function () {
+          done();
+        });
+      });
+    });
+
+    test('merges geometries', function () {
+      var sourceEl = this.sourceEl;
+      var targetEl = this.targetEl;
+      var sceneEl = sourceEl.sceneEl;
+      var targetGeometry = targetEl.getObject3D('mesh').geometry;
+      targetEl.id = 'mergeTarget';
+      sourceEl.id = 'mergeSource';
+      assert.ok(sceneEl.querySelector('#mergeSource'));
+      assert.equal(targetGeometry.vertices.length, 8);
+      sourceEl.setAttribute('geometry', 'buffer: false; skipCache: true; primitive: box; mergeTo: #mergeTarget');
+      assert.equal(sceneEl.querySelector('#mergeSource'), null);
+      assert.equal(targetGeometry.vertices.length, 16);
     });
   });
 


### PR DESCRIPTION
It is destructive / no revertible. Once an entity is merged into another one the entity is removed from the scene. Making this dynamic would add a lot of overhead (we would have to cache all the meshes in case the operation wants to be reverted). It would also lead to tons of edge cases that will affect performance in ways that are difficult to understand. For instance if you change position or material one of the entities the whole merge group would have to be regenerated. On the provided example we reduce the number of calls from 1988 to a single one when merging the entities.