### PR TITLE
Expose the zoom property of THREE.PerspectiveCamera to the camera component.

### DIFF
--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -10,7 +10,8 @@ module.exports.Component = registerComponent('camera', {
     active: { default: true },
     far: { default: 10000 },
     fov: { default: 80, min: 0 },
-    near: { default: 0.5, min: 0 }
+    near: { default: 0.5, min: 0 },
+    zoom: { default: 1, min: 0 }
   },
 
   /**
@@ -43,6 +44,7 @@ module.exports.Component = registerComponent('camera', {
     camera.far = data.far;
     camera.fov = data.fov;
     camera.near = data.near;
+    camera.zoom = data.zoom;
     camera.updateProjectionMatrix();
 
     // Active property did not change.

--- a/src/extras/primitives/primitives/a-camera.js
+++ b/src/extras/primitives/primitives/a-camera.js
@@ -13,7 +13,8 @@ registerPrimitive('a-camera', {
     fov: 'camera.fov',
     'look-controls-enabled': 'look-controls.enabled',
     near: 'camera.near',
-    'wasd-controls-enabled': 'wasd-controls.enabled'
+    'wasd-controls-enabled': 'wasd-controls.enabled',
+    zoom: 'camera.zoom'
   },
 
   deprecatedMappings: {


### PR DESCRIPTION
A small addition to allow animating the camera's zoom property.