### PR TITLE
share updateMap helper between flat/standard shaders

### DIFF
--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -22,41 +22,14 @@ module.exports.Component = registerShader('flat', {
   init: function (data) {
     this.textureSrc = null;
     this.material = new THREE.MeshBasicMaterial(getMaterialData(data));
-    this.updateTexture(data);
+    utils.material.updateMap(this, data);
     return this.material;
   },
 
   update: function (data) {
     this.updateMaterial(data);
-    this.updateTexture(data);
+    utils.material.updateMap(this, data);
     return this.material;
-  },
-
-  /**
-   * Update or create material.
-   *
-   * @param {object|null} oldData
-   */
-  updateTexture: function (data) {
-    var el = this.el;
-    var src = data.src;
-    var material = this.material;
-    var materialSystem = el.sceneEl.systems.material;
-
-    if (src) {
-      if (src === this.textureSrc) { return; }
-      // Texture added or changed.
-      this.textureSrc = src;
-      utils.srcLoader.validateSrc(
-        src,
-        function loadImageCb (src) { materialSystem.loadImage(el, material, data, src); },
-        function loadVideoCb (src) { materialSystem.loadVideo(el, material, data, src); }
-      );
-      return;
-    }
-
-    // Texture removed.
-    utils.material.updateMaterialTexture(material, null);
   },
 
   /**
@@ -80,9 +53,8 @@ module.exports.Component = registerShader('flat', {
  * @returns {object} data - Processed material data.
  */
 function getMaterialData (data) {
-  var materialData = {
+  return {
     fog: data.fog,
     color: new THREE.Color(data.color)
   };
-  return materialData;
 }

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -26,42 +26,16 @@ module.exports.Component = registerShader('standard', {
    */
   init: function (data) {
     this.material = new THREE.MeshStandardMaterial(getMaterialData(data));
-    this.updateTexture(data);
+    utils.material.updateMap(this, data);
     this.updateEnvMap(data);
     return this.material;
   },
 
   update: function (data) {
     this.updateMaterial(data);
-    this.updateTexture(data);
+    utils.material.updateMap(this, data);
     this.updateEnvMap(data);
     return this.material;
-  },
-
-  /**
-   * Update or create material.
-   *
-   * @param {object|null} oldData
-   */
-  updateTexture: function (data) {
-    var el = this.el;
-    var src = data.src;
-    var material = this.material;
-    var materialSystem = el.sceneEl.systems.material;
-
-    if (src) {
-      if (src === this.textureSrc) { return; }
-      // Texture added or changed.
-      this.textureSrc = src;
-      utils.srcLoader.validateSrc(
-        src,
-        function loadImageCb (src) { materialSystem.loadImage(el, material, data, src); },
-        function loadVideoCb (src) { materialSystem.loadVideo(el, material, data, src); }
-      );
-    } else {
-      // Texture removed.
-      utils.material.updateMaterialTexture(material, null);
-    }
   },
 
   /**
@@ -125,10 +99,9 @@ module.exports.Component = registerShader('standard', {
  * @returns {object} data - Processed material data.
  */
 function getMaterialData (data) {
-  var materialData = {
+  return {
     color: new THREE.Color(data.color),
     metalness: data.metalness,
     roughness: data.roughness
   };
-  return materialData;
 }

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -1,10 +1,40 @@
+var srcLoader = require('./src-loader');
+
+/**
+ * Update shader instance's `material.map` given `data.src`.
+ *
+ * @param {object} shader - A-Frame shader instance.
+ * @param {object} data
+ */
+module.exports.updateMap = function (shader, data) {
+  var el = shader.el;
+  var src = data.src;
+  var material = shader.material;
+  var materialSystem = el.sceneEl.systems.material;
+
+  if (src) {
+    if (src === shader.mapSrc) { return; }
+    // Texture added or changed.
+    shader.mapSrc = src;
+    srcLoader.validateSrc(
+      src,
+      function loadImageCb (src) { materialSystem.loadImage(el, material, data, src); },
+      function loadVideoCb (src) { materialSystem.loadVideo(el, material, data, src); }
+    );
+    return;
+  }
+
+  // Texture removed.
+  updateMaterialTexture(material, null);
+};
+
 /**
  * Set material texture and update if necessary.
  *
  * @param {object} material
  * @param {object} texture
  */
-module.exports.updateMaterialTexture = function (material, texture) {
+function updateMaterialTexture (material, texture) {
   var oldMap = material.map;
   if (texture) { texture.needsUpdate = true; }
   material.map = texture;
@@ -13,4 +43,5 @@ module.exports.updateMaterialTexture = function (material, texture) {
   if (oldMap === null && material.map || material.map === null && oldMap) {
     material.needsUpdate = true;
   }
-};
+}
+module.exports.updateMaterialTexture = updateMaterialTexture;


### PR DESCRIPTION
**Description:**

Precursor to https://github.com/aframevr/aframe/pull/1364 where the shader will be managing the setting of textures on the material. And to emphasize that `map` is just one of many possible textures.

**Changes proposed:**
- Move map updating code to a utility function since shader/flat are the exact same code


