### PR TITLE
Graph based behavior execution scheduling and post processing support

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -229,6 +229,7 @@
       <li><a href="test/video/">Video</a></li>
       <li><a href="test/videosphere/">Video 360&deg;</a></li>
       <li><a href="test/visibility/">Visibility</a></li>
+      <li><a href="test/post-processing/">Post Processing</a></li>
     </ul>
 
     <h2>Primitives</h2>

--- a/examples/test/post-processing/components/bloom-toggler.js
+++ b/examples/test/post-processing/components/bloom-toggler.js
@@ -1,0 +1,23 @@
+/* global AFRAME */
+
+AFRAME.registerComponent('bloom-toggler', {
+  init: function () {
+    this.evHandler = this.clickHandler.bind(this);
+    window.addEventListener('contextmenu', this.evHandler);
+  },
+
+  remove: function () {
+    window.removeEventListener('contextmenu', this.evHandler);
+  },
+
+  clickHandler: function () {
+    var scene = this.el.sceneEl;
+    console.log('EXECUTION PRECEDENCE', this.el.sceneEl.precedence.getOrder('component:execution'));
+
+    if (scene.hasAttribute('bloom')) {
+      scene.removeAttribute('bloom');
+    } else {
+      scene.setAttribute('bloom', 'intensity: 0.5');
+    }
+  }
+});

--- a/examples/test/post-processing/components/bloom.js
+++ b/examples/test/post-processing/components/bloom.js
@@ -1,0 +1,119 @@
+/* global AFRAME THREE */
+
+/*
+Kawase bloom, described here
+https://software.intel.com/en-us/blogs/2014/07/15/an-investigation-of-fast-real-time-gpu-based-image-blur-algorithms
+*/
+
+AFRAME.registerComponent('bloom', {
+  dependencies: ['post-process'],
+  following: true, // boolean true is shortcut for reusing the  definition of the dependencies property.
+
+  schema: {
+    passes: { default: '-0.5 0 1 2 2 3' },
+    intensity: { default: 1.0 }
+  },
+
+  setupPostState: function () {
+    this.scenePost = new THREE.Scene();
+
+    // The camera is not actually used.
+    this.cameraPost = new THREE.OrthographicCamera(1, 1, 1, 1, 1, 1);
+
+    this.quadPost = new THREE.Mesh(new THREE.PlaneBufferGeometry(2, 2), null);
+    this.scenePost.add(this.quadPost);
+  },
+
+  init: function () {
+    this.setupPostState();
+    this.quadPost.material = new THREE.ShaderMaterial({
+      uniforms: {
+        srcTexture: { type: 't', value: null },
+        resolution: {type: 'v2', value: new THREE.Vector2(0, 0)},
+        step: { type: 'v2', value: new THREE.Vector2(0, 0) },
+        threxp: { type: 'v2', value: new THREE.Vector2(0, 0) }
+      },
+      vertexShader: this.vertexText,
+      fragmentShader: this.fragmentText,
+
+      depthWrite: false
+
+    });
+    var rtOptions = { minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat };
+    this.renderTargets = [
+      new THREE.WebGLRenderTarget(1, 1, rtOptions),
+      new THREE.WebGLRenderTarget(1, 1, rtOptions)
+    ];
+    this.el.emit('post-modified');
+  },
+
+  remove: function () {
+    this.el.emit('post-modified');
+  },
+
+  update: function () {
+    this.postIntensity = this.data.intensity;
+  },
+
+  // We're doing bloom at half resolution for performance. Most blurry effects can get away with that.
+  getTargets: function () {
+    var srt = this.el.sceneEl.renderTarget;
+    for (var i = 0; i < 2; i++) {
+      var rt = this.renderTargets[i];
+      if (rt.width !== srt.width / 2 || rt.height !== srt.height / 2) {
+        rt.setSize(srt.width / 2, srt.height / 2);
+      }
+    }
+    return this.renderTargets;
+  },
+
+  tock: function () {
+    var rts = this.getTargets();
+    var el = this.el;
+    var scene = el.sceneEl;
+    var uns = this.quadPost.material.uniforms;
+    var rt = scene.renderTarget;
+
+    // Ping pong the render targets progressively blurring more on each pass.
+    var passes = this.data.passes.split(' ');
+    for (var i = 0; i < passes.length; i++) {
+      var ps = +(passes[i]) + 0.5;
+      uns.step.value.set(ps, ps);
+      uns.srcTexture.value = rt;
+      if (!i) uns.threxp.value.set(16, 0); else uns.threxp.value.set(1, 0);
+      rt = rts[i & 1];
+      uns.resolution.value.set(rt.width, rt.height);
+
+      scene.renderer.render(this.scenePost, this.cameraPost, rt);
+    }
+    this.renderTarget = rt;
+  },
+
+  vertexText: [
+    'uniform vec2 resolution;',
+
+    'void main() {',
+    '    gl_Position =  vec4(( position.xy ) * resolution, 1.0, 1.0 );',
+    '}'
+  ].join('\n'),
+
+  fragmentText: [
+    'uniform sampler2D srcTexture;',
+    'uniform vec2 resolution;',
+    'uniform vec2 threxp;',
+    'uniform vec2 step;',
+
+    'void main(){',
+    '    vec2 uv = gl_FragCoord.xy/resolution;',
+    '    vec2 st = step/resolution;',
+    '    vec4 color = vec4(0.0);',
+
+    '   color += texture2D(srcTexture,uv + st);',
+    '    color += texture2D(srcTexture,uv + vec2(st.x,-st.y));',
+    '    color += texture2D(srcTexture,uv - vec2(st.x,-st.y));',
+    '    color += texture2D(srcTexture,uv - st);',
+    '    color /= 4.0;',
+    '    gl_FragColor = vec4(pow(color.rgb,vec3(threxp.x))+vec3(threxp.y), 1.0);',
+    '}'
+  ].join('\n')
+});

