### PR TITLE
include reason in error message for scene enterVR/exitVR errors

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -138,8 +138,12 @@ module.exports = registerElement('a-scene', {
             window.screen.orientation.lock('landscape');
           }
         }
-        function enterVRFailure () {
-          throw new Error('enter VR mode error. requestPresent failed');
+        function enterVRFailure (err) {
+          if (err && err.message) {
+            throw new Error('Failed to enter VR mode (`requestPresent`): ' + err.message);
+          } else {
+            throw new Error('Failed to enter VR mode (`requestPresent`).');
+          }
         }
       }
     },
@@ -157,8 +161,12 @@ module.exports = registerElement('a-scene', {
           self.resize();
           self.emit('exit-vr', {target: self});
         }
-        function exitVRFailure () {
-          throw new Error('exit VR mode error. exitPresent failed');
+        function exitVRFailure (err) {
+          if (err && err.message) {
+            throw new Error('Failed to exit VR mode (`exitPresent`): ' + err.message);
+          } else {
+            throw new Error('Failed to exit VR mode (`exitPresent`).');
+          }
         }
       }
     },


### PR DESCRIPTION
**Description:**

The true error messages for `vrDisplay.requestPresent()` and `vrDisplay.exitPresent()` calls were getting swallowed.

**Changes proposed:**
- Include the error's `message` in the message we print.