### PR TITLE
fix broken links to mozvr.com in docs

### DIFF
--- a/docs/guide/building-a-basic-scene.md
+++ b/docs/guide/building-a-basic-scene.md
@@ -213,7 +213,7 @@ And that wraps up our basic scene. Once we get past the novelty of placing stati
 [events]: ../extras/declarative-events.md
 [light]: ../primitives/light.md
 [mesh]: ../primitives/mesh-attributes.md
-[mozvr]: https://mozvr.com#start
+[mozvr]: http://mozvr.com/#start
 [next]: ./using-and-writing-components.md
 [position]: ../components/position.md
 [primitives]: ../primitives/

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -88,7 +88,7 @@ Read through the documentation front-to-back for more details, and if you have a
 [custom]: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements
 [ecs]: ../core/index.md
 [entity]: ../core/entity.md
-[mozvr]: https://mozvr.com
+[mozvr]: http://mozvr.com
 [slack]: https://aframevr-slack.herokuapp.com/
 [three]: http://three.js.org/
 [webvr]: http://mozvr.com/#start


### PR DESCRIPTION
I have issues on file to get mozvr.com transferred to CF + GH Pages so we can serve TLS.

for now https://mozvr.com/ ain't work!