### PR TITLE
track the fact that a canvas is provided so we don't overwrite its size

### DIFF
--- a/examples/boilerplate-embedded-scenes/index.html
+++ b/examples/boilerplate-embedded-scenes/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Hello, World! • A-Frame</title>
+    <meta name="description" content="Hello, World! • A-Frame">
+    <script src="../../dist/aframe.js"></script>
+    <style>
+    #mycanvas {
+      width: 200px;
+      height: 200px;
+    }
+    </style>
+  </head>
+  <body>
+    <p>Through the looking glass.</p>
+    <canvas id="mycanvas"></canvas>
+    <p>’Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe:
+All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+“Beware the Jabberwock, my son!
+      The jaws that bite, the claws that catch!
+Beware the Jubjub bird, and shun
+      The frumious Bandersnatch!”
+    </p>
+
+
+     <a-scene canvas="canvas: #mycanvas; height: 10; width: 10;">
+      <!-- Camera with customized cursor -->
+      <a-sphere position="0 1.25 -1" radius="1.25" color="#EF2D5E"></a-sphere>
+      <a-box position="-1 0.5 1" rotation="0 45 0" width="1" height="1" depth="1"  color="#4CC3D9"></a-box>
+      <a-cylinder position="1 0.75 1" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
+      <a-plane rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
+
+
+      <!-- Sky -->
+      <a-sky color="#ecfcf4"></a-sky>
+    </a-scene>
+
+    <script>
+      var scene = document.querySelector('a-scene')
+      function check() {
+        var canvas = document.getElementById("mycanvas")
+        console.log(canvas.width, canvas.height);
+      }
+      if(scene.hasLoaded) {
+      } else {
+        scene.addEventListener('loaded', check);
+      }
+    </script>
+  </body>
+</html>

--- a/examples/boilerplate-embedded-scenes/index.html
+++ b/examples/boilerplate-embedded-scenes/index.html
@@ -28,9 +28,9 @@ Beware the Jubjub bird, and shun
     </p>
 
     <!-- This scene will be rendered inside the referenced canvas element -->
-    <a-scene canvas="canvas: #mycanvas;">
+    <a-scene canvas="canvas: #mycanvas">
       <a-sphere position="0 1.25 -1" radius="1.25" color="#EF2D5E"></a-sphere>
-      <a-box position="-1 0.5 1" rotation="0 45 0" width="1" height="1" depth="1"  color="#4CC3D9"></a-box>
+      <a-box position="-1 0.5 1" rotation="0 45 0" width="1" height="1" depth="1" color="#4CC3D9"></a-box>
       <a-cylinder position="1 0.75 1" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
       <a-plane rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
       <!-- Sky -->
@@ -48,6 +48,7 @@ Beware the Jubjub bird, and shun
       } else {
         scene.addEventListener('loaded', check);
       }
+      window.addEventListener('resize', check);
     </script>
   </body>
 </html>

--- a/examples/boilerplate-embedded-scenes/index.html
+++ b/examples/boilerplate-embedded-scenes/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Hello, World! • A-Frame</title>
-    <meta name="description" content="Hello, World! • A-Frame">
+    <title>Embedded scene • A-Frame</title>
+    <meta name="description" content="Embedded scene • A-Frame">
     <script src="../../dist/aframe.js"></script>
     <style>
     #mycanvas {
@@ -13,39 +13,38 @@
     </style>
   </head>
   <body>
-    <p>Through the looking glass.</p>
+    <h2>Through the looking glass.</h2>
+    <!-- this canvas element may be anywhere in the document -->
     <canvas id="mycanvas"></canvas>
+
     <p>’Twas brillig, and the slithy toves
       Did gyre and gimble in the wabe:
 All mimsy were the borogoves,
       And the mome raths outgrabe.
-
 “Beware the Jabberwock, my son!
       The jaws that bite, the claws that catch!
 Beware the Jubjub bird, and shun
       The frumious Bandersnatch!”
     </p>
 
-
-     <a-scene canvas="canvas: #mycanvas; height: 10; width: 10;">
-      <!-- Camera with customized cursor -->
+    <!-- This scene will be rendered inside the referenced canvas element -->
+    <a-scene canvas="canvas: #mycanvas;">
       <a-sphere position="0 1.25 -1" radius="1.25" color="#EF2D5E"></a-sphere>
       <a-box position="-1 0.5 1" rotation="0 45 0" width="1" height="1" depth="1"  color="#4CC3D9"></a-box>
       <a-cylinder position="1 0.75 1" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
       <a-plane rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
-
-
       <!-- Sky -->
       <a-sky color="#ecfcf4"></a-sky>
     </a-scene>
 
     <script>
