### PR TITLE
expose schema module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ module.exports = window.AFRAME = {
   primitives: {
     getMeshMixin: require('./extras/primitives/getMeshMixin')
   },
+  schema: require('./core/schema'),
   shaders: shaders,
   systems: systems,
   THREE: THREE,


### PR DESCRIPTION
**Description:**

Mainly to gain access for `isSingleProperty`, which the Editor is currently duplicating.
