### PR TITLE
fix a-videosphere radius at doc

### DIFF
--- a/docs/primitives/a-videosphere.md
+++ b/docs/primitives/a-videosphere.md
@@ -33,7 +33,7 @@ Note that the videosphere primitive inherits common [mesh attributes](./mesh-att
 | autoplay        | `<video>`.autoplay      | true          |
 | crossOrigin     | `<video>`.crossOrigin   | anonymous     |
 | loop            | `<video>`.loop          | true          |
-| radius          | geometry.radius         | 5000          |
+| radius          | geometry.radius         | 100           |
 | segments-height | geometry.segmentsHeight | 64            |
 | segments-width  | geometry.segmentsWidth  | 64            |
 


### PR DESCRIPTION
Found the inconsistency with https://github.com/aframevr/aframe/blob/master/src/extras/primitives/primitives/a-videosphere.js#L9