### PR TITLE
remove translate mapping from primitives, fix primitive bug

### DIFF
--- a/src/extras/primitives/primitives/a-box.js
+++ b/src/extras/primitives/primitives/a-box.js
@@ -2,7 +2,7 @@ var getMeshMixin = require('../getMeshMixin');
 var registerPrimitive = require('../registerPrimitive');
 var utils = require('../../../utils/');
 
-var boxDefinition = utils.extendDeep({}, getMeshMixin(), {
+registerPrimitive('a-box', utils.extendDeep({}, getMeshMixin(), {
   defaultComponents: {
     geometry: {
       primitive: 'box'
@@ -12,9 +12,6 @@ var boxDefinition = utils.extendDeep({}, getMeshMixin(), {
   mappings: {
     depth: 'geometry.depth',
     height: 'geometry.height',
-    translate: 'geometry.translate',
     width: 'geometry.width'
   }
-});
-
-registerPrimitive('a-box', boxDefinition);
+}));

--- a/src/extras/primitives/primitives/a-cone.js
+++ b/src/extras/primitives/primitives/a-cone.js
@@ -17,7 +17,6 @@ registerPrimitive('a-cone', utils.extendDeep({}, getMeshMixin(), {
     'segments-height': 'geometry.segmentsHeight',
     'segments-radial': 'geometry.segmentsRadial',
     'theta-length': 'geometry.thetaLength',
-    'theta-start': 'geometry.thetaStart',
-    translate: 'geometry.translate'
+    'theta-start': 'geometry.thetaStart'
   }
 }));

--- a/src/extras/primitives/primitives/a-cylinder.js
+++ b/src/extras/primitives/primitives/a-cylinder.js
@@ -17,7 +17,6 @@ registerPrimitive('a-cylinder', utils.extendDeep({}, getMeshMixin(), {
     'radius-top': 'geometry.radiusTop',
     'segments-radial': 'geometry.segmentsRadial',
     'theta-length': 'geometry.thetaLength',
-    'theta-start': 'geometry.thetaStart',
-    translate: 'geometry.translate'
+    'theta-start': 'geometry.thetaStart'
   }
 }));

--- a/src/extras/primitives/primitives/a-image.js
+++ b/src/extras/primitives/primitives/a-image.js
@@ -17,7 +17,6 @@ registerPrimitive('a-image', utils.extendDeep({}, getMeshMixin(), {
 
   mappings: {
     height: 'geometry.height',
-    translate: 'geometry.translate',
     width: 'geometry.width'
   }
 }));

--- a/src/extras/primitives/primitives/a-plane.js
+++ b/src/extras/primitives/primitives/a-plane.js
@@ -11,7 +11,6 @@ registerPrimitive('a-plane', utils.extendDeep({}, getMeshMixin(), {
 
   mappings: {
     height: 'geometry.height',
-    translate: 'geometry.translate',
     width: 'geometry.width'
   }
 }));

--- a/src/extras/primitives/primitives/a-sphere.js
+++ b/src/extras/primitives/primitives/a-sphere.js
@@ -17,7 +17,6 @@ registerPrimitive('a-sphere', utils.extendDeep({}, getMeshMixin(), {
     'phi-length': 'geometry.phiLength',
     'phi-start': 'geometry.phiStart',
     'theta-length': 'geometry.thetaLength',
-    'theta-start': 'geometry.thetaStart',
-    translate: 'geometry.translate'
+    'theta-start': 'geometry.thetaStart'
   }
 }));

--- a/src/extras/primitives/primitives/a-video.js
+++ b/src/extras/primitives/primitives/a-video.js
@@ -17,7 +17,6 @@ registerPrimitive('a-video', utils.extendDeep({}, getMeshMixin(), {
 
   mappings: {
     height: 'geometry.height',
-    translate: 'geometry.translate',
     width: 'geometry.width'
   }
 }));

--- a/src/extras/primitives/registerPrimitive.js
+++ b/src/extras/primitives/registerPrimitive.js
@@ -78,7 +78,7 @@ module.exports = function registerPrimitive (name, definition) {
             var componentData = defaultData[componentName];
 
             // Set component properties individually to not overwrite user-defined components.
-            if (componentData instanceof Object && Object.keys(componentData).length) {
+            if (componentData instanceof Object) {
               var component = components[componentName];
               var attrValues = self.getAttribute(componentName) || {};
               var data = component.parse(attrValues);
@@ -88,7 +88,6 @@ module.exports = function registerPrimitive (name, definition) {
                 if (data[propName]) { return; }
                 data[propName] = componentData[propName];
               });
-              console.log(self, data);
               self.setAttribute(componentName, data);
               return;
             }

--- a/src/extras/primitives/registerPrimitive.js
+++ b/src/extras/primitives/registerPrimitive.js
@@ -72,19 +72,23 @@ module.exports = function registerPrimitive (name, definition) {
         value: function () {
           var self = this;
           var defaultData = this.defaultComponentsFromPrimitive;
+
           // Apply default components.
           Object.keys(defaultData).forEach(function applyDefault (componentName) {
             var componentData = defaultData[componentName];
+
             // Set component properties individually to not overwrite user-defined components.
             if (componentData instanceof Object && Object.keys(componentData).length) {
               var component = components[componentName];
               var attrValues = self.getAttribute(componentName) || {};
               var data = component.parse(attrValues);
+
+              // Check if component property already defined.
               Object.keys(componentData).forEach(function setProperty (propName) {
-                // Check if component property already defined.
                 if (data[propName]) { return; }
                 data[propName] = componentData[propName];
               });
+              console.log(self, data);
               self.setAttribute(componentName, data);
               return;
             }


### PR DESCRIPTION
**Description:**

Was previously updating Pano for guide. Will move that to separate repo.

**Changes proposed:**
- remove old translate mapping from primitives
- fix primitives when trying to define `material` properties
