### PR TITLE
fix dynamically-attached entities not playing due to load conditions (fixes #1383)

### DIFF
--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -43,20 +43,20 @@ module.exports.AAnimation = registerElement('a-animation', {
     attachedCallback: {
       value: function () {
         var self = this;
-        var el = self.el = self.parentNode;
+        var el = this.el = this.parentNode;
 
-        if (el.isNode) {
-          if (el.hasLoaded) {
-            init();
-          } else {
-            el.addEventListener('loaded', init.bind(self));
-          }
-        } else {
-          // To handle elements that are not yet `<a-entity>`s (e.g., templates).
-          el.addEventListener('nodeready', init.bind(self));
-        }
+        init();
 
         function init () {
+          if (!el.isPlaying) {
+            el.addEventListener('play', init);
+            return;
+          }
+          if (!el.hasLoaded) {
+            el.addEventListener('loaded', init);
+            return;
+          }
+
           self.applyMixin();
           self.update();
           self.load();

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -59,13 +59,14 @@ var proto = Object.create(ANode.prototype, {
     }
   },
 
+  /**
+   * Add to parent, load, play.
+   */
   attachedCallback: {
     value: function () {
       this.addToParent();
-      if (!this.isScene) {
-        this.load();
-        if (this.parentEl.isPlaying) { this.play(); }
-      }
+      if (this.isScene) { return; }
+      this.load();
     }
   },
 
@@ -211,15 +212,26 @@ var proto = Object.create(ANode.prototype, {
 
   load: {
     value: function () {
+      var self = this;
+
       if (this.hasLoaded) { return; }
+
       // Attach to parent object3D.
       this.addToParent();
+
+      // Scene load.
+      function sceneLoadCallback () { self.updateComponents(); }
       if (this.isScene) {
-        ANode.prototype.load.call(this, this.updateComponents.bind(this));
-      } else {
-        ANode.prototype.load.call(this, this.updateComponents.bind(this),
-                                  function (el) { return el.isEntity; });
+        ANode.prototype.load.call(this, sceneLoadCallback);
+        return;
       }
+
+      // Entity load.
+      function entityLoadCallback () {
+        self.updateComponents();
+        if (self.parentNode.isPlaying) { self.play(); }
+      }
+      ANode.prototype.load.call(this, entityLoadCallback, isEntity);
     },
     writable: window.debug
   },
@@ -435,8 +447,8 @@ var proto = Object.create(ANode.prototype, {
       });
 
       // Tell all child entities to play.
-      this.getChildEntities().forEach(function play (obj) {
-        obj.play();
+      this.getChildEntities().forEach(function play (entity) {
+        entity.play();
       });
 
       this.emit('play');
@@ -698,6 +710,10 @@ function playComponent (component, sceneEl) {
   // Add tick behavior.
   if (!component.tick) { return; }
   sceneEl.addBehavior(component);
+}
+
+function isEntity (el) {
+  return el.isEntity;
 }
 
 AEntity = registerElement('a-entity', {

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -93,15 +93,26 @@ suite('a-entity', function () {
       });
     });
 
+    test('is playing when loaded', function (done) {
+      var el = document.createElement('a-entity');
+
+      el.addEventListener('loaded', function () {
+        assert.ok(el.isPlaying);
+        done();
+      });
+      this.el.sceneEl.appendChild(el);
+    });
+
     test('plays when entity is attached after scene load', function (done) {
       var el = document.createElement('a-entity');
       this.sinon.spy(AEntity.prototype, 'play');
 
-      this.el.sceneEl.appendChild(el);
-      el.addEventListener('loaded', function () {
+      el.addEventListener('play', function () {
+        assert.ok(el.hasLoaded);
         sinon.assert.called(AEntity.prototype.play);
         done();
       });
+      this.el.sceneEl.appendChild(el);
     });
   });
 


### PR DESCRIPTION
**Description:**

Caught this using the template component that dynamically attached entities that also had the template component to dynamically attach entities.

1. Entity is attached.
2. Entity tries to `play()`
3. Entity not yet `loaded`
4. Entity never plays because not loaded (early return statement)

**Changes proposed:**
- Animations wait for entity to both load + play before playing.
- Ensure entities call `play()` after they are loaded.
- Remove unnecessary `.bind` calls.