### PR TITLE
Update THREE to r75 (fixes #1186)

### DIFF
--- a/examples/test-geometry-gallery/index.html
+++ b/examples/test-geometry-gallery/index.html
@@ -32,7 +32,7 @@
                             segments: 32; segmentsTubular: 10;"></a-mixin>
         <a-mixin id="torus-knot"
                   geometry="primitive: torusKnot; p: 3; q: 7; radius: .25;
-                            segments: 32; radiusTubular: .07; segmentsTubular: 10">
+                            segmentsRadial: 10; radiusTubular: .07; segmentsTubular: 32">
         </a-mixin>
 
         <!-- Layout mixins. -->

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "present": "0.0.6",
     "request-interval": "^1.0.0",
     "style-attr": "^1.0.2",
-    "three": "^0.74.0",
+    "three": "^0.75.0",
     "tween.js": "^15.0.0",
     "webvr-polyfill": "borismus/webvr-polyfill#3f47796"
   },

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -30,12 +30,11 @@ module.exports.Component = registerComponent('geometry', {
     radiusInner: { default: 0.8, min: 0, if: { primitive: ['ring'] } },
     radiusOuter: { default: 1.2, min: 0, if: { primitive: ['ring'] } },
     radiusTop: { default: DEFAULT_RADIUS, if: { primitive: ['cylinder'] } },
-    radiusTubular: { default: 0.2, min: 0, if: { primitive: ['torus'] } },
-    scaleHeight: { default: 1, min: 0, if: { primitive: ['torusKnot'] } },
+    radiusTubular: { default: 0.2, min: 0, if: { primitive: ['torus', 'torusKnot'] } },
     segments: { default: 32, min: 0, if: { primitive: ['circle'] }, type: 'int' },
     segmentsHeight: { default: 18, min: 0, if: { primitive: ['cylinder', 'sphere'] }, type: 'int' },
     segmentsPhi: { default: 8, min: 0, if: { primitive: ['ring'] }, type: 'int' },
-    segmentsRadial: { default: 36, min: 0, if: { primitive: ['cylinder'] }, type: 'int' },
+    segmentsRadial: { default: 36, min: 0, if: { primitive: ['cylinder', 'torusKnot'] }, type: 'int' },
     segmentsTheta: { default: 32, min: 0, if: { primitive: ['ring'] }, type: 'int' },
     segmentsTubular: { default: 32, min: 0, if: { primitive: ['torus', 'torusKnot'] }, type: 'int' },
     segmentsWidth: { default: 36, min: 0, if: { primitive: ['sphere'] }, type: 'int' },
@@ -131,8 +130,8 @@ function getGeometry (data, schema) {
     }
     case 'torusKnot': {
       return new THREE.TorusKnotGeometry(
-        data.radius, data.radiusTubular * 2, data.segmentsRadial, data.segmentsTubular,
-        data.p, data.q, data.scaleHeight);
+        data.radius, data.radiusTubular * 2, data.segmentsTubular, data.segmentsRadial,
+        data.p, data.q);
     }
     default: {
       warn('Primitive type not supported: ' + data.primitive);


### PR DESCRIPTION
- Bump THREE to r75 (fixes #1186)
- Update Torus Knot to fix tests and reflect changes in r75
- Remove deprecated scaleHeight parameter from Torus Knot schema
- Update the order of constructor arguments for THREE.TorusKnotGeometry
- Add torusKnot to relevant geometry schema properties
- Fix the Geometry Gallery example