### PR TITLE
registerGeometry API (fixes #1162)

### DIFF
--- a/src/core/geometry.js
+++ b/src/core/geometry.js
@@ -1,0 +1,72 @@
+var schema = require('./schema');
+
+var processSchema = schema.process;
+var geometries = module.exports.geometries = {};  // Registered geometries.
+var geometryNames = module.exports.geometryNames = [];  // Names of registered geometries.
+var THREE = require('../lib/three');
+
+/**
+ * Geometry class definition.
+ *
+ * Geometries extend the geometry component API to create and register geometry types.
+ */
+var Geometry = module.exports.Geometry = function () {};
+
+Geometry.prototype = {
+  /**
+   * Contains the type schema and defaults for the data values.
+   * Data is coerced into the types of the values of the defaults.
+   */
+  schema: {},
+
+  /**
+   * Init handler. Similar to attachedCallback.
+   * Called during shader initialization and is only run once.
+   */
+  init: function (data) {
+    this.geometry = new THREE.Geometry();
+    return this.geometry;
+  },
+
+  /**
+   * Update handler. Similar to attributeChangedCallback.
+   * Called whenever the associated geometry data changes.
+   *
+   * @param {object} data - New geometry data.
+   */
+  update: function (data) { /* no-op */ }
+};
+
+/**
+ * Registers a geometry to A-Frame.
+ *
+ * @param {string} name - Geometry name.
+ * @param {object} definition - Geometry property and methods.
+ * @returns {object} Geometry.
+ */
+module.exports.registerGeometry = function (name, definition) {
+  var NewGeometry;
+  var proto = {};
+
+  // Format definition object to prototype object.
+  Object.keys(definition).forEach(function expandDefinition (key) {
+    proto[key] = {
+      value: definition[key],
+      writable: true
+    };
+  });
+
+  if (geometries[name]) {
+    throw new Error('The geometry `' + name + '` has been already registered');
+  }
+  NewGeometry = function () { Geometry.call(this); };
+  NewGeometry.prototype = Object.create(Geometry.prototype, proto);
+  NewGeometry.prototype.name = name;
+  NewGeometry.prototype.constructor = NewGeometry;
+  geometries[name] = {
+    Geometry: NewGeometry,
+    schema: processSchema(NewGeometry.prototype.schema)
+  };
+  geometryNames.push(name);
+  return NewGeometry;
+};

--- a/src/core/shader.js
+++ b/src/core/shader.js
@@ -142,7 +142,7 @@ module.exports.registerShader = function (name, definition) {
   });
 
   if (shaders[name]) {
-    throw Error('The shader ' + name + ' has been already registered');
+    throw new Error('The shader ' + name + ' has been already registered');
   }
   NewShader = function () { Shader.call(this); };
   NewShader.prototype = Object.create(Shader.prototype, proto);

--- a/src/geometries/box.js
+++ b/src/geometries/box.js
@@ -1,0 +1,14 @@
+var registerGeometry = require('../core/geometry').registerGeometry;
+var THREE = require('../lib/three');
+
+registerGeometry('box', {
+  schema: {
+    depth: {default: 1, min: 0},
+    height: {default: 1, min: 0},
+    width: {default: 1, min: 0}
+  },
+
+  init: function (data) {
+    this.geometry = new THREE.BoxGeometry(data.width, data.height, data.depth);
+  }
+});

--- a/src/geometries/circle.js
+++ b/src/geometries/circle.js
@@ -1,0 +1,18 @@
+var registerGeometry = require('../core/geometry').registerGeometry;
+var THREE = require('../lib/three');
+
+var degToRad = THREE.Math.degToRad;
+
+registerGeometry('circle', {
+  schema: {
+    radius: {default: 1, min: 0},
+    segments: {default: 32, min: 0, type: 'int'},
+    thetaLength: {default: 360, min: 0},
+    thetaStart: {default: 0}
+  },
+
+  init: function (data) {
+    this.geometry = new THREE.CircleGeometry(
+      data.radius, data.segments, degToRad(data.thetaStart), degToRad(data.thetaLength));
+  }
+});

