### PR TITLE
fix parents loading before children because parents tried to wait on children that were not ready (fixes #1652)

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -63,8 +63,10 @@ module.exports = registerElement('a-assets', {
 
     load: {
       value: function () {
-        ANode.prototype.load.call(this, null, function waitOnFilter (el) {
+        ANode.prototype.load.call(this, null, function waitChildLoadedFilter (el) {
           return el.isAssetItem && el.hasAttribute('src');
+        }, function waitChildReadyFilter (el) {
+          return el.isAssetItem;
         });
       }
     }

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -27,9 +27,7 @@ suite('a-assets', function () {
     img.setAttribute('src', IMG_SRC);
     el.appendChild(img);
 
-    scene.addEventListener('loaded', function () {
-      done();
-    });
+    scene.addEventListener('loaded', function () { done(); });
 
     // Load image.
     document.body.appendChild(scene);

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -126,6 +126,34 @@ suite('a-entity', function () {
     });
   });
 
+  suite('load', function () {
+    /**
+     * @see Issue #1652.
+     */
+    test('waits for children entity to load first', function (done) {
+      var containerEl = document.createElement('div');
+      document.body.appendChild(containerEl);
+
+      registerComponent('test', {
+        init: function () {
+          var child = this.el.children[0];
+          assert.ok(child.hasLoaded);
+          assert.ok(child.isNodeReady);
+          assert.equal(child.getComputedAttribute('position').x, 0);
+          done();
+        }
+      });
+
+      containerEl.innerHTML = [
+        '<a-scene>',
+        '<a-entity id="parent" test>',
+        '<a-entity id="child"></a-entity>',
+        '</a-entity>',
+        '</a-scene>'
+      ].join('');
+    });
+  });
+
   suite('addState', function () {
     test('adds state', function () {
       var el = this.el;


### PR DESCRIPTION
**Description:**

Consider:

```html
<a-entity id="parent">
  <a-entity id="child"></a-entity>
</a-entity>
```

Currently, we want the child to completely attach + initialize (including all components) before the parent starts initializing. If the parent starts initializing when the child is not yet fully attached, then components are not initialized, then `getComputedAttribute('position')` will return a falsy value.

I ran into this case. The parent generally looks at all child **entities** and wait for them to load. We use `el.isEntity` to filter for entities. **However**, the children were not yet attached, and the `child.isEntity` was `undefined`. This makes the parent think it has no child entities and then it starts to initialize.

**Solution:**

We can detect that the child was attached by using the `nodeready` events. So we first wait for `nodeready` (if it is `isNode`), THEN wait for `loaded`. It seems that `isNode` is somehow initialized by this time

There was a hitch with assets because `<img>` and `<video>` and such aren't nodes. So we have to add an argument that allows `<a-assets>` to configure which elements to wait for `nodeready`, e.g., only `<a-asset-item>`.