### PR TITLE
Remove declarative example links from index

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -245,12 +245,5 @@
       <li><a href="primitives/ring/">Ring</a></li>
       <li><a href="primitives/torus/">Torus</a></li>
     </ul>
-
-    <h2>Declarative Events</h2>
-
-    <ul class="links">
-      <li><a href="declarative-events/cursor/">Cursor</a></li>
-      <li><a href="declarative-events/hovers/">Hovers</a></li>
-    </ul>
   </body>
 </html>


### PR DESCRIPTION
**Description:**
The "Declarative" links on the A-Frame Examples page are 404'ing  :(

**Changes proposed:**
- Remove said links until the examples are in place.