--- a/src/geometries/cone.js
+++ b/src/geometries/cone.js
@@ -1,0 +1,24 @@
+var registerGeometry = require('../core/geometry').registerGeometry;
+var THREE = require('../lib/three');
+
+var degToRad = THREE.Math.degToRad;
+
+registerGeometry('cone', {
+  schema: {
+    height: {default: 1, min: 0},
+    openEnded: {default: false},
+    radiusBottom: {default: 1, min: 0},
+    radiusTop: {default: 0.8, min: 0},
+    segmentsHeight: {default: 18, min: 0, type: 'int'},
+    segmentsRadial: {default: 36, min: 0, type: 'int'},
+    thetaLength: {default: 360, min: 0},
+    thetaStart: {default: 0}
+  },
+
+  init: function (data) {
+    this.geometry = new THREE.CylinderGeometry(
+        data.radiusTop, data.radiusBottom, data.height, data.segmentsRadial,
+        data.segmentsHeight, data.openEnded, degToRad(data.thetaStart),
+        degToRad(data.thetaLength));
+  }
+});

--- a/src/geometries/cylinder.js
+++ b/src/geometries/cylinder.js
@@ -1,0 +1,22 @@
+var registerGeometry = require('../core/geometry').registerGeometry;
+var THREE = require('../lib/three');
+
+var degToRad = THREE.Math.degToRad;
+
+registerGeometry('cylinder', {
+  schema: {
+    height: {default: 1, min: 0},
+    openEnded: {default: false},
+    radius: {default: 1, min: 0},
+    segmentsHeight: {default: 18, min: 0, type: 'int'},
+    segmentsRadial: {default: 36, min: 0, type: 'int'},
+    thetaLength: {default: 360, min: 0},
+    thetaStart: {default: 0}
+  },
+
+  init: function (data) {
+    this.geometry = new THREE.CylinderGeometry(
+        data.radius, data.radius, data.height, data.segmentsRadial, data.segmentsHeight,
+        data.openEnded, degToRad(data.thetaStart), degToRad(data.thetaLength));
+  }
+});

--- a/src/geometries/index.js
+++ b/src/geometries/index.js
@@ -1,0 +1,9 @@
+require('./box.js');
+require('./circle.js');
+require('./cone.js');
+require('./cylinder.js');
+require('./plane.js');
+require('./ring.js');
+require('./sphere.js');
+require('./torus.js');
+require('./torusKnot.js');

--- a/src/geometries/plane.js
+++ b/src/geometries/plane.js
@@ -1,0 +1,13 @@
+var registerGeometry = require('../core/geometry').registerGeometry;
+var THREE = require('../lib/three');
+
+registerGeometry('plane', {
+  schema: {
+    height: {default: 1, min: 0},
+    width: {default: 1, min: 0}
+  },
+
+  init: function (data) {
+    this.geometry = new THREE.PlaneBufferGeometry(data.width, data.height);
+  }
+});

--- a/src/geometries/ring.js
+++ b/src/geometries/ring.js
@@ -1,0 +1,21 @@
+var registerGeometry = require('../core/geometry').registerGeometry;
+var THREE = require('../lib/three');
+
+var degToRad = THREE.Math.degToRad;
+
+registerGeometry('ring', {
+  schema: {
+    radiusInner: {default: 0.8, min: 0},
+    radiusOuter: {default: 1.2, min: 0},
+    segmentsPhi: { default: 8, min: 0, type: 'int' },
+    segmentsTheta: {default: 32, min: 0, type: 'int'},
+    thetaLength: {default: 360, min: 0},
+    thetaStart: {default: 0}
+  },
+
+  init: function (data) {
+    this.geometry = new THREE.RingGeometry(
+        data.radiusInner, data.radiusOuter, data.segmentsTheta, data.segmentsPhi,
+        degToRad(data.thetaStart), degToRad(data.thetaLength));
+  }
+});

