### PR TITLE
Create new instance of THREE.ColladaLoader on collada-model init

### DIFF
--- a/src/components/collada-model.js
+++ b/src/components/collada-model.js
@@ -1,9 +1,6 @@
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
 
-var loader = new THREE.ColladaLoader();
-loader.options.convertUpAxis = true;
-
 module.exports.Component = registerComponent('collada-model', {
   schema: {
     type: 'src'
@@ -11,6 +8,8 @@ module.exports.Component = registerComponent('collada-model', {
 
   init: function () {
     this.model = null;
+    this.loader = new THREE.ColladaLoader();
+    this.loader.options.convertUpAxis = true;
   },
 
   update: function () {
@@ -22,7 +21,7 @@ module.exports.Component = registerComponent('collada-model', {
 
     this.remove();
 
-    loader.load(src, function (colladaModel) {
+    this.loader.load(src, function (colladaModel) {
       self.model = colladaModel.scene;
       el.setObject3D('mesh', self.model);
       el.emit('model-loaded', {format: 'collada', model: self.model});


### PR DESCRIPTION
**Description:**
Fixes #1510. Creates new instance of collada loader for each collada-model component to prevent issue where using multiple collada models causes them to render incorrectly. 

**Changes proposed:**
- Move new 'THREE.ColladaLoader()' from outside component registration to within init method of collada-model component

