### PR TITLE
remove default A-Frame favicon (fixes #1450)

### DIFF
--- a/src/core/scene/metaTags.js
+++ b/src/core/scene/metaTags.js
@@ -5,8 +5,7 @@ var MOBILE_HEAD_TAGS = module.exports.MOBILE_HEAD_TAGS = [
 
   // W3C-standardised meta tags.
   Meta({name: 'mobile-web-app-capable', content: 'yes'}),
-  Meta({name: 'theme-color', content: 'black'}),
-  Link({rel: 'icon', sizes: '192x192', href: 'https://aframe.io/images/aframe-logo-192.png'})
+  Meta({name: 'theme-color', content: 'black'})
 ];
 
 var MOBILE_IOS_HEAD_TAGS = [


### PR DESCRIPTION
per https://github.com/aframevr/aframe/issues/1450#issuecomment-220213425 and http://stackoverflow.com/questions/37312783/favicon-only-showing-up-in-chrome