### PR TITLE
don't require shader to return materials, only set

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -82,12 +82,15 @@ module.exports.Component = registerComponent('material', {
   updateShader: function (shaderName) {
     var data = this.data;
     var Shader = shaders[shaderName] && shaders[shaderName].Shader;
-    var material;
+    var shaderInstance;
+
     if (!Shader) { throw new Error('Unknown shader ' + shaderName); }
-    this.shader = new Shader();
-    this.shader.el = this.el;
-    material = this.shader.init(data);
-    this.setMaterial(material);
+
+    // Get material from A-Frame shader.
+    shaderInstance = this.shader = new Shader();
+    shaderInstance.el = this.el;
+    shaderInstance.init(data);
+    this.setMaterial(shaderInstance.material);
     this.updateSchema(data);
   },
 

--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -23,13 +23,11 @@ module.exports.Component = registerShader('flat', {
     this.textureSrc = null;
     this.material = new THREE.MeshBasicMaterial(getMaterialData(data));
     utils.material.updateMap(this, data);
-    return this.material;
   },
 
   update: function (data) {
     this.updateMaterial(data);
     utils.material.updateMap(this, data);
-    return this.material;
   },
 
   /**

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -28,14 +28,12 @@ module.exports.Component = registerShader('standard', {
     this.material = new THREE.MeshStandardMaterial(getMaterialData(data));
     utils.material.updateMap(this, data);
     this.updateEnvMap(data);
-    return this.material;
   },
 
   update: function (data) {
     this.updateMaterial(data);
     utils.material.updateMap(this, data);
     this.updateEnvMap(data);
-    return this.material;
   },
 
   /**


### PR DESCRIPTION
This matches geometry registration. And the extra return is not needed since it's set on the instance, and it's weird for init/update methods to be returning.