### PR TITLE
fix <a-obj-model>.mtl url() wrapping (fixes #1251)

### DIFF
--- a/docs/primitives/a-obj-model.md
+++ b/docs/primitives/a-obj-model.md
@@ -20,7 +20,7 @@ The .OBJ model primitive displays a 3D Wavefront model. It is an entity that map
   <!-- Using the asset management system. -->
   <a-obj-model src="#crate-obj" mtl="#crate-mtl"></a-obj-model>
 
-  <!-- Defining the URL inline. Not recommended but more comfortable for web developers. -->
+  <!-- Defining the URL inline. Not recommended but may be more comfortable. -->
   <a-obj-model src="crate.obj" mtl="crate.mtl"></a-obj-model>
 </a-scene>
 ```

--- a/src/extras/primitives/primitives/a-obj-model.js
+++ b/src/extras/primitives/primitives/a-obj-model.js
@@ -9,6 +9,6 @@ registerPrimitive('a-obj-model', utils.extendDeep({}, meshMixin, {
   },
 
   transforms: {
-    mtl: meshMixin.src
+    mtl: meshMixin.transforms.src
   }
 }));

--- a/tests/extras/primitives/primitives/a-obj-model.test.js
+++ b/tests/extras/primitives/primitives/a-obj-model.test.js
@@ -1,0 +1,31 @@
+/* global assert, suite, test, setup */
+var helpers = require('../../../helpers');
+
+suite('a-obj-model', function () {
+  setup(function (done) {
+    var el = helpers.entityFactory();
+    var objModelEl = this.objModelEl = document.createElement('a-obj-model');
+    el.addEventListener('loaded', function () {
+      el.sceneEl.appendChild(objModelEl);
+    });
+    objModelEl.addEventListener('loaded', function () {
+      done();
+    });
+  });
+
+  test('can set obj-model.mtl', function () {
+    var el = this.objModelEl;
+    el.setAttribute('mtl', 'mymtl.mtl');
+    process.nextTick(function () {
+      assert.equal(el.getAttribute('obj-model').mtl, 'url(mymtl.mtl)');
+    });
+  });
+
+  test('can set obj-model.obj', function () {
+    var el = this.objModelEl;
+    el.setAttribute('obj', 'myobj.obj');
+    process.nextTick(function () {
+      assert.equal(el.getAttribute('obj-model').mtl, 'url(myobj.obj)');
+    });
+  });
+});

--- a/tests/extras/primitives/primitives/a-torus.test.js
+++ b/tests/extras/primitives/primitives/a-torus.test.js
@@ -1,37 +1,39 @@
 /* global assert, suite, test, setup */
-suite('a-torus', function () {
-  var scene;
-  var torus;
-  var torus2;
+var helpers = require('../../../helpers');
 
+suite('a-torus', function () {
   setup(function (done) {
-    scene = document.createElement('a-scene');
-    torus = document.createElement('a-torus');
-    document.body.appendChild(scene);
-    scene.appendChild(torus);
-    torus2 = document.createElement('a-torus');
-    torus2.addEventListener('loaded', function () {
+    var el = helpers.entityFactory();
+    var torusEl = this.torusEl = document.createElement('a-torus');
+    el.addEventListener('loaded', function () {
+      el.sceneEl.appendChild(torusEl);
+    });
+    torusEl.addEventListener('loaded', function () {
       done();
     });
-    torus2.setAttribute('segments-tubular', '100');
-    torus2.setAttribute('radius', '2');
-    torus2.setAttribute('radius-tubular', '0.1');
-    scene.appendChild(torus2);
   });
 
   test('has default position when created', function () {
-    assert.deepEqual(torus.getComputedAttribute('position'), { x: 0, y: 0, z: 0 });
+    assert.deepEqual(this.torusEl.getComputedAttribute('position'), {x: 0, y: 0, z: 0});
   });
 
-  test('has torus geometry', function () {
-    assert.strictEqual(torus.getAttribute('geometry').primitive, 'torus');
+  test('sets geometry.primitive', function () {
+    assert.equal(this.torusEl.getAttribute('geometry').primitive, 'torus');
   });
 
-  test('has inherited attributes on geometry', function () {
-    var geometry = torus2.getAttribute('geometry');
-    assert.strictEqual(geometry.primitive, 'torus');
-    assert.strictEqual(geometry.segmentsTubular, 100);
-    assert.strictEqual(geometry.radius, 2);
-    assert.strictEqual(geometry.radiusTubular, 0.1);
+  test('can set torus properties', function () {
+    var geometry;
+    var torusEl = this.torusEl;
+    torusEl.setAttribute('segments-tubular', '100');
+    torusEl.setAttribute('radius', '2');
+    torusEl.setAttribute('radius-tubular', '0.1');
+
+    process.nextTick(function () {
+      geometry = torusEl.getAttribute('geometry');
+      assert.equal(geometry.primitive, 'torus');
+      assert.equal(geometry.segmentsTubular, 100);
+      assert.equal(geometry.radius, 2);
+      assert.equal(geometry.radiusTubular, 0.1);
+    });
   });
 });


### PR DESCRIPTION
**Description:** Should have been `meshMixin.transforms.src` instead `meshMixin.src` which is undefined.

**Changes proposed:**
- Fix transform
- Add `<a-obj-model>` tests
- Match `<a-torus>` tests to `<a-obj-model>` tests

