### PR TITLE
Add intensity to ambient light (fixes #1201)

### DIFF
--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -25,7 +25,7 @@ We will go through the different types of lights and their respective properties
 
 ### Ambient
 
-Ambient lights are applied to all entities in the scene globally. They are defined only by the `color` property. And, `position`, `rotation`, and `scale` have no effect on ambient lights.
+Ambient lights are applied to all entities in the scene globally. They are defined by the `color` and `intensity` properties. Additionally, `position`, `rotation`, and `scale` have no effect on ambient lights.
 
 It is recommended to have some form of ambient light such that shadowed areas
 are not completely black and to mimic indirect lighting.

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -17,7 +17,7 @@ module.exports.Component = registerComponent('light', {
     decay: { default: 1, if: { type: ['point', 'spot'] } },
     distance: { default: 0.0, min: 0, if: { type: ['point', 'spot'] } },
     exponent: { default: 10.0, if: { type: ['spot'] } },
-    intensity: { default: 1.0, min: 0, if: { type: ['directional', 'hemisphere', 'point', 'spot'] } },
+    intensity: { default: 1.0, min: 0, if: { type: ['ambient', 'directional', 'hemisphere', 'point', 'spot'] } },
     type: { default: 'directional',
             oneOf: ['ambient', 'directional', 'hemisphere', 'point', 'spot']
     }
@@ -96,7 +96,7 @@ function getLight (data) {
 
   switch (type.toLowerCase()) {
     case 'ambient': {
-      return new THREE.AmbientLight(color);
+      return new THREE.AmbientLight(color, intensity);
     }
     case 'directional': {
       return new THREE.DirectionalLight(color, intensity);

--- a/tests/components/light.test.js
+++ b/tests/components/light.test.js
@@ -36,6 +36,12 @@ suite('light', function () {
       el.setAttribute('light', 'type: ambient');
       assert.equal(el.object3D.children[0].type, 'AmbientLight');
     });
+
+    test('can update parameters on updated light', function () {
+      var el = this.el;
+      el.setAttribute('light', 'intensity: 5');
+      assert.equal(el.object3D.children[0].intensity, 5);
+    });
   });
 
   suite('getLight', function () {


### PR DESCRIPTION
**Description:**
three.js r74 introduced intensity property on ambient light mrdoob/three.js#7621 . Add that to the light component.
**Changes proposed:**
- updated component
- added test
