### PR TITLE
postMessage scene events for detecting load state, managing entering/exiting VR

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -64,8 +64,8 @@ module.exports = registerElement('a-scene', {
         this.addEventListener('render-target-loaded', function () {
           this.setupRenderer();
           this.resize();
+          initPostMessageAPI(this);
         });
-        initPostMessageAPI(this);
       },
       writable: true
     },
@@ -139,7 +139,10 @@ module.exports = registerElement('a-scene', {
           }
         }
         function enterVRFailure () {
-          throw new Error('enter VR mode error. requestPresent failed');
+          var msg = 'enter VR mode error. requestPresent failed';
+          var event = {error: msg};
+          self.emit('enter-vr-error', event);
+          throw new Error(msg);
         }
       }
     },
@@ -147,6 +150,7 @@ module.exports = registerElement('a-scene', {
     exitVR: {
       value: function () {
         var self = this;
+        var event = {target: self};
         return this.effect.exitPresent().then(exitVRSuccess, exitVRFailure);
         function exitVRSuccess () {
           self.removeState('vr-mode');
@@ -155,10 +159,13 @@ module.exports = registerElement('a-scene', {
             window.screen.orientation.unlock();
           }
           self.resize();
-          self.emit('exit-vr', {target: self});
+          self.emit('exit-vr', event);
         }
         function exitVRFailure () {
-          throw new Error('exit VR mode error. exitPresent failed');
+          var msg = 'exit VR mode error. exitPresent failed';
+          var event = {error: msg};
+          self.emit('exit-vr-error', event);
+          throw new Error(msg);
         }
       }
     },

--- a/src/core/scene/postMessage.js
+++ b/src/core/scene/postMessage.js
@@ -1,28 +1,70 @@
-var isIframed = require('../../utils/').isIframed;
-
 /**
- * Provides a post message API for scenes contained
- * in an iframe.
+ * Provides a postMessage API for manipulating a scene from within
+ * from an iframe, a webview, or within the document itself.
  */
+var SCENE_TIMEOUT = 30000;  // 30 seconds.
+
 module.exports = function initPostMessageAPI (scene) {
-  // Handles fullscreen behavior when inside an iframe.
-  if (!isIframed()) { return; }
-  // postMessage API handler
-  window.addEventListener('message', postMessageAPIHandler.bind(scene));
+  var timeout = setTimeout(function () {
+    var err = new Error('Scene timeout after ' + SCENE_TIMEOUT + ' ms');
+    postMsgEvent('scene-load', scene, err);
+  }, SCENE_TIMEOUT);
+  scene.addEventListener('loaded', function () {
+    // postMessage API handler for this specific scene.
+    window.addEventListener('message', postMessageAPIHandler.bind(scene));
+    postMsgEvent('scene-load', scene);
+    clearTimeout(timeout);
+  });
+  var eventHandler = postMsgEvent.bind(scene);
+  scene.addEventListener('enter-vr', eventHandler);
+  scene.addEventListener('enter-vr-error', eventHandler);
+  scene.addEventListener('exit-vr', eventHandler);
+  scene.addEventListener('exit-vr-error', eventHandler);
 };
+
+function postMsg (type, data, origin) {
+  // console.log(data);
+  // HELP:
+  // Try this in your Dev Tools' Console:
+  //
+  //   >> window.postMessage({type: 'aframe-scene', data: 'enter-vr'}, '*')
+  //   << postMessage.js:27 Uncaught DataCloneError: Failed to execute 'postMessage' on 'Window': An object could not be cloned.
+  //
+  // I can't clone DOM elements and `postMessage` those.
+  // So what should I send back as an identifier for the scene?
+  // Should we create unique `id`s for each `<a-scene>`?
+  return window.top.postMessage({
+    type: type,
+    data: data
+  }, origin || '*');
+}
+
+function postMsgEvent (event) {
+  event = event || {};
+  event.sceneEl = this;
+  return postMsg('aframe-event', event);
+}
 
 function postMessageAPIHandler (event) {
   var scene = this;
-  if (!event.data) { return; }
-
-  switch (event.data.type) {
-    case 'vr': {
-      switch (event.data.data) {
-        case 'enter':
-          scene.enterVR();
+  var eventData = event.data;
+  if (!eventData) { return; }
+  var targetScene = eventData.sceneEl;
+  if (targetScene) {
+    // Compare elements (and try querying by CSS selector).
+    if (scene !== targetScene ||
+        (typeof targetScene === 'string' && !scene.matches(targetScene))) {
+      return false;
+    }
+  }
+  switch (eventData.type) {
+    case 'aframe-scene': {
+      switch (eventData.data) {
+        case 'enter-vr':
+          scene.enterVR().catch(console.error.bind(console));
           break;
-        case 'exit':
-          scene.exitVR();
+        case 'exit-vr':
+          scene.exitVR().catch(console.error.bind(console));
           break;
       }
     }

--- a/tests/core/a-node.test.js
+++ b/tests/core/a-node.test.js
@@ -50,6 +50,33 @@ suite('a-node', function () {
         done();
       }, 50);
     });
+
+    test('can postMessage', function (done) {
+      var el = this.el;
+      var child = document.createElement('a-node');
+      el.appendChild(child);
+      window.top.addEventListener('message', function (event) {
+        assert.equal(event.detail.type, 'event');
+        assert.equal(event.detail.data.type, 'hadouken');
+        done();
+      });
+      child.emit('hadouken', {}, undefined, true);
+      setTimeout(function () { done(); }, 50);
+    });
+
+    test('defaults to not postMessage', function (done) {
+      var el = this.el;
+      var child = document.createElement('a-node');
+      el.appendChild(child);
+      window.top.addEventListener('message', function (event) {
+        // Failure case.
+        assert.notEqual(event.detail.type, 'event');
+        assert.notEqual(event.detail.data.type, 'hadouken');
+        done();
+      });
+      child.emit('hadouken');
+      setTimeout(function () { done(); }, 50);
+    });
   });
 
   suite('getChildren', function () {


### PR DESCRIPTION
**Description:**

I want to be able to know when a scene is loaded. And I want a programmatic way of entering VR - from the console, from a JS file included on the page, a content script (via Greasemonkey/dotjs/etc.), or from an `<iframe>`/`<webview>`.

**Changes proposed:**
- because the parent script needs to know when the scene(s) has loaded, we first `postMessage` an event indicating whether the scene(s) is loaded, and then the parent script can _then_ reliably `postMessage` to enter VR and exit VR. (previously we were blindly receiving `postMessage` events, which were not getting received unless you were working with `<iframe>`'d scenes on your origin that you  could introspect to get `load` events.)
- introduce `enter-vr-error` and `exit-vr-error` events.
- introduce `load-error` event (based on a timeout, which defaults to 30 seconds). not completely sold on this. thoughts?
- `postMessage` success + error events for loading, entering VR, and exiting VR.
- do not restrict only `<iframe>`s to be able to `postMessage` (see example cases above) - example code: `window.postMessage({type: 'aframe-scene', data: 'enter-vr'}, '*')`
