### PR TITLE
fix parentNode error on load callback (fixes #1471)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -229,7 +229,8 @@ var proto = Object.create(ANode.prototype, {
       // Entity load.
       function entityLoadCallback () {
         self.updateComponents();
-        if (self.parentNode.isPlaying) { self.play(); }
+        // self.parentNode should work but that is null during this cb for unknown (#1483).
+        if (self.parentEl.isPlaying) { self.play(); }
       }
       ANode.prototype.load.call(this, entityLoadCallback, isEntity);
     },


### PR DESCRIPTION
**Description:**

@dmarcos and I don't know why this is needed. Before the callback, parentNode is defined. At the callback parentNode is briefly null. parentEl works for some reason. Have no idea what is happening to the read-only parentNode.

**Changes proposed:**
-
-
-

