### PR TITLE
Update selectorAllParse to return an Array instead of a NodeList

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -85,7 +85,7 @@ function selectorParse (value) {
 function selectorAllParse (value) {
   if (!value) { return null; }
   if (typeof value !== 'string') { return value; }
-  return document.querySelectorAll(value);
+  return Array.from(document.querySelectorAll(value));
 }
 
 function selectorStringify (value) {
@@ -96,14 +96,10 @@ function selectorStringify (value) {
 }
 
 function selectorAllStringify (value) {
-  if (value.item) {
-    var els = '';
-    var i;
-    for (i = 0; i < value.length; ++i) {
-      els += '#' + value[i].getAttribute('id');
-      if (i !== value.length - 1) { els += ', '; }
-    }
-    return els;
+  if (value instanceof Array) {
+    return value.map(function (element) {
+      return '#' + element.getAttribute('id');
+    }).join(', ');
   }
   return defaultStringify(value);
 }

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -91,15 +91,15 @@ suite('propertyTypes', function () {
     });
 
     test('parses a set of valid selectors', function () {
-      assert.deepEqual(parse('#hello.itsme, #cool.itworks'), this.el.childNodes);
+      assert.deepEqual(parse('#hello.itsme, #cool.itworks'), Array.from(this.el.childNodes));
     });
 
     test('parses null selector', function () {
-      assert.deepEqual(parse('#goodbye'), this.el1.childNodes);
+      assert.deepEqual(parse('#goodbye'), Array.from(this.el1.childNodes));
     });
 
     test('stringifies valid selector', function () {
-      assert.equal(stringify(this.el.childNodes), '#hello, #cool');
+      assert.equal(stringify(Array.from(this.el.childNodes)), '#hello, #cool');
     });
   });
 


### PR DESCRIPTION
**Description:**
Fixes https://github.com/aframevr/aframe/issues/1129

I suspect this one will require much more work.  I've run tests and all passes but things to consider:

*  Is this a breaking change moving forward where API docs must be updated?  Is it work the breaking change?
*  What other components may need updating to accommodate an array instead of a NodeList?