### PR TITLE
set use-credentials for crossorigin loading

### DIFF
--- a/src/lib/three.js
+++ b/src/lib/three.js
@@ -5,12 +5,12 @@ var THREE = global.THREE = require('three');
 // This should not be on `THREE.Loader` nor `THREE.ImageUtils`.
 // Must be on `THREE.TextureLoader`.
 if (THREE.TextureLoader) {
-  THREE.TextureLoader.prototype.crossOrigin = '';
+  THREE.TextureLoader.prototype.crossOrigin = 'use-credentials';
 }
 
 // This is for images loaded from the model loaders.
 if (THREE.ImageLoader) {
-  THREE.ImageLoader.prototype.crossOrigin = '';
+  THREE.ImageLoader.prototype.crossOrigin = 'use-credentials';
 }
 
 // In-memory caching for XHRs (for images, audio files, textures, etc.).
@@ -25,5 +25,9 @@ require('three/examples/js/BlendCharacter');  // THREE.BlendCharacter
 require('three/examples/js/loaders/ColladaLoader');  // THREE.ColladaLoader
 require('../../vendor/VRControls');  // THREE.VRControls
 require('../../vendor/VREffect');  // THREE.VREffect
+
+THREE.ColladaLoader.prototype.crossOrigin = 'use-credentials';
+THREE.MTLLoader.prototype.crossOrigin = 'use-credentials';
+THREE.OBJLoader.prototype.crossOrigin = 'use-credentials';
 
 module.exports = THREE;


### PR DESCRIPTION
**Description:**

Setting to `use-credentials` seems harmless even the asset does not need credentials. But opens up in case people are hosting assets on S3 or something.

