### PR TITLE
Added default primitive to geometry

### DIFF
--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -15,7 +15,7 @@ module.exports.Component = registerComponent('geometry', {
   schema: {
     buffer: { default: true },
     mergeTo: { type: 'selector' },
-    primitive: { default: '', oneOf: geometryNames },
+    primitive: { default: 'box', oneOf: geometryNames },
     skipCache: { default: false }
   },
 

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -16,6 +16,10 @@ suite('geometry', function () {
   });
 
   suite('update', function () {
+    test('allows empty geometry', function () {
+      this.el.setAttribute('geometry', '');
+    });
+
     test('creates geometry', function () {
       var mesh = this.el.getObject3D('mesh');
       assert.ok(mesh.geometry);


### PR DESCRIPTION
**Description:** 
When you try to add an empty entity with an empty geometry Aframe throws an error as it looks for a `primitive` value to return the expected geometryBuffer. 
We should add a default value so empty component doesn't give you any error and also give you some kind of basic behaviour (the same as if you put an empty material).
So basically what I've done is add a `default: 'box'` to the primitive schema and you'll get a box by default.
Fixes https://github.com/aframevr/aframe/issues/1514