--- a/examples/test/post-processing/components/compositor.js
+++ b/examples/test/post-processing/components/compositor.js
@@ -1,0 +1,198 @@
+/* global AFRAME THREE */
+
+// The compositor. Blends the blurred renderTarget from the bloom component.
+// It also checks opacity and converts parts of the frame to ascii(Alpha masking).
+AFRAME.registerComponent('post-process', {
+
+  init: function () {
+    this.setupPostState();
+    this.postModified();
+
+    this.el.sceneEl.renderTarget.depthTexture = new THREE.DepthTexture();
+    this.el.sceneEl.renderTarget.stencilBuffer = false;
+    this.el.sceneEl.enablePostProcessing = true;
+
+    this.evh = this.postModified.bind(this);
+    this.el.sceneEl.addEventListener('post-modified', this.evh);
+  },
+
+  setupPostState: function () {
+    this.scenePost = new THREE.Scene();
+
+    // The camera is not actually used.
+    this.cameraPost = new THREE.OrthographicCamera(1, 1, 1, 1, 1, 1);
+
+    this.quadPost = new THREE.Mesh(new THREE.PlaneBufferGeometry(2, 2), null);
+    this.scenePost.add(this.quadPost);
+  },
+
+  postModified: function (ev) {
+    this.needsConfig = true;
+  },
+
+  // Whenever the postproc setup changes, the compositor shader is recompiled
+  config: function () {
+    var behaviors = this.el.sceneEl.behaviors.tock('bloom');
+    var bloom = behaviors.length ? behaviors[0] : null;
+    console.log('POST-MODIFIED', behaviors);
+    this.needsConfig = false;
+
+    var uniforms = {
+      srcTexture: { type: 't', value: this.el.sceneEl.renderTarget },
+      resolution: {type: 'v2', value: new THREE.Vector2(0, 0)}
+    };
+    var defines = {};
+    var scene = this.el.sceneEl;
+    if (bloom) {
+      uniforms.bloomTexture = { type: 't', value: null };
+      uniforms.bloomIntensity = { type: 'f', value: bloom.postIntensity };
+      defines['BLEND_BLOOM'] = 1;
+      this.bloomComponent = bloom;
+    }
+
+    uniforms.cameraNear = { type: 'f', value: scene.camera.near };
+    uniforms.cameraFar = { type: 'f', value: scene.camera.far };
+
+    if (scene.renderTarget.depthTexture) {
+      uniforms.depthTexture = { type: 't', value: null };
+      defines['BLEND_DEPTH'] = 1;
+    }
+
+    this.quadPost.material = new THREE.ShaderMaterial({
+      defines: defines,
+      uniforms: uniforms,
+      vertexShader: this.vertexText,
+      fragmentShader: this.fragmentText,
+
+      depthWrite: false
+
+    });
+  },
+
+  // Traverse scene objects and set opacity based on the postOpacity attribute set by the pulse component.
+  tick: function (time) {
+    this.el.sceneEl.object3D.traverse(function (obj) {
+      var mat = obj.material;
+      if (mat && mat.postOpacity !== undefined) {
+        mat.opacity = mat.postOpacity;
+      }
+    });
+    var renderTarget = this.el.sceneEl.renderTarget;
+    if (!renderTarget.depthTexture) {
+      renderTarget.depthTexture = new THREE.DepthTexture();
+      renderTarget.stencilBuffer = false;
+    }
+  },
+
+  // Cleanup the scene objects opacities.
+  remove: function () {
+    this.el.sceneEl.object3D.traverse(function (obj) {
+      var mat = obj.material;
+      if (mat && mat.postOpacity !== undefined) {
+        mat.opacity = 1;
+      }
+    });
+    this.el.sceneEl.removeEventListener('post-modified', this.evh);
+  },
+
+  tock: function () {
+    var el = this.el;
+    var scene = el.sceneEl;
+    var rt = scene.renderTarget;
+
+    if (this.needsConfig) {
+      this.config();
+    }
+
+    var uns = this.quadPost.material.uniforms;
+    uns.resolution.value.set(rt.width, rt.height);
+
+    if (uns.bloomTexture) {
+      uns.bloomTexture.value = this.bloomComponent.renderTarget;
+    }
+
+    if (uns.depthTexture) {
+      uns.depthTexture.value = scene.renderTarget.depthTexture;
+    }
+
+    scene.renderer.render(this.scenePost, this.cameraPost);
+  },
+
+  vertexText: [
+    'uniform vec2 resolution;',
+
+    'void main() {',
+    '    gl_Position =  vec4(( position.xy ) * resolution, 1.0, 1.0 );',
+    '}'
+  ].join('\n'),
+
+  fragmentText: [
+    'uniform sampler2D srcTexture;',
+    'uniform vec2 resolution;',
+    'uniform float cameraNear;',
+    'uniform float cameraFar;',
+
+    '#if defined BLEND_BLOOM',
+    'uniform sampler2D bloomTexture;',
+    'uniform float bloomIntensity;',
+    '#endif',
+
+    '#if defined BLEND_DEPTH',
+    'uniform sampler2D depthTexture;',
+
+    'float readDepth (vec2 uv) {',
+    '  float cameraFarPlusNear = cameraFar + cameraNear;',
+    '  float cameraFarMinusNear = cameraFar - cameraNear;',
+    '  float cameraCoef = 2.0 * cameraNear;',
+    '  return cameraCoef / (cameraFarPlusNear - texture2D(depthTexture, uv).x * cameraFarMinusNear);',
+    '}',
+    '#endif',
+
+    '// Bitmap to ASCII (not really) fragment shader by movAX13h, September 2013',
+    '// --- This shader is now used in Pixi JS ---',
+
+    'float character(float n, vec2 p) // some compilers have the word "char" reserved',
+    '{',
+    '  p = floor(p*vec2(4.0, -4.0) + 2.5);',
+    '  if (clamp(p.x, 0.0, 4.0) == p.x && clamp(p.y, 0.0, 4.0) == p.y)',
+    '  {',
+    '    if (int(mod(n/exp2(p.x + 5.0*p.y), 2.0)) == 1) return 1.0;',
+    '  }	',
+    '  return 0.0;',
+    '}',
+
+    'void main()',
+    '{',
+    '  vec2 uv = gl_FragCoord.xy/resolution;',
+    '  vec4 col = texture2D(srcTexture, floor(gl_FragCoord.xy/8.0)*8.0/resolution);	',
+    '  ',
+    '  float gray = (col.r + col.g + col.b)/3.0;',
+    '  ',
+    '  float n = 65536.0;       // .',
+    '  if (gray > 0.2) n = 65600.0;  // :',
+    '  if (gray > 0.3) n = 332772.0;  // *',
+    '  if (gray > 0.4) n = 15255086.0; // o ',
+    '  if (gray > 0.5) n = 23385164.0; // &',
+    '  if (gray > 0.6) n = 15252014.0; // 8',
+    '  if (gray > 0.7) n = 13199452.0; // @',
+    '  if (gray > 0.8) n = 11512810.0; // #',
+    '  float split = 0.33;',
+    '  #if defined BLEND_DEPTH',
+    '  split = smoothstep(0.3,0.9,readDepth(uv));',
+    '  #endif',
+
+    '  vec2 p = mod(gl_FragCoord.xy/4.0, 2.0) - vec2(1.0);',
+    '  vec4 ocol = texture2D(srcTexture, uv );',
+    '  vec3 acol = ((1.0-split) * col.rgb * character(n, p) + split * ocol.rgb);',
+
+    '  vec3 color = mix(ocol.rgb,acol.rgb,ocol.a);',
+    '  ',
+
+    '  #if defined BLEND_BLOOM',
+    '  color += texture2D(bloomTexture,uv).rgb * bloomIntensity;',
+    '  #endif',
+
+    '  gl_FragColor = vec4(color,1.0);',
+    '}'
+  ].join('\n')
+});

