### PR TITLE
default to BufferGeometry for all geometries (fixes #633)

### DIFF
--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -12,6 +12,7 @@ var error = utils.debug('components:geometry:error');
  */
 module.exports.Component = registerComponent('geometry', {
   schema: {
+    buffer: {default: true},
     primitive: {default: ''},
     translate: {type: 'vec3'}
   },
@@ -29,7 +30,7 @@ module.exports.Component = registerComponent('geometry', {
     var translateNeedsUpdate = !utils.deepEqual(data.translate, currentTranslate);
 
     if (geometryNeedsUpdate) { this.setGeometry(); }
-    if (translateNeedsUpdate) {
+    if (translateNeedsUpdate && !data.buffer) {
       applyTranslate(this.el.getObject3D('mesh').geometry, data.translate, currentTranslate);
     }
   },
@@ -46,6 +47,7 @@ module.exports.Component = registerComponent('geometry', {
    * Create geometry and set on mesh.
    */
   setGeometry: function () {
+    var bufferGeometry;
     var data = this.data;
     var mesh = this.el.getOrCreateObject3D('mesh', THREE.Mesh);
     var geometryInstance;
@@ -59,6 +61,13 @@ module.exports.Component = registerComponent('geometry', {
     geometryInstance.el = this.el;
     geometryInstance.init(data);
     this.geometry = geometryInstance.geometry;
+
+    // Transform to BufferGeometry if specified.
+    if (data.buffer) {
+      bufferGeometry = new THREE.BufferGeometry().fromGeometry(this.geometry);
+      this.geometry.dispose();
+      this.geometry = bufferGeometry;
+    }
 
     // Dispose and set.
     if (mesh.geometry) { mesh.geometry.dispose(); }

--- a/src/geometries/plane.js
+++ b/src/geometries/plane.js
@@ -8,6 +8,6 @@ registerGeometry('plane', {
   },
 
   init: function (data) {
-    this.geometry = new THREE.PlaneBufferGeometry(data.width, data.height);
+    this.geometry = new THREE.PlaneGeometry(data.width, data.height);
   }
 });

--- a/src/geometries/sphere.js
+++ b/src/geometries/sphere.js
@@ -16,7 +16,7 @@ registerGeometry('sphere', {
   },
 
   init: function (data) {
-    this.geometry = new THREE.SphereBufferGeometry(
+    this.geometry = new THREE.SphereGeometry(
       data.radius, data.segmentsWidth, data.segmentsHeight, degToRad(data.phiStart),
       degToRad(data.phiLength), degToRad(data.thetaStart), degToRad(data.thetaLength));
   }

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -2,10 +2,14 @@
 var helpers = require('../helpers');
 var degToRad = require('index').THREE.Math.degToRad;
 
+/**
+ * Most geometry tests will disable BufferGeometries in order to assert on geometry types and
+ * parameters. That info is mostly lost when converting a Geometry to a BufferGeometry.
+ */
 suite('geometry', function () {
   setup(function (done) {
     var el = this.el = helpers.entityFactory();
-    el.setAttribute('geometry', 'primitive: box');
+    el.setAttribute('geometry', 'buffer: false; primitive: box');
     el.addEventListener('loaded', function () {
       done();
     });
@@ -20,24 +24,24 @@ suite('geometry', function () {
 
     test('updates geometry', function () {
       var mesh = this.el.getObject3D('mesh');
-      this.el.setAttribute('geometry', 'primitive: box; width: 5');
+      this.el.setAttribute('geometry', 'buffer: false; primitive: box; width: 5');
       assert.equal(mesh.geometry.parameters.width, 5);
     });
 
     test('updates geometry for segment-related attribute', function () {
       var el = this.el;
       var mesh = el.getObject3D('mesh');
-      el.setAttribute('geometry', 'primitive: sphere');
-      el.setAttribute('geometry', 'primitive: sphere; segmentsWidth: 8');
+      el.setAttribute('geometry', 'buffer: false; primitive: sphere');
+      el.setAttribute('geometry', 'buffer: false; primitive: sphere; segmentsWidth: 8');
       assert.equal(mesh.geometry.parameters.widthSegments, 8);
     });
 
     test('can change type of geometry', function () {
       var el = this.el;
       var mesh = el.getObject3D('mesh');
-      el.setAttribute('geometry', 'primitive: sphere');
-      assert.equal(mesh.geometry.type, 'SphereBufferGeometry');
-      el.setAttribute('geometry', 'primitive: box');
+      el.setAttribute('geometry', 'buffer: false; primitive: sphere');
+      assert.equal(mesh.geometry.type, 'SphereGeometry');
+      el.setAttribute('geometry', 'buffer: false; primitive: box');
       assert.equal(mesh.geometry.type, 'BoxGeometry');
     });
 
@@ -75,6 +79,7 @@ suite('geometry', function () {
 
     setup(function () {
       this.el.setAttribute('geometry', {
+        buffer: false,
         primitive: 'box',
         depth: 1,
         height: 1,
@@ -109,6 +114,7 @@ suite('geometry', function () {
       var el = this.el;
       el.setAttribute('geometry', 'translate', '-2 4 2');
       this.el.setAttribute('geometry', {
+        buffer: false,
         primitive: 'box',
         depth: 1,
         height: 1,
@@ -122,6 +128,15 @@ suite('geometry', function () {
       var uuid = el.getObject3D('mesh').geometry.uuid;
       el.setAttribute('geometry', 'translate', '-2 4 2');
       assert.equal(el.getObject3D('mesh').geometry.uuid, uuid);
+    });
+  });
+
+  suite('buffer', function () {
+    test('uses BufferGeometry', function () {
+      var el = this.el;
+      assert.notEqual(el.getObject3D('mesh').geometry.type, 'BufferGeometry');
+      el.setAttribute('geometry', 'buffer', true);
+      assert.equal(el.getObject3D('mesh').geometry.type, 'BufferGeometry');
     });
   });
 });
@@ -139,7 +154,8 @@ suite('standard geometries', function () {
     var el = this.el;
     var geometry;
     el.setAttribute('geometry', {
-      primitive: 'circle', radius: 5, segments: 4, thetaStart: 0, thetaLength: 350
+      buffer: false, primitive: 'circle', radius: 5, segments: 4, thetaStart: 0,
+      thetaLength: 350
     });
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'CircleGeometry');
@@ -153,7 +169,7 @@ suite('standard geometries', function () {
     var el = this.el;
     var geometry;
     el.setAttribute('geometry', {
-      primitive: 'cylinder', radius: 1, height: 2, segmentsRadial: 3,
+      buffer: false, primitive: 'cylinder', radius: 1, height: 2, segmentsRadial: 3,
       segmentsHeight: 4, openEnded: true, thetaStart: 240, thetaLength: 350
     });
     geometry = el.getObject3D('mesh').geometry;
@@ -172,8 +188,8 @@ suite('standard geometries', function () {
     var el = this.el;
     var geometry;
     el.setAttribute('geometry', {
-      primitive: 'cone', radiusTop: 1, radiusBottom: 5, height: 2, segmentsRadial: 3,
-      segmentsHeight: 4, openEnded: true, thetaStart: 240, thetaLength: 350
+      buffer: false, primitive: 'cone', radiusTop: 1, radiusBottom: 5, height: 2,
+      segmentsRadial: 3, segmentsHeight: 4, openEnded: true, thetaStart: 240, thetaLength: 350
     });
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'CylinderGeometry');
@@ -189,9 +205,9 @@ suite('standard geometries', function () {
   test('plane', function () {
     var el = this.el;
     var geometry;
-    el.setAttribute('geometry', { primitive: 'plane', width: 1, height: 2 });
+    el.setAttribute('geometry', {buffer: false, primitive: 'plane', width: 1, height: 2});
     geometry = el.getObject3D('mesh').geometry;
-    assert.equal(geometry.type, 'PlaneBufferGeometry');
+    assert.equal(geometry.type, 'PlaneGeometry');
     assert.equal(geometry.parameters.width, 1);
     assert.equal(geometry.parameters.height, 2);
   });
@@ -200,7 +216,7 @@ suite('standard geometries', function () {
     var el = this.el;
     var geometry;
     el.setAttribute('geometry', {
-      primitive: 'ring', radiusInner: 1, radiusOuter: 2, segmentsTheta: 3});
+      buffer: false, primitive: 'ring', radiusInner: 1, radiusOuter: 2, segmentsTheta: 3});
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'RingGeometry');
     assert.equal(geometry.parameters.innerRadius, 1);
@@ -212,11 +228,11 @@ suite('standard geometries', function () {
     var el = this.el;
     var geometry;
     el.setAttribute('geometry', {
-      primitive: 'sphere', radius: 1, segmentsWidth: 2, segmentsHeight: 3,
+      buffer: false, primitive: 'sphere', radius: 1, segmentsWidth: 2, segmentsHeight: 3,
       phiStart: 45, phiLength: 90, thetaStart: 45
     });
     geometry = el.getObject3D('mesh').geometry;
-    assert.equal(geometry.type, 'SphereBufferGeometry');
+    assert.equal(geometry.type, 'SphereGeometry');
     assert.equal(geometry.parameters.radius, 1);
     assert.equal(geometry.parameters.widthSegments, 2);
     assert.equal(geometry.parameters.heightSegments, 3);
@@ -230,8 +246,8 @@ suite('standard geometries', function () {
     var el = this.el;
     var geometry;
     el.setAttribute('geometry', {
-      primitive: 'torus', radius: 1, radiusTubular: 2, segmentsRadial: 3, segmentsTubular: 4,
-      arc: 350
+      buffer: false, primitive: 'torus', radius: 1, radiusTubular: 2, segmentsRadial: 3,
+      segmentsTubular: 4, arc: 350
     });
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'TorusGeometry');
@@ -246,7 +262,7 @@ suite('standard geometries', function () {
     var el = this.el;
     var geometry;
     el.setAttribute('geometry', {
-      primitive: 'torusKnot', radius: 1, radiusTubular: 2, segmentsRadial: 3,
+      buffer: false, primitive: 'torusKnot', radius: 1, radiusTubular: 2, segmentsRadial: 3,
       segmentsTubular: 4, p: 5, q: 6
     });
     geometry = el.getObject3D('mesh').geometry;


### PR DESCRIPTION
**Description:**

http://threejs.org/docs/#Reference/Core/BufferGeometry

```
This class is an efficient alternative to Geometry, because it stores all data, including vertex positions, face indices, normals, colors, UVs, and custom attributes within buffers; this reduces the cost of passing all this data to the GPU. This also makes BufferGeometry harder to work with than Geometry; rather than accessing position data as Vector3 objects, color data as Color objects, and so on, you have to access the raw data from the appropriate attribute buffer. This makes BufferGeometry best-suited for static objects where you don't need to manipulate the geometry much after instantiating it. 
```

**Changes proposed:**
- Default to use BufferGeometry for all geometries using `BufferGeometry.fromGeometry`.
- Have tests not use BufferGeometry to be able to assert geometry type/parameters.
- [ ] replace geometry.translate with a separate `pivot/translate` component, place it in `extras/` since geometry.translate does not work with buffer geometries.
