### PR TITLE
setActiveCamera: call play() and modified `camera-set-active` event

### DIFF
--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -77,8 +77,8 @@ module.exports.System = registerSystem('camera', {
 
     // Make new camera active.
     this.activeCameraEl = newCameraEl;
+    this.activeCameraEl.play();
     sceneEl.camera = newCamera;
-    sceneEl.emit('camera-set-active', {cameraEl: newCameraEl});
 
     // Disable current camera
     if (previousCamera) {
@@ -91,6 +91,7 @@ module.exports.System = registerSystem('camera', {
       cameraEl.setAttribute('camera', 'active', false);
       cameraEl.pause();
     }
+    sceneEl.emit('camera-set-active', {cameraEl: newCameraEl});
   }
 });
 


### PR DESCRIPTION
**Description:**
Fixes https://github.com/aframevr/aframe/issues/1500: Calls `play()` when we change the active camera `this.activeCameraEl.play();` so it activates the controls attached to the camera (eg: `look-controls`)

I've also moved the emission of the `camera-set-active` to the end of the function. In the editor for example I was listening to that event to check if you've added a new camera so I could save it for later but switch automatically to the editor camera. The problem is that the event was emitted and after all the other cameras (including the one I wanted to set in the event) were deactivated.
So by just moving the event to the end you ensure that you've already a consistent state for all the cameras in the scene and you can do whatever you want like, in my case, switching to another default camera.