### PR TITLE
change default animation easing method as linear #1333

### DIFF
--- a/docs/core/animations.md
+++ b/docs/core/animations.md
@@ -29,7 +29,7 @@ Many attributes and values are used to define animations. We'll delve into more 
 | begin     | Delay (in milliseconds) or event name to wait on before beginning animation.                                           | 0              |
 | direction | Direction of the animation (between `from` and `to`). One of `alternate`, `alternateReverse`, `normal`, `reverse`.     | normal         |
 | dur       | Duration in (milliseconds) of the animation.                                                                           | 1000           |
-| easing    | Easing function of the animation. There are very many to choose from.                                                  | ease           |
+| easing    | Easing function of the animation. There are very many to choose from.                                                  | linear         |
 | fill      | Determines effect of animation when not actively in play. One of `backwards`, `both`, `forwards`, `none`.              | forwards       |
 | from      | Starting value.                                                                                                        | Current value. |
 | repeat    | Repeat count or `indefinite`.                                                                                          | 0              |

--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -97,7 +97,8 @@ module.exports.AAnimation = registerElement('a-animation', {
         var begin = parseInt(data.begin, 10);
         var currentValue = el.getComputedAttribute(attribute);
         var direction = self.getDirection(data.direction);
-        var easing = EASING_FUNCTIONS[data.easing];
+        var animationType = data.easing | 'linear';
+        var easing = EASING_FUNCTIONS[animationType];
         var fill = data.fill;
         var from;
         var repeat = data.repeat === REPEATS.indefinite ? Infinity : 0;


### PR DESCRIPTION
**Changes proposed:**
- set default animation type as 'linear' https://github.com/aframevr/aframe/blob/master/src/constants/animation.js#L15
- update doc accordingly

