### PR TITLE
Typo: segmentsRadial missing 'd'

### DIFF
--- a/src/geometries/torus.js
+++ b/src/geometries/torus.js
@@ -8,7 +8,7 @@ registerGeometry('torus', {
     arc: {default: 360},
     radius: {default: 1, min: 0},
     radiusTubular: {default: 0.2, min: 0},
-    segmentsRadial: {efault: 36, min: 2, type: 'int'},
+    segmentsRadial: {default: 36, min: 2, type: 'int'},
     segmentsTubular: {default: 32, min: 3, type: 'int'}
   },
 


### PR DESCRIPTION
schema.segmentsRadial: {efault: 36, min: 2, type: 'int'}