### PR TITLE
fix Getting Started > Builds buttons (for aframevr/aframe-site#265)

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -50,18 +50,9 @@ If we want to just include the JS build from the CDN, we can drop a `<script>` t
 <script src="https://aframe.io/releases/{{ version }}/aframe.js"></script>
 ```
 
-<script>
-  // NOTE: Hack because variables doesn't get interpolated correctly in Markdown code blocks.
-  var versionEls = document.querySelectorAll('.highlight .code .string');
-  for (var i = 0; i < versionEls.length; ++i) {
-    versionEls[i].textContent = versionEls[i].textContent.replace('\{\{ version \}\}', '{{ version }}');
-  }
-</script>
-
 If we want to serve it locally, we can download the JS build:
 
 <a id="builds-prod" class="btn btn-download" href="https://aframe.io/releases/{{ version }}/aframe.min.js" download>Production Version <span>{{ version }}</span></a> <em class="install-note">Minified</em>
-
 <a id="builds-dev" class="btn btn-download" href="https://aframe.io/releases/{{ version }}/aframe.js" download>Development Version <span>{{ version }}</span></a> <em class="install-note">Uncompressed with Source Maps</em>
 
 ## npm


### PR DESCRIPTION
for
- https://aframe.io/docs/0.1.0/guide/installation.html
- https://aframe.io/docs/0.2.0/guide/getting-started.html
- https://aframe.io/docs/master/guide/getting-started.html
