### PR TITLE
geometry caching system (fixes #1306)

### DIFF
--- a/docs/components/geometry.md
+++ b/docs/components/geometry.md
@@ -12,10 +12,11 @@ The geometry component provides a basic shape for an entity. The general geometr
 
 We will go through the basic primitives and their respective properties one by one.
 
-| Property  | Description                                                                                  | Default Value |
-|-----------|----------------------------------------------------------------------------------------------|---------------|
-| primitive | One of `box`, `circle`, `cone`, `cylinder`, `plane`, `ring`, `sphere`, `torus`, `torusKnot`. | None          |
-| translate | Translates the geometry relative to its pivot point.                                         | 0 0 0         |
+| Property  | Description                                                                                                      | Default Value |
+|-----------|------------------------------------------------------------------------------------------------------------------|---------------|
+| buffer    | Transform geometry into a BufferGeometry to reduce memory usage at the cost of being harder to manipulate.       | true          |
+| primitive | One of `box`, `circle`, `cone`, `cylinder`, `plane`, `ring`, `sphere`, `torus`, `torusKnot`.                     | None          |
+| skipCache | Disable retrieving the shared geometry object from the cache.                                                    | false         |
 
 ### Box
 

--- a/examples/test-geometry-gallery/index.html
+++ b/examples/test-geometry-gallery/index.html
@@ -14,7 +14,7 @@
                  geometry="primitive: box; depth: .125; height: .125;
                            width: .125"></a-mixin>
         <a-mixin id="circle"
-                 geometry="primitive: circle; openEnded: true; radius: .2;
+                 geometry="primitive: circle; radius: .2;
                            segments: 100; thetaStart: 0; thetaLength: 350">
         </a-mixin>
         <a-mixin id="cylinder"
@@ -23,13 +23,13 @@
                            openEnded: true; thetaStart: 0; thetaLength: 350">
         </a-mixin>
         <a-mixin id="ring"
-                  geometry="primitive: ring; radiusInner: .3; openEnded: true; radiusOuter: .5;
+                  geometry="primitive: ring; radiusInner: .3; radiusOuter: .5;
                             segmentsTheta: 50"></a-mixin>
         <a-mixin id="sphere"
                   geometry="primitive: sphere; radius: .1"></a-mixin>
         <a-mixin id="torus"
                   geometry="primitive: torus; arc: 720; radius: .3; radiusTubular: .05;
-                            segments: 32; segmentsTubular: 10;"></a-mixin>
+                            segmentsTubular: 10;"></a-mixin>
         <a-mixin id="torus-knot"
                   geometry="primitive: torusKnot; p: 3; q: 7; radius: .25;
                             segmentsRadial: 10; radiusTubular: .07; segmentsTubular: 32">

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -1,10 +1,8 @@
 var geometries = require('../core/geometry').geometries;
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
-var utils = require('../utils');
 
-var helperMatrix = new THREE.Matrix4();
-var error = utils.debug('components:geometry:error');
+var dummyGeometry = new THREE.Geometry();
 
 /**
  * Geometry component. Combined with material component to make a mesh in 3D object.
@@ -14,64 +12,39 @@ module.exports.Component = registerComponent('geometry', {
   schema: {
     buffer: {default: true},
     primitive: {default: ''},
-    translate: {type: 'vec3'}
+    skipCache: {default: false}
+  },
+
+  init: function () {
+    this.geometry = null;
   },
 
   /**
-   * Creates a new geometry on every update as there's not an easy way to
-   * update a geometry that would be faster than just creating a new one.
+   * Talk to geometry system to get or create geometry.
    */
   update: function (previousData) {
-    previousData = previousData || {};
-    var data = this.data;
-    var currentTranslate = previousData.translate || this.schema.translate.default;
-    var diff = utils.diff(previousData, data);
-    var geometryNeedsUpdate = !(Object.keys(diff).length === 1 && 'translate' in diff);
-    var translateNeedsUpdate = !utils.deepEqual(data.translate, currentTranslate);
-
-    if (geometryNeedsUpdate) { this.setGeometry(); }
-    if (translateNeedsUpdate && !data.buffer) {
-      applyTranslate(this.el.getObject3D('mesh').geometry, data.translate, currentTranslate);
-    }
-  },
-
-  /**
-   * Removes geometry on remove (callback).
-   */
-  remove: function () {
-    this.el.getObject3D('mesh').geometry.dispose();
-    this.el.getObject3D('mesh').geometry = new THREE.Geometry();
-  },
-
-  /**
-   * Create geometry and set on mesh.
-   */
-  setGeometry: function () {
-    var bufferGeometry;
     var data = this.data;
     var mesh = this.el.getOrCreateObject3D('mesh', THREE.Mesh);
-    var geometryInstance;
-    var geometryType = data.primitive;
-    var GeometryClass = geometries[geometryType] && geometries[geometryType].Geometry;
+    var system = this.system;
 
-    if (!GeometryClass) { throw new Error('Unknown geometry `' + geometryType + '`'); }
-
-    // Create geometry instance. Set it up. Have it create the geometry.
-    geometryInstance = new GeometryClass();
-    geometryInstance.el = this.el;
-    geometryInstance.init(data);
-    this.geometry = geometryInstance.geometry;
-
-    // Transform to BufferGeometry if specified.
-    if (data.buffer) {
-      bufferGeometry = new THREE.BufferGeometry().fromGeometry(this.geometry);
-      this.geometry.dispose();
-      this.geometry = bufferGeometry;
+    // Dispose old geometry if we created one.
+    if (this.geometry) {
+      system.unuseGeometry(previousData);
+      this.geometry = null;
     }
 
-    // Dispose and set.
-    if (mesh.geometry) { mesh.geometry.dispose(); }
-    mesh.geometry = this.geometry;
+    // Create new geometry.
+    this.geometry = mesh.geometry = system.getOrCreateGeometry(data);
+  },
+
+  /**
+   * Tell geometry system that entity is no longer using the geometry.
+   * Unset the geometry on the mesh
+   */
+  remove: function () {
+    this.system.unuseGeometry(this.data);
+    this.el.getObject3D('mesh').geometry = dummyGeometry;
+    this.geometry = null;
   },
 
   /**
@@ -85,27 +58,10 @@ module.exports.Component = registerComponent('geometry', {
     var schema = geometries[newGeometryType] && geometries[newGeometryType].schema;
 
     // Geometry has no schema.
-    if (!schema) { error('Unknown geometry schema `' + newGeometryType + '`'); }
+    if (!schema) { throw new Error('Unknown geometry schema `' + newGeometryType + '`'); }
     // Nothing has changed.
     if (currentGeometryType && currentGeometryType === newGeometryType) { return; }
 
     this.extendSchema(schema);
   }
 });
-
-/**
- * Translates geometry vertices.
- *
- * @param {object} geometry - three.js geometry.
- * @param {object} translate - New translation.
- * @param {object} currentTranslate - Currently applied translation.
- */
-function applyTranslate (geometry, translate, currentTranslate) {
-  var translation = helperMatrix.makeTranslation(
-    translate.x - currentTranslate.x,
-    translate.y - currentTranslate.y,
-    translate.z - currentTranslate.z
-  );
-  geometry.applyMatrix(translation);
-  geometry.verticesNeedsUpdate = true;
-}

--- a/src/systems/geometry.js
+++ b/src/systems/geometry.js
@@ -1,0 +1,133 @@
+var geometries = require('../core/geometry').geometries;
+var registerSystem = require('../core/system').registerSystem;
+var THREE = require('../lib/three');
+
+/**
+ * System for geometry component.
+ * Handle geometry caching.
+ *
+ * @member {object} cache - Mapping of stringified component data to THREE.Geometry objects.
+ * @member {object} cacheCount - Keep track of number of entities using a geometry to
+ *         know whether to dispose on removal.
+ */
+module.exports.System = registerSystem('geometry', {
+  init: function () {
+    this.cache = {};
+    this.cacheCount = {};
+  },
+
+  /**
+   * Reset cache. Mainly for testing.
+   */
+  clearCache: function () {
+    this.cache = {};
+    this.cacheCount = {};
+  },
+
+  /**
+   * Attempt to retrieve from cache.
+   *
+   * @returns {Object|null} A geometry if it exists, else null.
+   */
+  getOrCreateGeometry: function (data) {
+    var cache = this.cache;
+    var cachedGeometry;
+    var hash;
+
+    // Skip all caching logic.
+    if (data.skipCache) { return createGeometry(data); }
+
+    // Try to retrieve from cache first.
+    hash = this.hash(data);
+    cachedGeometry = cache[hash];
+    incrementCacheCount(this.cacheCount, hash);
+
+    if (cachedGeometry) { return cachedGeometry; }
+
+    // Create geometry.
+    cachedGeometry = createGeometry(data);
+
+    // Cache and return geometry.
+    cache[hash] = cachedGeometry;
+    return cachedGeometry;
+  },
+
+  /**
+   * Let system know that an entity is no longer using a geometry.
+   */
+  unuseGeometry: function (data) {
+    var cache = this.cache;
+    var cacheCount = this.cacheCount;
+    var geometry;
+    var hash = this.hash(data);
+
+    if (!cache[hash] || data.skipCache) { return; }
+
+    decrementCacheCount(cacheCount, hash);
+
+    // Another entity is still using this geometry. No need to do anything.
+    if (cacheCount[hash] > 0) { return; }
+
+    // No more entities are using this geometry. Dispose.
+    geometry = cache[hash];
+    geometry.dispose();
+    delete cache[hash];
+    delete cacheCount[hash];
+  },
+
+  /**
+   * Use JSON.stringify to turn component data into hash.
+   * Should be deterministic within a single browser engine.
+   * If not, then look into json-stable-stringify.
+   */
+  hash: function (data) {
+    return JSON.stringify(data);
+  }
+});
+
+/**
+ * Create geometry using component data.
+ *
+ * @param {object} data - Component data.
+ * @returns {object} Geometry.
+ */
+function createGeometry (data) {
+  var geometryType = data.primitive;
+  var GeometryClass = geometries[geometryType] && geometries[geometryType].Geometry;
+  var geometryInstance = new GeometryClass();
+
+  if (!GeometryClass) { throw new Error('Unknown geometry `' + geometryType + '`'); }
+
+  geometryInstance.init(data);
+  return toBufferGeometry(geometryInstance.geometry, data.buffer);
+}
+
+/**
+ * Decreate count of entity using a geometry.
+ */
+function decrementCacheCount (cacheCount, hash) {
+  cacheCount[hash]--;
+}
+
+/**
+ * Increase count of entity using a geometry.
+ */
+function incrementCacheCount (cacheCount, hash) {
+  cacheCount[hash] = cacheCount[hash] === undefined ? 1 : cacheCount[hash] + 1;
+}
+
+/**
+ * Transform geometry to BufferGeometry if `doBuffer`.
+ *
+ * @param {object} geometry
+ * @param {boolean} doBuffer
+ * @returns {object} Geometry.
+ */
+function toBufferGeometry (geometry, doBuffer) {
+  var bufferGeometry;
+  if (!doBuffer) { return geometry; }
+
+  bufferGeometry = new THREE.BufferGeometry().fromGeometry(geometry);
+  geometry.dispose();  // Dispose no longer needed non-buffer geometry.
+  return bufferGeometry;
+}

--- a/src/systems/index.js
+++ b/src/systems/index.js
@@ -1,3 +1,4 @@
 require('./camera');
+require('./geometry');
 require('./material');
 require('./light');

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -70,67 +70,6 @@ suite('geometry', function () {
     });
   });
 
