### PR TITLE
[doc fix] a-curvedimage component/value table is reverted

### DIFF
--- a/docs/primitives/a-curvedimage.md
+++ b/docs/primitives/a-curvedimage.md
@@ -30,13 +30,13 @@ The curved image primitive creates images that bend around the user. Curved imag
 
 Note that the curved image primitive inherits common [mesh attributes](./mesh-attributes.md).
 
-| Attribute       | Component Mapping | Default Value           |
-|-----------------|-------------------|-------------------------|
-| height          | 1                 | geometry.height         |
-| radius          | 2                 | geometry.radius         |
-| segments-radial | 48                | geometry.segmentsRadial |
-| theta-length    | 360               | geometry.thetaLength    |
-| theta-start     | 0                 | geometry.thetaStart     |
+| Attribute       | Component Mapping       | Default Value   |
+|-----------------|-------------------------|-----------------|
+| height          | geometry.height         | 1               |
+| radius          | geometry.radius         | 2               |
+| segments-radial | geometry.segmentsRadial | 48              |
+| theta-length    | geometry.thetaLength    | 270             |
+| theta-start     | geometry.thetaStart     | 0               |
 
 ## Fine-Tuning
 


### PR DESCRIPTION
**Description:**

doc for a-curvedimage component/default value table is reverted
https://aframe.io/docs/primitives/a-curvedimage.html

And some default values are not correspondent to the real value
https://github.com/aframevr/aframe/blob/master/src/extras/primitives/primitives/a-curvedimage.js

**Changes proposed:**
- reverse the component/default value
- fix default value according to real value

