### PR TITLE
allow system configuration (fixes #1464)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -606,11 +606,9 @@ var proto = Object.create(ANode.prototype, {
    */
   getAttribute: {
     value: function (attr) {
+      // If cached value exists, return partial component data.
       var component = this.components[attr];
-      // If there's a cached value we just return it
-      if (component && component.attrValue !== undefined) {
-        return component.attrValue;
-      }
+      if (component && component.attrValue !== undefined) { return component.attrValue; }
       return HTMLElement.prototype.getAttribute.call(this, attr);
     },
     writable: window.debug
@@ -627,6 +625,7 @@ var proto = Object.create(ANode.prototype, {
    */
   getComputedAttribute: {
     value: function (attr) {
+      // If component, return component data.
       var component = this.components[attr];
       if (component) { return component.getData(); }
       return HTMLElement.prototype.getAttribute.call(this, attr);

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -94,8 +94,7 @@ module.exports = registerElement('a-scene', {
       value: function (name) {
         var system;
         if (this.systems[name]) { return; }
-        system = this.systems[name] = new systems[name]();
-        system.sceneEl = this;
+        system = this.systems[name] = new systems[name](this);
         system.init();
       }
     },
@@ -168,6 +167,46 @@ module.exports = registerElement('a-scene', {
             throw new Error('Failed to exit VR mode (`exitPresent`).');
           }
         }
+      }
+    },
+
+    /**
+     * Wraps Entity.getAttribute to take into account for systems.
+     * If system exists, then return system data rather than possible component data.
+     */
+    getAttribute: {
+      value: function (attr) {
+        var system = this.systems[attr];
+        if (system) { return system.data; }
+        return AEntity.prototype.getAttribute.call(this, attr);
+      }
+    },
+
+    /**
+     * Wraps Entity.getComputedAttribute to take into account for systems.
+     * If system exists, then return system data rather than possible component data.
+     */
+    getComputedAttribute: {
+      value: function (attr) {
+        var system = this.systems[attr];
+        if (system) { return system.data; }
+        return AEntity.prototype.getComputedAttribute.call(this, attr);
+      }
+    },
+
+    /**
+     * Wraps Entity.setAttribute to take into account for systems.
+     * If system exists, then skip component initialization checks and do a normal
+     * setAttribute.
+     */
+    setAttribute: {
+      value: function (attr, value, componentPropValue) {
+        var system = this.systems[attr];
+        if (system) {
+          ANode.prototype.setAttribute.call(this, attr, value);
+          return;
+        }
+        AEntity.prototype.setAttribute.call(this, attr, value, componentPropValue);
       }
     },
 

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -105,10 +105,7 @@ module.exports.parseProperties = function (propData, schema, getPartialData, sil
   propNames.forEach(function parse (propName) {
     var propDefinition = schema[propName];
     var propValue = propData[propName];
-
     if (!(schema[propName])) { return; }
-
-    propValue = propValue === undefined ? propDefinition.default : propValue;
     propData[propName] = parseProperty(propValue, propDefinition);
   });
 
@@ -119,6 +116,7 @@ module.exports.parseProperties = function (propData, schema, getPartialData, sil
  * Deserialize a single property.
  */
 function parseProperty (value, propDefinition) {
+  value = (value === undefined || value === null) ? propDefinition.default : value;
   if (typeof value !== 'string') { return value; }
   if (typeof value === 'undefined') { return value; }
   return propDefinition.parse(value);

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -1,8 +1,10 @@
-/* global assert, process, sinon, setup, suite, teardown, test */
-var helpers = require('../../helpers');
+/* global AFRAME, assert, process, sinon, setup, suite, teardown, test */
 var AEntity = require('core/a-entity');
 var ANode = require('core/a-node');
 var AScene = require('core/scene/a-scene');
+var components = require('core/component').components;
+var helpers = require('../../helpers');
+var systems = require('core/system').systems;
 
 /**
  * Tests in this suite should not involve WebGL contexts or renderer.
@@ -54,6 +56,36 @@ suite('a-scene (without renderer)', function () {
       sceneEl.reload(true);
       sinon.assert.called(AEntity.prototype.pause);
       sinon.assert.called(ANode.prototype.load);
+    });
+  });
+
+  suite('system', function () {
+    setup(function () {
+      delete components.test;
+      delete systems.test;
+    });
+
+    test('can getAttribute', function () {
+      var sceneEl = document.createElement('a-scene');
+
+      AFRAME.registerComponent('test', {schema: {default: 'component'}});
+      AFRAME.registerSystem('test', {schema: {default: 'system'}});
+
+      sceneEl.initSystem('test');
+      assert.equal(sceneEl.getAttribute('test'), 'system');
+      assert.equal(sceneEl.getComputedAttribute('test'), 'system');
+    });
+
+    test('does not initialize component on setAttribute', function () {
+      var sceneEl = document.createElement('a-scene');
+      var stub = sinon.stub();
+
+      AFRAME.registerComponent('test', {init: stub});
+      AFRAME.registerSystem('test', {});
+
+      sceneEl.initSystem('test');
+      sceneEl.setAttribute('test', '');
+      assert.notOk(stub.called);
     });
   });
 });

--- a/tests/core/system.test.js
+++ b/tests/core/system.test.js
@@ -1,5 +1,5 @@
-/* global assert, process, suite, test, setup */
-'use strict';
+/* global AFRAME, assert, process, suite, test, setup */
+var components = require('core/component').components;
 var systems = require('core/system').systems;
 var registerSystem = require('core/system').registerSystem;
 
@@ -23,6 +23,77 @@ suite('System', function () {
       assert.notOk('TestSystem' in systems);
       registerSystem('test', TestSystem);
       assert.ok('test' in systems);
+    });
+  });
+
+  suite('schema', function () {
+    setup(function () {
+      delete components.test;
+      delete systems.test;
+    });
+
+    test('initializes data for single-prop schema', function () {
+      var sceneEl = document.createElement('a-scene');
+      var system;
+      var TestSystem;
+
+      AFRAME.registerSystem('test', {
+        schema: {default: ''}
+      });
+      TestSystem = systems.test;
+
+      sceneEl.setAttribute('test', 'candy');
+      system = new TestSystem(sceneEl);
+      assert.equal(system.data, 'candy');
+    });
+
+    test('initializes data for multi-prop schema', function () {
+      var sceneEl = document.createElement('a-scene');
+      var system;
+      var TestSystem;
+
+      AFRAME.registerSystem('test', {
+        schema: {
+          a: {type: 'number'},
+          b: {type: 'string'}
+        }
+      });
+      TestSystem = systems.test;
+
+      sceneEl.setAttribute('test', 'a: 50; b: horses');
+      system = new TestSystem(sceneEl);
+      assert.equal(system.data.a, 50);
+      assert.equal(system.data.b, 'horses');
+    });
+
+    test('uses default values', function () {
+      var sceneEl = document.createElement('a-scene');
+      var system;
+      var TestSystem;
+
+      AFRAME.registerSystem('test', {
+        schema: {
+          a: {default: 50},
+          b: {default: 'horses'}
+        }
+      });
+      TestSystem = systems.test;
+
+      system = new TestSystem(sceneEl);
+      assert.equal(system.data.a, 50);
+      assert.equal(system.data.b, 'horses');
+    });
+
+    test('can be empty', function () {
+      var sceneEl = document.createElement('a-scene');
+      var system;
+      var TestSystem;
+
+      AFRAME.registerSystem('test', {schema: {}});
+      TestSystem = systems.test;
+
+      system = new TestSystem(sceneEl);
+      assert.notOk(system.data);
     });
   });
 });


### PR DESCRIPTION
**Description:**

Configurable systems. Use cases so far have been configurable Firebase system for API credentials, and configurable Physics system such as for gravity. 

```html
<a-scene firebase="apiKey: dsakldasd; authDomain: github.com">
```

So far we've had to work around using proxy components.

Currently does not support updates.

**Changes proposed:**
- Add schema and initial parsing to Systems.
- Have `Scene.getAttribute` and `Scene.setAttribute` to return system data (if exists) rather than component data that might have the same name (e.g., if you had a `physics` system and `physics` component, `sceneEl.getAttribute('physics')` should return physics system data.
- No actual changes to Entity, just shuffled code (to do early returns) around from leftover implementation.

