### PR TITLE
Return early from exitVR if not in VR mode.

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -150,6 +150,7 @@ module.exports = registerElement('a-scene', {
     exitVR: {
       value: function () {
         var self = this;
+        if (!this.is('vr-mode')) { return; }
         return this.effect.exitPresent().then(exitVRSuccess, exitVRFailure);
         function exitVRSuccess () {
           self.removeState('vr-mode');


### PR DESCRIPTION
Prevents an exception when <kbd>Esc</kbd> is pressed and not in VR mode. I use pointerlock while debugging components, as well as the "Pause On Caught Exceptions" option in dev tools, so the otherwise harmless exception gets in the way a bit.