--- a/examples/test/post-processing/components/envmap.js
+++ b/examples/test/post-processing/components/envmap.js
@@ -1,0 +1,15 @@
+/* global AFRAME THREE */
+
+AFRAME.registerComponent('envmap', {
+  dependencies: ['material'],
+
+  update: function () {
+    this.el.envEl = document.querySelector('a-videosphere');
+  },
+
+  tick: function () {
+    var et = this.el.envEl.object3DMap.mesh.material.map;
+    et.mapping = THREE.EquirectangularReflectionMapping;
+    this.el.object3DMap.mesh.material.map = et;
+  }
+});

--- a/examples/test/post-processing/components/pulse.js
+++ b/examples/test/post-processing/components/pulse.js
@@ -1,0 +1,33 @@
+/* global AFRAME */
+
+AFRAME.registerComponent('pulse', {
+  /*
+   * Two way connections for nodes of the runtime execution graph.
+   * .precedents here don't affect logic, but cause order to change.
+   */
+  precedents: ['envmap'], //  execute after all env-map components.
+  following: ['post-process'], // execute before any post-process component.
+
+  // .dependencies form the dependency graph. One way, incoming, one property.
+  dependencies: ['geometry', 'material'],
+
+  schema: {
+    phase: { default: 0, min: 0, max: 1 },
+    exponent: { default: 1 }
+  },
+
+  remove: function () {
+    var m = this.el.object3DMap.mesh;
+    delete m.postOpacity;
+  },
+
+  tick: function (time) {
+    var m = this.el.object3DMap.mesh;
+
+    // Don't set opacity immediately, let the post effect handle that in it's tock()
+    var calc = Math.abs(Math.sin(time / 1000 + this.data.phase));
+    m.material.postOpacity = Math.pow(calc, this.data.exponent);
+    var scale = 1 + 0.2 * (1 - calc);
+    m.scale.set(scale, scale, scale);
+  }
+});

