### PR TITLE
support runtime mixins (fixes #895)

### DIFF
--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -58,7 +58,7 @@ module.exports.AAnimation = registerElement('a-animation', {
             return;
           }
 
-          self.applyMixin();
+          self.handleMixinUpdate();
           self.update();
           self.load();
         }
@@ -69,7 +69,7 @@ module.exports.AAnimation = registerElement('a-animation', {
       value: function (attr, oldVal, newVal) {
         if (!this.hasLoaded || !this.isRunning) { return; }
         this.stop();
-        this.applyMixin();
+        this.handleMixinUpdate();
         this.update();
       }
     },
@@ -326,7 +326,7 @@ module.exports.AAnimation = registerElement('a-animation', {
      * Works the same as component mixins but reimplemented because animations
      * aren't components.
      */
-    applyMixin: {
+    handleMixinUpdate: {
       value: function () {
         var data = {};
         var elData;

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -87,13 +87,16 @@ var proto = Object.create(ANode.prototype, {
     }
   },
 
-  applyMixin: {
-    value: function (attr) {
-      if (!attr) {
+  /**
+   * Apply mixin to component.
+   */
+  handleMixinUpdate: {
+    value: function (attrName) {
+      if (!attrName) {
         this.updateComponents();
         return;
       }
-      this.updateComponent(attr, this.getAttribute(attr));
+      this.updateComponent(attrName, this.getAttribute(attrName));
     }
   },
 
@@ -299,7 +302,8 @@ var proto = Object.create(ANode.prototype, {
                         'components of type `' + componentName +
                         '`. There can only be one component of this type per entity.');
       }
-      component = this.components[attrName] = new components[componentName].Component(this, data, componentId);
+      component = this.components[attrName] = new components[componentName].Component(
+        this, data, componentId);
       if (this.isPlaying) { component.play(); }
 
       // Components are reflected in the DOM as attributes but the state is not shown
@@ -345,8 +349,9 @@ var proto = Object.create(ANode.prototype, {
   },
 
   /**
-   * Updates all the entity's components. Given by defaults, mixins and attributes
-   * Default components update before the rest.
+   * Update all components.
+   * Build data using defined attributes, mixins, and defaults.
+   * Update default components before the rest.
    */
   updateComponents: {
     value: function () {
@@ -354,25 +359,34 @@ var proto = Object.create(ANode.prototype, {
       var self = this;
       var i;
       if (!this.hasLoaded) { return; }
-      // Components defined on the entity element
+
+      // Gather entity-defined components.
       var attributes = this.attributes;
       for (i = 0; i < attributes.length; ++i) {
         addComponent(attributes[i].name);
       }
-      // Components defined as mixins
+
+      // Gather mixin-defined components.
       getMixedInComponents(this).forEach(addComponent);
-      // Updates default components first
+
+      // Set default components.
       Object.keys(this.defaultComponents).forEach(updateComponent);
-      // Updates the rest of the components
+
+      // Set rest of components.
       Object.keys(elComponents).forEach(updateComponent);
 
-      // add component to the list
+      /**
+       * Add component to the list.
+       */
       function addComponent (key) {
         var name = key.split(MULTIPLE_COMPONENT_DELIMITER)[0];
         if (!components[name]) { return; }
         elComponents[key] = true;
       }
-      // updates a component with a given name
+
+      /**
+       * Update component with given name.
+       */
       function updateComponent (name) {
         var attrValue = self.getAttribute(name);
         delete elComponents[name];
@@ -677,7 +691,7 @@ function checkComponentDefined (el, name) {
 function getMixedInComponents (entityEl) {
   var components = [];
   entityEl.mixinEls.forEach(function getMixedComponents (mixinEl) {
-    Object.keys(mixinEl.componentAttrCache).forEach(addComponent);
+    Object.keys(mixinEl.componentCache).forEach(addComponent);
     function addComponent (key) {
       components.push(key);
     }

--- a/src/core/a-mixin.js
+++ b/src/core/a-mixin.js
@@ -4,13 +4,15 @@ var registerElement = require('./a-register-element').registerElement;
 var components = require('./component').components;
 
 /**
- * @member {object} componentAttrCache - Cache of pre parsed component attributes
+ * @member {object} componentCache - Cache of pre-parsed values. An object where the keys
+ *         are component names and the values are already parsed by the component.
  */
 module.exports = registerElement('a-mixin', {
   prototype: Object.create(ANode.prototype, {
     createdCallback: {
       value: function () {
-        this.componentAttrCache = {};
+        this.componentCache = {};
+        this.id = this.getAttribute('id');
       }
     },
 
@@ -22,47 +24,78 @@ module.exports = registerElement('a-mixin', {
 
     attachedCallback: {
       value: function () {
+        this.sceneEl = this.closest('a-scene');
         this.cacheAttributes();
+        this.updateEntities();
         this.load();
-      },
-      writable: window.debug
+      }
     },
 
+    /**
+     * setAttribute that parses and caches component values.
+     */
     setAttribute: {
       value: function (attr, value) {
         this.cacheAttribute(attr, value);
         HTMLElement.prototype.setAttribute.call(this, attr, value);
-      },
-      writable: window.debug
+      }
     },
 
+    /**
+     * If `attr` is a component, then parse the value using the schema and store it.
+     */
     cacheAttribute: {
       value: function (attr, value) {
         var component = components[attr];
         if (!component) { return; }
-        value = value === undefined ? HTMLElement.prototype.getAttribute.call(this, attr) : value;
-        this.componentAttrCache[attr] = component.parseAttrValueForCache(value);
+        if (value === undefined) {
+          value = HTMLElement.prototype.getAttribute.call(this, attr);
+        }
+        this.componentCache[attr] = component.parseAttrValueForCache(value);
       }
     },
 
+    /**
+     * If `attr` is a component, then grab pre-parsed value from the cache.
+     * Else do a normal getAttribute.
+     */
     getAttribute: {
       value: function (attr) {
-        return this.componentAttrCache[attr] || HTMLElement.prototype.getAttribute.call(this, attr);
-      },
-      writable: window.debug
+        return this.componentCache[attr] ||
+               HTMLElement.prototype.getAttribute.call(this, attr);
+      }
     },
 
     /**
-     * Update cache of parsed component attributes
+     * Parse and cache every component defined on the mixin.
      */
     cacheAttributes: {
       value: function () {
         var attributes = this.attributes;
         var attrName;
         var i;
-        for (i = 0; i < attributes.length; ++i) {
+        for (i = 0; i < attributes.length; i++) {
           attrName = attributes[i].name;
           this.cacheAttribute(attrName);
+        }
+      }
+    },
+
+    /**
+     * For entities that already have been loaded by the time the mixin was attached, tell
+     * those entities to register the mixin and refresh their component data.
+     */
+    updateEntities: {
+      value: function () {
+        if (!this.sceneEl) { return; }
+        var entities = this.sceneEl.querySelectorAll('[mixin~=' + this.id + ']');
+        for (var i = 0; i < entities.length; i++) {
+          var entity = entities[i];
+          if (!entity.hasLoaded) { continue; }
+          entity.registerMixin(this.id);
+          Object.keys(this.componentCache).forEach(function updateComponent (componentName) {
+            entity.updateComponent(componentName);
+          });
         }
       }
     }

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -180,7 +180,7 @@ module.exports = registerElement('a-node', {
         if (currentObserver) { return; }
         var observer = new MutationObserver(function (mutations) {
           var attr = mutations[0].attributeName;
-          self.applyMixin(attr);
+          self.handleMixinUpdate(attr);
         });
         var config = { attributes: true };
         observer.observe(mixinEl, config);
@@ -188,7 +188,7 @@ module.exports = registerElement('a-node', {
       }
     },
 
-    applyMixin: {
+    handleMixinUpdate: {
       value: function () { /* no-op */ }
     },
 

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -127,7 +127,7 @@ Component.prototype = {
   },
 
   /**
-   * Update the cache of the preparsed attribute value
+   * Update the cache of the pre-parsed attribute value.
    *
    * @param {string} value - HTML attribute value.
    */
@@ -178,13 +178,15 @@ Component.prototype = {
    * Apply new component data if data has changed.
    *
    * @param {string} value - HTML attribute value.
+   *        If undefined, use the cached attribute value and continue updating properties.
    */
   updateProperties: function (value) {
     var el = this.el;
     var isSinglePropSchema = isSingleProp(this.schema);
     var oldData = extendProperties({}, this.data, isSinglePropSchema);
 
-    this.updateCachedAttrValue(value);
+    if (value !== undefined) { this.updateCachedAttrValue(value); }
+
     if (this.updateSchema) {
       this.updateSchema(buildData(el, this.name, this.schema, this.attrValue, true));
     }
@@ -323,8 +325,8 @@ function buildData (el, name, schema, elData, silent) {
   }
 
   // 2. Mixin values.
-  mixinEls.forEach(applyMixin);
-  function applyMixin (mixinEl) {
+  mixinEls.forEach(handleMixinUpdate);
+  function handleMixinUpdate (mixinEl) {
     var mixinData = mixinEl.getAttribute(name);
     if (mixinData) {
       data = extendProperties(data, mixinData, isSinglePropSchema);

--- a/tests/core/a-mixin.test.js
+++ b/tests/core/a-mixin.test.js
@@ -1,19 +1,70 @@
-/* global assert, suite, test */
+/* global assert, setup, suite, test */
+var helpers = require('../helpers');
 
 suite('a-mixin', function () {
+  setup(function (done) {
+    var el = this.el = helpers.entityFactory();
+    var self = this;
+
+    el.addEventListener('loaded', function () {
+      var sceneEl = self.sceneEl = el.sceneEl;
+      self.assetsEl = sceneEl.querySelector('a-assets');
+      done();
+    });
+  });
+
+  test('applies to already loaded entity', function (done) {
+    var el = this.el;
+    var mixinEl = document.createElement('a-mixin');
+    el.setAttribute('mixin', 'ring');
+
+    mixinEl.setAttribute('id', 'ring');
+    mixinEl.setAttribute('geometry', 'primitive: ring');
+    this.assetsEl.appendChild(mixinEl);
+
+    mixinEl.addEventListener('loaded', function () {
+      assert.equal(el.getComputedAttribute('geometry').primitive, 'ring');
+      mixinEl.setAttribute('geometry', 'primitive: circle');
+      process.nextTick(function () {
+        assert.equal(el.getComputedAttribute('geometry').primitive, 'circle');
+        done();
+      });
+    });
+  });
+
+  test('applies to already loaded entity with component', function (done) {
+    var el = this.el;
+    var mixinEl = document.createElement('a-mixin');
+    el.setAttribute('mixin', 'ring');
+    el.setAttribute('geometry', 'buffer: false');
+
+    mixinEl.setAttribute('id', 'ring');
+    mixinEl.setAttribute('geometry', 'primitive: ring');
+    this.assetsEl.appendChild(mixinEl);
+
+    mixinEl.addEventListener('loaded', function () {
+      var geometry = el.getComputedAttribute('geometry');
+      assert.equal(geometry.buffer, false);
+      assert.equal(geometry.primitive, 'ring');
+      done();
+    });
+  });
+});
+
+suite('a-mixin (detached)', function () {
   suite('cacheAttributes', function () {
-    test('cache component attributes', function () {
+    test('caches component attributes', function () {
       var mixinEl = document.createElement('a-mixin');
       mixinEl.setAttribute('material', 'color: red');
       mixinEl.cacheAttributes();
-      assert.shallowDeepEqual(mixinEl.componentAttrCache.material, { color: 'red' });
+      assert.shallowDeepEqual(mixinEl.componentCache.material, {color: 'red'});
     });
 
-    test('does not cache non component attributes', function () {
+    test('does not cache non-component attributes', function () {
       var mixinEl = document.createElement('a-mixin');
       mixinEl.setAttribute('test', 'src: url(www.mozilla.com)');
       mixinEl.cacheAttributes();
-      assert.equal(mixinEl.componentAttrCache.test, undefined);
+      assert.equal(mixinEl.componentCache.test, undefined);
     });
   });
 });


### PR DESCRIPTION
**Description:**

Support mixins being attached/injected after entities have already loaded.

**Changes proposed:**
- When a mixin is attached, find all entities using it that have already loaded, and apply the mixin.
- Change `Component.updateProperties` to take an undefined `attrValue`. This means continue updating properties using mixins and such, but use cached attr value.
- Rename `applyMixin` to `handleMixinUpdate` to signify that it is asynchronous and that it doesn't apply when the mixin is attached. It only handles observed mutations.
- Rename `componentAttrCache` to `componentCache` because after parsing, anything related to the attribute value becomes irrelevant. It becomes purely component data.
- Various docstrings/comments and max 100-char style stuff.