--- a/src/geometries/sphere.js
+++ b/src/geometries/sphere.js
@@ -1,0 +1,23 @@
+var registerGeometry = require('../core/geometry').registerGeometry;
+var THREE = require('../lib/three');
+
+var degToRad = THREE.Math.degToRad;
+
+registerGeometry('sphere', {
+  schema: {
+    radius: {default: 1, min: 0},
+    segments: {default: 32, min: 0, type: 'int'},
+    phiLength: {default: 360},
+    phiStart: {default: 0, min: 0},
+    thetaLength: {default: 180, min: 0},
+    thetaStart: {default: 0},
+    segmentsHeight: {default: 18, min: 0, type: 'int'},
+    segmentsWidth: {default: 36, min: 0, type: 'int'}
+  },
+
+  init: function (data) {
+    this.geometry = new THREE.SphereBufferGeometry(
+      data.radius, data.segmentsWidth, data.segmentsHeight, degToRad(data.phiStart),
+      degToRad(data.phiLength), degToRad(data.thetaStart), degToRad(data.thetaLength));
+  }
+});

--- a/src/geometries/torus.js
+++ b/src/geometries/torus.js
@@ -1,0 +1,20 @@
+var registerGeometry = require('../core/geometry').registerGeometry;
+var THREE = require('../lib/three');
+
+var degToRad = THREE.Math.degToRad;
+
+registerGeometry('torus', {
+  schema: {
+    arc: {default: 360},
+    radius: {default: 1, min: 0},
+    radiusTubular: {default: 0.2, min: 0},
+    segmentsRadial: {efault: 36, min: 0, type: 'int'},
+    segmentsTubular: {default: 32, min: 0, type: 'int'}
+  },
+
+  init: function (data) {
+    this.geometry = new THREE.TorusGeometry(
+      data.radius, data.radiusTubular * 2, data.segmentsRadial, data.segmentsTubular,
+      degToRad(data.arc));
+  }
+});

