### PR TITLE
refactor material + texture system

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -164,6 +164,12 @@
       <li><a href="test-visibility/">Visibility</a></li>
     </ul>
 
+    <h2>Performance</h2>
+    <ul class="links">
+      <li><a href="performance-animations/">Animations</a></li>
+      <li><a href="performance-entity-count/">Entity Count</a></li>
+    </ul>
+
     <h2>Primitives</h2>
 
     <ul class="links">

--- a/examples/performance-animations/index.html
+++ b/examples/performance-animations/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Animation</title>
-    <meta name="description" content="Animation - A-Frame">
+    <title>Performance - Animations</title>
+    <meta name="description" content="Performance - Animations - A-Frame">
     <script src="../../dist/aframe.js"></script>
   </head>
   <body>
@@ -22,7 +22,7 @@
       </a-entity>
 
       <a-entity id="fans"></a-entity>
-      
+
     </a-scene>
   </body>
   <script>

--- a/examples/performance-entity-count/index.html
+++ b/examples/performance-entity-count/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Stress Test - Large Number of Entities</title>
-    <meta name="description" content="Stress Test - Large Number of Entities - A-Frame">
+    <title>Performance - Entity Count</title>
+    <meta name="description" content="Performance - Entity Count - A-Frame">
     <script src="../../dist/aframe.js"></script>
     <style>
       body { background-color: black; }

--- a/examples/test-animation/index.html
+++ b/examples/test-animation/index.html
@@ -56,6 +56,8 @@
           </a-entity>
         </a-entity>
       </a-entity>
+
+      <a-sky color="#222"></a-sky>
     </a-scene>
   </body>
 </html>

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -1,12 +1,9 @@
 /* global Promise */
-var debug = require('../utils/debug');
-var utils = require('../utils');
 var component = require('../core/component');
 var THREE = require('../lib/three');
 var shader = require('../core/shader');
 
-var error = debug('components:material:error');
-var diff = utils.diff;
+var dummyMaterial = new THREE.MeshBasicMaterial();
 var registerComponent = component.registerComponent;
 var shaders = shader.shaders;
 var shaderNames = shader.shaderNames;
