### PR TITLE
remove `beforeunload` event listener that exits VR

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -77,7 +77,6 @@ module.exports = registerElement('a-scene', {
         initWakelock(this);
 
         window.addEventListener('load', resize);
-        window.addEventListener('beforeunload', this.exitVR.bind(this));
         window.addEventListener('resize', resize);
         this.play();
       },


### PR DESCRIPTION
it's unneeded since Chromium builds do this automatically now (for quite some time now)