-      var scene = document.querySelector('a-scene')
-      function check() {
-        var canvas = document.getElementById("mycanvas")
+      var scene = document.querySelector('a-scene');
+      function check () {
+        var canvas = document.getElementById('mycanvas');
         console.log(canvas.width, canvas.height);
       }
-      if(scene.hasLoaded) {
+      if (scene.hasLoaded) {
+        check();
       } else {
         scene.addEventListener('loaded', check);
       }

--- a/src/components/scene/canvas.js
+++ b/src/components/scene/canvas.js
@@ -29,6 +29,8 @@ module.exports.Component = register('canvas', {
       canvas.style.height = data.height + '%';
       canvas.style.width = data.width + '%';
       scene.appendChild(canvas);
+    } else {
+      canvas.provided = true;
     }
 
     // Prevent overscroll on mobile.

--- a/src/components/scene/canvas.js
+++ b/src/components/scene/canvas.js
@@ -30,7 +30,7 @@ module.exports.Component = register('canvas', {
       canvas.style.width = data.width + '%';
       scene.appendChild(canvas);
     } else {
-      canvas.provided = true;
+      canvas.dataset.aframeProvided = true;
     }
 
     // Prevent overscroll on mobile.

--- a/src/components/scene/canvas.js
+++ b/src/components/scene/canvas.js
@@ -28,9 +28,8 @@ module.exports.Component = register('canvas', {
       canvas.classList.add('a-canvas');
       canvas.style.height = data.height + '%';
       canvas.style.width = data.width + '%';
-      scene.appendChild(canvas);
-    } else {
       canvas.dataset.aframeProvided = true;
+      scene.appendChild(canvas);
     }
 
     // Prevent overscroll on mobile.

--- a/src/components/scene/canvas.js
+++ b/src/components/scene/canvas.js
@@ -28,7 +28,7 @@ module.exports.Component = register('canvas', {
       canvas.classList.add('a-canvas');
       canvas.style.height = data.height + '%';
       canvas.style.width = data.width + '%';
-      // Mark canvas as provided/injected by A-Frame
+      // Mark canvas as provided/injected by A-Frame.
       canvas.dataset.aframeProvided = true;
       scene.appendChild(canvas);
     }

--- a/src/components/scene/canvas.js
+++ b/src/components/scene/canvas.js
@@ -29,7 +29,7 @@ module.exports.Component = register('canvas', {
       canvas.style.height = data.height + '%';
       canvas.style.width = data.width + '%';
       // Mark canvas as provided/injected by A-Frame.
-      canvas.dataset.aframeProvided = true;
+      canvas.dataset.aframeDefault = true;
       scene.appendChild(canvas);
     }
 

--- a/src/components/scene/canvas.js
+++ b/src/components/scene/canvas.js
@@ -28,6 +28,7 @@ module.exports.Component = register('canvas', {
       canvas.classList.add('a-canvas');
       canvas.style.height = data.height + '%';
       canvas.style.width = data.width + '%';
+      // Mark canvas as provided/injected by A-Frame
       canvas.dataset.aframeProvided = true;
       scene.appendChild(canvas);
     }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -169,7 +169,7 @@ var AScene = module.exports = registerElement('a-scene', {
         if (!camera || !canvas) { return; }
 
         // Update canvas.
-        if (!isMobile) {
+        if (!isMobile && !canvas.provided) {
           canvas.style.width = '100%';
           canvas.style.height = '100%';
         }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -169,7 +169,7 @@ var AScene = module.exports = registerElement('a-scene', {
         if (!camera || !canvas) { return; }
 
         // Update canvas.
-        if (!isMobile && !canvas.provided) {
+        if (!isMobile && !canvas.dataset.aframeProvided) {
           canvas.style.width = '100%';
           canvas.style.height = '100%';
         }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -169,7 +169,7 @@ var AScene = module.exports = registerElement('a-scene', {
         if (!camera || !canvas) { return; }
 
         // Update canvas.
-        if (!isMobile && !canvas.dataset.aframeProvided) {
+        if (!isMobile && canvas.dataset.aframeProvided) {
           canvas.style.width = '100%';
           canvas.style.height = '100%';
         }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -168,7 +168,7 @@ var AScene = module.exports = registerElement('a-scene', {
         // Possible camera or canvas not injected yet.
         if (!camera || !canvas) { return; }
 
-        // Update canvas if canvas was provided by A-Frame
+        // Update canvas if canvas was provided by A-Frame.
         if (!isMobile && canvas.dataset.aframeProvided) {
           canvas.style.width = '100%';
           canvas.style.height = '100%';

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -169,7 +169,7 @@ var AScene = module.exports = registerElement('a-scene', {
         if (!camera || !canvas) { return; }
 
         // Update canvas if canvas was provided by A-Frame.
-        if (!isMobile && canvas.dataset.aframeProvided) {
+        if (!isMobile && canvas.dataset.aframeDefault) {
           canvas.style.width = '100%';
           canvas.style.height = '100%';
         }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -168,7 +168,7 @@ var AScene = module.exports = registerElement('a-scene', {
         // Possible camera or canvas not injected yet.
         if (!camera || !canvas) { return; }
 
-        // Update canvas.
+        // Update canvas if canvas was provided by A-Frame
         if (!isMobile && canvas.dataset.aframeProvided) {
           canvas.style.width = '100%';
           canvas.style.height = '100%';


### PR DESCRIPTION
**Description:**
This attempts to fix #1289 by keeping track of whether a canvas element was provided, and if so don't override it's width and height styles during resize.

**Changes proposed:**
- adds a boolean to the canvas element that the scene will check for in the resize function.

I've made a new example including these changes in a aframe.min.js dist (ran `npm run dist` on my branch) which shows it seems to work:
http://blockbuilder.org/enjalot/dfb4b1220ba76b63b8fa2ed2c5d517c3
