### PR TITLE
don't replace polyfilled document.registerElement

### DIFF
--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -1,22 +1,20 @@
+/*
+  ------------------------------------------------------------
+  ------------- WARNING WARNING WARNING WARNING --------------
+  ------------------------------------------------------------
+
+  This module wraps registerElement to deal with components that inherit from
+  `ANode` and `AEntity`.  It's a pass through in any other case.
+
+  It wraps some of the prototype methods of the created element to make sure
+  that the corresponding functions in the base classes (`AEntity` and `ANode`)
+  are also invoked. The method in the base class is always called before the one
+  in the derived object.
+*/
+
 // Polyfill `document.registerElement`.
 require('document-register-element');
 
-/*
- ------------------------------------------------------------
- ------------- WARNING WARNING WARNING WARNING --------------
- ------------------------------------------------------------
-
- This module wraps registerElement to deal with
- components that inherit from `ANode` and `AEntity`.
- It's a pass through in any other case.
-
- It wraps some of the prototype methods
- of the created element to make sure that the corresponding
- functions in the base classes (`AEntity` and `ANode`) are also
- invoked. The method in the base class is always called before the
- one in the derived object.
-
-*/
 var registerElement = document.registerElement;
 
 var knownTags = module.exports.knownTags = {};
@@ -37,11 +35,11 @@ module.exports.isNode = function (node) {
 };
 
 /**
- * @param   {string} tagName The name of the tag to register
- * @param   {object} obj The prototype of the new element
- * @returns {object} The prototype of the new element
+ * @param {string} tagName - The name of the tag to register.
+ * @param {object} obj - The prototype of the new element.
+ * @returns {object} The prototype of the new element.
  */
-module.exports.registerElement = document.registerElement = function (tagName, obj) {
+module.exports.registerElement = function (tagName, obj) {
   var proto = Object.getPrototypeOf(obj.prototype);
   var newObj = obj;
   var isANode = ANode && proto === ANode.prototype;
@@ -66,7 +64,8 @@ module.exports.registerElement = document.registerElement = function (tagName, o
 
 /**
  * This wraps some of the obj methods to call those on `ANode` base clase.
- * @param  {object} obj The objects that contains the methods that will be wrapped.
+ *
+ * @param {object} obj - Object that contains the methods that will be wrapped.
  * @return {object} An object with the same properties as the input parameter but
  * with some of methods wrapped.
  */
@@ -84,8 +83,9 @@ function wrapANodeMethods (obj) {
 
 /**
  * This wraps some of the obj methods to call those on `AEntity` base class.
- * @param  {object} obj The objects that contains the methods that will be wrapped.
- * @return {object} An object with the same properties as the input parameter but
+ *
+ * @param {object} obj - The objects that contains the methods that will be wrapped.
+ * @return {object} - An object with the same properties as the input parameter but
  * with some of methods wrapped.
  */
 function wrapAEntityMethods (obj) {
@@ -103,18 +103,19 @@ function wrapAEntityMethods (obj) {
   ];
   wrapMethods(newObj, ANodeMethods, obj, ANode.prototype);
   wrapMethods(newObj, AEntityMethods, obj, AEntity.prototype);
-  // Copies the remaining properties into the new object
+  // Copies the remaining properties into the new object.
   copyProperties(obj, newObj);
   return newObj;
 }
 
 /**
- * Wraps a list a methods to ensure that those in the base class are called through the derived one.
- * @param  {object} targetObj Object that will contain the wrapped methods
- * @param  {array} methodList List of methods from the derivedObj that will be wrapped
- * @param  {object} derivedObject Object that inherits from the baseObj
- * @param  {object} baseObj Object that derivedObj inherits from
- * @return {undefined}
+ * Wraps a list a methods to ensure that those in the base class are called
+ * through the derived one.
+ *
+ * @param {object} targetObj - Object that will contain the wrapped methods.
+ * @param {array} methodList - List of methods from the derivedObj that will be wrapped.
+ * @param {object} derivedObject - Object that inherits from the baseObj.
+ * @param {object} baseObj - Object that derivedObj inherits from.
  */
 function wrapMethods (targetObj, methodList, derivedObj, baseObj) {
   methodList.forEach(function (methodName) {
@@ -123,13 +124,13 @@ function wrapMethods (targetObj, methodList, derivedObj, baseObj) {
 }
 
 /**
- * Wraps one method to ensure that the one in the base class is called before the one
- * in the derived one
- * @param  {object} obj Object that will contain the wrapped method
- * @param  {string} methodName The name of the method that will be wrapped
- * @param  {object} derivedObject Object that inherits from the baseObj
- * @param  {object} baseObj Object that derivedObj inherits from
- * @return {undefined}
+ * Wraps one method to ensure that the one in the base class is called before
+ * the one in the derived one.
+ *
+ * @param {object} obj - Object that will contain the wrapped method.
+ * @param {string} methodName - The name of the method that will be wrapped.
+ * @param {object} derivedObject - Object that inherits from the baseObj.
+ * @param {object} baseObj - Object that derivedObj inherits from.
  */
 function wrapMethod (obj, methodName, derivedObj, baseObj) {
   var derivedMethod = derivedObj[methodName];
@@ -147,11 +148,11 @@ function wrapMethod (obj, methodName, derivedObj, baseObj) {
 }
 
 /**
- * It copies the properties from source to destination object
- * if they don't exist already
- * @param  {object} source The object where properties are copied from
- * @param  {type} destination The object where properties are copied to
- * @return {undefined}
+ * It copies the properties from source to destination object if they don't
+ * exist already.
+ *
+ * @param {object} source - The object where properties are copied from.
+ * @param {type} destination - The object where properties are copied to.
  */
 function copyProperties (source, destination) {
   var props = Object.getOwnPropertyNames(source);

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ module.exports = window.AFRAME = {
   components: components,
   geometries: require('./core/geometry').geometries,
   registerComponent: registerComponent,
+  registerElement: require('./core/a-register-element').registerElement,
   registerGeometry: registerGeometry,
   registerPrimitive: registerPrimitive,
   registerShader: registerShader,


### PR DESCRIPTION
**Description:**

This doesn't really affect anything, but just wanted to protect against the case that a website depends on `document.registerElement`. Even though the polyfill writes one in anyways, it's a little bit better than completely overwriting with our own custom one.

And provide an `AFRAME.registerElement` in case someone wants to make nodes?