### PR TITLE
Cursor .onIntersection timout, a-cursor cursor.fuseTimeout

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -100,7 +100,7 @@ module.exports.Component = registerComponent('cursor', {
     this.fuseTimeout = setTimeout(function fuse () {
       cursorEl.removeState(STATES.FUSING);
       self.twoWayEmit(EVENTS.CLICK);
-    }, data.timeout);
+    }, data.fuseTimeout);
   },
 
   /**

--- a/src/extras/primitives/primitives/a-cursor.js
+++ b/src/extras/primitives/primitives/a-cursor.js
@@ -21,7 +21,9 @@ registerPrimitive('a-cursor', utils.extendDeep({}, getMeshMixin(), {
       y: 0,
       z: -1
     },
-    raycaster: {}
+    raycaster: {
+    	far: 1000
+    }
   },
 
   mappings: {
@@ -29,6 +31,6 @@ registerPrimitive('a-cursor', utils.extendDeep({}, getMeshMixin(), {
     fuse: 'cursor.fuse',
     interval: 'raycaster.interval',
     objects: 'raycaster.objects',
-    timeout: 'cursor.timeout'
+    timeout: 'cursor.fuseTimeout'
   }
 }));

--- a/src/extras/primitives/primitives/a-cursor.js
+++ b/src/extras/primitives/primitives/a-cursor.js
@@ -31,6 +31,6 @@ registerPrimitive('a-cursor', utils.extendDeep({}, getMeshMixin(), {
     fuse: 'cursor.fuse',
     interval: 'raycaster.interval',
     objects: 'raycaster.objects',
-    timeout: 'cursor.fuseTimeout'
+    'fuse-timeout': 'cursor.fuseTimeout'
   }
 }));

--- a/src/extras/primitives/primitives/a-cursor.js
+++ b/src/extras/primitives/primitives/a-cursor.js
@@ -22,7 +22,7 @@ registerPrimitive('a-cursor', utils.extendDeep({}, getMeshMixin(), {
       z: -1
     },
     raycaster: {
-    	far: 1000
+      far: 1000
     }
   },
 

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -162,7 +162,7 @@ suite('cursor', function () {
     test('removes fuse state and emits event on fuse click', function (done) {
       var cursorEl = this.cursorEl;
       var intersectedEl = this.intersectedEl;
-      cursorEl.setAttribute('cursor', {fuse: true, timeout: 1});
+      cursorEl.setAttribute('cursor', {fuse: true, fuseTimeout: 1});
       cursorEl.emit('raycaster-intersection', {els: [intersectedEl]});
       cursorEl.addEventListener('click', function () {
         assert.notOk(cursorEl.is('cursor-fusing'));
@@ -173,7 +173,7 @@ suite('cursor', function () {
     test('emits event on intersectedEl on fuse click', function (done) {
       var cursorEl = this.cursorEl;
       var intersectedEl = this.intersectedEl;
-      cursorEl.setAttribute('cursor', {fuse: true, timeout: 1});
+      cursorEl.setAttribute('cursor', {fuse: true, fuseTimeout: 1});
       cursorEl.emit('raycaster-intersection', {els: [intersectedEl]});
       intersectedEl.addEventListener('click', function () {
         done();


### PR DESCRIPTION
**Description:**
- #859 Could be potentially closed

**Changes proposed:**
- `cursor.timeout` -> `cursor.fuseTimeout`
- `raycaster: { }` -> `raycaster: { far: 1000 }`


Added default value for raycaster.far