### PR TITLE
don't use object diff if not necessary

### DIFF
--- a/src/components/light.js
+++ b/src/components/light.js
@@ -37,7 +37,7 @@ module.exports.Component = registerComponent('light', {
    */
   update: function (oldData) {
     var data = this.data;
-    var diffData = diff(data, oldData || {});
+    var diffData = diff(data, oldData);
     var light = this.light;
 
     // Existing light.

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -1,12 +1,10 @@
 /* global Promise */
-var debug = require('../utils/debug');
-var utils = require('../utils');
+var utils = require('../utils/');
 var component = require('../core/component');
 var THREE = require('../lib/three');
 var shader = require('../core/shader');
 
-var error = debug('components:material:error');
-var diff = utils.diff;
+var error = utils.debug('components:material:error');
 var registerComponent = component.registerComponent;
 var shaders = shader.shaders;
 var shaderNames = shader.shaderNames;
@@ -38,9 +36,7 @@ module.exports.Component = registerComponent('material', {
    */
   update: function (oldData) {
     var data = this.data;
-    var dataDiff = oldData ? diff(oldData, data) : data;
-
-    if (!this.shader || dataDiff.shader) {
+    if (!this.shader || data.shader !== oldData.shader) {
       this.updateShader(data.shader);
     }
     this.shader.update(this.data);

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -1,5 +1,4 @@
 var debug = require('../utils/debug');
-var diff = require('../utils').diff;
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
 
@@ -24,44 +23,30 @@ module.exports.Component = registerComponent('sound', {
 
   update: function (oldData) {
     var data = this.data;
-    var diffData = diff(oldData || {}, data);
     var el = this.el;
     var sound = this.sound;
-    var src = data.src;
-    var srcChanged = 'src' in diffData;
+    var srcChanged = data.src !== oldData.src;
 
     // Create new sound if not yet created or changing `src`.
     if (srcChanged) {
-      if (!src) {
+      if (!data.src) {
         warn('Audio source was not specified with `src`');
         return;
       }
       sound = this.setupSound();
     }
 
-    if (srcChanged || 'autoplay' in diffData) {
-      sound.autoplay = data.autoplay;
-    }
+    sound.autoplay = data.autoplay;
+    sound.setLoop(data.loop);
+    sound.setVolume(data.volume);
 
-    if (srcChanged || 'loop' in diffData) {
-      sound.setLoop(data.loop);
-    }
-
-    if (srcChanged || 'volume' in diffData) {
-      sound.setVolume(data.volume);
-    }
-
-    if ('on' in diffData) {
-      if (oldData && oldData.on) {
-        el.removeEventListener(oldData.on);
-      }
+    if (data.on !== oldData.on) {
+      if (oldData.on) { el.removeEventListener(oldData.on); }
       el.addEventListener(data.on, this.play.bind(this));
     }
 
-    // All sound values set. Load in `src.
-    if (srcChanged) {
-      sound.load(src);
-    }
+    // All sound values set. Load in `src`.
+    if (srcChanged) { sound.load(data.src); }
   },
 
   remove: function () {

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -189,7 +189,8 @@ Component.prototype = {
   updateProperties: function (value) {
     var el = this.el;
     var isSinglePropSchema = isSingleProp(this.schema);
-    var previousData = extendProperties({}, this.data, isSinglePropSchema);
+    var oldData = extendProperties({}, this.data, isSinglePropSchema);
+
     this.updateCachedAttrValue(value);
     if (this.updateSchema) {
       this.updateSchema(buildData(el, this.name, this.schema, this.attrValue, true));
@@ -197,18 +198,18 @@ Component.prototype = {
     this.data = buildData(el, this.name, this.schema, this.attrValue);
 
     // Don't update if properties haven't changed
-    if (!isSinglePropSchema && utils.deepEqual(previousData, this.data)) { return; }
+    if (!isSinglePropSchema && utils.deepEqual(oldData, this.data)) { return; }
 
     if (!this.initialized) {
       this.init();
       this.initialized = true;
     }
-    this.update(previousData);
+    this.update(oldData);
 
     el.emit('componentchanged', {
       name: this.name,
       newData: this.getData(),
-      oldData: previousData
+      oldData: oldData
     });
   },
 
@@ -342,12 +343,6 @@ module.exports.buildData = buildData;
 * @returns Overridden object or value.
 */
 function extendProperties (dest, source, isSinglePropSchema) {
-  if (isSinglePropSchema) {
-    if (source === undefined || source === null ||
-        (typeof source === 'object' && Object.keys(source).length === 0)) {
-      return dest;
-    }
-    return source;
-  }
+  if (isSinglePropSchema) { return source; }
   return utils.extend(dest, source);
 }


### PR DESCRIPTION
**Description:** For material + sound, full object diffing was not necessary. Saves some CPU.

**Changes proposed:**
- Don't use object diff in material/sound.
- Compare only properties needed
- make `oldData` to be `undefined` for single prop schemas on first init