@@ -29,6 +26,7 @@ module.exports.Component = registerComponent('material', {
 
   init: function () {
     this.material = null;
+    this.shader = null;
   },
 
   /**
@@ -38,22 +36,48 @@ module.exports.Component = registerComponent('material', {
    */
   update: function (oldData) {
     var data = this.data;
-    var dataDiff = oldData ? diff(oldData, data) : data;
+    var el = this.el;
+    var mesh = this.el.getOrCreateObject3D('mesh', THREE.Mesh);
+    var system = this.system;
 
-    if (!this.shader || dataDiff.shader) {
-      this.updateShader(data.shader);
+    // If shader has changed, ask material system for new material.
+    if (!this.material || oldData.shader !== data.shader) {
+      if (this.shader) { system.unuseShader(this.shader); }
+      this.shader = system.createShader(el, data);
+      // Set material on mesh.
+      mesh.material = this.material = this.shader.material;
     }
-    this.shader.update(this.data);
-    this.updateMaterial();
+
+    // If shader has not changed, ask material system to update the material.
+    system.updateShader(this.shader, data);
   },
 
+  /**
+   * Remove material on remove (callback).
+   * Dispose of it from memory and unsubscribe from scene updates.
+   */
+  remove: function () {
+    var mesh = this.el.getObject3D('mesh');
+    if (!mesh) { return; }
+    this.system.unuseShader(this.shader);
+    mesh.material = dummyMaterial;
+  },
+
+  /**
+   * Update material component schema based on material/shader type.
+   *
+   * @param {object} data - New data passed by Component.
+   */
   updateSchema: function (data) {
     var newShader = data.shader;
     var currentShader = this.data && this.data.shader;
-    var shader = newShader || currentShader;
-    var schema = shaders[shader] && shaders[shader].schema;
-    if (!schema) { error('Unknown shader schema ' + shader); }
+    var schema = shaders[newShader] && shaders[newShader].schema;
+
+    // Material has no schema.
+    if (!schema) { throw new Error('Unknown shader schema `' + newShader + '`'); }
+    // Nothing has changed.
     if (currentShader && newShader === currentShader) { return; }
+
     this.extendSchema(schema);
     this.updateBehavior();
   },
@@ -80,84 +104,5 @@ module.exports.Component = registerComponent('material', {
     if (Object.keys(tickProperties).length === 0) {
       scene.removeBehavior(this);
     }
-  },
-
-  updateShader: function (shaderName) {
-    var data = this.data;
-    var Shader = shaders[shaderName] && shaders[shaderName].Shader;
-    var material;
-    if (!Shader) { throw new Error('Unknown shader ' + shaderName); }
-    this.shader = new Shader();
-    this.shader.el = this.el;
-    material = this.shader.init(data);
-    this.setMaterial(material);
-    this.updateSchema(data);
-  },
-
-  updateMaterial: function () {
-    var data = this.data;
-    var material = this.material;
-    material.side = parseSide(data.side);
-    material.opacity = data.opacity;
-    material.transparent = data.transparent !== false || data.opacity < 1.0;
-    material.depthTest = data.depthTest !== false;
-  },
-
-  /**
-   * Remove material on remove (callback).
-   * Dispose of it from memory and unsubscribe from scene updates.
-   */
-  remove: function () {
-    var defaultMaterial = new THREE.MeshBasicMaterial();
-    var material = this.material;
-    var object3D = this.el.getObject3D('mesh');
-    if (object3D) { object3D.material = defaultMaterial; }
-    disposeMaterial(material, this.system);
-  },
-
-  /**
-   * (Re)create new material. Has side-effects of setting `this.material` and updating
-   * material registration in scene.
-   *
-   * @param {object} data - Material component data.
-   * @param {object} type - Material type to create.
-   * @returns {object} Material.
-   */
-  setMaterial: function (material) {
-    var mesh = this.el.getOrCreateObject3D('mesh', THREE.Mesh);
-    var system = this.system;
-    if (this.material) { disposeMaterial(this.material, system); }
-    this.material = mesh.material = material;
-    system.registerMaterial(material);
   }
 });
-
-/**
- * Returns a three.js constant determining which material face sides to render
- * based on the side parameter (passed as a component property).
- *
- * @param {string} [side=front] - `front`, `back`, or `double`.
- * @returns {number} THREE.FrontSide, THREE.BackSide, or THREE.DoubleSide.
- */
-function parseSide (side) {
-  switch (side) {
-    case 'back': {
-      return THREE.BackSide;
-    }
-    case 'double': {
-      return THREE.DoubleSide;
-    }
-    default: {
-      // Including case `front`.
-      return THREE.FrontSide;
-    }
-  }
-}
-
-/**
- * Dispose of material from memory and unsubscribe material from scene updates like fog.
- */
-function disposeMaterial (material, system) {
-  material.dispose();
-  system.unregisterMaterial(material);
-}

--- a/src/components/scene/fog.js
+++ b/src/components/scene/fog.js
@@ -30,7 +30,7 @@ module.exports.Component = register('fog', {
     // (Re)create fog if fog doesn't exist or fog type changed.
     if (!fog || data.type !== fog.name) {
       el.object3D.fog = getFog(data);
-      el.systems.material.updateMaterials();
+      el.systems.material.needsUpdate();
       return;
     }
 

--- a/src/core/shader.js
+++ b/src/core/shader.js
@@ -2,7 +2,7 @@ var schema = require('./schema');
 
 var processSchema = schema.process;
 var shaders = module.exports.shaders = {};  // Keep track of registered shaders.
-var shaderNames = module.exports.shaderNames = [];  // Keep track of the names of registered shaders.
+var shaderNames = module.exports.shaderNames = [];  // Names of registered shaders.
 var THREE = require('../lib/three');
 
 var propertyToThreeMapping = {
@@ -17,18 +17,21 @@ var propertyToThreeMapping = {
 /**
  * Shader class definition.
  *
- * Shaders extend the material component API so you can create your own library
- * of customized materials
+ * Shaders extend the material component API for custom three.js materials. The default
+ * custom materials revolve around ShaderMaterial to enable custom shaders.
  *
+ * @param {Element} el - Entity.
  */
-var Shader = module.exports.Shader = function () {};
+var Shader = module.exports.Shader = function (el) {
+  this.el = el;
+};
 
 Shader.prototype = {
   /**
    * Contains the type schema and defaults for the data values.
    * Data is coerced into the types of the values of the defaults.
    */
-  schema: { },
+  schema: {},
 
   vertexShader:
     'void main() {' +
@@ -60,9 +63,8 @@ Shader.prototype = {
     var self = this;
     var variables = {};
     var schema = this.schema;
-    var squemaKeys = Object.keys(schema);
-    squemaKeys.forEach(processSquema);
-    function processSquema (key) {
+    var schemaKeys = Object.keys(schema);
+    schemaKeys.forEach(function processSchema (key) {
       if (schema[key].is !== type) { return; }
       var varType = propertyToThreeMapping[schema[key].type];
       var varValue = schema[key].parse(data[key] || schema[key].default);
@@ -70,7 +72,7 @@ Shader.prototype = {
         type: varType,
         value: self.parseValue(schema[key].type, varValue)
       };
-    }
+    });
     return variables;
   },
 
@@ -144,7 +146,7 @@ module.exports.registerShader = function (name, definition) {
   if (shaders[name]) {
     throw new Error('The shader ' + name + ' has been already registered');
   }
-  NewShader = function () { Shader.call(this); };
+  NewShader = function (el) { Shader.call(this, el); };
   NewShader.prototype = Object.create(Shader.prototype, proto);
   NewShader.prototype.name = name;
   NewShader.prototype.constructor = NewShader;

--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -1,6 +1,6 @@
 var registerShader = require('../core/shader').registerShader;
 var THREE = require('../lib/three');
-var utils = require('../utils/');
+var utils = require('../utils');
 
 /**
  * Flat shader using THREE.MeshBasicMaterial.
@@ -22,41 +22,12 @@ module.exports.Component = registerShader('flat', {
   init: function (data) {
     this.textureSrc = null;
     this.material = new THREE.MeshBasicMaterial(getMaterialData(data));
-    this.updateTexture(data);
-    return this.material;
+    utils.material.updateMap(this, data);
   },
 
   update: function (data) {
     this.updateMaterial(data);
-    this.updateTexture(data);
-    return this.material;
-  },
-
-  /**
-   * Update or create material.
-   *
-   * @param {object|null} oldData
-   */
-  updateTexture: function (data) {
-    var el = this.el;
-    var src = data.src;
-    var material = this.material;
-    var materialSystem = el.sceneEl.systems.material;
-
-    if (src) {
-      if (src === this.textureSrc) { return; }
-      // Texture added or changed.
-      this.textureSrc = src;
-      utils.srcLoader.validateSrc(
-        src,
-        function loadImageCb (src) { materialSystem.loadImage(el, material, data, src); },
-        function loadVideoCb (src) { materialSystem.loadVideo(el, material, data, src); }
-      );
-      return;
-    }
-
-    // Texture removed.
-    utils.material.updateMaterialTexture(material, null);
+    utils.material.updateMap(this, data);
   },
 
   /**
@@ -80,9 +51,8 @@ module.exports.Component = registerShader('flat', {
  * @returns {object} data - Processed material data.
  */
 function getMaterialData (data) {
-  var materialData = {
+  return {
     fog: data.fog,
     color: new THREE.Color(data.color)
   };
-  return materialData;
 }

--- a/src/systems/index.js
+++ b/src/systems/index.js
@@ -2,3 +2,4 @@ require('./camera');
 require('./geometry');
 require('./material');
 require('./light');
+require('./texture');

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -1,297 +1,99 @@
 var registerSystem = require('../core/system').registerSystem;
+var shaders = require('../core/shader').shaders;
 var THREE = require('../lib/three');
-var utils = require('../utils/');
-
-var EVENTS = {
-  TEXTURE_LOADED: 'material-texture-loaded'
-};
-var debug = utils.debug;
-var error = debug('components:texture:error');
-var TextureLoader = new THREE.TextureLoader();
-var warn = debug('components:texture:warn');
 
 /**
  * System for material component.
- * Handle material registration, updates (for fog), and texture caching.
- *
- * @member materials {object} - Registered materials.
- * @member textureCache {object} - Texture cache for:
- *   - Images: textureCache has mapping of src -> repeat -> cached three.js texture.
- *   - Videos: textureCache has mapping of videoElement -> cached three.js texture.
+ * Handle material creation, material updates.
  */
 module.exports.System = registerSystem('material', {
   init: function () {
-    this.materials = {};
-    this.textureCache = {};
-  },
-
-  clearTextureCache: function () {
-    this.textureCache = {};
+    this.shaders = [];
   },
 
   /**
-   * High-level function for loading image textures. Meat of logic is in `loadImageTexture`.
-   *
-   * @param {Element} el - Entity, used to emit event.
-   * @param {object} material - three.js material, bound by the A-Frame shader.
-   * @param {object} data - Shader data, bound by the A-Frame shader.
-   * @param {Element|string} src - Texture source, bound by `src-loader` utils.
+   * Create and register material.
    */
-  loadImage: function (el, material, data, src) {
-    var repeat = data.repeat || '1 1';
-    var srcString = src;
-    var textureCache = this.textureCache;
+  createShader: function (el, data) {
+    var shader = createShader(el, data);
+    this.shaders.push(shader);
+    return shader;
+  },
 
-    if (typeof src !== 'string') { srcString = src.getAttribute('src'); }
-
-    // Another material is already loading this texture. Wait on promise.
-    if (textureCache[src] && textureCache[src][repeat]) {
-      textureCache[src][repeat].then(handleImageTextureLoaded);
-      return;
-    }
-
-    // Material instance is first to try to load this texture. Load it.
-    textureCache[srcString] = textureCache[srcString] || {};
-    textureCache[srcString][repeat] = textureCache[srcString][repeat] || {};
-    textureCache[srcString][repeat] = loadImageTexture(material, src, repeat);
-    textureCache[srcString][repeat].then(handleImageTextureLoaded);
-
-    function handleImageTextureLoaded (texture) {
-      utils.material.updateMaterialTexture(material, texture);
-      el.emit(EVENTS.TEXTURE_LOADED, { src: src, texture: texture });
-    }
+  updateShader: function (shader, data) {
+    shader.update(data);
   },
 
   /**
-   * Load video texture.
-   * Note that creating a video texture is more synchronous than creating an image texture.
-   *
-   * @param {Element} el - Entity, used to emit event.
-   * @param {object} material - three.js material.
-   * @param data {object} - Shader data, bound by the A-Frame shader.
-   * @param src {Element|string} - Texture source, bound by `src-loader` utils.
+   * Create and register material.
    */
-  loadVideo: function (el, material, data, src) {
-    var hash;
-    var texture;
-    var textureCache = this.textureCache;
-    var videoEl;
-    var videoTextureResult;
-
-    if (typeof src !== 'string') {
-      // Check cache before creating texture.
-      videoEl = src;
-      hash = calculateVideoCacheHash(videoEl);
-      if (textureCache[hash]) {
-        textureCache[hash].then(handleVideoTextureLoaded);
-        return;
-      }
-      // If not in cache, fix up the attributes then start to create the texture.
-      fixVideoAttributes(videoEl);
-    }
-
-    // Use video element to create texture.
-    videoEl = videoEl || createVideoEl(material, src, data.width, data.height);
-
-    // Generated video element already cached. Use that.
-    hash = calculateVideoCacheHash(videoEl);
-    if (textureCache[hash]) {
-      textureCache[hash].then(handleVideoTextureLoaded);
-      return;
-    }
-
-    // Create new video texture.
-    texture = new THREE.VideoTexture(videoEl);
-    texture.minFilter = THREE.LinearFilter;
-
-    // Cache as promise to be consistent with image texture caching.
-    videoTextureResult = {
-      texture: texture,
-      videoEl: videoEl
-    };
-    textureCache[hash] = Promise.resolve(videoTextureResult);
-    handleVideoTextureLoaded(videoTextureResult);
-
-    function handleVideoTextureLoaded (res) {
-      texture = res.texture;
-      videoEl = res.videoEl;
-      utils.material.updateMaterialTexture(material, texture);
-      el.emit(EVENTS.TEXTURE_LOADED, { element: videoEl, src: src });
-      videoEl.addEventListener('loadeddata', function () {
-        el.emit('material-video-loadeddata', { element: videoEl, src: src });
-      });
-      videoEl.addEventListener('ended', function () {
-        // Works for non-looping videos only.
-        el.emit('material-video-ended', { element: videoEl, src: src });
-      });
-    }
+  unuseShader: function (shader) {
+    var shaders = this.shaders;
+    var index = shaders.indexOf(shader);
+    shader.material.dispose();
+    shaders.splice(index, 1);
   },
 
   /**
-   * Keep track of material in case an update trigger is needed (e.g., fog).
-   *
-   * @param {object} material
+   * Trigger update to all materials.
    */
-  registerMaterial: function (material) {
-    this.materials[material.uuid] = material;
-  },
-
-  /**
-   * Stop tracking material.
-   *
-   * @param {object} material
-   */
-  unregisterMaterial: function (material) {
-    delete this.materials[material.uuid];
-  },
-
-  /**
-   * Trigger update to all registered materials.
-   */
-  updateMaterials: function (material) {
-    var materials = this.materials;
-    Object.keys(materials).forEach(function (uuid) {
-      materials[uuid].needsUpdate = true;
+  needsUpdate: function () {
+    Object.keys(this.shaders).forEach(function setNeedsUpdate (key) {
+      shaders[key].material.needsUpdate = true;
     });
   }
 });
 
 /**
- * Calculates consistent hash from a video element using its attributes.
- * If the video element has an ID, use that.
- * Else build a hash that looks like `src:myvideo.mp4;height:200;width:400;`.
+ * Create geometry using component data.
  *
- * @param videoEl {Element} - Video element.
- * @returns {string}
+ * @param {object} data - Component data.
+ * @returns {object} Geometry.
  */
-function calculateVideoCacheHash (videoEl) {
-  var i;
-  var id = videoEl.getAttribute('id');
-  var hash;
-  var videoAttributes;
+function createShader (el, data) {
+  var shaderInstance;
+  var shaderName = data.shader;
+  var ShaderClass = shaders[shaderName] && shaders[shaderName].Shader;
 
-  if (id) { return id; }
+  if (!ShaderClass) { throw new Error('Unknown shader `' + shaderName + '`'); }
 
-  // Calculate hash using sorted video attributes.
-  hash = '';
-  videoAttributes = {};
-  for (i = 0; i < videoEl.attributes.length; i++) {
-    videoAttributes[videoEl.attributes[i].name] = videoEl.attributes[i].value;
-  }
-  Object.keys(videoAttributes).sort().forEach(function (name) {
-    hash += name + ':' + videoAttributes[name] + ';';
-  });
-
-  return hash;
+  shaderInstance = new ShaderClass(el);
+  shaderInstance.init(data);
+  updateBaseMaterial(shaderInstance.material, data);
+  return shaderInstance;
 }
 
 /**
- * Set image texture on material as `map`.
+ * Update base material properties that are present among all types of materials.
  *
- * @private
- * @param {object} el - Entity element.
- * @param {object} material - three.js material.
- * @param {string|object} src - An <img> element or url to an image file.
- * @param {string} repeat - X and Y value for size of texture repeating (in UV units).
- * @returns {Promise} Resolves once texture is loaded.
+ * @param {object} material
+ * @param {object} data
  */
-function loadImageTexture (material, src, repeat) {
-  return new Promise(doLoadImageTexture);
+function updateBaseMaterial (material, data) {
+  material.side = parseSide(data.side);
+  material.opacity = data.opacity;
+  material.transparent = data.transparent !== false || data.opacity < 1.0;
+  material.depthTest = data.depthTest !== false;
+}
 
-  function doLoadImageTexture (resolve, reject) {
-    var isEl = typeof src !== 'string';
-
-    // Create texture from an element.
-    if (isEl) {
-      createTexture(src);
-      return;
+/**
+ * Returns a three.js constant determining which material face sides to render
+ * based on the side parameter (passed as a component property).
+ *
+ * @param {string} [side=front] - `front`, `back`, or `double`.
+ * @returns {number} THREE.FrontSide, THREE.BackSide, or THREE.DoubleSide.
+ */
+function parseSide (side) {
+  switch (side) {
+    case 'back': {
+      return THREE.BackSide;
     }
-
-    // Load texture from src string. THREE will create underlying element.
-    // Use THREE.TextureLoader (src, onLoad, onProgress, onError) to load texture.
-    TextureLoader.load(
-      src,
-      createTexture,
-      function () { /* no-op */ },
-      function (xhr) {
-        error('`$s` could not be fetched (Error code: %s; Response: %s)', xhr.status,
-              xhr.statusText);
-      }
-    );
-
-    /**
-     * Texture loaded. Set it.
-     */
-    function createTexture (texture) {
-      var repeatXY;
-      if (!(texture instanceof THREE.Texture)) { texture = new THREE.Texture(texture); }
-
-      // Handle UV repeat.
-      repeatXY = repeat.split(' ');
-      if (repeatXY.length === 2) {
-        texture.wrapS = THREE.RepeatWrapping;
-        texture.wrapT = THREE.RepeatWrapping;
-        texture.repeat.set(parseInt(repeatXY[0], 10), parseInt(repeatXY[1], 10));
-      }
-
-      resolve(texture);
+    case 'double': {
+      return THREE.DoubleSide;
+    }
+    default: {
+      // Including case `front`.
+      return THREE.FrontSide;
     }
   }
-}
-
-/**
- * Create video element to be used as a texture.
- *
- * @param {object} material - three.js material.
- * @param {string} src - Url to a video file.
- * @param {number} width - Width of the video.
- * @param {number} height - Height of the video.
- * @returns {Element} Video element.
- */
-function createVideoEl (material, src, width, height) {
-  var el = material.videoEl || document.createElement('video');
-  el.width = width;
-  el.height = height;
-  if (el !== this.videoEl) {
-    el.setAttribute('webkit-playsinline', '');  // To support inline videos in iOS webviews.
-    el.autoplay = true;
-    el.loop = true;
-    el.crossOrigin = true;
-    el.addEventListener('error', function () {
-      warn('`$s` is not a valid video', src);
-    }, true);
-    material.videoEl = el;
-  }
-  el.src = src;
-  return el;
-}
-
-/**
- * Fixes a video element's attributes to prevent developers from accidentally passing the
- * wrong attribute values to commonly misused video attributes.
- *
- * <video> does not treat `autoplay`, `controls`, `crossorigin`, `loop`, and `preload` as
- * as booleans. Existence of those attributes will mean truthy.
- *
- * For example, translates <video loop="false"> to <video>.
- *
- * @see https://developer.mozilla.org/docs/Web/HTML/Element/video#Attributes
- * @param {Element} videoEl - Video element.
- * @returns {Element} Video element with the correct properties updated.
- */
-function fixVideoAttributes (videoEl) {
-  videoEl.controls = videoEl.getAttribute('controls') !== 'false';
-  if (videoEl.getAttribute('autoplay') === 'false') {
-    videoEl.removeAttribute('autoplay');
-  }
-  if (videoEl.getAttribute('loop') === 'false') {
-    videoEl.removeAttribute('loop');
-  }
-  if (videoEl.getAttribute('preload') === 'false') {
-    videoEl.preload = 'none';
-  }
-  videoEl.crossOrigin = true;
-  // To support inline videos in iOS webviews.
-  videoEl.setAttribute('webkit-playsinline', '');
-  return videoEl;
 }

--- a/src/systems/texture.js
+++ b/src/systems/texture.js
@@ -1,0 +1,263 @@
+var registerSystem = require('../core/system').registerSystem;
+var THREE = require('../lib/three');
+var utils = require('../utils/');
+
+var debug = utils.debug;
+var error = debug('components:texture:error');
+var TextureLoader = new THREE.TextureLoader();
+var warn = debug('components:texture:warn');
+
+/**
+ * System to facilitate texture caching.
+ *
+ * @member cache {object} - Texture cache for:
+ *   - Images: mapping of JSON.stringified data -> Promise.resolve(THREE.Texture).
+ *   - Videos: mapping of videoElement attribute hash -> Promise.resolve(THREE.VideoTexture).
+ */
+module.exports.System = registerSystem('texture', {
+  init: function () {
+    this.cache = {};
+  },
+
+  clearTextureCache: function () {
+    this.cache = {};
+  },
+
+  /**
+   * Determine whether `src` is a image or video. Then try to load the asset, then call back.
+   *
+   * @param {string} src - Texture URL.
+   * @param {string} data - Relevant texture data used for caching.
+   * @param {function} cb - Callback to pass texture to.
+   */
+  loadTexture: function (src, data, cb) {
+    var self = this;
+    utils.srcLoader.validateSrc(src, loadImageCb, loadVideoCb);
+    function loadImageCb (src) { self.loadImage(src, data, cb); }
+    function loadVideoCb (src) { self.loadVideo(src, data, cb); }
+  },
+
+  /**
+   * High-level function for loading image textures (THREE.Texture).
+   *
+   * @param {Element|string} src - Texture source.
+   * @param {object} data - Texture data.
+   * @param {function} cb - Callback to pass texture to.
+   */
+  loadImage: function (src, data, cb) {
+    var hash = this.hash(data);
+    var handleImageTextureLoaded = cb;
+    var cache = this.cache;
+
+    // Texture already being loaded or already loaded. Wait on promise.
+    if (cache[hash]) {
+      cache[hash].then(handleImageTextureLoaded);
+      return;
+    }
+
+    // Texture not yet being loaded. Start loading it.
+    cache[hash] = loadImageTexture(src, data);
+    cache[hash].then(handleImageTextureLoaded);
+  },
+
+  /**
+   * Load video texture (THREE.VideoTexture).
+   * Which is just an image texture that RAFs + needsUpdate.
+   * Note that creating a video texture is synchronous unlike loading an image texture.
+   * Made asynchronous to be consistent with image textures.
+   *
+   * @param {Element|string} src - Texture source.
+   * @param {object} data - Texture data.
+   * @param {function} cb - Callback to pass texture to.
+   */
+  loadVideo: function (src, data, cb) {
+    var hash;
+    var texture;
+    var cache = this.cache;
+    var videoEl;
+    var videoTextureResult;
+
+    function handleVideoTextureLoaded (result) {
+      cb(result.texture, result.videoEl);
+    }
+
+    // Video element provided.
+    if (typeof src !== 'string') {
+      // Check cache before creating texture.
+      videoEl = src;
+      hash = this.hashVideo(data, videoEl);
+      if (cache[hash]) {
+        cache[hash].then(handleVideoTextureLoaded);
+        return;
+      }
+      // If not in cache, fix up the attributes then start to create the texture.
+      fixVideoAttributes(videoEl);
+    }
+
+    // Only URL provided. Use video element to create texture.
+    videoEl = videoEl || createVideoEl(src, data.width, data.height);
+
+    // Generated video element already cached. Use that.
+    hash = this.hashVideo(data, videoEl);
+    if (cache[hash]) {
+      cache[hash].then(handleVideoTextureLoaded);
+      return;
+    }
+
+    // Create new video texture.
+    texture = new THREE.VideoTexture(videoEl);
+    texture.minFilter = THREE.LinearFilter;
+    setTextureProperties(texture, data);
+
+    // Cache as promise to be consistent with image texture caching.
+    videoTextureResult = {texture: texture, videoEl: videoEl};
+    cache[hash] = Promise.resolve(videoTextureResult);
+    handleVideoTextureLoaded(videoTextureResult);
+  },
+
+  hash: function (data) {
+    return JSON.stringify(data);
+  },
+
+  hashVideo: function (data, videoEl) {
+    return calculateVideoCacheHash(data, videoEl);
+  }
+});
+
+/**
+ * Calculates consistent hash from a video element using its attributes.
+ * If the video element has an ID, use that.
+ * Else build a hash that looks like `src:myvideo.mp4;height:200;width:400;`.
+ *
+ * @param data {object} - Texture data such as repeat.
+ * @param videoEl {Element} - Video element.
+ * @returns {string}
+ */
+function calculateVideoCacheHash (data, videoEl) {
+  var i;
+  var id = videoEl.getAttribute('id');
+  var hash;
+  var videoAttributes;
+
+  if (id) { return id; }
+
+  // Calculate hash using sorted video attributes.
+  hash = '';
+  videoAttributes = data || {};
+  for (i = 0; i < videoEl.attributes.length; i++) {
+    videoAttributes[videoEl.attributes[i].name] = videoEl.attributes[i].value;
+  }
+  Object.keys(videoAttributes).sort().forEach(function (name) {
+    hash += name + ':' + videoAttributes[name] + ';';
+  });
+
+  return hash;
+}
+
+/**
+ * Load image texture.
+ *
+ * @private
+ * @param {string|object} src - An <img> element or url to an image file.
+ * @param {object} data - Data to set texture properties like `repeat`.
+ * @returns {Promise} Resolves once texture is loaded.
+ */
+function loadImageTexture (src, data) {
+  return new Promise(doLoadImageTexture);
+
+  function doLoadImageTexture (resolve, reject) {
+    var isEl = typeof src !== 'string';
+
+    function resolveTexture (texture) {
+      setTextureProperties(texture, data);
+      resolve(texture);
+    }
+
+    // Create texture from an element.
+    if (isEl) {
+      resolveTexture(new THREE.Texture(src));
+      return;
+    }
+
+    // Load texture from src string. THREE will create underlying element.
+    // Use THREE.TextureLoader (src, onLoad, onProgress, onError) to load texture.
+    TextureLoader.load(
+      src,
+      resolveTexture,
+      function () { /* no-op */ },
+      function (xhr) {
+        error('`$s` could not be fetched (Error code: %s; Response: %s)', xhr.status,
+              xhr.statusText);
+      }
+    );
+  }
+}
+
+/**
+ * Set texture properties such as repeat.
+ *
+ * @param {object} data - With keys like `repeat`.
+ */
+function setTextureProperties (texture, data) {
+  // Handle UV repeat.
+  var repeat = data.repeat || '1 1';
+  var repeatXY = repeat.split(' ');
+
+  // Don't bother setting repeat if it is 1/1. Power-of-two is required to repeat.
+  if (repeat === '1 1' || repeatXY.length !== 2) { return; }
+
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(parseInt(repeatXY[0], 10), parseInt(repeatXY[1], 10));
+}
+
+/**
+ * Create video element to be used as a texture.
+ *
+ * @param {string} src - Url to a video file.
+ * @param {number} width - Width of the video.
+ * @param {number} height - Height of the video.
+ * @returns {Element} Video element.
+ */
+function createVideoEl (src, width, height) {
+  var videoEl = document.createElement('video');
+  videoEl.width = width;
+  videoEl.height = height;
+  videoEl.setAttribute('webkit-playsinline', '');  // Support inline videos for iOS webviews.
+  videoEl.autoplay = true;
+  videoEl.loop = true;
+  videoEl.crossOrigin = true;
+  videoEl.addEventListener('error', function () {
+    warn('`$s` is not a valid video', src);
+  }, true);
+  videoEl.src = src;
+  return videoEl;
+}
+
+/**
+ * Fixes a video element's attributes to prevent developers from accidentally passing the
+ * wrong attribute values to commonly misused video attributes.
+ *
+ * <video> does not treat `autoplay`, `controls`, `crossorigin`, `loop`, and `preload` as
+ * as booleans. Existence of those attributes will mean truthy.
+ *
+ * For example, translates <video loop="false"> to <video>.
+ *
+ * @see https://developer.mozilla.org/docs/Web/HTML/Element/video#Attributes
+ * @param {Element} videoEl - Video element.
+ * @returns {Element} Video element with the correct properties updated.
+ */
+function fixVideoAttributes (videoEl) {
+  videoEl.autoplay = videoEl.getAttribute('autoplay') !== 'false';
+  videoEl.controls = videoEl.getAttribute('controls') !== 'false';
+  if (videoEl.getAttribute('loop') === 'false') {
+    videoEl.removeAttribute('loop');
+  }
+  if (videoEl.getAttribute('preload') === 'false') {
+    videoEl.preload = 'none';
+  }
+  videoEl.crossOrigin = true;
+  // To support inline videos in iOS webviews.
+  videoEl.setAttribute('webkit-playsinline', '');
+  return videoEl;
+}

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -1,16 +1,52 @@
 /**
- * Set material texture and update if necessary.
+ * Update `material.map` given `data.src`. For standard and flat shaders.
  *
- * @param {object} material
- * @param {object} texture
+ * @param {object} shader - A-Frame shader instance.
+ * @param {object} data
  */
-module.exports.updateMaterialTexture = function (material, texture) {
-  var oldMap = material.map;
-  if (texture) { texture.needsUpdate = true; }
-  material.map = texture;
+module.exports.updateMap = function (shader, data) {
+  var el = shader.el;
+  var material = shader.material;
+  var src = data.src;
 
-  // Only need to update three.js material if presence or not of texture has changed.
-  if (oldMap === null && material.map || material.map === null && oldMap) {
+  if (src) {
+    if (src === shader.textureSrc) { return; }
+    // Texture added or changed.
+    shader.textureSrc = src;
+    el.sceneEl.systems.texture.loadTexture(src, {src: src, repeat: data.repeat}, setMap);
+    return;
+  }
+
+  // Texture removed.
+  if (!material.map) { return; }
+  setMap(null);
+
+  function setMap (texture) {
+    material.map = texture;
     material.needsUpdate = true;
+    handleTextureEvents(el, texture);
   }
 };
+
+/**
+ * Emit event on entities on texture-related events.
+ *
+ * @param {Element} el - Entity.
+ * @param {object} texture - three.js Texture.
+ */
+function handleTextureEvents (el, texture) {
+  if (!texture) { return; }
+
+  el.emit('material-texture-loaded', {src: texture.image, texture: texture});
+
+  // Video events.
+  if (texture.image.tagName !== 'VIDEO') { return; }
+  texture.image.addEventListener('loadeddata', function emitVideoTextureLoadedDataAll () {
+    el.emit('material-video-loadeddata', {src: texture.image, texture: texture});
+  });
+  texture.image.addEventListener('ended', function emitVideoTextureEndedAll () {
+    // Works for non-looping videos only.
+    el.emit('material-video-ended', {src: texture.image, texture: texture});
+  });
+}
+module.exports.handleTextureEvents = handleTextureEvents;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
-Unit tests use karma + Mocha (in TDD mode) + and Firefox Nightly.
+Unit tests use karma + Mocha (in TDD mode) + Firefox Nightly.
 
 ## Testing Tips
 

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -1,5 +1,6 @@
 /* global assert, process, setup, suite, test, AFRAME */
 var entityFactory = require('../helpers').entityFactory;
+var shaders = require('core/shader').shaders;
 var THREE = require('index').THREE;
 
 suite('material', function () {
@@ -23,6 +24,13 @@ suite('material', function () {
       assert.shallowDeepEqual(el.getObject3D('mesh').material.color,
                              {r: 1, g: 0, b: 1});
       assert.shallowDeepEqual(el.getObject3D('mesh').material.side, THREE.DoubleSide);
+    });
+
+    test('updates material shader', function () {
+      var el = this.el;
+      assert.equal(el.getObject3D('mesh').material.type, 'MeshBasicMaterial');
+      el.setAttribute('material', 'shader', 'standard');
+      assert.equal(el.getObject3D('mesh').material.type, 'MeshStandardMaterial');
     });
 
     test('disposes material when changing to new material', function () {
@@ -64,14 +72,23 @@ suite('material', function () {
       var imageUrl = 'base/tests/assets/test.png';
       el.setAttribute('material', 'src: url(' + imageUrl + ')');
       el.addEventListener('material-texture-loaded', function (evt) {
-        assert.equal(evt.detail.src, imageUrl);
+        assert.equal(evt.detail.texture.image.getAttribute('src'), imageUrl);
         done();
       });
+    });
+
+    test('sets material to MeshShaderMaterial for custom shaders', function () {
+      var el = this.el;
+      delete shaders.test;
+      AFRAME.registerShader('test', {});
+      assert.equal(el.getObject3D('mesh').material.type, 'MeshBasicMaterial');
+      el.setAttribute('material', 'shader', 'test');
+      assert.equal(el.getObject3D('mesh').material.type, 'ShaderMaterial');
     });
   });
 
   suite('updateSchema', function () {
-    test('updates schema', function () {
+    test('updates schema for flat shader', function () {
       var el = this.el;
       el.components.material.updateSchema({shader: 'flat'});
       assert.ok(el.components.material.schema.color);
@@ -84,39 +101,21 @@ suite('material', function () {
       assert.notOk(el.components.material.schema.roughness);
       assert.notOk(el.components.material.schema.envMap);
     });
-  });
 
-  suite('updateShader', function () {
-    test('updates material shader', function () {
+    test('updates schema for custom shader', function () {
       var el = this.el;
-      assert.equal(el.getObject3D('mesh').material.type, 'MeshBasicMaterial');
-      el.components.material.updateShader('standard');
-      assert.equal(el.getObject3D('mesh').material.type, 'MeshStandardMaterial');
-    });
-
-    test('sets material to MeshShaderMaterial for custom shaders', function () {
-      var el = this.el;
+      delete shaders.test;
       AFRAME.registerShader('test', {
         schema: {
-          'luminance': { default: 1 }
-        },
-
-        vertexShader: [
-          'varying vec3 vWorldPosition;',
-          'void main() {',
-          'vec4 worldPosition = modelMatrix * vec4( position, 1.0 );',
-          'vWorldPosition = worldPosition.xyz;',
-          'gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
-          '}'
-        ].join('\n'),
-
-        fragmentShader: [
-          'void main() { gl_FragColor = vec4(1.0,0.0,1.0,1.0); }'
-        ].join('\n')
+          color: {type: 'color'},
+          luminance: {default: 1}
+        }
       });
-      assert.equal(el.getObject3D('mesh').material.type, 'MeshBasicMaterial');
-      el.components.material.updateShader('test');
-      assert.equal(el.getObject3D('mesh').material.type, 'ShaderMaterial');
+      el.setAttribute('material', 'shader', 'test');
+      assert.ok(el.components.material.schema.opacity);
+      assert.ok(el.components.material.schema.color);
+      assert.ok(el.components.material.schema.luminance);
+      assert.notOk(el.components.material.schema.src);
     });
   });
 

--- a/tests/components/scene/fog.test.js
+++ b/tests/components/scene/fog.test.js
@@ -2,12 +2,10 @@
 var entityFactory = require('../../helpers').entityFactory;
 
 suite('fog', function () {
-  'use strict';
-
   setup(function () {
     this.entityEl = entityFactory();
     var el = this.el = this.entityEl.parentNode;
-    this.updateMaterialsSpy = this.sinon.spy(el.systems.material, 'updateMaterials');
+    this.needsUpdateSpy = this.sinon.spy(el.systems.material, 'needsUpdate');
 
     // Stub scene load to avoid WebGL code.
     el.hasLoaded = true;
@@ -26,7 +24,7 @@ suite('fog', function () {
     });
 
     test('triggers material update when adding fog', function () {
-      assert.ok(this.updateMaterialsSpy.called);
+      assert.ok(this.needsUpdateSpy.called);
     });
 
     test('updates fog', function () {

--- a/tests/systems/geometry.test.js
+++ b/tests/systems/geometry.test.js
@@ -30,7 +30,7 @@ suite('geometry system', function () {
       var data = {primitive: 'box', skipCache: true};
       var system = this.system;
       var hash = system.hash(data);
-      system.getOrCreateGeometry({primitive: 'box'});
+      system.getOrCreateGeometry(data);
       assert.notOk(system.cache[hash]);
     });
 

--- a/tests/systems/material.test.js
+++ b/tests/systems/material.test.js
@@ -1,137 +1,34 @@
 /* global assert, process, setup, suite, test */
 var entityFactory = require('../helpers').entityFactory;
-var THREE = require('index').THREE;
 
 suite('material system', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
+    var self = this;
     el.addEventListener('loaded', function () {
+      self.system = el.sceneEl.systems.material;
       done();
     });
   });
 
-  suite('registerMaterial', function () {
-    test('registers material to scene', function () {
-      var el = this.el;
-      var material;
-      var system;
-      el.setAttribute('material', '');
-      system = el.components.material.system;
-      material = el.getObject3D('mesh').material;
-      assert.equal(system.materials[material.uuid], material);
-    });
-
-    test('re-registers material when toggling material to flat shading', function () {
-      var el = this.el;
-      var oldMaterial;
-      var newMaterial;
-      var system;
-      el.setAttribute('material', 'shader: flat');
-      oldMaterial = el.getObject3D('mesh').material;
-      el.setAttribute('material', 'shader: standard');
-      system = el.components.material.system;
-      newMaterial = el.getObject3D('mesh').material;
-      assert.notOk(system.materials[oldMaterial.uuid]);
-      assert.equal(system.materials[newMaterial.uuid], newMaterial);
+  suite('createShader', function () {
+    test('registers shader', function () {
+      var shader;
+      var system = this.system;
+      assert.equal(system.shaders.indexOf(shader), -1);
+      shader = system.createShader(this.el, {shader: 'flat'});
+      assert.notEqual(system.shaders.indexOf(shader), -1);
     });
   });
 
-  suite('texture caching', function () {
-    setup(function () {
-      this.el.sceneEl.systems.material.clearTextureCache();
-    });
-
-    test('does not cache different image textures', function (done) {
-      var el = this.el;
-      var imageUrl = 'base/tests/assets/test.png';
-      var imageUrl2 = 'base/tests/assets/test2.png';
-      var textureSpy = this.sinon.spy(THREE, 'Texture');
-      assert.equal(textureSpy.callCount, 0);
-
-      el.setAttribute('material', 'src: url(' + imageUrl + ')');
-
-      el.addEventListener('material-texture-loaded', function (evt) {
-        var el2;
-        assert.equal(textureSpy.callCount, 1);
-
-        el2 = document.createElement('a-entity');
-        el2.setAttribute('material', 'src: url(' + imageUrl2 + ')');
-        el.sceneEl.appendChild(el2);
-        el2.addEventListener('material-texture-loaded', function () {
-          // Two textures created.
-          assert.equal(textureSpy.callCount, 2);
-          done();
-        });
-      });
-    });
-
-    test('can cache image textures', function (done) {
-      var el = this.el;
-      var imageUrl = 'base/tests/assets/test.png';
-      var textureSpy = this.sinon.spy(THREE, 'Texture');
-      assert.equal(textureSpy.callCount, 0);
-
-      el.setAttribute('material', 'src: url(' + imageUrl + ')');
-
-      el.addEventListener('material-texture-loaded', function () {
-        var el2;
-        assert.equal(textureSpy.callCount, 1);
-
-        el2 = document.createElement('a-entity');
-        el2.setAttribute('material', 'src: url(' + imageUrl + ')');
-        el.sceneEl.appendChild(el2);
-        el2.addEventListener('material-texture-loaded', function () {
-          // Only one texture created.
-          assert.equal(textureSpy.callCount, 1);
-          done();
-        });
-      });
-    });
-
-    test('does not cache different video textures', function (done) {
-      var el = this.el;
-      var videoUrl = 'base/tests/assets/test.mp4';
-      var videoUrl2 = 'base/tests/assets/test2.mp4';
-      var textureSpy = this.sinon.spy(THREE, 'VideoTexture');
-      assert.equal(textureSpy.callCount, 0);
-
-      el.setAttribute('material', 'src: url(' + videoUrl + ')');
-
-      el.addEventListener('material-texture-loaded', function (evt) {
-        var el2;
-        assert.equal(textureSpy.callCount, 1);
-
-        el2 = document.createElement('a-entity');
-        el2.setAttribute('material', 'src: url(' + videoUrl2 + ')');
-        el.sceneEl.appendChild(el2);
-        el2.addEventListener('material-texture-loaded', function () {
-          // Two textures created.
-          assert.equal(textureSpy.callCount, 2);
-          done();
-        });
-      });
-    });
-
-    test('can cache video textures', function (done) {
-      var el = this.el;
-      var videoUrl = 'base/tests/assets/test.mp4';
-      var textureSpy = this.sinon.spy(THREE, 'VideoTexture');
-      assert.equal(textureSpy.callCount, 0);
-
-      el.setAttribute('material', 'src: url(' + videoUrl + ')');
-
-      el.addEventListener('material-texture-loaded', function () {
-        var el2;
-        assert.equal(textureSpy.callCount, 1);
-
-        el2 = document.createElement('a-entity');
-        el2.setAttribute('material', 'src: url(' + videoUrl + ')');
-        el.sceneEl.appendChild(el2);
-        el2.addEventListener('material-texture-loaded', function () {
-          assert.equal(textureSpy.callCount, 1);
-          done();
-        });
-      });
+  suite('unuseShader', function () {
+    test('unregisters shader', function () {
+      var system = this.system;
+      var shader;
+      shader = system.createShader(this.el, {shader: 'flat'});
+      assert.notEqual(system.shaders.indexOf(shader), -1);
+      system.unuseShader(shader);
+      assert.equal(system.shaders.indexOf(shader), -1);
     });
   });
 });

--- a/tests/systems/texture.test.js
+++ b/tests/systems/texture.test.js
@@ -1,0 +1,196 @@
+/* global assert, process, setup, suite, test */
+var entityFactory = require('../helpers').entityFactory;
+
+var IMAGE1 = 'base/tests/assets/test.png';
+var IMAGE2 = 'base/tests/assets/test2.png';
+var VIDEO1 = 'base/tests/assets/test.mp4';
+var VIDEO2 = 'base/tests/assets/test2.mp4';
+
+suite('texture system', function () {
+  setup(function (done) {
+    var el = this.el = entityFactory();
+    var self = this;
+    el.addEventListener('loaded', function () {
+      self.system = el.sceneEl.systems.texture;
+      done();
+    });
+  });
+
+  suite('loadImage', function () {
+    test('loads image texture', function (done) {
+      var system = this.system;
+      var src = IMAGE1;
+      var data = {src: IMAGE1};
+      var hash = system.hash(data);
+
+      system.loadImage(src, data, function (texture) {
+        assert.equal(texture.image.getAttribute('src'), src);
+        system.cache[hash].then(function (texture2) {
+          assert.equal(texture, texture2);
+          done();
+        });
+      });
+    });
+
+    test('loads image given an <img> element', function (done) {
+      var img = document.createElement('img');
+      var system = this.system;
+      var data = {src: IMAGE1};
+      var hash = system.hash(data);
+
+      img.setAttribute('src', IMAGE1);
+      system.loadImage(img, data, function (texture) {
+        assert.equal(texture.image, img);
+        system.cache[hash].then(function (texture2) {
+          assert.equal(texture, texture2);
+          done();
+        });
+      });
+    });
+
+    test('caches identical image textures', function (done) {
+      var system = this.system;
+      var src = IMAGE1;
+      var data = {src: src};
+      var hash = system.hash(data);
+
+      Promise.all([
+        new Promise(function (resolve) { system.loadImage(src, data, resolve); }),
+        new Promise(function (resolve) { system.loadImage(src, data, resolve); })
+      ]).then(function (results) {
+        assert.equal(results[0], results[1]);
+        assert.equal(results[0].image.getAttribute('src'), src);
+        assert.ok(system.cache[hash]);
+        assert.equal(Object.keys(system.cache).length, 1);
+        done();
+      });
+    });
+
+    test('caches different textures for different images', function (done) {
+      var system = this.system;
+      var src1 = IMAGE1;
+      var src2 = IMAGE2;
+      var data1 = {src: src1};
+      var data2 = {src: src2};
+
+      Promise.all([
+        new Promise(function (resolve) { system.loadImage(src1, data1, resolve); }),
+        new Promise(function (resolve) { system.loadImage(src2, data2, resolve); })
+      ]).then(function (results) {
+        assert.equal(results[0].image.getAttribute('src'), src1);
+        assert.equal(results[1].image.getAttribute('src'), src2);
+        assert.notEqual(results[0].uuid, results[1].uuid);
+        done();
+      });
+    });
+
+    test('caches different textures for different repeat', function (done) {
+      var system = this.system;
+      var src = IMAGE1;
+      var data1 = {src: src};
+      var data2 = {src: src, repeat: '5 5'};
+      var hash1 = system.hash(data1);
+      var hash2 = system.hash(data2);
+
+      Promise.all([
+        new Promise(function (resolve) { system.loadImage(src, data1, resolve); }),
+        new Promise(function (resolve) { system.loadImage(src, data2, resolve); })
+      ]).then(function (results) {
+        assert.notEqual(results[0].uuid, results[1].uuid);
+        assert.shallowDeepEqual(results[0].repeat, {x: 1, y: 1});
+        assert.shallowDeepEqual(results[1].repeat, {x: 5, y: 5});
+        assert.equal(Object.keys(system.cache).length, 2);
+        assert.ok(system.cache[hash1]);
+        assert.ok(system.cache[hash2]);
+        done();
+      });
+    });
+  });
+
+  suite('loadVideo', function () {
+    test('loads video texture', function (done) {
+      var system = this.system;
+      var src = VIDEO1;
+      var data = {src: VIDEO1};
+
+      system.loadVideo(src, data, function (texture) {
+        var hash = Object.keys(system.cache)[0];
+        assert.equal(texture.image.getAttribute('src'), src);
+        system.cache[hash].then(function (result) {
+          assert.equal(texture, result.texture);
+          assert.equal(texture.image, result.videoEl);
+          done();
+        });
+      });
+    });
+
+    test('loads image given a <video> element', function (done) {
+      var videoEl = document.createElement('video');
+      var system = this.system;
+      var data = {src: VIDEO1};
+
+      videoEl.setAttribute('src', VIDEO1);
+      system.loadVideo(videoEl, data, function (texture) {
+        var hash = Object.keys(system.cache)[0];
+        assert.equal(texture.image, videoEl);
+        system.cache[hash].then(function (result) {
+          assert.equal(texture, result.texture);
+          assert.equal(texture.image, result.videoEl);
+          done();
+        });
+      });
+    });
+
+    test('caches identical video textures', function (done) {
+      var system = this.system;
+      var src = VIDEO1;
+      var data = {src: src};
+
+      Promise.all([
+        new Promise(function (resolve) { system.loadVideo(src, data, resolve); }),
+        new Promise(function (resolve) { system.loadVideo(src, data, resolve); })
+      ]).then(function (results) {
+        assert.equal(results[0], results[1]);
+        assert.equal(results[0].image.getAttribute('src'), src);
+        assert.equal(Object.keys(system.cache).length, 1);
+        done();
+      });
+    });
+
+    test('caches different textures for different videos', function (done) {
+      var system = this.system;
+      var src1 = VIDEO1;
+      var src2 = VIDEO2;
+      var data1 = {src: src1};
+      var data2 = {src: src2};
+
+      Promise.all([
+        new Promise(function (resolve) { system.loadVideo(src1, data1, resolve); }),
+        new Promise(function (resolve) { system.loadVideo(src2, data2, resolve); })
+      ]).then(function (results) {
+        assert.equal(results[0].image.getAttribute('src'), src1);
+        assert.equal(results[1].image.getAttribute('src'), src2);
+        assert.notEqual(results[0].uuid, results[1].uuid);
+        done();
+      });
+    });
+
+    test('caches different textures for different repeat', function (done) {
+      var system = this.system;
+      var src = VIDEO1;
+      var data1 = {src: src};
+      var data2 = {src: src, repeat: '5 5'};
+
+      Promise.all([
+        new Promise(function (resolve) { system.loadVideo(src, data1, resolve); }),
+        new Promise(function (resolve) { system.loadVideo(src, data2, resolve); })
+      ]).then(function (results) {
+        assert.notEqual(results[0].uuid, results[1].uuid);
+        assert.shallowDeepEqual(results[0].repeat, {x: 1, y: 1});
+        assert.shallowDeepEqual(results[1].repeat, {x: 5, y: 5});
+        assert.equal(Object.keys(system.cache).length, 2);
+        done();
+      });
+    });
+  });
+});

--- a/vendor/rStats.extras.js
+++ b/vendor/rStats.extras.js
@@ -110,7 +110,7 @@ window.threeStats = function ( renderer ) {
         'renderer.info.memory.textures': {
             caption: 'Textures'
         },
-        'renderer.info.memory.programs': {
+        'renderer.info.programs': {
             caption: 'Programs'
         },
         'renderer.info.render.calls': {
@@ -129,10 +129,10 @@ window.threeStats = function ( renderer ) {
     };
 
     var _groups = [ {
-        caption: 'Three.js - memory',
-        values: [ 'renderer.info.memory.geometries', 'renderer.info.memory.programs', 'renderer.info.memory.textures' ]
+        caption: 'Three.js - Memory',
+        values: [ 'renderer.info.memory.geometries', 'renderer.info.programs', 'renderer.info.memory.textures' ]
     }, {
-        caption: 'Three.js - render',
+        caption: 'Three.js - Render',
         values: [ 'renderer.info.render.calls', 'renderer.info.render.faces', 'renderer.info.render.points', 'renderer.info.render.vertices' ]
     } ];
 
@@ -141,7 +141,7 @@ window.threeStats = function ( renderer ) {
     function _update () {
 
         _rS( 'renderer.info.memory.geometries' ).set( renderer.info.memory.geometries );
-        _rS( 'renderer.info.memory.programs' ).set( renderer.info.memory.programs );
+        _rS( 'renderer.info.programs' ).set( renderer.info.programs.length );
         _rS( 'renderer.info.memory.textures' ).set( renderer.info.memory.textures );
         _rS( 'renderer.info.render.calls' ).set( renderer.info.render.calls );
         _rS( 'renderer.info.render.faces' ).set( renderer.info.render.faces );
@@ -256,7 +256,6 @@ window.BrowserStats = function () {
 
 if (typeof module === 'object') {
   module.exports = {
-    aframeStats: window.aframeStats,
     glStats: window.glStats,
     threeStats: window.threeStats,
     BrowserStats: window.BrowserStats


### PR DESCRIPTION
**Description:**

This started off as trying to cache materials (#1350), but I found that negatively impacted CPU performance, although it did save relatively a lot of memory. Now it's mostly a refactor with a couple enhancements.

**Changes proposed:**
- Split material system + texture system.
- Move handling of loaded texture to the shader. `standard` and `flat` shaders now handle setting `material.map` and the texture system should only worry about loading/caching the texture.
- Shader talks to texture system.
- Move material/shader creation to material system.
- Set `material.shader` to shader instance such that shader methods can be manually envoked.
- Utility function between `standard`/`flat` shader to load textures for `material.map`.
- Flatten texture cache. Cache is keyed off of serialized data like geometry component. The subset of data to use to make the key is determined by shader.
- Support `repeat` (and future texture properties) for videos.
- Fix unnecessary `<img>` creation when loading img elements.
- Bump rStats to get program stats
- Namespace and link performance tests
- Add more tests for texture caching
- Slightly improve material component perf by not calling `utils.diff`