### PR TITLE
use webcomponents-lite polyfill #567

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "browserify-css": "^0.8.2",
     "debug": "^2.2.0",
     "deep-assign": "^2.0.0",
-    "document-register-element": "dmarcos/document-register-element#8ccc532b7",
-    "promise-polyfill": "^3.1.0",
     "object-assign": "^4.0.1",
     "present": "0.0.6",
+    "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
     "three": "^0.76.1",
     "tween.js": "^15.0.0",
+    "webcomponents.js": "^0.7.22",
     "webvr-polyfill": "borismus/webvr-polyfill#f45f87a"
   },
   "devDependencies": {

--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -1,5 +1,5 @@
 // Polyfill `document.registerElement`.
-require('document-register-element');
+require('webcomponents.js/CustomElements.js');
 
 /*
  ------------------------------------------------------------


### PR DESCRIPTION
**Description:**

experiment with webcomponents-lite polyfill, 

the exported file (via `npm run dist`) is 30k bigger than the origin one (863k vs 892.6k)

The webcomponents-lite does not contain shadowdom polyfill, and the last update is a year old
https://github.com/webcomponents/webcomponents-lite