### PR TITLE
Fix typo removeEventLister -> removeEventListener

### DIFF
--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -55,7 +55,7 @@ module.exports.Component = registerComponent('vive-controls', {
     el.removeEventListener('buttonchanged', this.onButtonChanged);
     el.removeEventListener('buttondown', this.onButtonDown);
     el.removeEventListener('buttonup', this.onButtonUp);
-    el.removeEventLister('model-loaded', this.onModelLoaded);
+    el.removeEventListener('model-loaded', this.onModelLoaded);
   },
 
   update: function () {


### PR DESCRIPTION
**Description:** Just ran into this while testing pause() on a component attached to the same entity as vive-controls.

**Changes proposed:**
- Change "removeEventLister" to "removeEventListener"

