### PR TITLE
fix fog property for standard material (fixes #1572)

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -18,12 +18,13 @@ var shaderNames = shader.shaderNames;
  */
 module.exports.Component = registerComponent('material', {
   schema: {
-    shader: { default: 'standard', oneOf: shaderNames },
-    transparent: { default: false },
-    opacity: { default: 1.0, min: 0.0, max: 1.0 },
-    side: { default: 'front', oneOf: ['front', 'back', 'double'] },
-    depthTest: { default: true },
-    flatShading: { default: false }
+    depthTest: {default: true},
+    flatShading: {default: false},
+    fog: {default: true},
+    opacity: {default: 1.0, min: 0.0, max: 1.0},
+    shader: {default: 'standard', oneOf: shaderNames},
+    side: {default: 'front', oneOf: ['front', 'back', 'double']},
+    transparent: {default: false}
   },
 
   init: function () {
@@ -97,11 +98,12 @@ module.exports.Component = registerComponent('material', {
   updateMaterial: function () {
     var data = this.data;
     var material = this.material;
-    material.side = parseSide(data.side);
-    material.opacity = data.opacity;
-    material.transparent = data.transparent !== false || data.opacity < 1.0;
     material.depthTest = data.depthTest !== false;
+    material.fog = data.fog;
+    material.opacity = data.opacity;
     material.shading = data.flatShading ? THREE.FlatShading : THREE.SmoothShading;
+    material.side = parseSide(data.side);
+    material.transparent = data.transparent !== false || data.opacity < 1.0;
   },
 
   /**

--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -8,7 +8,6 @@ var utils = require('../utils/');
 module.exports.Component = registerShader('flat', {
   schema: {
     color: { type: 'color' },
-    fog: { default: true },
     height: { default: 256 },
     repeat: { default: '' },
     src: { default: '' },
@@ -52,7 +51,6 @@ module.exports.Component = registerShader('flat', {
  */
 function getMaterialData (data) {
   return {
-    fog: data.fog,
     color: new THREE.Color(data.color)
   };
 }

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -12,7 +12,6 @@ module.exports.Component = registerShader('standard', {
   schema: {
     color: { type: 'color' },
     envMap: { default: '' },
-    fog: { default: true },
     height: { default: 256 },
     metalness: { default: 0.0, min: 0.0, max: 1.0 },
     repeat: { default: '' },


### PR DESCRIPTION
**Description:**

Fog is a base material property. https://github.com/mrdoob/three.js/blob/master/src/materials/Material.js#L15

Wasn't being set on standard material.


