### PR TITLE
added a check in tick() to make sure navigator.getGamepads is defined…

### DIFF
--- a/src/systems/tracked-controls.js
+++ b/src/systems/tracked-controls.js
@@ -17,6 +17,7 @@ module.exports.System = registerSystem('tracked-controls', {
   },
 
   tick: function () {
+    if (!navigator.getGamepads) { return; }
     var gamepads = navigator.getGamepads();
     var gamepad;
     var controllers = this.controllers = [];


### PR DESCRIPTION
tracked-controls tick method was crashing on safari because getGamepads() isn't defined

**Changes proposed:**
- added a simple test, similar to the one in the init method, for the existence of the method
