### PR TITLE
Refactors component updates to minimize the number of string parsings…

### DIFF
--- a/examples/boilerplate-panoexplorer/index.html
+++ b/examples/boilerplate-panoexplorer/index.html
@@ -82,7 +82,7 @@
 
           var el = document.createElement('a-entity');
           el.dataset.id = idx;
-          el.setAttribute('position', {x: xPos});
+          el.setAttribute('position', {x: xPos, y: 0, z: 0});
           el.setAttribute('mixin', 'link');
           el.setAttribute('material', {shader: 'flat', src: pano.thumb});
           panos[idx].el = el;

--- a/examples/stress-animation/index.html
+++ b/examples/stress-animation/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Animation</title>
+    <meta name="description" content="Animation - A-Frame">
+    <script src="../../dist/aframe.js"></script>
+  </head>
+  <body>
+    <a-scene stats="true">
+      <a-assets>
+        <a-mixin id="ball" geometry="primitive: sphere; radius:1"  material="shader: flat; color: red">
+        </a-mixin>
+        <a-mixin id="opacity" attribute="material.opacity" dur="2000" direction="alternate" fill="forwards"
+                  ease="linear" repeat="indefinite" from="0.3" to="1.0"><a-mixin>
+        <a-mixin id="spin" attribute="rotation" dur="4000"
+                 repeat="indefinite" easing="linear" dur="3000" to="0 0 360"><a-mixin>
+      </a-assets>
+
+      <a-entity position="0 0 80">
+        <a-entity camera look-controls wasd-controls></a-entity>
+      </a-entity>
+
+      <a-entity id="fans"></a-entity>
+      
+    </a-scene>
+  </body>
+  <script>
+    var i;
+    var fansEl = document.querySelector('#fans');
+    var numRows = 4;
+    var numFans = 3
+    var numFanRows = 3;
+    var numBalls = 11;
+    var ball =
+      '<a-entity>' +
+        '<a-entity mixin="ball">' +
+          '<a-animation mixin="opacity"></a-animation>' +
+        '</a-entity>' +
+      '</a-entity>';
+    var ballEl;
+    var rowEl;
+    var ballInitX = -15;
+    var fanInitX = -60;
+    var fanInitY = -40;
+    var offset;
+
+    for (var n = 0; n < numFanRows; ++n) {
+      var fanRow = document.createElement('a-entity');
+      fanRow.setAttribute('position', { x: 0, y: fanInitY - (n * fanInitY), z: 0 });
+      for (var k = 0; k < numFans; ++k) {
+        var fanEl = document.createElement('a-entity');
+        fanEl.setAttribute('position', { x: fanInitX - (k * fanInitX), y: 0, z: 0});
+        var animationEl = document.createElement('a-animation');
+        animationEl.setAttribute('mixin', 'spin');
+        fanEl.appendChild(animationEl);
+        for (var i = 0; i < numRows; ++i) {
+          var rowEl = document.createElement('a-entity');
+          rowEl.setAttribute('rotation', { x: 0, y: 0, z: i * (180 / numRows) });
+          for (var j = 0; j < numBalls; ++j) {
+            offset = ballInitX + 3 * j;
+            if (offset === 0) { continue; }
+            var ballEl = document.createElement('a-entity');
+            ballEl.setAttribute('position', { x: ballInitX + 3 * j, y: 0, z: 0 });
+            ballEl.innerHTML = ball;
+            animationEl = ballEl.querySelector('a-animation');
+            animationEl.setAttribute('begin', Math.random() * 2000);
+            rowEl.appendChild(ballEl)
+          }
+          fanEl.appendChild(rowEl);
+        }
+        fanRow.appendChild(fanEl);
+      }
+      fansEl.appendChild(fanRow);
+    }
+  </script>
+</html>

