### PR TITLE
Preserve old geometry metadata.

### DIFF
--- a/src/systems/geometry.js
+++ b/src/systems/geometry.js
@@ -132,6 +132,7 @@ function toBufferGeometry (geometry, doBuffer) {
   if (!doBuffer) { return geometry; }
 
   bufferGeometry = new THREE.BufferGeometry().fromGeometry(geometry);
+  bufferGeometry.oldMetadata = {type: geometry.type, parameters: geometry.parameters || {}};
   geometry.dispose();  // Dispose no longer needed non-buffer geometry.
   return bufferGeometry;
 }

--- a/src/systems/geometry.js
+++ b/src/systems/geometry.js
@@ -132,7 +132,7 @@ function toBufferGeometry (geometry, doBuffer) {
   if (!doBuffer) { return geometry; }
 
   bufferGeometry = new THREE.BufferGeometry().fromGeometry(geometry);
-  bufferGeometry.oldMetadata = {type: geometry.type, parameters: geometry.parameters || {}};
+  bufferGeometry.metadata = {type: geometry.type, parameters: geometry.parameters || {}};
   geometry.dispose();  // Dispose no longer needed non-buffer geometry.
   return bufferGeometry;
 }

--- a/tests/systems/geometry.test.js
+++ b/tests/systems/geometry.test.js
@@ -54,8 +54,8 @@ suite('geometry system', function () {
     test('preserves original metadata on BufferGeometry', function () {
       var data = {primitive: 'box', width: 5, buffer: true};
       var geometry = this.system.getOrCreateGeometry(data);
-      assert.equal(geometry.oldMetadata.type, 'BoxGeometry');
-      assert.equal(geometry.oldMetadata.width, 5);
+      assert.equal(geometry.metadata.type, 'BoxGeometry');
+      assert.equal(geometry.metadata.width, 5);
     });
   });
 

--- a/tests/systems/geometry.test.js
+++ b/tests/systems/geometry.test.js
@@ -50,6 +50,13 @@ suite('geometry system', function () {
       assert.equal(geometry1, geometry2);
       assert.equal(system.cacheCount[hash], 2);
     });
+
+    test('preserves original metadata on BufferGeometry', function () {
+      var data = {primitive: 'box', width: 5, buffer: true};
+      var geometry = this.system.getOrCreateGeometry(data);
+      assert.equal(geometry.oldMetadata.type, 'BoxGeometry');
+      assert.equal(geometry.oldMetadata.width, 5);
+    });
   });
 
   suite('unuseGeometry', function () {


### PR DESCRIPTION
Fixes #1538

If we're using BufferGeometry instead of BoxBufferGeometry / PlaneBufferGeometry (not sure what the performance implications are on that switch), it would be helpful to preserve some of the metadata. For example, I use this to [construct CANNON.Shape instances from the geometry](https://github.com/donmccurdy/aframe-extras/blob/master/lib/CANNON-mesh2shape.js). 