### PR TITLE
Multiple components

### DIFF
--- a/examples/test/cursor/index.html
+++ b/examples/test/cursor/index.html
@@ -40,7 +40,9 @@
       </a-entity>
 
       <a-entity position="0 1 0">
-        <a-entity mixin="green cube">
+        <a-entity mixin="green cube"
+                  sound__1="on: cursor-click; src: ../../showcase/anime-UI/audio/321103__nsstudios__blip1.wav;"
+                  sound__2="on: cursor-mouseenter; src: ../../showcase/anime-UI/audio/321104__nsstudios__blip2.wav;">
           <a-animation begin="cursor-click" attribute="rotation" to="0 360 0"
                        easing="linear" dur="2000" fill="backwards"></a-animation>
         </a-entity>

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -549,6 +549,24 @@ suite('a-entity', function () {
       el.initComponent('material', true);
       assert.equal(el.getAttribute('material'), materialAttribute);
     });
+
+    test('does not initialize with id if the component is not multiple', function () {
+      var el = this.el;
+      assert.throws(function setAttribute () {
+        el.setAttribute('geometry__1', {primitive: 'box'});
+      }, Error);
+      assert.notOk(el.components.geometry_1);
+    });
+
+    test('initializes components with id if it opts in to multiple', function () {
+      var el = this.el;
+      el.setAttribute('sound__1', {'src': 'mysoundfile.mp3'});
+      el.setAttribute('sound__2', {'src': 'mysoundfile.mp3'});
+      assert.ok(el.components.sound__1);
+      assert.ok(el.components.sound__2);
+      assert.ok(el.components.sound__1 instanceof components.sound.Component);
+      assert.ok(el.components.sound__2 instanceof components.sound.Component);
+    });
   });
 
   suite('removeComponent', function () {

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -144,6 +144,14 @@ suite('Component', function () {
         done();
       });
     });
+
+    test('cannot be registered if it uses the character _ in the name', function () {
+      assert.notOk('my__component' in components);
+      assert.throws(function register () {
+        registerComponent('my__component', CloneComponent);
+      }, Error);
+      assert.notOk('my__component' in components);
+    });
   });
 
   suite('schema', function () {


### PR DESCRIPTION
**Description:**

It allows defining multiple component of a specific kind by appending an id to the component name followed by a `__` character. e.g:

````javascript
el.setAttribute('sound__1', { src: '...' });
el.setAttribute('sound__explosion', { src: '...' });
````
Components have to opt into multiplicity otherwise an error is thrown.

This PR depends on https://github.com/aframevr/aframe/pull/1565

Needs feedback from @fernandojsg
