### PR TITLE
Allow material repeat to be float

### DIFF
--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -241,7 +241,7 @@ function setTextureProperties (texture, data) {
 
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
-  texture.repeat.set(parseInt(repeatXY[0], 10), parseInt(repeatXY[1], 10));
+  texture.repeat.set(parseFloat(repeatXY[0]), parseFloat(repeatXY[1]));
 }
 
 /**


### PR DESCRIPTION
**Description:**
Repeat need not be an integer, like underlying threejs material:texture property.

**Changes proposed:**
Change repeat values to parse as float instead of int.

