### PR TITLE
Fix issue building when installed as a dependency with npm3

### DIFF
--- a/src/lib/three.js
+++ b/src/lib/three.js
@@ -19,10 +19,10 @@ if (THREE.Cache) {
 }
 
 // TODO: Eventually include these only if they are needed by a component.
-require('../../node_modules/three/examples/js/loaders/OBJLoader');  // THREE.OBJLoader
-require('../../node_modules/three/examples/js/loaders/MTLLoader');  // THREE.MTLLoader
-require('../../node_modules/three/examples/js/loaders/ColladaLoader');  // THREE.ColladaLoader
-require('../../node_modules/three/examples/js/controls/VRControls');  // THREE.VRControls
-require('../../node_modules/three/examples/js/effects/VREffect');  // THREE.VREffect
+require('three/examples/js/loaders/OBJLoader');  // THREE.OBJLoader
+require('three/examples/js/loaders/MTLLoader');  // THREE.MTLLoader
+require('three/examples/js/loaders/ColladaLoader');  // THREE.ColladaLoader
+require('three/examples/js/controls/VRControls');  // THREE.VRControls
+require('three/examples/js/effects/VREffect');  // THREE.VREffect
 
 module.exports = THREE;


### PR DESCRIPTION
**Description:**

The way three.js examples (loaders, controls, effects) are currently required with an explicit node_modules path breaks the ability to build aframe from source when aframe is installed as a dependency with npm3 (flat dependency structure). This scenario should be supported given requiring from source instead of prebuilt is sometimes more appropriate (e.g. avoiding duplicate THREE object in prebuilt file if another three dependency exists in the project outside of aframe)

**Changes proposed:**
- Do not provide explicit node_modules path, allowing browserify/webpack/etc to find the appropriate three location

