### PR TITLE
fix <a-scene debug> equating to false (fixes #1466)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -539,7 +539,7 @@ var proto = Object.create(ANode.prototype, {
    */
   setAttribute: {
     value: function (attr, value, componentPropValue) {
-      var isDebugMode = this.sceneEl && this.sceneEl.getAttribute('debug');
+      var isDebugMode = this.sceneEl && this.sceneEl.hasAttribute('debug');
       if (components[attr]) {
         // Just update one of the component properties
         if (typeof value === 'string' && componentPropValue !== undefined) {

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -660,11 +660,13 @@ suite('a-entity', function () {
       el.setAttribute('debug', true);
       el.addEventListener('loaded', function () {
         var child = document.createElement('a-entity');
+        child.addEventListener('loaded', function () {
+          child.setAttribute('position', '1 2 3');
+          assert.equal(child.attributes[0].value, '1 2 3');
+          done();
+        });
         el.appendChild(child);
         document.body.appendChild(el);
-        child.setAttribute('position', '1 2 3');
-        assert.equal(child.attributes[0].value, '1 2 3');
-        done();
       });
       document.body.appendChild(el);
     });
@@ -674,11 +676,13 @@ suite('a-entity', function () {
       el.attributes.setNamedItem(document.createAttribute('debug'));
       el.addEventListener('loaded', function () {
         var child = document.createElement('a-entity');
+        child.addEventListener('loaded', function () {
+          child.setAttribute('position', '1 2 3');
+          assert.equal(child.attributes[0].value, '1 2 3');
+          done();
+        });
         el.appendChild(child);
         document.body.appendChild(el);
-        child.setAttribute('position', '1 2 3');
-        assert.equal(child.attributes[0].value, '1 2 3');
-        done();
       });
       document.body.appendChild(el);
     });

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -653,6 +653,36 @@ suite('a-entity', function () {
       assert.shallowDeepEqual(el.getComputedAttribute('material').color, 'red');
     });
   });
+
+  suite('debug', function () {
+    test('does flush attributes to the DOM', function (done) {
+      var el = document.createElement('a-scene');
+      el.setAttribute('debug', true);
+      el.addEventListener('loaded', function () {
+        var child = document.createElement('a-entity');
+        el.appendChild(child);
+        document.body.appendChild(el);
+        child.setAttribute('position', '1 2 3');
+        assert.equal(child.attributes[0].value, '1 2 3');
+        done();
+      });
+      document.body.appendChild(el);
+    });
+
+    test('does allow debug to be a boolean attribute', function (done) {
+      var el = document.createElement('a-scene');
+      el.attributes.setNamedItem(document.createAttribute('debug'));
+      el.addEventListener('loaded', function () {
+        var child = document.createElement('a-entity');
+        el.appendChild(child);
+        document.body.appendChild(el);
+        child.setAttribute('position', '1 2 3');
+        assert.equal(child.attributes[0].value, '1 2 3');
+        done();
+      });
+      document.body.appendChild(el);
+    });
+  });
 });
 
 suite('a-entity component lifecycle management', function () {


### PR DESCRIPTION
**Description:**

- Added tests for the `debug` property of `a-entity`
- Fixed behaviour when `debug` is used as a boolean property

**Changes proposed:**
- `debug` property can either be a normal string property (`debug=true`) or a boolean one (`debug` without any value)

