### PR TITLE
Fixed toggle stats component visibility with attr, (fixes #1619)

### DIFF
--- a/src/components/scene/stats.js
+++ b/src/components/scene/stats.js
@@ -11,10 +11,7 @@ var AFrameStats = window.aframeStats;
  * Stats appended to document.body by RStats.
  */
 module.exports.Component = registerComponent('stats', {
-  schema: {
-    type: 'boolean',
-    default: true
-  },
+  schema: { default: true },
 
   init: function () {
     var scene = this.el;

--- a/src/components/scene/stats.js
+++ b/src/components/scene/stats.js
@@ -11,6 +11,11 @@ var AFrameStats = window.aframeStats;
  * Stats appended to document.body by RStats.
  */
 module.exports.Component = registerComponent('stats', {
+  schema: {
+    type: 'boolean',
+    default: true
+  },
+
   init: function () {
     var scene = this.el;
     this.stats = createStats(scene);
@@ -21,6 +26,10 @@ module.exports.Component = registerComponent('stats', {
 
     scene.addEventListener('enter-vr', this.hideBound);
     scene.addEventListener('exit-vr', this.showBound);
+  },
+
+  update: function () {
+    return (!this.data) ? this.hide() : this.show();
   },
 
   remove: function () {

--- a/src/components/visible.js
+++ b/src/components/visible.js
@@ -4,10 +4,7 @@ var registerComponent = require('../core/component').registerComponent;
  * Visibility component.
  */
 module.exports.Component = registerComponent('visible', {
-  schema: {
-    type: 'boolean',
-    default: true
-  },
+  schema: { default: true },
 
   update: function () {
     this.el.object3D.visible = this.data;


### PR DESCRIPTION
**Description:**
Enables you to toggle stats component visibility with DOM attribute
without need of explicitly remove the stats attribute which is expected
result next to already available methods stats.hide() and stats.show()

**Changes proposed:**
- Use component `data` to hold `true|false`
- Upon DOM update determine either to hide or to show stats  

