### PR TITLE
reduces the radius of sky component's default in order to increase pe…

### DIFF
--- a/src/extras/primitives/primitives/a-sky.js
+++ b/src/extras/primitives/primitives/a-sky.js
@@ -6,9 +6,9 @@ registerPrimitive('a-sky', utils.extendDeep({}, getMeshMixin(), {
   defaultAttributes: {
     geometry: {
       primitive: 'sphere',
-      radius: 5000,
+      radius: 100,
       segmentsWidth: 64,
-      segmentsHeight: 64
+      segmentsHeight: 20
     },
     material: {
       color: '#FFF',


### PR DESCRIPTION
**Description:**
  Reduces the number of default vertices used in the a-sky component. In reference to issue #1310 
**Changes proposed:**
-  Reduce the radius 
-  Reduce the heightSegments for equatorial projection distortion reduction.