### PR TITLE
[doc fix] correct a-sky default value

### DIFF
--- a/docs/primitives/a-sky.md
+++ b/docs/primitives/a-sky.md
@@ -28,8 +28,8 @@ Note that the sky primitive inherits common [mesh attributes](./mesh-attributes.
 
 | Attribute       | Component Mapping       | Default Value |
 |-----------------|-------------------------|---------------|
-| radius          | geometry.radius         | 5000          |
-| segments-height | geometry.segmentsHeight | 64            |
+| radius          | geometry.radius         | 100           |
+| segments-height | geometry.segmentsHeight | 20            |
 | segments-width  | geometry.segmentsWidth  | 64            |
 
 ## Equirectangular Image


### PR DESCRIPTION
**Description:**
a-sky default value does not match https://github.com/aframevr/aframe/blob/master/docs/primitives/a-sky.md

**Changes proposed:**
- correct a-sky default value

