### PR TITLE
GearVR browser should not be treated as a mobile browser by aframe be…

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -122,10 +122,10 @@ module.exports.isMobile = function () {
     if (isIOS()) {
       check = true;
     }
+    if (isGearVR()) {
+      check = false;
+    }
   })(navigator.userAgent || navigator.vendor || window.opera);
-  if (isGearVR()) {
-    check = false;
-  }
   return check;
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -123,11 +123,18 @@ module.exports.isMobile = function () {
       check = true;
     }
   })(navigator.userAgent || navigator.vendor || window.opera);
+  if (isGearVR()) {
+    check = false;
+  }
   return check;
 };
 
 var isIOS = module.exports.isIOS = function () {
   return /iPad|iPhone|iPod/.test(navigator.platform);
+};
+
+var isGearVR = module.exports.isGearVR = function () {
+  return /SamsungBrowser.+Mobile VR/i.test(navigator.userAgent);
 };
 
 /**


### PR DESCRIPTION
**Description:**
Samsung GearVR Browser now supports WebVR so this browser should not be treated as a mobile browser by aframe.
**Changes proposed:**
- Check within the isMobile function if the browser isGearVR. If so isMobile should return false.
- Used same style as isIOS check

Tested all examples on Gear VR with Galaxy S7 and this change makes them work.

#1346 