### PR TITLE
initialize systems only after scene attach

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -61,7 +61,6 @@ module.exports = registerElement('a-scene', {
         this.hasLoaded = false;
         this.isPlaying = false;
         this.originalHTML = this.innerHTML;
-        this.setupSystems();
         this.addEventListener('render-target-loaded', function () {
           this.setupRenderer();
           this.resize();
@@ -95,6 +94,7 @@ module.exports = registerElement('a-scene', {
         var resize = this.resize.bind(this);
         initMetaTags(this);
         initWakelock(this);
+        this.initSystems();
 
         window.addEventListener('load', resize);
         window.addEventListener('resize', resize);
@@ -103,10 +103,9 @@ module.exports = registerElement('a-scene', {
       writable: window.debug
     },
 
-    setupSystems: {
+    initSystems: {
       value: function () {
-        var systemsKeys = Object.keys(systems);
-        systemsKeys.forEach(this.initSystem.bind(this));
+        Object.keys(systems).forEach(this.initSystem.bind(this));
       }
     },
 

--- a/tests/components/scene/fog.test.js
+++ b/tests/components/scene/fog.test.js
@@ -2,16 +2,20 @@
 var entityFactory = require('../../helpers').entityFactory;
 
 suite('fog', function () {
-  'use strict';
-
-  setup(function () {
+  setup(function (done) {
     this.entityEl = entityFactory();
     var el = this.el = this.entityEl.parentNode;
-    this.updateMaterialsSpy = this.sinon.spy(el.systems.material, 'updateMaterials');
+    var self = this;
 
-    // Stub scene load to avoid WebGL code.
-    el.hasLoaded = true;
-    el.setAttribute('fog', '');
+    el.addEventListener('loaded', function () {
+      self.updateMaterialsSpy = self.sinon.spy(el.systems.material, 'updateMaterials');
+
+      // Stub scene load to avoid WebGL code.
+      el.hasLoaded = true;
+      el.setAttribute('fog', '');
+
+      done();
+    });
   });
 
   test('does not set fog for entities', function () {

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -28,6 +28,21 @@ suite('a-scene (without renderer)', function () {
     test('initializes scene object', function () {
       assert.equal(this.el.object3D.type, 'Scene');
     });
+
+    test('does not initialize systems', function () {
+      var sceneEl = document.createElement('a-scene');
+      assert.notOk(Object.keys(sceneEl.systems).length);
+    });
+  });
+
+  suite('attachedCallback', function () {
+    test('initializes systems', function (done) {
+      var self = this;
+      self.el.addEventListener('loaded', function () {
+        assert.ok(Object.keys(self.el.systems).length);
+        done();
+      });
+    });
   });
 
   suite('init', function () {


### PR DESCRIPTION
**Description:**

Was trying to unit test a system that required a schema. But was unable to set the schema data before the system was initialized.

```js
var scene = document.createElement('a-scene');
// `my-system` already initialized when not ready.
scene.setAttribute('my-system', config);
```

- Move system init to attachedCallback for better control.
