### PR TITLE
utils to get/set delimited component properties (fixes #1592)

### DIFF
--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -4,9 +4,10 @@ var coordinates = require('../utils/').coordinates;
 var parseProperty = require('./schema').parseProperty;
 var registerElement = require('./a-register-element').registerElement;
 var TWEEN = require('tween.js');
-var utils = require('../utils/');
 var THREE = require('../lib/three');
+var utils = require('../utils/');
 
+var getComponentProperty = utils.entity.getComponentProperty;
 var DEFAULTS = constants.defaults;
 var DIRECTIONS = constants.directions;
 var EASING_FUNCTIONS = constants.easingFunctions;
@@ -95,7 +96,7 @@ module.exports.AAnimation = registerElement('a-animation', {
         var animationValues;
         var attribute = data.attribute;
         var delay = parseInt(data.delay, 10);
-        var currentValue = getComputedAttributeFor(el, attribute);
+        var currentValue = getComponentProperty(el, attribute);
         var direction = self.getDirection(data.direction);
         var easing = EASING_FUNCTIONS[data.easing];
         var fill = data.fill;
@@ -418,7 +419,7 @@ function getAnimationValues (el, attribute, dataFrom, dataTo, currentValue) {
     }
     schema = component.schema;
     if (dataFrom === undefined) {  // dataFrom can be 0.
-      from[attribute] = getComputedAttributeFor(el, attribute);
+      from[attribute] = getComponentProperty(el, attribute);
     } else {
       from[attribute] = dataFrom;
     }
@@ -491,7 +492,6 @@ function getAnimationValues (el, attribute, dataFrom, dataTo, currentValue) {
   }
 }
 module.exports.getAnimationValues = getAnimationValues;
-module.exports.getComputedAttributeFor = getComputedAttributeFor;
 
 /**
  * Converts string to bool.
@@ -512,26 +512,6 @@ function strToBool (str) {
  */
 function boolToNum (bool) {
   return bool ? 1 : 0;
-}
-
-/**
- * A getComputedAttribute that supports dot notation to look up a component property.
- *
- * @param {Element} el - To look up attribute on.
- * @param {string} attr - dot notation or singular 'color' or 'material.color'
- * @returns Resulting value of component property.
- */
-function getComputedAttributeFor (el, attribute) {
-  var attributeSplit = attribute.split('.');
-  var componentName = attributeSplit[0];
-  var componentPropName = attributeSplit[1];
-  var attributeValue = el.getComputedAttribute(componentName);
-  // If the attribute is singular call normal getComputedAttribute function
-  if (attributeSplit.length === 1) { return attributeValue; }
-  // If the component exists as an attribute return the property on it
-  if (attributeValue) { return attributeValue[componentPropName]; }
-  // Otherwise Fall back to native get attribute with the component prop name
-  return el.getComputedAttribute(componentPropName);
 }
 
 /**

--- a/src/extras/declarative-events/index.js
+++ b/src/extras/declarative-events/index.js
@@ -1,5 +1,8 @@
 var ANode = require('../../core/a-node');
 var registerElement = require('../../core/a-register-element').registerElement;
+var utils = require('../../utils/');
+
+var setComponentProperty = utils.entity.setComponentProperty;
 
 /**
  * Declarative events to help register event listeners that set attributes on other entities.
@@ -74,7 +77,6 @@ module.exports = registerElement('a-event', {
         return el.addEventListener(name, function () {
           var attribute;
           var attributeName;
-          var attributeSplit;
           var attributeValue;
           var targetEl;
 
@@ -87,17 +89,7 @@ module.exports = registerElement('a-event', {
 
               // target is a keyword for <a-event>.
               if (attributeName === 'target') { continue; }
-
-              // Handle component property selector like `material.color`.
-              if (attributeName.indexOf('.') !== -1) {
-                attributeSplit = attributeName.split('.');
-                targetEl.setAttribute(attributeSplit[0], attributeSplit[1],
-                                      attributeValue);
-                continue;
-              }
-
-              // Set plain attribute.
-              targetEl.setAttribute(attributeName, attributeValue);
+              setComponentProperty(targetEl, attributeName, attributeValue);
             }
           }
         });

--- a/src/extras/primitives/registerPrimitive.js
+++ b/src/extras/primitives/registerPrimitive.js
@@ -4,6 +4,7 @@ var registerElement = require('../../core/a-register-element').registerElement;
 var utils = require('../../utils/');
 
 var debug = utils.debug;
+var setComponentProperty = utils.entity.setComponentProperty;
 var log = debug('extras:primitives:debug');
 
 module.exports = function registerPrimitive (name, definition) {
@@ -104,37 +105,18 @@ module.exports = function registerPrimitive (name, definition) {
        */
       syncAttributeToComponent: {
         value: function (attr, value) {
-          var componentName;
-          var split;
-          var propertyName;
+          var componentName = this.mappings[attr];
 
           if (attr in this.deprecatedMappings) {
             console.warn(this.deprecatedMappings[attr]);
           }
-
-          if (!attr || !this.mappings[attr]) { return; }
-
-          // Differentiate between single-property and multi-property component.
-          componentName = this.mappings[attr];
-          if (componentName.indexOf('.') !== -1) {
-            split = this.mappings[attr].split('.');
-            componentName = split[0];
-            propertyName = split[1];
-          }
-
-          if (!components[componentName]) { return; }
+          if (!attr || !componentName) { return; }
 
           // Run transform.
           value = this.getTransformedValue(attr, value);
 
-          // If multi-property schema, set as update to component to not overwrite.
-          if (propertyName) {
-            this.setAttribute(componentName, propertyName, value);
-            return;
-          }
-
-          // Single-property schema, just set the value.
-          this.setAttribute(componentName, value);
+          // Set value.
+          setComponentProperty(this, componentName, value);
         }
       },
 

--- a/src/utils/entity.js
+++ b/src/utils/entity.js
@@ -1,0 +1,28 @@
+/**
+ * Get component property using encoded component name + component property name with a
+ * delimiter.
+ */
+module.exports.getComponentProperty = function (el, name, delimiter) {
+  var splitName;
+  delimiter = delimiter || '.';
+  if (name.indexOf(delimiter) !== -1) {
+    splitName = name.split(delimiter);
+    return el.getComputedAttribute(splitName[0])[splitName[1]];
+  }
+  return el.getComputedAttribute(name);
+};
+
+/**
+ * Set component property using encoded component name + component property name with a
+ * delimiter.
+ */
+module.exports.setComponentProperty = function (el, name, value, delimiter) {
+  var splitName;
+  delimiter = delimiter || '.';
+  if (name.indexOf(delimiter) !== -1) {
+    splitName = name.split(delimiter);
+    el.setAttribute(splitName[0], splitName[1], value);
+    return;
+  }
+  el.setAttribute(name, value);
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,6 +6,7 @@ var objectAssign = require('object-assign');
 
 module.exports.coordinates = require('./coordinates');
 module.exports.debug = require('./debug');
+module.exports.entity = require('./entity');
 module.exports.material = require('./material');
 module.exports.styleParser = require('./styleParser');
 

--- a/tests/core/a-animation.test.js
+++ b/tests/core/a-animation.test.js
@@ -3,7 +3,9 @@
 var helpers = require('../helpers.js');
 var AAnimation = require('core/a-animation').AAnimation;
 var getAnimationValues = require('core/a-animation').getAnimationValues;
-var getComputedAttributeFor = require('core/a-animation').getComputedAttributeFor;
+var utils = require('utils/');
+
+var getComponentProperty = utils.entity.getComponentProperty;
 
 /**
  * Helpers to start initialize an animation.
@@ -57,9 +59,7 @@ function generateColorAnimationTest (description, from, to, attribute) {
         attributeSplit = attribute.split('.');
         elAttrs = {};
         elAttrs[attribute] = '';
-        elAttrs[attributeSplit[0]] = {
-          shader: 'flat'
-        };
+        elAttrs[attributeSplit[0]] = {shader: 'flat'};
         elAttrs[attributeSplit[0]][attributeSplit[1]] = '#FFF';
       }
       setupAnimation({
@@ -74,24 +74,24 @@ function generateColorAnimationTest (description, from, to, attribute) {
         self.animationEl = animationEl;
         self.startTime = startTime;
         done();
-      }, elAttrs || { color: '' });
+      }, elAttrs || {color: ''});
     });
 
     test('start value', function () {
-      assert.equal(this.el.getComputedAttribute(attribute || 'color'), '#ffffff');
+      assert.equal(getComponentProperty(this.el, attribute || 'color'), '#ffffff');
     });
 
     test('between value', function () {
       var color;
       this.animationEl.tween.update(this.startTime + 500);
-      color = this.el.getComputedAttribute(attribute || 'color');
+      color = getComponentProperty(this.el, attribute || 'color');
       assert.isAbove(color, '#000000');
       assert.isBelow(color, '#ffffff');
     });
 
     test('finish value', function () {
       this.animationEl.tween.update(this.startTime + 1000);
-      assert.equal(this.el.getComputedAttribute(attribute || 'color'), '#000000');
+      assert.equal(getComponentProperty(this.el, attribute || 'color'), '#000000');
     });
   });
 }
@@ -662,29 +662,6 @@ suite('a-animation', function () {
     test('finish value', function () {
       this.animationEl.tween.update(this.startTime + 1000);
       assert.equal(this.el.getComputedAttribute(attribute), '#0000ff');
-    });
-  });
-
-  suite('getComputedAttributeFor', function () {
-    setup(function (done) {
-      var el = this.el = helpers.entityFactory();
-      el.addEventListener('loaded', function () {
-        done();
-      });
-    });
-
-    test('can get value of normal attribute', function (done) {
-      var el = this.el;
-      el.setAttribute('color', '#ffffff');
-      assert.equal(getComputedAttributeFor(el, 'color'), '#ffffff');
-      done();
-    });
-
-    test('can get value of attribute using dot notation', function (done) {
-      var el = this.el;
-      el.setAttribute('material', 'color', '#ffffff');
-      assert.equal(getComputedAttributeFor(el, 'material.color'), '#ffffff');
-      done();
     });
   });
 

--- a/tests/utils/entity.test.js
+++ b/tests/utils/entity.test.js
@@ -1,0 +1,55 @@
+/* global assert, setup, suite, test */
+var helpers = require('../helpers');
+var entity = require('utils/').entity;
+
+var getComponentProperty = entity.getComponentProperty;
+var setComponentProperty = entity.setComponentProperty;
+
+suite('utils.entity', function () {
+  setup(function (done) {
+    var el = this.el = helpers.entityFactory();
+    el.addEventListener('loaded', function () {
+      done();
+    });
+  });
+
+  suite('getComponentProperty', function () {
+    test('can get normal attribute', function () {
+      var el = this.el;
+      el.setAttribute('visible', true);
+      assert.equal(getComponentProperty(el, 'visible'), true);
+    });
+
+    test('can get dot-delimited attribute', function () {
+      var el = this.el;
+      el.setAttribute('material', {color: 'red'});
+      assert.equal(getComponentProperty(el, 'material.color'), 'red');
+    });
+
+    test('can get custom-delimited attribute', function () {
+      var el = this.el;
+      el.setAttribute('material', {color: 'red'});
+      assert.equal(getComponentProperty(el, 'material|color', '|'), 'red');
+    });
+  });
+
+  suite('setComponentProperty', function () {
+    test('can set normal attribute', function () {
+      var el = this.el;
+      setComponentProperty(el, 'visible', true);
+      assert.equal(el.getAttribute('visible'), true);
+    });
+
+    test('can set dot-delimited attribute', function () {
+      var el = this.el;
+      setComponentProperty(el, 'material.color', 'red');
+      assert.equal(el.getAttribute('material').color, 'red');
+    });
+
+    test('can get custom-delimited attribute', function () {
+      var el = this.el;
+      setComponentProperty(el, 'material|color', 'red', '|');
+      assert.equal(el.getAttribute('material').color, 'red');
+    });
+  });
+});


### PR DESCRIPTION
**Description:**

Helpers that wrap get/setAttribute to handle encoded component property names (e.g., `material.color`).

**Changes Proposed:**

- `utils.entity.getComponentProperty(el, name, delimiter)`
- `utils.entity.setComponentProperty(el, name, value, delimiter)`