--- a/examples/test/post-processing/index.html
+++ b/examples/test/post-processing/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Post-processing</title>
+    <meta name="description" content="Post-processing — A-Frame">
+    <script src="../../../dist/aframe.js"></script>
+    <script src="components/pulse.js"></script>
+    <script src="components/envmap.js"></script>
+    <script src="components/bloom.js"></script>
+    <script src="components/compositor.js"></script>   
+    <script src="components/bloom-toggler.js"></script>
+  </head>
+  <body>
+    <a-scene title="right click to toggle bloom" stats bloom="" bloom-toggler="">
+      <a-assets>
+        <video id="video" src="https://ucarecdn.com/bcece0a8-86ce-460e-856b-40dac4875f15/"
+               autoplay loop></video>
+      </a-assets>
+      <a-entity position="0 1.8 5">
+        <a-entity camera="far:10000; near:10;" look-controls></a-entity>
+      </a-entity>
+      <a-sphere envmap="" pulse="phase:1.58" rotation="0 180 0" color="white" position="0 -50 -160" radius="40"></a-sphere>
+      <a-videosphere pulse="phase:0; exponent:5;" src="#video" rotation="0 180 0"></a-videosphere>
+    </a-scene>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "style-attr": "^1.0.2",
     "three": "^0.76.1",
     "tween.js": "^15.0.0",
