### PR TITLE
fixes explicit uses of 'a-scene'

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -99,7 +99,7 @@ module.exports.Component = registerComponent('look-controls', {
   },
 
   removeEventListeners: function () {
-    var sceneEl = document.querySelector('a-scene');
+    var sceneEl = this.el.sceneEl;
     var canvasEl = sceneEl && sceneEl.canvas;
     if (!canvasEl) { return; }
 

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -57,7 +57,7 @@ module.exports.Component = registerComponent('raycaster', {
 
     // Push meshes onto list of objects to intersect.
     if (data.objects) {
-      objectEls = this.el.closest('a-scene').querySelectorAll(data.objects);
+      objectEls = this.el.sceneEl.querySelectorAll(data.objects);
       this.objects = [];
       for (i = 0; i < objectEls.length; i++) {
         this.objects.push(objectEls[i].object3D);

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -26,7 +26,7 @@ module.exports = registerElement('a-assets', {
         var timeout = parseInt(this.getAttribute('timeout'), 10) || 3000;
         var videos = this.querySelectorAll('video');
 
-        if (this.parentNode.tagName !== 'A-SCENE') {
+        if (!this.parentNode.isScene) {
           throw new Error('<a-assets> must be a child of a <a-scene>.');
         }
 

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -22,7 +22,7 @@ module.exports = registerElement('a-node', {
     attachedCallback: {
       value: function () {
         var mixins = this.getAttribute('mixin');
-        this.sceneEl = this.tagName === 'A-SCENE' ? this : this.closest('a-scene');
+        this.sceneEl = this.isScene ? this : this.closestScene();
         this.emit('nodeready', {}, false);
         if (mixins) { this.updateMixins(mixins); }
       }
@@ -31,6 +31,21 @@ module.exports = registerElement('a-node', {
     attributeChangedCallback: {
       value: function (attr, oldVal, newVal) {
         if (attr === 'mixin') { this.updateMixins(newVal, oldVal); }
+      }
+    },
+
+   /**
+    * Returns the first scene by traversing up the tree starting from and
+    * including receiver element.
+    */
+    closestScene: {
+      value: function closest () {
+        var element = this;
+        while (element) {
+          if (element.isScene) { break; }
+          element = element.parentElement;
+        }
+        return element;
       }
     },
 

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -88,7 +88,7 @@ module.exports.registerSystem = function (name, definition) {
   var i;
   var NewSystem;
   var proto = {};
-  var scenes = document.querySelectorAll('a-scene');
+  var scenes = utils.findAllScenes(document);
 
   // Format definition object to prototype object.
   Object.keys(definition).forEach(function (key) {

--- a/src/extras/declarative-events/index.js
+++ b/src/extras/declarative-events/index.js
@@ -38,7 +38,7 @@ module.exports = registerElement('a-event', {
           'Use https://github.com/ngokevin/aframe-event-set-component instead.');
 
         if (targetSelector) {
-          this.targetEls = this.closest('a-scene').querySelectorAll(targetSelector);
+          this.targetEls = this.el.sceneEl.querySelectorAll(targetSelector);
         } else {
           this.targetEls = [this.el];
         }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -189,5 +189,21 @@ module.exports.isIframed = function () {
   return window.top !== window.self;
 };
 
+/**
+ * Finds all elements under the element that have the isScene
+ * property set to true
+ */
+module.exports.findAllScenes = function (el) {
+  var matchingElements = [];
+  var allElements = el.getElementsByTagName('*');
+  for (var i = 0, n = allElements.length; i < n; i++) {
+    if (allElements[i].isScene) {
+      // Element exists with isScene set.
+      matchingElements.push(allElements[i]);
+    }
+  }
+  return matchingElements;
+};
+
 // Must be at bottom to avoid circular dependency.
 module.exports.srcLoader = require('./src-loader');


### PR DESCRIPTION
Description:
A number of places in the source assumed that the only possible scene would be an 'a-scene' element. In most places in the code, however, the .sceneEl (property on any element contained in a scene) and .isScene (property on a scene) are used. By directly using 'a-scene' (when searching for elements, and so on), we cannot create new kinds of scenes.

Changes proposed:

replace different references with existing alternatives (el.sceneEl, el.isScene)
add new closestScene() method to a-node.js, and use it instead of closest('a-scene')
add new findAllScenes() method to utils.js, and use it instead of document.querySelectorAll('a-scene');