-  suite('translate', function () {
-    var DEFAULT_VERTICES = [
-      {x: 0.5, y: 0.5, z: 0.5}, {x: 0.5, y: 0.5, z: -0.5}, {x: 0.5, y: -0.5, z: 0.5},
-      {x: 0.5, y: -0.5, z: -0.5}, {x: -0.5, y: 0.5, z: -0.5}, {x: -0.5, y: 0.5, z: 0.5},
-      {x: -0.5, y: -0.5, z: -0.5}, {x: -0.5, y: -0.5, z: 0.5}
-    ];
-
-    setup(function () {
-      this.el.setAttribute('geometry', {
-        buffer: false,
-        primitive: 'box',
-        depth: 1,
-        height: 1,
-        width: 1
-      });
-    });
-
-    test('defaults translate to center', function () {
-      assert.shallowDeepEqual(this.el.getObject3D('mesh').geometry.vertices, DEFAULT_VERTICES);
-    });
-
-    test('can set translate', function () {
-      var el = this.el;
-      el.setAttribute('geometry', 'translate', '-2 4 2');
-      assert.shallowDeepEqual(el.getObject3D('mesh').geometry.vertices, [
-        {x: -1.5, y: 4.5, z: 2.5}, {x: -1.5, y: 4.5, z: 1.5}, {x: -1.5, y: 3.5, z: 2.5},
-        {x: -1.5, y: 3.5, z: 1.5}, {x: -2.5, y: 4.5, z: 1.5}, {x: -2.5, y: 4.5, z: 2.5},
-        {x: -2.5, y: 3.5, z: 1.5}, {x: -2.5, y: 3.5, z: 2.5}]);
-    });
-
-    test('can update translate', function (done) {
-      var el = this.el;
-      el.setAttribute('geometry', 'translate', '-2 4 2');
-      el.setAttribute('geometry', 'translate', '0 0 0');
-      setTimeout(function () {
-        assert.shallowDeepEqual(el.getObject3D('mesh').geometry.vertices, DEFAULT_VERTICES);
-        done();
-      });
-    });
-
-    test('can remove translate', function () {
-      var el = this.el;
-      el.setAttribute('geometry', 'translate', '-2 4 2');
-      this.el.setAttribute('geometry', {
-        buffer: false,
-        primitive: 'box',
-        depth: 1,
-        height: 1,
-        width: 1
-      });
-      assert.shallowDeepEqual(el.getObject3D('mesh').geometry.vertices, DEFAULT_VERTICES);
-    });
-
-    test('does not recreate geometry when just translating', function () {
-      var el = this.el;
-      var uuid = el.getObject3D('mesh').geometry.uuid;
-      el.setAttribute('geometry', 'translate', '-2 4 2');
-      assert.equal(el.getObject3D('mesh').geometry.uuid, uuid);
-    });
-  });
-
   suite('buffer', function () {
     test('uses BufferGeometry', function () {
       var el = this.el;
@@ -157,6 +96,7 @@ suite('standard geometries', function () {
       buffer: false, primitive: 'circle', radius: 5, segments: 4, thetaStart: 0,
       thetaLength: 350
     });
+
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'CircleGeometry');
     assert.equal(geometry.parameters.radius, 5);
@@ -172,6 +112,7 @@ suite('standard geometries', function () {
       buffer: false, primitive: 'cylinder', radius: 1, height: 2, segmentsRadial: 3,
       segmentsHeight: 4, openEnded: true, thetaStart: 240, thetaLength: 350
     });
+
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'CylinderGeometry');
     assert.equal(geometry.parameters.radiusTop, 1);
@@ -191,6 +132,7 @@ suite('standard geometries', function () {
       buffer: false, primitive: 'cone', radiusTop: 1, radiusBottom: 5, height: 2,
       segmentsRadial: 3, segmentsHeight: 4, openEnded: true, thetaStart: 240, thetaLength: 350
     });
+
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'CylinderGeometry');
     assert.equal(geometry.parameters.radiusTop, 1);
@@ -206,6 +148,7 @@ suite('standard geometries', function () {
     var el = this.el;
     var geometry;
     el.setAttribute('geometry', {buffer: false, primitive: 'plane', width: 1, height: 2});
+
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'PlaneGeometry');
     assert.equal(geometry.parameters.width, 1);
@@ -217,6 +160,7 @@ suite('standard geometries', function () {
     var geometry;
     el.setAttribute('geometry', {
       buffer: false, primitive: 'ring', radiusInner: 1, radiusOuter: 2, segmentsTheta: 3});
+
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'RingGeometry');
     assert.equal(geometry.parameters.innerRadius, 1);
@@ -231,6 +175,7 @@ suite('standard geometries', function () {
       buffer: false, primitive: 'sphere', radius: 1, segmentsWidth: 2, segmentsHeight: 3,
       phiStart: 45, phiLength: 90, thetaStart: 45
     });
+
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'SphereGeometry');
     assert.equal(geometry.parameters.radius, 1);
@@ -249,6 +194,7 @@ suite('standard geometries', function () {
       buffer: false, primitive: 'torus', radius: 1, radiusTubular: 2, segmentsRadial: 3,
       segmentsTubular: 4, arc: 350
     });
+
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'TorusGeometry');
     assert.equal(geometry.parameters.radius, 1);
@@ -265,6 +211,7 @@ suite('standard geometries', function () {
       buffer: false, primitive: 'torusKnot', radius: 1, radiusTubular: 2, segmentsRadial: 3,
       segmentsTubular: 4, p: 5, q: 6
     });
+
     geometry = el.getObject3D('mesh').geometry;
     assert.equal(geometry.type, 'TorusKnotGeometry');
     assert.equal(geometry.parameters.radius, 1);

--- a/tests/systems/geometry.test.js
+++ b/tests/systems/geometry.test.js
@@ -1,0 +1,91 @@
+/* global assert, process, setup, suite, teardown, test */
+var entityFactory = require('../helpers').entityFactory;
+
+suite('geometry system', function () {
+  setup(function (done) {
+    var el = entityFactory();
+    var self = this;
+    el.addEventListener('loaded', function () {
+      self.system = el.sceneEl.systems.geometry;
+      done();
+    });
+  });
+
+  suite('getOrCreateGeometry', function () {
+    teardown(function () {
+      this.system.clearCache();
+    });
+
+    test('sets hash on cache', function () {
+      var data = {primitive: 'box'};
+      var system = this.system;
+      var hash = system.hash(data);
+
+      assert.notOk(system.cache[hash]);
+      system.getOrCreateGeometry(data);
+      assert.ok(system.cache[hash]);
+    });
+
+    test('does not hash on cache if skipCache', function () {
+      var data = {primitive: 'box', skipCache: true};
+      var system = this.system;
+      var hash = system.hash(data);
+      system.getOrCreateGeometry({primitive: 'box'});
+      assert.notOk(system.cache[hash]);
+    });
+
+    test('caches identical geometries', function () {
+      var data = {primitive: 'box', width: 5};
+      var geometry1;
+      var geometry2;
+      var system = this.system;
+      var hash = system.hash(data);
+
+      geometry1 = system.getOrCreateGeometry(data);
+      assert.ok(geometry1);
+
+      geometry2 = system.getOrCreateGeometry(data);
+      assert.ok(geometry2);
+
+      assert.equal(geometry1, geometry2);
+      assert.equal(system.cacheCount[hash], 2);
+    });
+  });
+
+  suite('unuseGeometry', function () {
+    teardown(function () {
+      this.system.clearCache();
+    });
+
+    test('disposes geometry if no longer used', function () {
+      var data = {primitive: 'box'};
+      var system = this.system;
+      var hash = system.hash(data);
+      var sinon = this.sinon;
+
+      var geometry = system.getOrCreateGeometry(data);
+      var disposeSpy = sinon.spy(geometry, 'dispose');
+      system.unuseGeometry(data);
+
+      assert.ok(disposeSpy.called);
+      assert.notOk(system.cache[hash]);
+      assert.notOk(system.cacheCount[hash]);
+    });
+
+    test('does not dispose geometry if still used', function () {
+      var data = {primitive: 'box'};
+      var system = this.system;
+      var hash = system.hash(data);
+      var sinon = this.sinon;
+
+      var geometry = system.getOrCreateGeometry(data);
+      var disposeSpy = sinon.spy(geometry, 'dispose');
+
+      system.getOrCreateGeometry(data);
+      system.unuseGeometry(data);
+      assert.notOk(disposeSpy.called);
+      assert.ok(system.cache[hash]);
+      assert.equal(system.cacheCount[hash], 1);
+    });
+  });
+});


### PR DESCRIPTION
**Description:** 

- Uses **JSON.stringify** on component data to determine which geometry components should share geometries.

**Changes proposed:**
- Add **geometry system** that handles geometry creation, caching, and disposal
- Remove geometry.translate which is going to be removed in https://github.com/aframevr/aframe/pull/1339
- [x] docs
- [x] update tests

**Perf:** 

- In the number of entities stress test, reduced 4000 geometries to just 1.
- Reduced memory usage from 85MB to just 60MB. Previously without buffer geometries, it was at 150MB!
- Cut scene load time to 1/3 (e.g., reduced by 66%). From 6-7 seconds to 2-3 seconds.

<img width="1302" alt="screen shot 2016-04-06 at 3 23 29 pm" src="https://cloud.githubusercontent.com/assets/674727/14334838/ecb75b3e-fc0b-11e5-8f85-ae6e1c7fbb0d.png">
