### PR TITLE
Close the code block in docs (geometry.md)

### DIFF
--- a/docs/components/geometry.md
+++ b/docs/components/geometry.md
@@ -248,6 +248,7 @@ AFRAME.registerComponent('my-geometry', {
     this.el.getObject3D('mesh').geometry = new THREE.Geometry();
   }
 });
+```
 
 [cd]: https://en.wikipedia.org/wiki/Compact_disc
 [hexagon-codepen]: http://codepen.io/team/mozvr/pen/jWzVXJ


### PR DESCRIPTION
**Description:**
- This change fixes the malformed html in [the online docs](https://aframe.io/docs/components/geometry.html#Defining-Your-Own-Geometry). It also fixes the footnote hyperlinks, which weren't displayed properly before.

**Changes proposed:**
- Add backticks to close the unclosed code block.