### PR TITLE
enable lights uniforms, fog, textures in custom shaders

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -20,11 +20,12 @@ var shaderNames = shader.shaderNames;
  */
 module.exports.Component = registerComponent('material', {
   schema: {
-    shader: { default: 'standard', oneOf: shaderNames },
-    transparent: { default: false },
+    depthTest: { default: true },
+    fog: { default: true },
     opacity: { default: 1.0, min: 0.0, max: 1.0 },
+    shader: { default: 'standard', oneOf: shaderNames },
     side: { default: 'front', oneOf: ['front', 'back', 'double'] },
-    depthTest: { default: true }
+    transparent: { default: false }
   },
 
   init: function () {
@@ -97,6 +98,7 @@ module.exports.Component = registerComponent('material', {
   updateMaterial: function () {
     var data = this.data;
     var material = this.material;
+    material.fog = data.fog;
     material.side = parseSide(data.side);
     material.opacity = data.opacity;
     material.transparent = data.transparent !== false || data.opacity < 1.0;

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -15,6 +15,7 @@ registerPropertyType('selector', '', selectorParse, selectorStringify);
 registerPropertyType('selectorAll', '', selectorAllParse, selectorAllStringify);
 registerPropertyType('src', '', srcParse);
 registerPropertyType('string', '', defaultParse, defaultStringify);
+registerPropertyType('texture', '', srcParse);
 registerPropertyType('time', 0, intParse);
 registerPropertyType('vec2', { x: 0, y: 0 }, vecParse, coordinates.stringify);
 registerPropertyType('vec3', { x: 0, y: 0, z: 0 }, vecParse, coordinates.stringify);

--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -8,7 +8,6 @@ var utils = require('../utils/');
 module.exports.Component = registerShader('flat', {
   schema: {
     color: { type: 'color' },
-    fog: { default: true },
     height: { default: 256 },
     repeat: { default: '' },
     src: { default: '' },
@@ -80,9 +79,7 @@ module.exports.Component = registerShader('flat', {
  * @returns {object} data - Processed material data.
  */
 function getMaterialData (data) {
-  var materialData = {
-    fog: data.fog,
+  return {
     color: new THREE.Color(data.color)
   };
-  return materialData;
 }

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -12,7 +12,6 @@ module.exports.Component = registerShader('standard', {
   schema: {
     color: { type: 'color' },
     envMap: { default: '' },
-    fog: { default: true },
     height: { default: 256 },
     metalness: { default: 0.0, min: 0.0, max: 1.0 },
     repeat: { default: '' },


### PR DESCRIPTION
**Description:** Blocked trying to do some custom shaders.

**Changes proposed:**
- Specify `lights: true` in shader to pass light uniforms to shader
- `material.fog` works for all materials, move it to base material component
- Add texture property type