--- a/src/geometries/torusKnot.js
+++ b/src/geometries/torusKnot.js
@@ -1,0 +1,19 @@
+var registerGeometry = require('../core/geometry').registerGeometry;
+var THREE = require('../lib/three');
+
+registerGeometry('torusKnot', {
+  schema: {
+    p: {default: 2, type: 'int'},
+    q: {default: 3, type: 'int'},
+    radius: {default: 1, min: 0},
+    radiusTubular: {default: 0.2, min: 0},
+    segmentsRadial: {efault: 36, min: 0, type: 'int'},
+    segmentsTubular: {default: 32, min: 0, type: 'int'}
+  },
+
+  init: function (data) {
+    this.geometry = new THREE.TorusKnotGeometry(
+      data.radius, data.radiusTubular * 2, data.segmentsTubular, data.segmentsRadial,
+      data.p, data.q);
+  }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ require('./style/rStats.css');
 var AScene = require('./core/scene/a-scene');
 var components = require('./core/component').components;
 var registerComponent = require('./core/component').registerComponent;
+var registerGeometry = require('./core/geometry').registerGeometry;
 var registerPrimitive = require('./extras/primitives/registerPrimitive');
 var registerShader = require('./core/shader').registerShader;
 var registerSystem = require('./core/system').registerSystem;
@@ -22,9 +23,10 @@ var TWEEN = window.TWEEN = require('tween.js');
 var pkg = require('../package');
 var utils = require('./utils/');
 
-require('./systems/index'); // Register core systems.
-require('./components/index'); // Register core components.
-require('./shaders/index'); // Register core shaders.
+require('./components/index'); // Register standard components.
+require('./geometries/index'); // Register standard geometries.
+require('./shaders/index'); // Register standard shaders.
+require('./systems/index'); // Register standard systems.
 var ANode = require('./core/a-node');
 var AEntity = require('./core/a-entity'); // Depends on ANode and core components.
 
@@ -55,9 +57,10 @@ module.exports = window.AFRAME = {
   AScene: AScene,
   components: components,
   registerComponent: registerComponent,
+  registerGeometry: registerGeometry,
+  registerPrimitive: registerPrimitive,
   registerShader: registerShader,
   registerSystem: registerSystem,
-  registerPrimitive: registerPrimitive,
   shaders: shaders,
   systems: systems,
   THREE: THREE,

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -66,132 +66,6 @@ suite('geometry', function () {
     });
   });
 
-  suite('getGeometry', function () {
-    test('creates circle geometry', function () {
-      var el = this.el;
-      var geometry;
-      el.setAttribute('geometry', {
-        primitive: 'circle', radius: 5, segments: 4, thetaStart: 0, thetaLength: 350
-      });
-      geometry = el.getObject3D('mesh').geometry;
-      assert.equal(geometry.type, 'CircleGeometry');
-      assert.equal(geometry.parameters.radius, 5);
-      assert.equal(geometry.parameters.segments, 4);
-      assert.equal(geometry.parameters.thetaStart, 0);
-      assert.equal(geometry.parameters.thetaLength, degToRad(350));
-    });
-
-    test('creates cylinder geometry', function () {
-      var el = this.el;
-      var geometry;
-      el.setAttribute('geometry', {
-        primitive: 'cylinder', radius: 1, height: 2, segmentsRadial: 3,
-        segmentsHeight: 4, openEnded: true, thetaStart: 240, thetaLength: 350
-      });
-      geometry = el.getObject3D('mesh').geometry;
-      assert.equal(geometry.type, 'CylinderGeometry');
-      assert.equal(geometry.parameters.radiusTop, 1);
-      assert.equal(geometry.parameters.radiusTop, 1);
-      assert.equal(geometry.parameters.height, 2);
-      assert.equal(geometry.parameters.radialSegments, 3);
-      assert.equal(geometry.parameters.heightSegments, 4);
-      assert.equal(geometry.parameters.openEnded, true);
-      assert.equal(geometry.parameters.thetaStart, degToRad(240));
-      assert.equal(geometry.parameters.thetaLength, degToRad(350));
-    });
-
-    test('creates cone geometry', function () {
-      var el = this.el;
-      var geometry;
-      el.setAttribute('geometry', {
-        primitive: 'cone', radiusTop: 1, radiusBottom: 5, height: 2, segmentsRadial: 3,
-        segmentsHeight: 4, openEnded: true, thetaStart: 240, thetaLength: 350
-      });
-      geometry = el.getObject3D('mesh').geometry;
-      assert.equal(geometry.type, 'CylinderGeometry');
-      assert.equal(geometry.parameters.radiusTop, 1);
-      assert.equal(geometry.parameters.radiusBottom, 5);
-      assert.equal(geometry.parameters.radialSegments, 3);
-      assert.equal(geometry.parameters.heightSegments, 4);
-      assert.equal(geometry.parameters.openEnded, true);
-      assert.equal(geometry.parameters.thetaStart, degToRad(240));
-      assert.equal(geometry.parameters.thetaLength, degToRad(350));
-    });
-
-    test('creates plane geometry', function () {
-      var el = this.el;
-      var geometry;
-      el.setAttribute('geometry', { primitive: 'plane', width: 1, height: 2 });
-      geometry = el.getObject3D('mesh').geometry;
-      assert.equal(geometry.type, 'PlaneBufferGeometry');
-      assert.equal(geometry.parameters.width, 1);
-      assert.equal(geometry.parameters.height, 2);
-    });
-
-    test('creates ring geometry', function () {
-      var el = this.el;
-      var geometry;
-      el.setAttribute('geometry', {
-        primitive: 'ring', radiusInner: 1, radiusOuter: 2, segmentsTheta: 3});
-      geometry = el.getObject3D('mesh').geometry;
-      assert.equal(geometry.type, 'RingGeometry');
-      assert.equal(geometry.parameters.innerRadius, 1);
-      assert.equal(geometry.parameters.outerRadius, 2);
-      assert.equal(geometry.parameters.thetaSegments, 3);
-    });
-
-    test('creates sphere geometry', function () {
-      var el = this.el;
-      var geometry;
-      el.setAttribute('geometry', {
-        primitive: 'sphere', radius: 1, segmentsWidth: 2, segmentsHeight: 3,
-        phiStart: 45, phiLength: 90, thetaStart: 45
-      });
-      geometry = el.getObject3D('mesh').geometry;
-      assert.equal(geometry.type, 'SphereBufferGeometry');
-      assert.equal(geometry.parameters.radius, 1);
-      assert.equal(geometry.parameters.widthSegments, 2);
-      assert.equal(geometry.parameters.heightSegments, 3);
-      assert.equal(geometry.parameters.phiStart, degToRad(45));
-      assert.equal(geometry.parameters.phiLength, degToRad(90));
-      assert.equal(geometry.parameters.thetaStart, degToRad(45));
-      assert.equal(geometry.parameters.thetaLength, degToRad(180));
-    });
-
-    test('creates torus geometry', function () {
-      var el = this.el;
-      var geometry;
-      el.setAttribute('geometry', {
-        primitive: 'torus', radius: 1, radiusTubular: 2, segmentsRadial: 3, segmentsTubular: 4,
-        arc: 350
-      });
-      geometry = el.getObject3D('mesh').geometry;
-      assert.equal(geometry.type, 'TorusGeometry');
-      assert.equal(geometry.parameters.radius, 1);
-      assert.equal(geometry.parameters.radialSegments, 3);
-      assert.equal(geometry.parameters.tube, 4);
-      assert.equal(geometry.parameters.tubularSegments, 4);
-      assert.equal(geometry.parameters.arc, degToRad(350));
-    });
-
-    test('creates torus knot geometry', function () {
-      var el = this.el;
-      var geometry;
-      el.setAttribute('geometry', {
-        primitive: 'torusKnot', radius: 1, radiusTubular: 2, segmentsRadial: 3,
-        segmentsTubular: 4, p: 5, q: 6
-      });
-      geometry = el.getObject3D('mesh').geometry;
-      assert.equal(geometry.type, 'TorusKnotGeometry');
-      assert.equal(geometry.parameters.radius, 1);
-      assert.equal(geometry.parameters.tube, 4);
-      assert.equal(geometry.parameters.radialSegments, 3);
-      assert.equal(geometry.parameters.tubularSegments, 4);
-      assert.equal(geometry.parameters.p, 5);
-      assert.equal(geometry.parameters.q, 6);
-    });
-  });
-
   suite('translate', function () {
     var DEFAULT_VERTICES = [
       {x: 0.5, y: 0.5, z: 0.5}, {x: 0.5, y: 0.5, z: -0.5}, {x: 0.5, y: -0.5, z: 0.5},
@@ -249,5 +123,139 @@ suite('geometry', function () {
       el.setAttribute('geometry', 'translate', '-2 4 2');
       assert.equal(el.getObject3D('mesh').geometry.uuid, uuid);
     });
+  });
+});
+
+suite('standard geometries', function () {
+  setup(function (done) {
+    var el = this.el = helpers.entityFactory();
+    el.setAttribute('geometry', 'primitive: box');
+    el.addEventListener('loaded', function () {
+      done();
+    });
+  });
+
+  test('circle', function () {
+    var el = this.el;
+    var geometry;
+    el.setAttribute('geometry', {
+      primitive: 'circle', radius: 5, segments: 4, thetaStart: 0, thetaLength: 350
+    });
+    geometry = el.getObject3D('mesh').geometry;
+    assert.equal(geometry.type, 'CircleGeometry');
+    assert.equal(geometry.parameters.radius, 5);
+    assert.equal(geometry.parameters.segments, 4);
+    assert.equal(geometry.parameters.thetaStart, 0);
+    assert.equal(geometry.parameters.thetaLength, degToRad(350));
+  });
+
+  test('cylinder', function () {
+    var el = this.el;
+    var geometry;
+    el.setAttribute('geometry', {
+      primitive: 'cylinder', radius: 1, height: 2, segmentsRadial: 3,
+      segmentsHeight: 4, openEnded: true, thetaStart: 240, thetaLength: 350
+    });
+    geometry = el.getObject3D('mesh').geometry;
+    assert.equal(geometry.type, 'CylinderGeometry');
+    assert.equal(geometry.parameters.radiusTop, 1);
+    assert.equal(geometry.parameters.radiusTop, 1);
+    assert.equal(geometry.parameters.height, 2);
+    assert.equal(geometry.parameters.radialSegments, 3);
+    assert.equal(geometry.parameters.heightSegments, 4);
+    assert.equal(geometry.parameters.openEnded, true);
+    assert.equal(geometry.parameters.thetaStart, degToRad(240));
+    assert.equal(geometry.parameters.thetaLength, degToRad(350));
+  });
+
+  test('cone', function () {
+    var el = this.el;
+    var geometry;
+    el.setAttribute('geometry', {
+      primitive: 'cone', radiusTop: 1, radiusBottom: 5, height: 2, segmentsRadial: 3,
+      segmentsHeight: 4, openEnded: true, thetaStart: 240, thetaLength: 350
+    });
+    geometry = el.getObject3D('mesh').geometry;
+    assert.equal(geometry.type, 'CylinderGeometry');
+    assert.equal(geometry.parameters.radiusTop, 1);
+    assert.equal(geometry.parameters.radiusBottom, 5);
+    assert.equal(geometry.parameters.radialSegments, 3);
+    assert.equal(geometry.parameters.heightSegments, 4);
+    assert.equal(geometry.parameters.openEnded, true);
+    assert.equal(geometry.parameters.thetaStart, degToRad(240));
+    assert.equal(geometry.parameters.thetaLength, degToRad(350));
+  });
+
+  test('plane', function () {
+    var el = this.el;
+    var geometry;
+    el.setAttribute('geometry', { primitive: 'plane', width: 1, height: 2 });
+    geometry = el.getObject3D('mesh').geometry;
+    assert.equal(geometry.type, 'PlaneBufferGeometry');
+    assert.equal(geometry.parameters.width, 1);
+    assert.equal(geometry.parameters.height, 2);
+  });
+
+  test('ring', function () {
+    var el = this.el;
+    var geometry;
+    el.setAttribute('geometry', {
+      primitive: 'ring', radiusInner: 1, radiusOuter: 2, segmentsTheta: 3});
+    geometry = el.getObject3D('mesh').geometry;
+    assert.equal(geometry.type, 'RingGeometry');
+    assert.equal(geometry.parameters.innerRadius, 1);
+    assert.equal(geometry.parameters.outerRadius, 2);
+    assert.equal(geometry.parameters.thetaSegments, 3);
+  });
+
+  test('sphere', function () {
+    var el = this.el;
+    var geometry;
+    el.setAttribute('geometry', {
+      primitive: 'sphere', radius: 1, segmentsWidth: 2, segmentsHeight: 3,
+      phiStart: 45, phiLength: 90, thetaStart: 45
+    });
+    geometry = el.getObject3D('mesh').geometry;
+    assert.equal(geometry.type, 'SphereBufferGeometry');
+    assert.equal(geometry.parameters.radius, 1);
+    assert.equal(geometry.parameters.widthSegments, 2);
+    assert.equal(geometry.parameters.heightSegments, 3);
+    assert.equal(geometry.parameters.phiStart, degToRad(45));
+    assert.equal(geometry.parameters.phiLength, degToRad(90));
+    assert.equal(geometry.parameters.thetaStart, degToRad(45));
+    assert.equal(geometry.parameters.thetaLength, degToRad(180));
+  });
+
+  test('torus', function () {
+    var el = this.el;
+    var geometry;
+    el.setAttribute('geometry', {
+      primitive: 'torus', radius: 1, radiusTubular: 2, segmentsRadial: 3, segmentsTubular: 4,
+      arc: 350
+    });
+    geometry = el.getObject3D('mesh').geometry;
+    assert.equal(geometry.type, 'TorusGeometry');
+    assert.equal(geometry.parameters.radius, 1);
+    assert.equal(geometry.parameters.radialSegments, 3);
+    assert.equal(geometry.parameters.tube, 4);
+    assert.equal(geometry.parameters.tubularSegments, 4);
+    assert.equal(geometry.parameters.arc, degToRad(350));
+  });
+
+  test('torus knot', function () {
+    var el = this.el;
+    var geometry;
+    el.setAttribute('geometry', {
+      primitive: 'torusKnot', radius: 1, radiusTubular: 2, segmentsRadial: 3,
+      segmentsTubular: 4, p: 5, q: 6
+    });
+    geometry = el.getObject3D('mesh').geometry;
+    assert.equal(geometry.type, 'TorusKnotGeometry');
+    assert.equal(geometry.parameters.radius, 1);
+    assert.equal(geometry.parameters.tube, 4);
+    assert.equal(geometry.parameters.radialSegments, 3);
+    assert.equal(geometry.parameters.tubularSegments, 4);
+    assert.equal(geometry.parameters.p, 5);
+    assert.equal(geometry.parameters.q, 6);
   });
 });

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -507,16 +507,19 @@ suite('a-entity', function () {
       assert.shallowDeepEqual(el.getComputedAttribute('material'), { shader: 'flat', color: 'red' });
     });
 
