### PR TITLE
Component play should not execute if the component is not initialized

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -291,7 +291,7 @@ var proto = Object.create(ANode.prototype, {
       // Check if component already initialized.
       if (name in this.components) { return; }
       component = this.components[name] = new components[name].Component(this, data);
-      if (this.isPlaying) { playComponent(component, this.sceneEl); }
+      if (this.isPlaying) { component.play(); }
 
       // Components are reflected in the DOM as attributes but the state is not shown
       // hence we set the attribute to empty string.
@@ -328,7 +328,7 @@ var proto = Object.create(ANode.prototype, {
       var isMixedIn = isComponentMixedIn(name, this.mixinEls);
       // Don't remove default or mixed in components
       if (isDefault || isMixedIn) { return; }
-      pauseComponent(component, this.sceneEl);
+      component.pause();
       component.remove();
       delete this.components[name];
       this.emit('componentremoved', { name: name });
@@ -443,15 +443,14 @@ var proto = Object.create(ANode.prototype, {
     value: function () {
       var components = this.components;
       var componentKeys = Object.keys(components);
-      var sceneEl = this.sceneEl;
 
       // Already playing.
       if (this.isPlaying || !this.hasLoaded) { return; }
       this.isPlaying = true;
 
       // Wake up all components.
-      componentKeys.forEach(function _playComponent (key) {
-        playComponent(components[key], sceneEl);
+      componentKeys.forEach(function playComponent (key) {
+        components[key].play();
       });
 
       // Tell all child entities to play.
@@ -472,14 +471,13 @@ var proto = Object.create(ANode.prototype, {
     value: function () {
       var components = this.components;
       var componentKeys = Object.keys(components);
-      var sceneEl = this.sceneEl;
 
       if (!this.isPlaying) { return; }
       this.isPlaying = false;
 
       // Sleep all components.
-      componentKeys.forEach(function _pauseComponent (key) {
-        pauseComponent(components[key], sceneEl);
+      componentKeys.forEach(function pauseComponent (key) {
+        components[key].pause();
       });
 
       // Tell all child entities to pause.
@@ -692,32 +690,6 @@ function isComponentMixedIn (name, mixinEls) {
     if (inMixin) { break; }
   }
   return inMixin;
-}
-
-/**
- * Pause component by removing tick behavior and calling pause handler.
- *
- * @param component {object} - Component to pause.
- * @param sceneEl {Element} - Scene, needed to remove the tick behavior.
- */
-function pauseComponent (component, sceneEl) {
-  component.pause();
-  // Remove tick behavior.
-  if (!component.tick) { return; }
-  sceneEl.removeBehavior(component);
-}
-
-/**
- * Play component by adding tick behavior and calling play handler.
- *
- * @param component {object} - Component to play.
- * @param sceneEl {Element} - Scene, needed to add the tick behavior.
- */
-function playComponent (component, sceneEl) {
-  component.play();
-  // Add tick behavior.
-  if (!component.tick) { return; }
-  sceneEl.addBehavior(component);
 }
 
 function isEntity (el) {

--- a/tests/components/sound.test.js
+++ b/tests/components/sound.test.js
@@ -70,6 +70,7 @@ suite('sound', function () {
         isPlaying: true,
         source: {buffer: true}
       };
+      el.components.sound.isPlaying = true;
       el.pause();
       assert.ok(sound.pause.called);
     });

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -343,4 +343,84 @@ suite('Component', function () {
       assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), 'color:blue');
     });
   });
+
+  suite('play', function () {
+    setup(function () {
+      components.dummy = undefined;
+      var playStub = this.playStub = sinon.stub();
+      registerComponent('dummy', {play: playStub});
+    });
+
+    test('not called if entity is not playing', function () {
+      var el = document.createElement('a-entity');
+      var dummyComponent;
+      el.isPlaying = false;
+      el.setAttribute('dummy', '');
+      dummyComponent = el.components.dummy;
+      dummyComponent.initialized = true;
+      dummyComponent.play();
+      sinon.assert.notCalled(this.playStub);
+    });
+
+    test('not called if component is not initialized', function () {
+      var el = document.createElement('a-entity');
+      el.isPlaying = true;
+      el.setAttribute('dummy', '');
+      el.components.dummy.play();
+      sinon.assert.notCalled(this.playStub);
+    });
+
+    test('not called if component is already playing', function () {
+      var el = document.createElement('a-entity');
+      var dummyComponent;
+      el.isPlaying = true;
+      el.setAttribute('dummy', '');
+      dummyComponent = el.components.dummy;
+      dummyComponent.initialized = true;
+      dummyComponent.play();
+      dummyComponent.play();
+      sinon.assert.calledOnce(this.playStub);
+    });
+  });
+
+  suite('pause', function () {
+    setup(function () {
+      components.dummy = undefined;
+      var pauseStub = this.pauseStub = sinon.stub();
+      registerComponent('dummy', {
+        schema: {color: { default: 'red' }},
+        pause: pauseStub
+      });
+    });
+
+    test('not called if component is not playing', function () {
+      var el = document.createElement('a-entity');
+      el.setAttribute('dummy', '');
+      el.components.dummy.pause();
+      sinon.assert.notCalled(this.pauseStub);
+    });
+
+    test('called if component is playing', function () {
+      var el = document.createElement('a-entity');
+      var dummyComponent;
+      el.setAttribute('dummy', '');
+      el.isPlaying = true;
+      dummyComponent = el.components.dummy;
+      dummyComponent.initialized = true;
+      dummyComponent.isPlaying = true;
+      dummyComponent.pause();
+      sinon.assert.called(this.pauseStub);
+    });
+
+    test('not called if component is already paused', function () {
+      var el = document.createElement('a-entity');
+      var dummyComponent;
+      el.setAttribute('dummy', '');
+      dummyComponent = el.components.dummy;
+      dummyComponent.isPlaying = true;
+      dummyComponent.pause();
+      dummyComponent.pause();
+      sinon.assert.calledOnce(this.pauseStub);
+    });
+  });
 });


### PR DESCRIPTION
**Description:**

There's a bogus situation if `play` is called on a component that has not been yet initialized and the logic relies on something done in the `init` method. 

The bug has manifested when the camera system pauses the inactive camera entity and plays the new active one. With the default camera the camera system calls play on the entity. The camera component is initialized before `look-controls` and its `play` method invoked before `init`. The `play` method of `look-controls` expects the methods to be bound before attaching the event listeners. 

**Changes proposed:**
Ensure that `play` is never invoked before `init` and also prevent play/pause logic to be executed multiple times if the component is already playing or paused respectively.