-    "webvr-polyfill": "borismus/webvr-polyfill#f45f87a"
+    "webvr-polyfill": "borismus/webvr-polyfill#f45f87a",
+    "precedence-maps": "^0.1.1"
   },
   "devDependencies": {
     "browserify": "^11.0.1",
@@ -46,7 +47,6 @@
     "chai-shallow-deep-equal": "^1.3.0",
     "exorcist": "^0.4.0",
     "gh-pages": "^0.6.0",
-    "husky": "^0.10.1",
     "karma": "^0.13.15",
     "karma-browserify": "^4.4.0",
     "karma-chai-shallow-deep-equal": "0.0.4",

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -441,8 +441,8 @@ var proto = Object.create(ANode.prototype, {
    */
   play: {
     value: function () {
-      var components = this.components;
-      var componentKeys = Object.keys(components);
+      var entityComponents = this.components;
+      var componentKeys = Object.keys(entityComponents);
       var sceneEl = this.sceneEl;
 
       // Already playing.
@@ -451,7 +451,7 @@ var proto = Object.create(ANode.prototype, {
 
       // Wake up all components.
       componentKeys.forEach(function _playComponent (key) {
-        playComponent(components[key], sceneEl);
+        playComponent(entityComponents[key], sceneEl);
       });
 
       // Tell all child entities to play.
@@ -695,6 +695,13 @@ function isComponentMixedIn (name, mixinEls) {
 }
 
 /**
+ * Checks if a component has defined a method that needs to run every frame.
+ */
+function hasBehavior (component) {
+  return component.tick || component.tock;
+}
+
+/**
  * Pause component by removing tick behavior and calling pause handler.
  *
  * @param component {object} - Component to pause.
@@ -703,7 +710,9 @@ function isComponentMixedIn (name, mixinEls) {
 function pauseComponent (component, sceneEl) {
   component.pause();
   // Remove tick behavior.
-  if (!component.tick) { return; }
+  if (!hasBehavior(component)) {
+    return;
+  }
   sceneEl.removeBehavior(component);
 }
 
@@ -716,7 +725,9 @@ function pauseComponent (component, sceneEl) {
 function playComponent (component, sceneEl) {
   component.play();
   // Add tick behavior.
-  if (!component.tick) { return; }
+  if (!hasBehavior(component)) {
+    return;
+  }
   sceneEl.addBehavior(component);
 }
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -56,7 +56,11 @@ module.exports = registerElement('a-scene', {
 
     init: {
       value: function () {
-        this.behaviors = [];
+        this.behaviors = {
+          tick: utils.precedence.newStore('component:execution', Array),
+          tock: utils.precedence.newStore('component:execution', Array)
+        };
+        this.precedence = utils.precedence; // Expose getOrder() to components, useful for post proc.
         this.hasLoaded = false;
         this.isPlaying = false;
         this.originalHTML = this.innerHTML;
@@ -111,15 +115,24 @@ module.exports = registerElement('a-scene', {
       }
     },
 
-    /**
+     /**
      * @param {object} behavior - Generally a component. Must implement a .update() method to
      *        be called on every tick.
      */
     addBehavior: {
       value: function (behavior) {
+        var self = this;
         var behaviors = this.behaviors;
-        if (behaviors.indexOf(behavior) !== -1) { return; }
-        behaviors.push(behavior);
+        var name = Object.getPrototypeOf(behavior).name || ' '; // unnamed components are used in tests.
+
+        // Check if behavior has tick and/or tock and add to the appropriate structure.
+        Object.keys(behaviors).forEach(function (behaviorType) {
+          if (!behavior[behaviorType]) { return; }
+          var behaviorArr = self.behaviors[behaviorType](name); // eg. behaviors.tick("material")
+          if (behaviorArr.indexOf(behavior) === -1) {
+            behaviorArr.push(behavior);
+          }
+        });
       }
     },
 
@@ -168,10 +181,17 @@ module.exports = registerElement('a-scene', {
      */
     removeBehavior: {
       value: function (behavior) {
+        var self = this;
         var behaviors = this.behaviors;
-        var index = behaviors.indexOf(behavior);
-        if (index === -1) { return; }
-        behaviors.splice(index, 1);
+        var name = Object.getPrototypeOf(behavior).name || ' ';
+
+        Object.keys(behaviors).forEach(function (behaviorType) {
+          var behaviorArr = self.behaviors[behaviorType](name);
+          var index = behaviorArr.indexOf(behavior);
+          if (index !== -1) {
+            behaviorArr.splice(index, 1);
+          }
+        });
       }
     },
 
@@ -197,6 +217,10 @@ module.exports = registerElement('a-scene', {
 
         // Notify renderer of size change.
         this.renderer.setSize(size.width, size.height, true);
+
+        // Resize render target to match renderer
+        var dpr = this.renderer.getPixelRatio();
+        this.renderTarget.setSize(size.width * dpr, size.height * dpr);
       },
       writable: window.debug
     },
@@ -212,6 +236,10 @@ module.exports = registerElement('a-scene', {
           antialias: antialias || window.hasNativeWebVRImplementation,
           alpha: true
         });
+
+        this.renderTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight, { minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat });
+        this.renderTarget.texture.generateMipmaps = false;
+
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
         this.effect = new THREE.VREffect(renderer);
@@ -275,7 +303,7 @@ module.exports = registerElement('a-scene', {
     },
 
     /**
-     * Behavior-updater meant to be called from scene render.
+     * Behavior-updater meant to be called before scene render.
      * Abstracted to a different function to facilitate unit testing (`scene.tick()`) without
      * needing to render.
      */
@@ -286,14 +314,40 @@ module.exports = registerElement('a-scene', {
         // Animations.
         TWEEN.update(time);
         // Components.
-        this.behaviors.forEach(function (component) {
-          if (!component.el.isPlaying) { return; }
-          component.tick(time, timeDelta);
+        this.behaviors.tick().forEach(function (behaviorList) {
+          behaviorList.forEach(function (component) {
+            if (!component.el.isPlaying) { return; }
+            component.tick(time, timeDelta);
+          });
         });
         // Systems.
         Object.keys(systems).forEach(function (key) {
-          if (!systems[key].tick) { return; }
-          systems[key].tick(time, timeDelta);
+          var system = systems[key];
+          if (!system.tick) { return; }
+          system.tick(time, timeDelta);
+        });
+      }
+    },
+
+    /**
+     * Behavior-updater meant to be called after scene render for post processing.
+     * Abstracted to a different function to facilitate unit testing (`scene.tock()`) without
+     * needing to render.
+     */
+    tock: {
+      value: function (time, timeDelta) {
+        // Components.
+        this.behaviors.tock().forEach(function (behaviorList) {
+          behaviorList.forEach(function (component) {
+            if (!component.el.isPlaying) { return; }
+            component.tock(time, timeDelta);
+          });
+        });
+        // Systems.
+        Object.keys(systems).forEach(function (key) {
+          var system = systems[key];
+          if (!system.tock) { return; }
+          system.tock(time, timeDelta);
         });
       }
     },
@@ -313,9 +367,24 @@ module.exports = registerElement('a-scene', {
         if (this.isPlaying) {
           this.tick(time, timeDelta);
         }
-        this.effect.render(this.object3D, camera);
+
+        window.performance.mark('render-iteration-started');
+
+        // Postproc must be explicitly enabled by a component or system.
+        if (this.enablePostProcessing) {
+          this.effect.render(this.object3D, camera, this.renderTarget);
+
+          window.performance.mark('post-processing-started');
+
+          this.tock(time, timeDelta);
+        } else {
+          this.effect.render(this.object3D, camera, null);
+        }
+
+        window.performance.mark('render-iteration-finished');
 
         this.time = time;
+
         this.animationFrameID = window.requestAnimationFrame(this.render.bind(this));
       },
       writable: window.debug

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -34,6 +34,16 @@ System.prototype = {
    */
   tick: undefined,
 
+ /**
+   * Tock handler.
+   * Called on each tock of the scene render loop. Ticks on all components will have run before this.
+   * Affected by play and pause.
+   *
+   * @param {number} time - Scene tick time.
+   * @param {number} timeDelta - Difference in current render time and previous render time.
+   */
+  tock: undefined,
+
   /**
    * Called to start any dynamic behavior (e.g., animation, AI, events, physics).
    */
@@ -75,6 +85,7 @@ module.exports.registerSystem = function (name, definition) {
   NewSystem.prototype = Object.create(System.prototype, proto);
   NewSystem.prototype.name = name;
   NewSystem.prototype.constructor = NewSystem;
+
   systems[name] = NewSystem;
 
   // Initialize systems for existing scenes

--- a/src/lib/rStatsAframe.js
+++ b/src/lib/rStatsAframe.js
@@ -2,6 +2,12 @@ window.aframeStats = function (scene) {
   var _rS = null;
   var _scene = scene;
   var _values = {
+    plt: {
+      caption: 'Post(ms)'
+    },
+    pte: {
+      caption: 'Scene(ms)'
+    },
     te: {
       caption: 'Entities'
     },
@@ -9,14 +15,42 @@ window.aframeStats = function (scene) {
       caption: 'Load Time'
     }
   };
-  var _groups = [ {
-    caption: 'A-Frame',
-    values: [ 'te', 'lt' ]
-  } ];
+  var _groups = [{
+    caption: 'A-Frame - General',
+    values: ['te', 'lt']
+  }, {
+    caption: 'A-Frame - Timings',
+    values: ['plt', 'pte']
+  }];
 
   function _update () {
+    var renderStarted = window.performance.getEntriesByName('render-iteration-started')[0];
+    var renderFinished = window.performance.getEntriesByName('render-iteration-finished')[0];
+    var postStarted = window.performance.getEntriesByName('post-processing-started')[0];
+    if (!this.averages) {
+      this.averages = {
+        sceneTime: 0,
+        postTime: 0,
+        count: 0
+      };
+    }
+
+    var count = this.averages.count++ & 15;
+    if (!count) {
+      _rS('plt').set((this.averages.postTime / 16 || 0).toFixed(1));
+      _rS('pte').set((this.averages.sceneTime / 16 || 0).toFixed(1));
+      this.averages.sceneTime = 0;
+      this.averages.postTime = 0;
+    }
+    this.averages.sceneTime += renderFinished && (postStarted || renderFinished).startTime - renderStarted.startTime;
+    this.averages.postTime += postStarted ? renderFinished.startTime - postStarted.startTime : 0;
+
     _rS('te').set(_scene.querySelectorAll('a-entity').length);
     _rS('lt').set(window.performance.getEntriesByName('render-started')[0].startTime.toFixed(0));
+
+    window.performance.clearMarks('render-iteration-started');
+    window.performance.clearMarks('render-iteration-finished');
+    window.performance.clearMarks('post-processing-started');
   }
 
   function _start () {}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,7 +8,7 @@ module.exports.coordinates = require('./coordinates');
 module.exports.debug = require('./debug');
 module.exports.material = require('./material');
 module.exports.styleParser = require('./styleParser');
-
+module.exports.precedence = require('precedence-maps');
 /**
  * Fires a custom DOM event.
  *

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -31,7 +31,7 @@ suite('a-entity', function () {
   });
 
   teardown(function () {
-    components.test = undefined;
+    delete components.test;
   });
 
   test('adds itself to parent when attached', function (done) {
@@ -338,14 +338,14 @@ suite('a-entity', function () {
     test('properly detaches components', function (done) {
       var el = this.el;
       var parentEl = el.parentNode;
-      components.test = undefined;
+      delete components.test;
       registerComponent('test', TestComponent);
       el.setAttribute('test', '');
-      assert.notEqual(el.sceneEl.behaviors.indexOf(el.components.test), -1);
+      assert.notEqual(el.sceneEl.behaviors.tick('test').indexOf(el.components.test), -1);
       parentEl.removeChild(el);
       process.nextTick(function () {
         assert.notOk('test' in el.components);
-        assert.equal(el.sceneEl.behaviors.indexOf(el.components.test), -1);
+        assert.equal(el.sceneEl.behaviors.tick('test').indexOf(el.components.test), -1);
         done();
       });
     });
@@ -559,9 +559,9 @@ suite('a-entity', function () {
       el.play();
       el.setAttribute('look-controls', '');
       component = el.components['look-controls'];
-      assert.notEqual(sceneEl.behaviors.indexOf(component), -1);
+      assert.notEqual(sceneEl.behaviors.tick('look-controls').indexOf(component), -1);
       el.removeAttribute('look-controls');
-      assert.equal(sceneEl.behaviors.indexOf(component), -1);
+      assert.equal(sceneEl.behaviors.tick('look-controls').indexOf(component), -1);
     });
   });
 
@@ -658,7 +658,7 @@ suite('a-entity', function () {
 suite('a-entity component lifecycle management', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
-    components.test = undefined;
+    delete components.test;
     this.TestComponent = registerComponent('test', TestComponent);
     el.addEventListener('loaded', function () {
       done();
@@ -666,7 +666,7 @@ suite('a-entity component lifecycle management', function () {
   });
 
   teardown(function () {
-    components.test = undefined;
+    delete components.test;
   });
 
   test('calls init on component attach', function () {
@@ -760,9 +760,9 @@ suite('a-entity component lifecycle management', function () {
     el.sceneEl.addEventListener('loaded', function () {
       el.setAttribute('test', '');
       testComponentInstance = el.components.test;
-      assert.notEqual(el.sceneEl.behaviors.indexOf(testComponentInstance), -1);
+      assert.notEqual(el.sceneEl.behaviors.tick('test').indexOf(testComponentInstance), -1);
       el.pause();
-      assert.equal(el.sceneEl.behaviors.indexOf(testComponentInstance), -1);
+      assert.equal(el.sceneEl.behaviors.tick('test').indexOf(testComponentInstance), -1);
       done();
     });
   });
@@ -773,10 +773,10 @@ suite('a-entity component lifecycle management', function () {
     el.sceneEl.addEventListener('loaded', function () {
       el.setAttribute('test', '');
       testComponentInstance = el.components.test;
-      el.sceneEl.behaviors = [];
-      assert.equal(el.sceneEl.behaviors.indexOf(testComponentInstance), -1);
+      el.sceneEl.behaviors.tick('test', []);
+      assert.equal(el.sceneEl.behaviors.tick('test').indexOf(testComponentInstance), -1);
       el.play();
-      assert.equal(el.sceneEl.behaviors.indexOf(testComponentInstance), -1);
+      assert.equal(el.sceneEl.behaviors.tick('test').indexOf(testComponentInstance), -1);
     });
   });
 });
@@ -809,7 +809,7 @@ suite('a-entity component dependency management', function () {
   });
 
   teardown(function () {
-    components.test = undefined;
+    delete components.test;
     components.codependency = undefined;
     components.dependency = undefined;
     components['nested-dependency'] = undefined;

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -30,7 +30,7 @@ suite('Component', function () {
 
   suite('buildData', function () {
     setup(function () {
-      components.dummy = undefined;
+      delete components.dummy;
     });
 
     test('uses default values', function () {
@@ -154,7 +154,7 @@ suite('Component', function () {
 
   suite('parse', function () {
     setup(function () {
-      components.dummy = undefined;
+      delete components.dummy;
     });
 
     test('parses single value component', function () {
@@ -182,7 +182,7 @@ suite('Component', function () {
 
   suite('parseAttrValueForCache', function () {
     setup(function () {
-      components.dummy = undefined;
+      delete components.dummy;
     });
 
     test('parses single value component', function () {
@@ -223,7 +223,7 @@ suite('Component', function () {
 
   suite('stringify', function () {
     setup(function () {
-      components.dummy = undefined;
+      delete components.dummy;
     });
 
     test('stringifies single value component', function () {
@@ -252,7 +252,7 @@ suite('Component', function () {
 
   suite('extendSchema', function () {
     setup(function () {
-      components.dummy = undefined;
+      delete components.dummy;
     });
 
     test('extends the schema', function () {
@@ -269,7 +269,7 @@ suite('Component', function () {
 
   suite('updateProperties', function () {
     setup(function () {
-      components.dummy = undefined;
+      delete components.dummy;
     });
 
     test('updates the schema of a component', function () {
@@ -310,7 +310,7 @@ suite('Component', function () {
 
   suite('update', function () {
     setup(function () {
-      components.dummy = undefined;
+      delete components.dummy;
     });
 
     test('not called if component data does not change', function () {
@@ -329,7 +329,7 @@ suite('Component', function () {
 
   suite('flushToDOM', function () {
     setup(function () {
-      components.dummy = undefined;
+      delete components.dummy;
     });
 
     test('updates component DOM attribute', function () {

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -110,7 +110,7 @@ helpers.getSkipCISuite()('a-scene (with renderer)', function () {
 
   test('calls behaviors', function () {
     var scene = this.el;
-    var Component = { el: { isPlaying: true }, tick: function () {} };
+    var Component = {el: { isPlaying: true }, tick: function () {}};
     this.sinon.spy(Component, 'tick');
     scene.addBehavior(Component);
     scene.render();

--- a/vendor/VREffect.js
+++ b/vendor/VREffect.js
@@ -232,7 +232,7 @@ THREE.VREffect = function ( renderer, onError ) {
 	var cameraR = new THREE.PerspectiveCamera();
 	cameraR.layers.enable( 2 );
 
-	this.render = function ( scene, camera ) {
+	this.render = function ( scene, camera, renderTarget, forceClear ) {
 
 		if ( vrHMD && isPresenting ) {
 
@@ -296,12 +296,12 @@ THREE.VREffect = function ( renderer, onError ) {
 			// render left eye
 			renderer.setViewport( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
 			renderer.setScissor( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
-			renderer.render( scene, cameraL );
+			renderer.render( scene, cameraL, renderTarget, forceClear );
 
 			// render right eye
 			renderer.setViewport( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
 			renderer.setScissor( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
-			renderer.render( scene, cameraR );
+			renderer.render( scene, cameraR, renderTarget, forceClear );
 
 			renderer.setScissorTest( false );
 
@@ -323,7 +323,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 		// Regular render mode if not HMD
 
-		renderer.render( scene, camera );
+		renderer.render( scene, camera, renderTarget, forceClear );
 
 	};
 


### PR DESCRIPTION
Following the discussions with @ngokevin @dmarcos @donmccurdy and @fernandojsg :

Enable post processing by extending components with a .tock() method which runs after the scene renders.

A-scene maintains a .renderTarget and switches rendering to that in the presence of at least one tock behavior.

A graph based mechanism is employed to allow for explicitly definable execution ordering for both tick and tock behaviors.

Components can define two way connections in the graph using the properties .precedents and .following, similar to .dependencies.

Sorting to define the execution order takes place only in registerComponent() and batching is done efficiently in a-scene using caches.

The graph based mechanism works fast and comfortable for the developer. Cyclic dependencies in the graph are errors and throw exceptions.

An example utilizing most of the functionality added by this PR at http://wizgrav.github.io/aframe/examples/test/post-processing/index.html