-    test('merges component properties from mixin', function () {
+    test('merges component properties from mixin', function (done) {
       var el = this.el;
-      el.setAttribute('geometry', { depth: 5, height: 5, width: 5 });
-      mixinFactory('box', { geometry: 'primitive: box' });
-      el.setAttribute('mixin', 'box');
-      assert.shallowDeepEqual(el.getComputedAttribute('geometry'), {
-        depth: 5,
-        height: 5,
-        primitive: 'box',
-        width: 5
+      mixinFactory('box', {geometry: 'primitive: box'});
+      process.nextTick(function () {
+        el.setAttribute('mixin', 'box');
+        el.setAttribute('geometry', {depth: 5, height: 5, width: 5});
+        assert.shallowDeepEqual(el.getComputedAttribute('geometry'), {
+          depth: 5,
+          height: 5,
+          primitive: 'box',
+          width: 5
+        });
+        done();
       });
     });
 

--- a/tests/core/geometry.test.js
+++ b/tests/core/geometry.test.js
@@ -1,0 +1,25 @@
+/* global assert, process, suite, test, setup */
+var registerGeometry = require('core/geometry').registerGeometry;
+var geometries = require('core/geometry').geometries;
+var geometryNames = require('core/geometry').geometryNames;
+
+suite('core/geometry', function () {
+  test('registers standard geometries', function () {
+    assert.ok('box' in geometries);
+    assert.ok('sphere' in geometries);
+    assert.notEqual(geometryNames.indexOf('box'), -1);
+    assert.notEqual(geometryNames.indexOf('sphere'), -1);
+  });
+
+  suite('registerGeometry', function () {
+    setup(function () {
+      delete geometries.test;
+    });
+
+    test('can register shaders', function () {
+      registerGeometry('test', {});
+      assert.ok('test' in geometries);
+      assert.notEqual(geometryNames.indexOf('test'), -1);
+    });
+  });
+});


### PR DESCRIPTION
**Description:** `registerGeometry`, similar to `registerShader`. Cleans up the geometry component, allows us to define a different schema per geometry type, allows us to set different defaults per geometry type, opens up another door for extensibility and sharing.

Prerequisite to geometry caching system and automatically using buffer geometries.

- [ ] docs

**Changes proposed:**
- registerGeometry API
- move geometries to individual files
- normalize all geometries to non-buffer to prepare for https://github.com/aframevr/aframe/issues/633

