### PR TITLE
add component/system name to prop warnings

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -97,7 +97,7 @@ Component.prototype = {
   parse: function (value, silent) {
     var schema = this.schema;
     if (isSingleProp(schema)) { return parseProperty(value, schema); }
-    return parseProperties(styleParser.parse(value), schema, true, silent);
+    return parseProperties(styleParser.parse(value), schema, true, this.name, silent);
   },
 
   /**
@@ -335,11 +335,11 @@ function buildData (el, name, schema, elData, silent) {
   if (componentDefined) {
     if (isSinglePropSchema) { return parseProperty(elData, schema); }
     data = extendProperties(data, elData, isSinglePropSchema);
-    return parseProperties(data, schema, undefined, silent);
+    return parseProperties(data, schema, undefined, name, silent);
   } else {
      // Parse and coerce using the schema.
     if (isSinglePropSchema) { return parseProperty(data, schema); }
-    return parseProperties(data, schema, undefined, silent);
+    return parseProperties(data, schema, undefined, name, silent);
   }
 }
 module.exports.buildData = buildData;

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -88,9 +88,11 @@ module.exports.processPropertyDefinition = processPropertyDefinition;
  * @param {object} schema - Property types definition.
  * @param {boolean} getPartialData - Whether to return full component data or just the data
  *        with keys in `propData`.
+ * @param {string } componentName - Name of the component, used for the property warning.
  * @param {boolean} silent - Suppress warning messages.
  */
-module.exports.parseProperties = function (propData, schema, getPartialData, silent) {
+module.exports.parseProperties = function (propData, schema, getPartialData, componentName,
+                                           silent) {
   var propNames = Object.keys(getPartialData ? propData : schema);
 
   if (propData === null || typeof propData !== 'object') { return propData; }
@@ -98,7 +100,8 @@ module.exports.parseProperties = function (propData, schema, getPartialData, sil
   // Validation errors.
   Object.keys(propData).forEach(function (propName) {
     if (!schema[propName] && !silent) {
-      warn('Unknown component property: ' + propName);
+      warn('Unknown property `' + propName +
+           '` for component/system `' + componentName + '`.');
     }
   });
 

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -41,7 +41,7 @@ var System = module.exports.System = function (sceneEl) {
     this.data = parseProperty(rawData, schema);
     return;
   }
-  this.data = parseProperties(styleParser.parse(rawData) || {}, schema);
+  this.data = parseProperties(styleParser.parse(rawData) || {}, schema, false, this.name);
 };
 
 System.prototype = {


### PR DESCRIPTION
**Description:**

It's getting to be a little bit too many arguments now, but this warning helps debug a lot.

**Changes proposed:**
- Add component or system name to the unknown property warning for multi-prop schemas.

