### PR TITLE
make shaders handle setting textures

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -46,8 +46,8 @@ The material component has only a few base properties, but more properties will 
 
 | Event Name              | Description                                                                                |
 |-------------------------|--------------------------------------------------------------------------------------------|
-| material-texture-loaded | Texture loaded onto material. Or when the first frame is playing for video textures.       |
-| material-video-ended    | For video textures, emitted when the video has reached its end (may not work with `loop`). |
+| materialtextureloaded | Texture loaded onto material. Or when the first frame is playing for video textures.       |
+| materialvideoended    | For video textures, emitted when the video has reached its end (may not work with `loop`). |
 
 ## Textures
 

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -2,9 +2,6 @@ var registerSystem = require('../core/system').registerSystem;
 var THREE = require('../lib/three');
 var utils = require('../utils/');
 
-var EVENTS = {
-  TEXTURE_LOADED: 'material-texture-loaded'
-};
 var debug = utils.debug;
 var error = debug('components:texture:error');
 var TextureLoader = new THREE.TextureLoader();
@@ -30,58 +27,69 @@ module.exports.System = registerSystem('material', {
   },
 
   /**
-   * High-level function for loading image textures. Meat of logic is in `loadImageTexture`.
+   * Determine whether `src` is a image or video. Then try to load the asset, then call back.
    *
-   * @param {Element} el - Entity, used to emit event.
-   * @param {object} material - three.js material, bound by the A-Frame shader.
-   * @param {object} data - Shader data, bound by the A-Frame shader.
-   * @param {Element|string} src - Texture source, bound by `src-loader` utils.
+   * @param {string} src - Texture URL.
+   * @param {string} data - Relevant texture data used for caching.
+   * @param {function} cb - Callback to pass texture to.
    */
-  loadImage: function (el, material, data, src) {
-    var repeat = data.repeat || '1 1';
-    var srcString = src;
-    var textureCache = this.textureCache;
-
-    if (typeof src !== 'string') { srcString = src.getAttribute('src'); }
-
-    // Another material is already loading this texture. Wait on promise.
-    if (textureCache[src] && textureCache[src][repeat]) {
-      textureCache[src][repeat].then(handleImageTextureLoaded);
-      return;
-    }
-
-    // Material instance is first to try to load this texture. Load it.
-    textureCache[srcString] = textureCache[srcString] || {};
-    textureCache[srcString][repeat] = textureCache[srcString][repeat] || {};
-    textureCache[srcString][repeat] = loadImageTexture(material, src, repeat);
-    textureCache[srcString][repeat].then(handleImageTextureLoaded);
-
-    function handleImageTextureLoaded (texture) {
-      utils.material.updateMaterialTexture(material, texture);
-      el.emit(EVENTS.TEXTURE_LOADED, { src: src, texture: texture });
-    }
+  loadTexture: function (src, data, cb) {
+    var self = this;
+    utils.srcLoader.validateSrc(src, loadImageCb, loadVideoCb);
+    function loadImageCb (src) { self.loadImage(src, data, cb); }
+    function loadVideoCb (src) { self.loadVideo(src, data, cb); }
   },
 
   /**
-   * Load video texture.
-   * Note that creating a video texture is more synchronous than creating an image texture.
+   * High-level function for loading image textures (THREE.Texture).
    *
-   * @param {Element} el - Entity, used to emit event.
-   * @param {object} material - three.js material.
-   * @param data {object} - Shader data, bound by the A-Frame shader.
-   * @param src {Element|string} - Texture source, bound by `src-loader` utils.
+   * @param {Element|string} src - Texture source.
+   * @param {object} data - Texture data.
+   * @param {function} cb - Callback to pass texture to.
    */
-  loadVideo: function (el, material, data, src) {
+  loadImage: function (src, data, cb) {
+    var hash = this.hash(data);
+    var handleImageTextureLoaded = cb;
+    var textureCache = this.textureCache;
+
+    // Texture already being loaded or already loaded. Wait on promise.
+    if (textureCache[hash]) {
+      textureCache[hash].then(handleImageTextureLoaded);
+      return;
+    }
+
+    // Texture not yet being loaded. Start loading it.
+    textureCache[hash] = loadImageTexture(src, data);
+    textureCache[hash].then(handleImageTextureLoaded);
+  },
+
+    /**
+   * Load video texture (THREE.VideoTexture).
+   * Which is just an image texture that RAFs + needsUpdate.
+   * Note that creating a video texture is synchronous unlike loading an image texture.
+   * Made asynchronous to be consistent with image textures.
+   *
+   * @param {Element|string} src - Texture source.
+   * @param {object} data - Texture data.
+   * @param {function} cb - Callback to pass texture to.
+   */
+  loadVideo: function (src, data, cb) {
     var hash;
     var texture;
     var textureCache = this.textureCache;
     var videoEl;
     var videoTextureResult;
 
+    function handleVideoTextureLoaded (result) {
+      result.texture.needsUpdate = true;
+      cb(result.texture, result.videoEl);
+    }
+
+    // Video element provided.
     if (typeof src !== 'string') {
       // Check cache before creating texture.
       videoEl = src;
-      hash = calculateVideoCacheHash(videoEl);
+      hash = this.hashVideo(data, videoEl);
       if (textureCache[hash]) {
         textureCache[hash].then(handleVideoTextureLoaded);
         return;
@@ -90,11 +98,11 @@ module.exports.System = registerSystem('material', {
       fixVideoAttributes(videoEl);
     }
 
-    // Use video element to create texture.
-    videoEl = videoEl || createVideoEl(material, src, data.width, data.height);
+    // Only URL provided. Use video element to create texture.
+    videoEl = videoEl || createVideoEl(src, data.width, data.height);
 
     // Generated video element already cached. Use that.
-    hash = calculateVideoCacheHash(videoEl);
+    hash = this.hashVideo(data, videoEl);
     if (textureCache[hash]) {
       textureCache[hash].then(handleVideoTextureLoaded);
       return;
@@ -103,28 +111,20 @@ module.exports.System = registerSystem('material', {
     // Create new video texture.
     texture = new THREE.VideoTexture(videoEl);
     texture.minFilter = THREE.LinearFilter;
+    setTextureProperties(texture, data);
 
     // Cache as promise to be consistent with image texture caching.
-    videoTextureResult = {
-      texture: texture,
-      videoEl: videoEl
-    };
+    videoTextureResult = {texture: texture, videoEl: videoEl};
     textureCache[hash] = Promise.resolve(videoTextureResult);
     handleVideoTextureLoaded(videoTextureResult);
+  },
 
-    function handleVideoTextureLoaded (res) {
-      texture = res.texture;
-      videoEl = res.videoEl;
-      utils.material.updateMaterialTexture(material, texture);
-      el.emit(EVENTS.TEXTURE_LOADED, { element: videoEl, src: src });
-      videoEl.addEventListener('loadeddata', function () {
-        el.emit('material-video-loadeddata', { element: videoEl, src: src });
-      });
-      videoEl.addEventListener('ended', function () {
-        // Works for non-looping videos only.
-        el.emit('material-video-ended', { element: videoEl, src: src });
-      });
-    }
+  hash: function (data) {
+    return JSON.stringify(data);
+  },
+
+  hashVideo: function (data, videoEl) {
+    return calculateVideoCacheHash(data, videoEl);
   },
 
   /**
@@ -161,10 +161,11 @@ module.exports.System = registerSystem('material', {
  * If the video element has an ID, use that.
  * Else build a hash that looks like `src:myvideo.mp4;height:200;width:400;`.
  *
+ * @param data {object} - Texture data such as repeat.
  * @param videoEl {Element} - Video element.
  * @returns {string}
  */
-function calculateVideoCacheHash (videoEl) {
+function calculateVideoCacheHash (data, videoEl) {
   var i;
   var id = videoEl.getAttribute('id');
   var hash;
@@ -174,7 +175,7 @@ function calculateVideoCacheHash (videoEl) {
 
   // Calculate hash using sorted video attributes.
   hash = '';
-  videoAttributes = {};
+  videoAttributes = data || {};
   for (i = 0; i < videoEl.attributes.length; i++) {
     videoAttributes[videoEl.attributes[i].name] = videoEl.attributes[i].value;
   }
@@ -186,24 +187,28 @@ function calculateVideoCacheHash (videoEl) {
 }
 
 /**
- * Set image texture on material as `map`.
+ * Load image texture.
  *
  * @private
- * @param {object} el - Entity element.
- * @param {object} material - three.js material.
  * @param {string|object} src - An <img> element or url to an image file.
- * @param {string} repeat - X and Y value for size of texture repeating (in UV units).
+ * @param {object} data - Data to set texture properties like `repeat`.
  * @returns {Promise} Resolves once texture is loaded.
  */
-function loadImageTexture (material, src, repeat) {
+function loadImageTexture (src, data) {
   return new Promise(doLoadImageTexture);
 
   function doLoadImageTexture (resolve, reject) {
     var isEl = typeof src !== 'string';
 
+    function resolveTexture (texture) {
+      setTextureProperties(texture, data);
+      texture.needsUpdate = true;
+      resolve(texture);
+    }
+
     // Create texture from an element.
     if (isEl) {
-      createTexture(src);
+      resolveTexture(new THREE.Texture(src));
       return;
     }
 
@@ -211,59 +216,55 @@ function loadImageTexture (material, src, repeat) {
     // Use THREE.TextureLoader (src, onLoad, onProgress, onError) to load texture.
     TextureLoader.load(
       src,
-      createTexture,
+      resolveTexture,
       function () { /* no-op */ },
       function (xhr) {
         error('`$s` could not be fetched (Error code: %s; Response: %s)', xhr.status,
               xhr.statusText);
       }
     );
-
-    /**
-     * Texture loaded. Set it.
-     */
-    function createTexture (texture) {
-      var repeatXY;
-      if (!(texture instanceof THREE.Texture)) { texture = new THREE.Texture(texture); }
-
-      // Handle UV repeat.
-      repeatXY = repeat.split(' ');
-      if (repeatXY.length === 2) {
-        texture.wrapS = THREE.RepeatWrapping;
-        texture.wrapT = THREE.RepeatWrapping;
-        texture.repeat.set(parseInt(repeatXY[0], 10), parseInt(repeatXY[1], 10));
-      }
-
-      resolve(texture);
-    }
   }
+}
+
+/**
+ * Set texture properties such as repeat.
+ *
+ * @param {object} data - With keys like `repeat`.
+ */
+function setTextureProperties (texture, data) {
+  // Handle UV repeat.
+  var repeat = data.repeat || '1 1';
+  var repeatXY = repeat.split(' ');
+
+  // Don't bother setting repeat if it is 1/1. Power-of-two is required to repeat.
+  if (repeat === '1 1' || repeatXY.length !== 2) { return; }
+
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(parseInt(repeatXY[0], 10), parseInt(repeatXY[1], 10));
 }
 
 /**
  * Create video element to be used as a texture.
  *
- * @param {object} material - three.js material.
  * @param {string} src - Url to a video file.
  * @param {number} width - Width of the video.
  * @param {number} height - Height of the video.
  * @returns {Element} Video element.
  */
-function createVideoEl (material, src, width, height) {
-  var el = material.videoEl || document.createElement('video');
-  el.width = width;
-  el.height = height;
-  if (el !== this.videoEl) {
-    el.setAttribute('webkit-playsinline', '');  // To support inline videos in iOS webviews.
-    el.autoplay = true;
-    el.loop = true;
-    el.crossOrigin = true;
-    el.addEventListener('error', function () {
-      warn('`$s` is not a valid video', src);
-    }, true);
-    material.videoEl = el;
-  }
-  el.src = src;
-  return el;
+function createVideoEl (src, width, height) {
+  var videoEl = document.createElement('video');
+  videoEl.width = width;
+  videoEl.height = height;
+  videoEl.setAttribute('webkit-playsinline', '');  // Support inline videos for iOS webviews.
+  videoEl.autoplay = true;
+  videoEl.loop = true;
+  videoEl.crossOrigin = true;
+  videoEl.addEventListener('error', function () {
+    warn('`$s` is not a valid video', src);
+  }, true);
+  videoEl.src = src;
+  return videoEl;
 }
 
 /**
@@ -280,10 +281,8 @@ function createVideoEl (material, src, width, height) {
  * @returns {Element} Video element with the correct properties updated.
  */
 function fixVideoAttributes (videoEl) {
+  videoEl.autoplay = videoEl.getAttribute('autoplay') !== 'false';
   videoEl.controls = videoEl.getAttribute('controls') !== 'false';
-  if (videoEl.getAttribute('autoplay') === 'false') {
-    videoEl.removeAttribute('autoplay');
-  }
   if (videoEl.getAttribute('loop') === 'false') {
     videoEl.removeAttribute('loop');
   }

--- a/tests/systems/material.test.js
+++ b/tests/systems/material.test.js
@@ -1,11 +1,17 @@
 /* global assert, process, setup, suite, test */
 var entityFactory = require('../helpers').entityFactory;
-var THREE = require('index').THREE;
+
+var IMAGE1 = 'base/tests/assets/test.png';
+var IMAGE2 = 'base/tests/assets/test2.png';
+var VIDEO1 = 'base/tests/assets/test.mp4';
+var VIDEO2 = 'base/tests/assets/test2.mp4';
 
 suite('material system', function () {
   setup(function (done) {
+    var self = this;
     var el = this.el = entityFactory();
     el.addEventListener('loaded', function () {
+      self.system = el.sceneEl.systems.material;
       done();
     });
   });
@@ -38,97 +44,182 @@ suite('material system', function () {
 
   suite('texture caching', function () {
     setup(function () {
-      this.el.sceneEl.systems.material.clearTextureCache();
+      this.system.clearTextureCache();
     });
 
-    test('does not cache different image textures', function (done) {
-      var el = this.el;
-      var imageUrl = 'base/tests/assets/test.png';
-      var imageUrl2 = 'base/tests/assets/test2.png';
-      var textureSpy = this.sinon.spy(THREE, 'Texture');
-      assert.equal(textureSpy.callCount, 0);
+    suite('loadImage', function () {
+      test('loads image texture', function (done) {
+        var system = this.system;
+        var src = IMAGE1;
+        var data = {src: IMAGE1};
+        var hash = system.hash(data);
 
-      el.setAttribute('material', 'src: url(' + imageUrl + ')');
+        system.loadImage(src, data, function (texture) {
+          assert.equal(texture.image.getAttribute('src'), src);
+          system.textureCache[hash].then(function (texture2) {
+            assert.equal(texture, texture2);
+            done();
+          });
+        });
+      });
 
-      el.addEventListener('material-texture-loaded', function (evt) {
-        var el2;
-        assert.equal(textureSpy.callCount, 1);
+      test('loads image given an <img> element', function (done) {
+        var img = document.createElement('img');
+        var system = this.system;
+        var data = {src: IMAGE1};
+        var hash = system.hash(data);
 
-        el2 = document.createElement('a-entity');
-        el2.setAttribute('material', 'src: url(' + imageUrl2 + ')');
-        el.sceneEl.appendChild(el2);
-        el2.addEventListener('material-texture-loaded', function () {
-          // Two textures created.
-          assert.equal(textureSpy.callCount, 2);
+        img.setAttribute('src', IMAGE1);
+        system.loadImage(img, data, function (texture) {
+          assert.equal(texture.image, img);
+          system.textureCache[hash].then(function (texture2) {
+            assert.equal(texture, texture2);
+            done();
+          });
+        });
+      });
+
+      test('caches identical image textures', function (done) {
+        var system = this.system;
+        var src = IMAGE1;
+        var data = {src: src};
+        var hash = system.hash(data);
+
+        Promise.all([
+          new Promise(function (resolve) { system.loadImage(src, data, resolve); }),
+          new Promise(function (resolve) { system.loadImage(src, data, resolve); })
+        ]).then(function (results) {
+          assert.equal(results[0], results[1]);
+          assert.equal(results[0].image.getAttribute('src'), src);
+          assert.ok(system.textureCache[hash]);
+          assert.equal(Object.keys(system.textureCache).length, 1);
+          done();
+        });
+      });
+
+      test('caches different textures for different images', function (done) {
+        var system = this.system;
+        var src1 = IMAGE1;
+        var src2 = IMAGE2;
+        var data1 = {src: src1};
+        var data2 = {src: src2};
+
+        Promise.all([
+          new Promise(function (resolve) { system.loadImage(src1, data1, resolve); }),
+          new Promise(function (resolve) { system.loadImage(src2, data2, resolve); })
+        ]).then(function (results) {
+          assert.equal(results[0].image.getAttribute('src'), src1);
+          assert.equal(results[1].image.getAttribute('src'), src2);
+          assert.notEqual(results[0].uuid, results[1].uuid);
+          done();
+        });
+      });
+
+      test('caches different textures for different repeat', function (done) {
+        var system = this.system;
+        var src = IMAGE1;
+        var data1 = {src: src};
+        var data2 = {src: src, repeat: '5 5'};
+        var hash1 = system.hash(data1);
+        var hash2 = system.hash(data2);
+
+        Promise.all([
+          new Promise(function (resolve) { system.loadImage(src, data1, resolve); }),
+          new Promise(function (resolve) { system.loadImage(src, data2, resolve); })
+        ]).then(function (results) {
+          assert.notEqual(results[0].uuid, results[1].uuid);
+          assert.shallowDeepEqual(results[0].repeat, {x: 1, y: 1});
+          assert.shallowDeepEqual(results[1].repeat, {x: 5, y: 5});
+          assert.equal(Object.keys(system.textureCache).length, 2);
+          assert.ok(system.textureCache[hash1]);
+          assert.ok(system.textureCache[hash2]);
           done();
         });
       });
     });
 
-    test('can cache image textures', function (done) {
-      var el = this.el;
-      var imageUrl = 'base/tests/assets/test.png';
-      var textureSpy = this.sinon.spy(THREE, 'Texture');
-      assert.equal(textureSpy.callCount, 0);
+    suite('loadVideo', function () {
+      test('loads video texture', function (done) {
+        var system = this.system;
+        var src = VIDEO1;
+        var data = {src: VIDEO1};
 
-      el.setAttribute('material', 'src: url(' + imageUrl + ')');
+        system.loadVideo(src, data, function (texture) {
+          var hash = Object.keys(system.textureCache)[0];
+          assert.equal(texture.image.getAttribute('src'), src);
+          system.textureCache[hash].then(function (result) {
+            assert.equal(texture, result.texture);
+            assert.equal(texture.image, result.videoEl);
+            done();
+          });
+        });
+      });
 
-      el.addEventListener('material-texture-loaded', function () {
-        var el2;
-        assert.equal(textureSpy.callCount, 1);
+      test('loads image given a <video> element', function (done) {
+        var videoEl = document.createElement('video');
+        var system = this.system;
+        var data = {src: VIDEO1};
 
-        el2 = document.createElement('a-entity');
-        el2.setAttribute('material', 'src: url(' + imageUrl + ')');
-        el.sceneEl.appendChild(el2);
-        el2.addEventListener('material-texture-loaded', function () {
-          // Only one texture created.
-          assert.equal(textureSpy.callCount, 1);
+        videoEl.setAttribute('src', VIDEO1);
+        system.loadVideo(videoEl, data, function (texture) {
+          var hash = Object.keys(system.textureCache)[0];
+          assert.equal(texture.image, videoEl);
+          system.textureCache[hash].then(function (result) {
+            assert.equal(texture, result.texture);
+            assert.equal(texture.image, result.videoEl);
+            done();
+          });
+        });
+      });
+
+      test('caches identical video textures', function (done) {
+        var system = this.system;
+        var src = VIDEO1;
+        var data = {src: src};
+
+        Promise.all([
+          new Promise(function (resolve) { system.loadVideo(src, data, resolve); }),
+          new Promise(function (resolve) { system.loadVideo(src, data, resolve); })
+        ]).then(function (results) {
+          assert.equal(results[0], results[1]);
+          assert.equal(results[0].image.getAttribute('src'), src);
+          assert.equal(Object.keys(system.textureCache).length, 1);
           done();
         });
       });
-    });
 
-    test('does not cache different video textures', function (done) {
-      var el = this.el;
-      var videoUrl = 'base/tests/assets/test.mp4';
-      var videoUrl2 = 'base/tests/assets/test2.mp4';
-      var textureSpy = this.sinon.spy(THREE, 'VideoTexture');
-      assert.equal(textureSpy.callCount, 0);
+      test('caches different textures for different videos', function (done) {
+        var system = this.system;
+        var src1 = VIDEO1;
+        var src2 = VIDEO2;
+        var data1 = {src: src1};
+        var data2 = {src: src2};
 
-      el.setAttribute('material', 'src: url(' + videoUrl + ')');
-
-      el.addEventListener('material-texture-loaded', function (evt) {
-        var el2;
-        assert.equal(textureSpy.callCount, 1);
-
-        el2 = document.createElement('a-entity');
-        el2.setAttribute('material', 'src: url(' + videoUrl2 + ')');
-        el.sceneEl.appendChild(el2);
-        el2.addEventListener('material-texture-loaded', function () {
-          // Two textures created.
-          assert.equal(textureSpy.callCount, 2);
+        Promise.all([
+          new Promise(function (resolve) { system.loadVideo(src1, data1, resolve); }),
+          new Promise(function (resolve) { system.loadVideo(src2, data2, resolve); })
+        ]).then(function (results) {
+          assert.equal(results[0].image.getAttribute('src'), src1);
+          assert.equal(results[1].image.getAttribute('src'), src2);
+          assert.notEqual(results[0].uuid, results[1].uuid);
           done();
         });
       });
-    });
 
-    test('can cache video textures', function (done) {
-      var el = this.el;
-      var videoUrl = 'base/tests/assets/test.mp4';
-      var textureSpy = this.sinon.spy(THREE, 'VideoTexture');
-      assert.equal(textureSpy.callCount, 0);
+      test('caches different textures for different repeat', function (done) {
+        var system = this.system;
+        var src = VIDEO1;
+        var data1 = {src: src};
+        var data2 = {src: src, repeat: '5 5'};
 
-      el.setAttribute('material', 'src: url(' + videoUrl + ')');
-
-      el.addEventListener('material-texture-loaded', function () {
-        var el2;
-        assert.equal(textureSpy.callCount, 1);
-
-        el2 = document.createElement('a-entity');
-        el2.setAttribute('material', 'src: url(' + videoUrl + ')');
-        el.sceneEl.appendChild(el2);
-        el2.addEventListener('material-texture-loaded', function () {
-          assert.equal(textureSpy.callCount, 1);
+        Promise.all([
+          new Promise(function (resolve) { system.loadVideo(src, data1, resolve); }),
+          new Promise(function (resolve) { system.loadVideo(src, data2, resolve); })
+        ]).then(function (results) {
+          assert.notEqual(results[0].uuid, results[1].uuid);
+          assert.shallowDeepEqual(results[0].repeat, {x: 1, y: 1});
+          assert.shallowDeepEqual(results[1].repeat, {x: 5, y: 5});
+          assert.equal(Object.keys(system.textureCache).length, 2);
           done();
         });
       });


### PR DESCRIPTION
**Description:** Make texture caching more agnostic than forcing setting of `material.map`.

Before the flow was:

1. Shader passes entity and material, and asks material system for texture.
2. Material system creates texture, caching with `{src: {repeat: {}}}` data structure.
3. Material system emits event on `el`.
4. Material system sets `material.map`

The new flow is:

1. Shader passes subset of data and callback, and asks material system for texture.
2. Material system creates texture, caching with JSON-hashed data for images.
3. Material system sends texture through callback.
4. The shader does whatever it wants with the material and handles notifying the entity.

Because we hash the data for cache key, we get to remove a lot of code from the previously complex data structure.

**Other Changes proposed:**
- If passing in an `img` element, use it rather than recreate another `img` element.
- Combine video texture video element hash with data when hashing
- Add more tests

