### PR TITLE
revert back to crossorigin=anonymous

### DIFF
--- a/src/lib/three.js
+++ b/src/lib/three.js
@@ -5,12 +5,12 @@ var THREE = global.THREE = require('three');
 // This should not be on `THREE.Loader` nor `THREE.ImageUtils`.
 // Must be on `THREE.TextureLoader`.
 if (THREE.TextureLoader) {
-  THREE.TextureLoader.prototype.crossOrigin = 'use-credentials';
+  THREE.TextureLoader.prototype.crossOrigin = 'anonymous';
 }
 
 // This is for images loaded from the model loaders.
 if (THREE.ImageLoader) {
-  THREE.ImageLoader.prototype.crossOrigin = 'use-credentials';
+  THREE.ImageLoader.prototype.crossOrigin = 'anonymous';
 }
 
 // In-memory caching for XHRs (for images, audio files, textures, etc.).
@@ -26,8 +26,8 @@ require('three/examples/js/loaders/ColladaLoader');  // THREE.ColladaLoader
 require('../../vendor/VRControls');  // THREE.VRControls
 require('../../vendor/VREffect');  // THREE.VREffect
 
-THREE.ColladaLoader.prototype.crossOrigin = 'use-credentials';
-THREE.MTLLoader.prototype.crossOrigin = 'use-credentials';
-THREE.OBJLoader.prototype.crossOrigin = 'use-credentials';
+THREE.ColladaLoader.prototype.crossOrigin = 'anonymous';
+THREE.MTLLoader.prototype.crossOrigin = 'anonymous';
+THREE.OBJLoader.prototype.crossOrigin = 'anonymous';
 
 module.exports = THREE;

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -274,7 +274,7 @@ function createVideoEl (src, width, height) {
   videoEl.setAttribute('webkit-playsinline', '');  // Support inline videos for iOS webviews.
   videoEl.autoplay = true;
   videoEl.loop = true;
-  videoEl.crossOrigin = 'use-credentials';
+  videoEl.crossOrigin = 'anonymous';
   videoEl.addEventListener('error', function () {
     warn('`$s` is not a valid video', src);
   }, true);
@@ -304,7 +304,7 @@ function fixVideoAttributes (videoEl) {
   if (videoEl.getAttribute('preload') === 'false') {
     videoEl.preload = 'none';
   }
-  videoEl.crossOrigin = videoEl.crossOrigin || 'use-credentials';
+  videoEl.crossOrigin = videoEl.crossOrigin || 'anonymous';
   // To support inline videos in iOS webviews.
   videoEl.setAttribute('webkit-playsinline', '');
   return videoEl;


### PR DESCRIPTION
**Description:**

I observed a case with UploadCare that setting use-credentials when you don't need it, or if the corresponding server header is not sent, then the request seems to fail. Revert back to **anonymous**.
Can still configure `use-credentials` on video/img elements, and later can add support for `<a-asset-item crossorigin>`.

