### PR TITLE
dispose geometries + materials when no longer in use (fixes #1215)

### DIFF
--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -61,6 +61,7 @@ module.exports.Component = registerComponent('geometry', {
     var translateNeedsUpdate = !utils.deepEqual(data.translate, currentTranslate);
 
     if (geometryNeedsUpdate) {
+      mesh.geometry.dispose();
       geometry = mesh.geometry = getGeometry(this.data, this.schema);
     }
     if (translateNeedsUpdate) {
@@ -72,6 +73,7 @@ module.exports.Component = registerComponent('geometry', {
    * Removes geometry on remove (callback).
    */
   remove: function () {
+    this.el.getObject3D('mesh').geometry.dispose();
     this.el.getObject3D('mesh').geometry = new THREE.Geometry();
   }
 });

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -105,12 +105,14 @@ module.exports.Component = registerComponent('material', {
 
   /**
    * Remove material on remove (callback).
+   * Dispose of it from memory and unsubscribe from scene updates.
    */
   remove: function () {
     var defaultMaterial = new THREE.MeshBasicMaterial();
+    var material = this.material;
     var object3D = this.el.getObject3D('mesh');
     if (object3D) { object3D.material = defaultMaterial; }
-    this.system.unregisterMaterial(this.material);
+    disposeMaterial(material, this.system);
   },
 
   /**
@@ -124,7 +126,7 @@ module.exports.Component = registerComponent('material', {
   setMaterial: function (material) {
     var mesh = this.el.getOrCreateObject3D('mesh', THREE.Mesh);
     var system = this.system;
-    if (this.material) { system.unregisterMaterial(this.material); }
+    if (this.material) { disposeMaterial(this.material, system); }
     this.material = mesh.material = material;
     system.registerMaterial(material);
   }
@@ -150,4 +152,12 @@ function parseSide (side) {
       return THREE.FrontSide;
     }
   }
+}
+
+/**
+ * Dispose of material from memory and unsubscribe material from scene updates like fog.
+ */
+function disposeMaterial (material, system) {
+  material.dispose();
+  system.unregisterMaterial(material);
 }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -211,12 +211,11 @@ var AScene = module.exports = registerElement('a-scene', {
         // Set at startup. To enable/disable antialias
         // at runttime we would have to recreate the whole context
         var antialias = this.getAttribute('antialias') === 'true';
-        var renderer = this.renderer = this.monoRenderer =
-          new THREE.WebGLRenderer({
-            canvas: canvas,
-            antialias: antialias,
-            alpha: true
-          });
+        var renderer = this.renderer = this.monoRenderer = new THREE.WebGLRenderer({
+          canvas: canvas,
+          antialias: antialias,
+          alpha: true
+        });
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
         AScene.renderer = renderer;

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -1,12 +1,10 @@
 /* global assert, process, setup, suite, test */
-var entityFactory = require('../helpers').entityFactory;
+var helpers = require('../helpers');
 var degToRad = require('index').THREE.Math.degToRad;
 
 suite('geometry', function () {
-  'use strict';
-
   setup(function (done) {
-    var el = this.el = entityFactory();
+    var el = this.el = helpers.entityFactory();
     el.setAttribute('geometry', 'primitive: box');
     el.addEventListener('loaded', function () {
       done();
@@ -43,12 +41,28 @@ suite('geometry', function () {
       assert.equal(mesh.geometry.type, 'BoxGeometry');
     });
 
-    suite('remove', function () {
-      test('removes geometry', function () {
-        var mesh = this.el.getObject3D('mesh');
-        this.el.removeAttribute('geometry');
-        assert.equal(mesh.geometry.type, 'Geometry');
-      });
+    test('disposes geometry', function () {
+      var el = this.el;
+      var geometry = el.getObject3D('mesh').geometry;
+      var disposeSpy = this.sinon.spy(geometry, 'dispose');
+      assert.notOk(disposeSpy.called);
+      el.setAttribute('geometry', 'primitive: sphere');
+      assert.ok(disposeSpy.called);
+    });
+  });
+
+  suite('remove', function () {
+    test('removes geometry', function () {
+      var mesh = this.el.getObject3D('mesh');
+      this.el.removeAttribute('geometry');
+      assert.equal(mesh.geometry.type, 'Geometry');
+    });
+
+    test('disposes geometry', function () {
+      var geometry = this.el.getObject3D('mesh').geometry;
+      var disposeSpy = this.sinon.spy(geometry, 'dispose');
+      this.el.removeAttribute('geometry');
+      assert.ok(disposeSpy.called);
     });
   });
 

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -26,6 +26,14 @@ suite('material', function () {
       assert.shallowDeepEqual(el.getObject3D('mesh').material.side, THREE.DoubleSide);
     });
 
+    test('disposes material when changing to new material', function () {
+      var el = this.el;
+      var material = el.getObject3D('mesh').material;
+      var disposeSpy = this.sinon.spy(material, 'dispose');
+      el.setAttribute('material', 'shader', 'standard');
+      assert.ok(disposeSpy.called);
+    });
+
     test('defaults to standard material', function () {
       this.el.setAttribute('material', '');
       assert.equal(this.el.getObject3D('mesh').material.type, 'MeshStandardMaterial');
@@ -64,7 +72,7 @@ suite('material', function () {
   });
 
   suite('updateSchema', function () {
-    test('Updates the schema', function () {
+    test('updates schema', function () {
       var el = this.el;
       el.components.material.updateSchema({shader: 'flat'});
       assert.ok(el.components.material.schema.color);
@@ -80,14 +88,14 @@ suite('material', function () {
   });
 
   suite('updateShader', function () {
-    test('the material is updated', function () {
+    test('updates material shader', function () {
       var el = this.el;
       assert.equal(el.getObject3D('mesh').material.type, 'MeshBasicMaterial');
       el.components.material.updateShader('standard');
       assert.equal(el.getObject3D('mesh').material.type, 'MeshStandardMaterial');
     });
 
-    test('the material is set to MeshShaderMaterial for custom shaders', function () {
+    test('sets material to MeshShaderMaterial for custom shaders', function () {
       var el = this.el;
       AFRAME.registerShader('test', {
         schema: {
@@ -119,6 +127,14 @@ suite('material', function () {
       assert.ok(el.getObject3D('mesh').material);
       el.removeAttribute('material');
       assert.equal(el.getObject3D('mesh').material.type, 'MeshBasicMaterial');
+    });
+
+    test('disposes material', function () {
+      var el = this.el;
+      var material = el.getObject3D('mesh').material;
+      var disposeSpy = this.sinon.spy(material, 'dispose');
+      el.removeAttribute('material');
+      assert.ok(disposeSpy.called);
     });
   });
 


### PR DESCRIPTION
**Description:** Reduce memory leaks.

Before, lots of geometries being created on every tick for the torus knot:

<img width="990" alt="screen shot 2016-03-28 at 2 55 32 pm" src="https://cloud.githubusercontent.com/assets/674727/14091454/3ab4c15a-f4f5-11e5-9f47-6971b899b212.png">

After, the geometry count stays at 3.

<img width="935" alt="screen shot 2016-03-28 at 2 55 21 pm" src="https://cloud.githubusercontent.com/assets/674727/14091455/3acbeeb6-f4f5-11e5-9300-75610dce57c6.png">

**Changes proposed:**
- Dispose geometry on type update or remove.
- Dispose material on shader update or remove.