--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -51,7 +51,7 @@ module.exports.Component = registerComponent('camera', {
     // If `active` property changes, or first update, handle active camera with system.
     if (data.active && system.activeCameraEl !== this.el) {
       // Camera enabled. Set camera to this camera.
-      system.setActiveCamera(el, camera);
+      system.setActiveCamera(el);
     } else if (!data.active && system.activeCameraEl === this.el) {
       // Camera disabled. Set camera to another camera.
       system.disableActiveCamera();

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -16,6 +16,7 @@ require('./visible');
 require('./wasd-controls');
 
 require('./scene/canvas');
+require('./scene/debug');
 require('./scene/fog');
 require('./scene/keyboard-shortcuts');
 require('./scene/stats');

--- a/src/components/obj-model.js
+++ b/src/components/obj-model.js
@@ -1,4 +1,3 @@
-/* global HTMLElement */
 var debug = require('../utils/debug');
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
@@ -39,7 +38,7 @@ module.exports.Component = registerComponent('obj-model', {
 
     if (mtlUrl) {
       // .OBJ with an .MTL.
-      if (HTMLElement.prototype.getAttribute.call(el, 'material')) {
+      if (el.hasAttribute('material')) {
         warn('Material component properties are ignored when a .MTL is provided');
       }
       mtlLoader.setBaseUrl(mtlUrl.substr(0, mtlUrl.lastIndexOf('/') + 1));

--- a/src/components/scene/debug.js
+++ b/src/components/scene/debug.js
@@ -1,0 +1,5 @@
+var register = require('../../core/component').registerComponent;
+
+module.exports.Component = register('debug', {
+  schema: { default: false }
+});

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -82,8 +82,8 @@ module.exports = registerElement('a-node', {
         });
 
         Promise.all(childrenLoaded).then(function emitLoaded () {
-          if (cb) { cb(); }
           self.hasLoaded = true;
+          if (cb) { cb(); }
           self.emit('loaded', {}, false);
         });
       },

--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -77,7 +77,7 @@ function wrapANodeMethods (obj) {
     'attributeChangedCallback',
     'createdCallback'
   ];
-  wrapMethods(newObj, ANodeMethods, obj, ANode.prototype);
+  wrapMethods(newObj, ANodeMethods, ANode.prototype, obj);
   copyProperties(obj, newObj);
   return newObj;
 }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -59,7 +59,7 @@ var AScene = module.exports = registerElement('a-scene', {
       value: function () {
         this.behaviors = [];
         this.hasLoaded = false;
-        this.isPlaying = true;
+        this.isPlaying = false;
         this.originalHTML = this.innerHTML;
         this.setupSystems();
         this.addEventListener('render-target-loaded', function () {
@@ -231,7 +231,6 @@ var AScene = module.exports = registerElement('a-scene', {
     play: {
       value: function () {
         var self = this;
-
         if (this.renderStarted) {
           AEntity.prototype.play.call(this);
           return;

--- a/src/extras/primitives/registerPrimitive.js
+++ b/src/extras/primitives/registerPrimitive.js
@@ -45,9 +45,7 @@ module.exports = function registerPrimitive (name, definition) {
         value: function () {
           var self = this;
           var attributes = this.attributes;
-
           this.applyDefaultComponents();
-
           // Apply initial attributes.
           Object.keys(attributes).forEach(function applyInitial (attributeName) {
             var attr = attributes[attributeName];
@@ -61,10 +59,6 @@ module.exports = function registerPrimitive (name, definition) {
        */
       attributeChangedCallback: {
         value: function (attr, oldVal, newVal) {
-          if (!this.mappings[attr]) {
-            AEntity.prototype.attributeChangedCallback.call(this, attr, oldVal, newVal);
-            return;
-          }
           this.syncAttributeToComponent(attr, newVal);
         }
       },
@@ -73,20 +67,20 @@ module.exports = function registerPrimitive (name, definition) {
         value: function () {
           var self = this;
           var defaultData = this.defaultAttributes;
-
           // Apply default components.
           Object.keys(defaultData).forEach(function applyDefault (componentName) {
             var componentData = defaultData[componentName];
-
             // Set component properties individually to not overwrite user-defined components.
             if (componentData instanceof Object && Object.keys(componentData).length) {
+              var component = components[componentName];
+              var attrValues = self.getAttribute(componentName) || {};
+              var data = component.parse(attrValues);
               Object.keys(componentData).forEach(function setProperty (propName) {
                 // Check if component property already defined.
-                var definedData = self.getAttribute(componentName);
-                if (definedData && definedData[propName] !== undefined) { return; }
-
-                self.setAttribute(componentName, propName, componentData[propName]);
+                if (data[propName]) { return; }
+                data[propName] = componentData[propName];
               });
+              self.setAttribute(componentName, data);
               return;
             }
 

--- a/src/utils/styleParser.js
+++ b/src/utils/styleParser.js
@@ -11,6 +11,8 @@ module.exports.parse = function (value) {
   var parsedData;
   if (typeof value !== 'string') { return value; }
   parsedData = styleParser.parse(value);
+  // The style parser returns an object { "" : "test"} when fed a string
+  if (parsedData['']) { return value; }
   return transformKeysToCamelCase(parsedData);
 };
 

--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -23,7 +23,5 @@ teardown(function () {
       els[i].parentNode.removeChild(els[i]);
     }
   });
-  AScene.scene = null;
-
   this.sinon.restore();
 });

--- a/tests/components/camera.test.js
+++ b/tests/components/camera.test.js
@@ -6,8 +6,9 @@ suite('camera', function () {
 
   setup(function (done) {
     var el = this.el = entityFactory();
-    el.setAttribute('camera', '');
-    process.nextTick(function () {
+    el.setAttribute('camera', 'active: false');
+    if (el.hasLoaded) { done(); }
+    el.addEventListener('loaded', function () {
       done();
     });
   });

--- a/tests/components/look-at.test.js
+++ b/tests/components/look-at.test.js
@@ -31,18 +31,13 @@ suite('look-at', function () {
       assert.ok(this.spy.notCalled);
     });
 
-    test('can look at a position', function (done) {
+    test('can look at a position', function () {
       var el = this.el;
       var spy = this.spy;
       el.setAttribute('look-at', '10 20 30');
-      setTimeout(function () {
-        assert.ok(spy.calledWith({x: 10, y: 20, z: 30}));
-        el.setAttribute('look-at', '30 15 0');
-        setTimeout(function () {
-          assert.ok(spy.calledWith({x: 30, y: 15, z: 0}));
-          done();
-        });
-      });
+      assert.ok(spy.calledWith({x: 10, y: 20, z: 30}));
+      el.setAttribute('look-at', '30 15 0');
+      assert.ok(spy.calledWith({x: 30, y: 15, z: 0}));
     });
 
     test('can look at an object', function (done) {

--- a/tests/components/obj-model.test.js
+++ b/tests/components/obj-model.test.js
@@ -6,14 +6,12 @@ suite('obj-model', function () {
     var el;
     var objAsset = document.createElement('a-asset-item');
     var mtlAsset = document.createElement('a-asset-item');
-
     mtlAsset.setAttribute('id', 'mtl');
     mtlAsset.setAttribute('src', '/base/tests/assets/crate/crate.mtl');
     objAsset.setAttribute('id', 'obj');
     objAsset.setAttribute('src', '/base/tests/assets/crate/crate.obj');
-
     el = this.el = entityFactory({assets: [mtlAsset, objAsset]});
-    el.setAttribute('obj-model', 'obj: #obj');
+    if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {
       done();
     });
@@ -57,8 +55,10 @@ suite('obj-model', function () {
       done();
     });
 
+    el2.addEventListener('loaded', function () {
+      el.setAttribute('obj-model', {obj: '#obj'});
+      el2.setAttribute('obj-model', {obj: '#obj'});
+    });
     el.sceneEl.appendChild(el2);
-    el.setAttribute('obj-model', {obj: '#obj'});
-    el2.setAttribute('obj-model', {obj: '#obj'});
   });
 });

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -6,10 +6,10 @@ suite('raycaster', function () {
     var parentEl = this.parentEl = entityFactory();
     var el = this.el = document.createElement('a-entity');
     el.setAttribute('raycaster', '');
-    parentEl.appendChild(el);
     parentEl.addEventListener('loaded', function () {
       done();
     });
+    parentEl.appendChild(el);
   });
 
   suite('init', function () {

--- a/tests/components/scene/canvas.test.js
+++ b/tests/components/scene/canvas.test.js
@@ -2,11 +2,14 @@
 'use strict';
 
 suite('canvas', function () {
-  test('adds canvas to a-scene element', function () {
+  test('adds canvas to a-scene element', function (done) {
     var el = document.createElement('a-scene');
-    el.setAttribute('canvas', '');
     document.body.appendChild(el);
-    assert.ok(el.querySelector('canvas'));
+    el.addEventListener('loaded', function () {
+      el.setAttribute('canvas', '');
+      assert.ok(el.querySelector('canvas'));
+      done();
+    });
   });
 
   test('can take a selector to existing canvas', function (done) {
@@ -15,9 +18,8 @@ suite('canvas', function () {
 
     canvas.setAttribute('id', 'canvas');
     document.body.appendChild(canvas);
-
-    el.setAttribute('canvas', 'canvas: #canvas');
     document.body.appendChild(el);
+    el.setAttribute('canvas', 'canvas: #canvas');
 
     el.addEventListener('loaded', function () {
       assert.equal(el.canvas, canvas);

--- a/tests/components/scene/fog.test.js
+++ b/tests/components/scene/fog.test.js
@@ -10,7 +10,7 @@ suite('fog', function () {
     this.updateMaterialsSpy = this.sinon.spy(el.systems.material, 'updateMaterials');
 
     // Stub scene load to avoid WebGL code.
-    el.load();
+    el.hasLoaded = true;
     el.setAttribute('fog', '');
   });
 
@@ -53,7 +53,7 @@ suite('fog', function () {
     test('can remove and add linear fog', function () {
       var el = this.el;
       el.removeAttribute('fog');
-      el.setAttribute('fog');
+      el.setAttribute('fog', '');
     });
   });
 

--- a/tests/components/scene/vr-mode-ui.test.js
+++ b/tests/components/scene/vr-mode-ui.test.js
@@ -6,12 +6,12 @@ var UI_CLASSES = ['.a-orientation-modal', '.a-enter-vr-button', '.a-enter-vr-mod
 suite('vr-mode-ui', function () {
   'use strict';
 
-  setup(function () {
+  setup(function (done) {
     this.entityEl = entityFactory();
     var el = this.el = this.entityEl.parentNode;
     el.setAttribute('vr-mode-ui', '');
     el.stereoRenderer = { setFullScreen: function () {} };
-    el.load();
+    el.addEventListener('loaded', function () { done(); });
   });
 
   test('appends UI', function () {

--- a/tests/components/sound.test.js
+++ b/tests/components/sound.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test */
+/* global assert, process, sinon, setup, suite, test */
 var entityFactory = require('../helpers').entityFactory;
 var Sound = require('components/sound').Component;
 
@@ -52,28 +52,26 @@ suite('sound', function () {
   suite('pause', function () {
     test('does not call sound pause if not playing', function () {
       var el = this.el;
-      var pauseStub = this.sinon.stub(el.components.sound.sound, 'pause');
-      el.components.sound.sound = {
-        disconnect: pauseStub,
-        pause: pauseStub,
+      var sound = el.components.sound.sound = {
+        disconnect: sinon.stub(),
+        pause: sinon.stub(),
         isPlaying: false,
         source: {buffer: true}
       };
       el.pause();
-      assert.notOk(pauseStub.called);
+      assert.notOk(sound.pause.called);
     });
 
     test('calls sound pause if playing', function () {
       var el = this.el;
-      var pauseStub = this.sinon.stub(el.components.sound.sound, 'pause');
-      el.components.sound.sound = {
-        disconnect: pauseStub,
-        pause: pauseStub,
+      var sound = el.components.sound.sound = {
+        disconnect: sinon.stub(),
+        pause: sinon.stub(),
         isPlaying: true,
         source: {buffer: true}
       };
       el.pause();
-      assert.ok(pauseStub.called);
+      assert.ok(sound.pause.called);
     });
   });
 });

--- a/tests/core/a-animation.test.js
+++ b/tests/core/a-animation.test.js
@@ -324,8 +324,8 @@ suite('a-animation', function () {
       var el = helpers.entityFactory();
       animationEl.setAttribute('begin', '1');
       el.appendChild(animationEl);
-      el.play();
-      process.nextTick(function () {
+      animationEl.addEventListener('loaded', function () {
+        el.play();
         assert.ok(animationEl.isRunning);
         done();
       });

--- a/tests/core/a-mixin.test.js
+++ b/tests/core/a-mixin.test.js
@@ -1,0 +1,20 @@
+/* global assert, suite, test */
+
+suite('a-mixin', function () {
+  suite('cacheAttributes', function () {
+    test('cache component attributes', function () {
+      var mixinEl = document.createElement('a-mixin');
+      mixinEl.setAttribute('material', 'color: red');
+      mixinEl.cacheAttributes();
+      assert.shallowDeepEqual(mixinEl.componentAttrCache.material, { color: 'red' });
+    });
+
+    test('does not cache non component attributes', function () {
+      var mixinEl = document.createElement('a-mixin');
+      mixinEl.setAttribute('test', 'src: url(www.mozilla.com)');
+      mixinEl.cacheAttributes();
+      assert.equal(mixinEl.componentAttrCache.test, undefined);
+    });
+  });
+});
+

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -14,8 +14,7 @@ var AScene = require('core/scene/a-scene');
  */
 suite('a-scene (without renderer)', function () {
   setup(function () {
-    var el;
-    el = this.el = document.createElement('a-scene');
+    var el = this.el = document.createElement('a-scene');
     document.body.appendChild(el);
   });
 
@@ -35,7 +34,7 @@ suite('a-scene (without renderer)', function () {
       sceneEl.isPlaying = false;
       sceneEl.hasLoaded = true;
       sceneEl.init();
-      assert.equal(sceneEl.isPlaying, true);
+      assert.equal(sceneEl.isPlaying, false);
       assert.equal(sceneEl.hasLoaded, false);
     });
   });

--- a/tests/extras/primitives/primitives/a-camera.test.js
+++ b/tests/extras/primitives/primitives/a-camera.test.js
@@ -6,7 +6,7 @@ suite('a-camera', function () {
     scene.appendChild(camera);
     document.body.appendChild(scene);
 
-    process.nextTick(function () {
+    camera.addEventListener('loaded', function () {
       assert.ok(camera.getComputedAttribute('camera').active);
       done();
     });

--- a/tests/extras/primitives/registerPrimitive.test.js
+++ b/tests/extras/primitives/registerPrimitive.test.js
@@ -34,18 +34,13 @@ suite('registerPrimitive', function () {
   });
 
   test('merges defined components with default components', function (done) {
-    var entity = helpers.entityFactory();
-    var tagName = 'a-test-' + primitiveId++;
-    registerPrimitive(tagName, {
+    primitiveFactory({
       defaultAttributes: {
         material: {color: '#FFF', metalness: 0.63}
       }
-    });
-
-    // Use innerHTML to set everything at once.
-    entity.innerHTML = '<' + tagName + ' material="color: tomato"></' + tagName + '>';
-    entity.addEventListener('loaded', function () {
-      var material = entity.children[0].getAttribute('material');
+    }, function (el) {
+      el.setAttribute('material', 'color', 'tomato');
+      var material = el.getAttribute('material');
       assert.equal(material.color, 'tomato');
       assert.equal(material.metalness, 0.63);
       done();
@@ -64,10 +59,9 @@ suite('registerPrimitive', function () {
         color: 'material.color'
       }
     });
-
     // Use innerHTML to set everything at once.
     entity.innerHTML = '<' + tag + ' color="red" material="fog: false"></' + tag + '>';
-    entity.addEventListener('loaded', function () {
+    entity.children[0].addEventListener('loaded', function () {
       var material = entity.children[0].getAttribute('material');
       assert.equal(material.color, 'red');
       assert.equal(material.fog, 'false');

--- a/tests/systems/camera.test.js
+++ b/tests/systems/camera.test.js
@@ -4,6 +4,7 @@ var entityFactory = require('../helpers').entityFactory;
 suite('camera system', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
+    if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {
       done();
     });
@@ -24,10 +25,9 @@ suite('camera system', function () {
       sceneEl.appendChild(camera1El);
       camera2El.setAttribute('camera', 'active: true');
       sceneEl.appendChild(camera2El);
-      process.nextTick(function () {
+      camera2El.addEventListener('loaded', function () {
         assert.notOk(camera1El.getAttribute('camera').active);
-        sceneEl.systems.camera.setActiveCamera(camera1El, camera1El.components.camera.camera);
-        assert.ok(camera1El.getAttribute('camera').active);
+        sceneEl.systems.camera.setActiveCamera(camera1El);
         assert.notOk(camera2El.getAttribute('camera').active);
         done();
       });
@@ -43,7 +43,7 @@ suite('camera system', function () {
       camera2El.setAttribute('camera', 'active: false');
       sceneEl.appendChild(camera2El);
 
-      process.nextTick(function () {
+      camera2El.addEventListener('loaded', function () {
         cameraEl.setAttribute('camera', 'active: true');
         camera2El.setAttribute('camera', 'active: true');
         assert.notOk(cameraEl.getAttribute('camera').active);
@@ -58,10 +58,10 @@ suite('camera system', function () {
       var sceneEl = this.el.sceneEl;
       cameraEl2.setAttribute('camera', 'active: true');
       process.nextTick(function () {
-        assert.ok(sceneEl.querySelector('[data-aframe-default-camera]'));
         sceneEl.appendChild(cameraEl2);
         // Need to setTimeout to wait for scene to remove element.
-        setTimeout(function () {
+        cameraEl2.addEventListener('loaded', function () {
+          assert.equal(cameraEl2.components.camera.camera, sceneEl.camera);
           assert.notOk(sceneEl.querySelector('[data-aframe-default-camera]'));
           done();
         });

--- a/tests/systems/light.test.js
+++ b/tests/systems/light.test.js
@@ -9,11 +9,12 @@ suite('light system', function () {
     });
   });
 
-  test('adds default lights to scene', function (done) {
+  test('adds default lights to scene', function () {
     var el = this.el;
     var sceneEl = el.sceneEl;
     var i;
     var lights = sceneEl.querySelectorAll('[light]');
+    var lightsNum = 0;
 
     // Remove lights to re-test.
     for (i = 0; i < lights.length; ++i) {
@@ -22,10 +23,13 @@ suite('light system', function () {
     assert.notOk(document.querySelectorAll('[light]').length);
 
     sceneEl.systems.light.setupDefaultLights();
-    process.nextTick(function () {
-      assert.ok(document.querySelectorAll('[light]').length);
-      done();
-    });
+    lights = sceneEl.querySelectorAll('a-entity');
+    // Remove lights to re-test.
+    for (i = 0; i < lights.length; ++i) {
+      if (!lights[i].components.light) { continue; }
+      lightsNum += 1;
+    }
+    assert.equal(lightsNum, 2);
   });
 
   test('removes default lights when more lights are added', function (done) {


### PR DESCRIPTION
Attributes updates is the most common operation in a-frame scenes. I've been looking for performance bottlenecks on setAttribute/getAttribute calls. Using the DOM to store the current state of the component incurs in a lot of component data stringifications (to feed the DOM attribute via HTMLElement.prototype.setAttribute) and parse calls to recalculate the component data from the attribute string or when getAttribute is called by the application logic. By caching the parsed attribute corresponding to the component we can save a lot of stringify/parse calls. The overhead is specially noticeable on scenes with a lot of dynamic behavior. I've added a stress test to illustrate the problem and show the performance gains. In the ```stress-animation``` demo I create a lot of elements with animations that will call ```setAttribute``` continuously. On my machine and without the patch the example runs in the lows-mids 20s FPS. With this patch applied it goes up to the lows-mids 30s FPS. That's approximately a 50% perf gain.