### PR TITLE
revert cursor event renames (fixes #1593)

### DIFF
--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -13,7 +13,7 @@ The cursor component lets us interact with entities through clicking and gazing.
 - Emits special mouse and hover events (e.g., relating to mouse down/up/enter/leave).
 - Has additional states for hovering.
 
-When the mouse is clicked, the closest visible entity intersecting the cursor, if any, will emit a `cursor-click` event. Note the cursor component only applies the raycasting behavior. To provide a shape or appearance to the cursor, you could apply the [geometry][geometry] and [material][material] components.
+When the mouse is clicked, the closest visible entity intersecting the cursor, if any, will emit a `click` event. Note the cursor component only applies the raycasting behavior. To provide a shape or appearance to the cursor, you could apply the [geometry][geometry] and [material][material] components.
 
 ## Example
 
@@ -36,7 +36,7 @@ For example, we can create a ring-shaped cursor that is fixed to the center of t
 AFRAME.registerComponent('click-color-change', {
   init: function () {
     var COLORS = ['red', 'green', 'blue'];
-    this.el.addEventListener('cursor-click', function () {
+    this.el.addEventListener('click', function () {
       var randomIndex = Math.floor(Math.random() * COLORS.length);
       this.setAttribute('material', 'color', COLORS[randomIndex]);
       console.log('I was clicked!');
@@ -58,11 +58,11 @@ Note, to further customize the cursor component, we can set the properties of th
 
 | Event             | Description                                                                                                                 |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| cursor-click      | Emitted on both cursor and intersected entity if a currently intersected entity is clicked (whether by mouse or by fuse).   |
-| cursor-mousedown  | Emitted on both cursor and intersected entity (if any) on mousedown on the canvas element.                                  |
-| cursor-mouseenter | Emitted on both cursor and intersected entity (if any) when cursor intersects with an entity.                               |
-| cursor-mouseleave | Emitted on both cursor and intersected entity (if any) when cursor no longer intersects with previously intersected entity. |
-| cursor-mouseup    | Emitted on both cursor and intersected entity (if any) on mouseup on the canvas element.                                    |
+| click      | Emitted on both cursor and intersected entity if a currently intersected entity is clicked (whether by mouse or by fuse).   |
+| mousedown  | Emitted on both cursor and intersected entity (if any) on mousedown on the canvas element.                                  |
+| mouseenter | Emitted on both cursor and intersected entity (if any) when cursor intersects with an entity.                               |
+| mouseleave | Emitted on both cursor and intersected entity (if any) when cursor no longer intersects with previously intersected entity. |
+| mouseup    | Emitted on both cursor and intersected entity (if any) on mouseup on the canvas element.                                    |
 
 ## States
 
@@ -102,7 +102,7 @@ To add visual feedback to the cursor in order to display indication when the cur
           position="0 0 -1"
           geometry="primitive: ring"
           material="color: black; shader: flat">
-  <a-animation begin="cursor-click" easing="ease-in" attribute="scale"
+  <a-animation begin="click" easing="ease-in" attribute="scale"
                fill="backwards" from="0.1 0.1 0.1" to="1 1 1"></a-animation>
   <a-animation begin="cursor-fusing" easing="ease-in" attribute="scale"
                fill="forwards" from="1 1 1" to="0.1 0.1 0.1"></a-animation>

--- a/examples/declarative-events/cursor/index.html
+++ b/examples/declarative-events/cursor/index.html
@@ -20,10 +20,10 @@
 
       <a-box id="orange-cube" position="0 3.5 -2" rotation="30 30 0" width="2" depth="2"
              height="2" color="#F16745" roughness="0.8">
-        <a-event name="cursor-mouseenter" scale="3 1 1" color="#FFC65D"></a-event>
-        <a-event name="cursor-mouseenter" target="#shadow" scale="3 2 2"></a-event>
-        <a-event name="cursor-mouseleave" scale="1 1 1" color="#F16745"></a-event>
-        <a-event name="cursor-mouseleave" target="#shadow" scale="2 2 2"></a-event>
+        <a-event name="mouseenter" scale="3 1 1" color="#FFC65D"></a-event>
+        <a-event name="mouseenter" target="#shadow" scale="3 2 2"></a-event>
+        <a-event name="mouseleave" scale="1 1 1" color="#F16745"></a-event>
+        <a-event name="mouseleave" target="#shadow" scale="2 2 2"></a-event>
       </a-box>
 
       <a-image id="shadow" position="0 0 -2" src="#shadow2" opacity="0.5" rotation="-90 0 0"

--- a/examples/declarative-events/hovers/index.html
+++ b/examples/declarative-events/hovers/index.html
@@ -30,16 +30,16 @@
       <a-entity mixin="short orange cube" position="-1 2 0" rotation="30 30 0"></a-entity>
 
       <a-entity mixin="short yellow cube" position="1 2 0" rotation="30 30 0">
-        <a-event name="cursor-click" target="#target" scale="1.5 1.5 1.5"></a-event>
-        <a-event name="cursor-click" scale="1.5 1.5 1.5"></a-event>
+        <a-event name="click" target="#target" scale="1.5 1.5 1.5"></a-event>
+        <a-event name="click" scale="1.5 1.5 1.5"></a-event>
       </a-entity>
 
       <a-entity mixin="green cube" position="-1 0 0" rotation="30 30 0"></a-entity>
 
       <a-entity mixin="blue cube" position="1 0 0" rotation="30 30 0">
-        <a-event name="cursor-click" material.color="#FFC65D"></a-event>
-        <a-event name="cursor-mouseenter" scale="1.5 1.5 1.5"></a-event>
-        <a-event name="cursor-mouseleave" scale="1 1 1"></a-event>
+        <a-event name="click" material.color="#FFC65D"></a-event>
+        <a-event name="mouseenter" scale="1.5 1.5 1.5"></a-event>
+        <a-event name="mouseleave" scale="1 1 1"></a-event>
       </a-entity>
 
       <a-sky color="#ECECEC"></a-sky>

--- a/examples/test/cursor/index.html
+++ b/examples/test/cursor/index.html
@@ -34,23 +34,23 @@
 
       <a-entity position="-3.5 1 0">
         <a-entity mixin="red cube">
-          <a-animation begin="cursor-click" attribute="position" from="0 0 0"
+          <a-animation begin="click" attribute="position" from="0 0 0"
                        to="0 0 -10" dur="2000" fill="both"></a-animation>
         </a-entity>
       </a-entity>
 
       <a-entity position="0 1 0">
         <a-entity mixin="green cube"
-                  sound__1="on: cursor-click; src: ../../showcase/anime-UI/audio/321103__nsstudios__blip1.wav;"
-                  sound__2="on: cursor-mouseenter; src: ../../showcase/anime-UI/audio/321104__nsstudios__blip2.wav;">
-          <a-animation begin="cursor-click" attribute="rotation" to="0 360 0"
+                  sound__1="on: click; src: ../../showcase/anime-UI/audio/321103__nsstudios__blip1.wav;"
+                  sound__2="on: mouseenter; src: ../../showcase/anime-UI/audio/321104__nsstudios__blip2.wav;">
+          <a-animation begin="click" attribute="rotation" to="0 360 0"
                        easing="linear" dur="2000" fill="backwards"></a-animation>
         </a-entity>
       </a-entity>
 
       <a-entity position="3.5 1 0" rotation="0 45 0">
         <a-entity mixin="blue cube">
-          <a-animation begin="cursor-click" fill="forwards" repeat="1"
+          <a-animation begin="click" fill="forwards" repeat="1"
                        direction="alternate" attribute="position" from="0 0 0"
                        to="15 0 0" dur="2000"></a-animation>
         </a-entity>
@@ -66,7 +66,7 @@
         var clickedEl = null;
         var els = document.querySelectorAll('a-entity');
         Array.prototype.forEach.call(els, function (el) {
-          el.addEventListener('cursor-click', function () {
+          el.addEventListener('click', function () {
             if (clickedEl && clickedEl !== el) {
               clickedEl.removeState('selected');
             }
@@ -80,7 +80,7 @@
         var cubes = document.querySelectorAll('a-entity[mixin*=cube]');
         var i;
         for (i = 0; i < cubes.length; ++i) {
-          cubes[i].addEventListener('cursor-click', function () {
+          cubes[i].addEventListener('click', function () {
             var href = this.getAttribute('href');
             if (!href) { return; }
             window.top.postMessage({type: 'navigate', data: {url: href}}, '*');

--- a/examples/test/visibility/index.html
+++ b/examples/test/visibility/index.html
@@ -55,7 +55,7 @@
         var blueCube = document.querySelector('#blueCube');
         var redSphere = document.querySelector('#redSphere');
         var greenCylinder = document.querySelector('#greenCylinder');
-        document.addEventListener('cursor-click', function (e) {
+        document.addEventListener('click', function (e) {
           switch (e.target) {
             case blueCube: {
               redSphere.setAttribute('visible', true);

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -2,11 +2,11 @@ var registerComponent = require('../core/component').registerComponent;
 var utils = require('../utils/');
 
 var EVENTS = {
-  CLICK: 'cursor-click',
-  MOUSEENTER: 'cursor-mouseenter',
-  MOUSEDOWN: 'cursor-mousedown',
-  MOUSELEAVE: 'cursor-mouseleave',
-  MOUSEUP: 'cursor-mouseup'
+  CLICK: 'click',
+  MOUSEENTER: 'mouseenter',
+  MOUSEDOWN: 'mousedown',
+  MOUSELEAVE: 'mouseleave',
+  MOUSEUP: 'mouseup'
 };
 
 var STATES = {

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -30,7 +30,7 @@ suite('cursor', function () {
       var cursorEl = this.cursorEl;
       var intersectedEl = this.intersectedEl;
       cursorEl.components.cursor.intersectedEl = intersectedEl;
-      cursorEl.addEventListener('cursor-mousedown', function () {
+      cursorEl.addEventListener('mousedown', function () {
         done();
       });
       cursorEl.components.cursor.onMouseDown();
@@ -40,7 +40,7 @@ suite('cursor', function () {
       var cursorEl = this.cursorEl;
       var intersectedEl = this.intersectedEl;
       cursorEl.components.cursor.intersectedEl = intersectedEl;
-      intersectedEl.addEventListener('cursor-mousedown', function () {
+      intersectedEl.addEventListener('mousedown', function () {
         done();
       });
       cursorEl.components.cursor.onMouseDown();
@@ -61,7 +61,7 @@ suite('cursor', function () {
       var cursorEl = this.cursorEl;
       var intersectedEl = this.intersectedEl;
       cursorEl.components.cursor.intersectedEl = intersectedEl;
-      cursorEl.addEventListener('cursor-mouseup', function () {
+      cursorEl.addEventListener('mouseup', function () {
         done();
       });
       cursorEl.components.cursor.onMouseUp();
@@ -72,7 +72,7 @@ suite('cursor', function () {
       var intersectedEl = this.intersectedEl;
       cursorEl.components.cursor.intersectedEl = intersectedEl;
       cursorEl.components.cursor.mouseDownEl = document.createElement('a-entity');
-      intersectedEl.addEventListener('cursor-mouseup', function () {
+      intersectedEl.addEventListener('mouseup', function () {
         done();
       });
       cursorEl.components.cursor.onMouseUp();
@@ -83,7 +83,7 @@ suite('cursor', function () {
       var intersectedEl = this.intersectedEl;
       cursorEl.components.cursor.intersectedEl = intersectedEl;
       cursorEl.components.cursor.mouseDownEl = intersectedEl;
-      cursorEl.addEventListener('cursor-click', function () {
+      cursorEl.addEventListener('click', function () {
         done();
       });
       cursorEl.components.cursor.onMouseUp();
@@ -94,7 +94,7 @@ suite('cursor', function () {
       var intersectedEl = this.intersectedEl;
       cursorEl.components.cursor.intersectedEl = intersectedEl;
       cursorEl.components.cursor.mouseDownEl = intersectedEl;
-      intersectedEl.addEventListener('cursor-click', function () {
+      intersectedEl.addEventListener('click', function () {
         done();
       });
       cursorEl.components.cursor.onMouseUp();
@@ -120,7 +120,7 @@ suite('cursor', function () {
     test('emits mouseenter event on cursorEl', function (done) {
       var cursorEl = this.cursorEl;
       var intersectedEl = this.intersectedEl;
-      cursorEl.addEventListener('cursor-mouseenter', function (evt) {
+      cursorEl.addEventListener('mouseenter', function (evt) {
         assert.equal(evt.detail.intersectedEl, intersectedEl);
         done();
       });
@@ -130,7 +130,7 @@ suite('cursor', function () {
     test('emits mouseenter event on intersectedEl', function (done) {
       var cursorEl = this.cursorEl;
       var intersectedEl = this.intersectedEl;
-      intersectedEl.addEventListener('cursor-mouseenter', function (evt) {
+      intersectedEl.addEventListener('mouseenter', function (evt) {
         assert.equal(evt.detail.cursorEl, cursorEl);
         done();
       });
@@ -164,7 +164,7 @@ suite('cursor', function () {
       var intersectedEl = this.intersectedEl;
       cursorEl.setAttribute('cursor', {fuse: true, timeout: 1});
       cursorEl.emit('raycaster-intersection', {els: [intersectedEl]});
-      cursorEl.addEventListener('cursor-click', function () {
+      cursorEl.addEventListener('click', function () {
         assert.notOk(cursorEl.is('cursor-fusing'));
         done();
       });
@@ -175,7 +175,7 @@ suite('cursor', function () {
       var intersectedEl = this.intersectedEl;
       cursorEl.setAttribute('cursor', {fuse: true, timeout: 1});
       cursorEl.emit('raycaster-intersection', {els: [intersectedEl]});
-      intersectedEl.addEventListener('cursor-click', function () {
+      intersectedEl.addEventListener('click', function () {
         done();
       });
     });
@@ -209,7 +209,7 @@ suite('cursor', function () {
       var cursorEl = this.cursorEl;
       var intersectedEl = this.intersectedEl;
       cursorEl.components.cursor.intersectedEl = intersectedEl;
-      cursorEl.addEventListener('cursor-mouseleave', function (evt) {
+      cursorEl.addEventListener('mouseleave', function (evt) {
         assert.equal(evt.detail.intersectedEl, intersectedEl);
         done();
       });
@@ -220,7 +220,7 @@ suite('cursor', function () {
       var cursorEl = this.cursorEl;
       var intersectedEl = this.intersectedEl;
       cursorEl.components.cursor.intersectedEl = intersectedEl;
-      intersectedEl.addEventListener('cursor-mouseleave', function (evt) {
+      intersectedEl.addEventListener('mouseleave', function (evt) {
         assert.equal(evt.detail.cursorEl, cursorEl);
         done();
       });


### PR DESCRIPTION
**Description:**

This attempts to make the cursor event names (e.g., `click`, `mouseenter`) "standard". Meaning we won't expect only the cursor component to emit these events.

If someone creates a box, hopefully they'll only have to listen to `click` rather than having to listen to a new event name for each type of interaction method or controller.

The question is how cursor event names, or mouse event names, should interoperate with controller event names. How should we try to normalize them?

Or maybe if we don't want to normalize them at all, and consider them completely separate, then maybe we should be keeping the event names as is.

