### PR TITLE
fix pixel ratio for VR mode (fixes #1541)

### DIFF
--- a/vendor/VREffect.js
+++ b/vendor/VREffect.js
@@ -73,7 +73,7 @@ THREE.VREffect = function ( renderer, onError ) {
 		if ( isPresenting ) {
 
 			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
-			renderer.setPixelRatio( 1 );
+			renderer.setPixelRatio( rendererPixelRatio );
 
 			if ( isDeprecatedAPI ) {
 
@@ -124,7 +124,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			renderer.setPixelRatio( 1 );
+			renderer.setPixelRatio( rendererPixelRatio );
 			renderer.setSize( eyeWidth * 2, eyeHeight, false );
 
 		} else {
@@ -146,7 +146,7 @@ THREE.VREffect = function ( renderer, onError ) {
 			rendererSize = renderer.getSize();
 
 			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
-			renderer.setPixelRatio( 1 );
+			renderer.setPixelRatio( rendererPixelRatio );
 			renderer.setSize( eyeParamsL.renderWidth * 2, eyeParamsL.renderHeight, false );
 
 		} else {


### PR DESCRIPTION
**Description:**

VREffect wasn't listening to A-Frame's set pixel ratio.

To test, open VR mode on mobile with the Composite example. Compare resolution quality before/after.

**Changes proposed:**
- Proposed upstream of VREffect changes to https://github.com/mrdoob/three.js/pull/9304

