### PR TITLE
fix missing quotation mark

### DIFF
--- a/docs/core/asset-management-system.md
+++ b/docs/core/asset-management-system.md
@@ -35,7 +35,7 @@ We can define all of our assets in `<a-assets>` and point to those assets from o
 
     <img id="advertisement" src="ad.png">
 
-    <video id="kentucky-derby" src="derby.mp4>
+    <video id="kentucky-derby" src="derby.mp4">
   </a-assets>
 
   <!-- Scene. -->


### PR DESCRIPTION
Small change I just noticed there was a quotation mark missing in the docs for the asset manager example.
