### PR TITLE
use less contrasty colors for vive wand buttons

### DIFF
--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -12,8 +12,8 @@ module.exports.Component = registerComponent('vive-controls', {
 
   schema: {
     hand: {default: 'left'},
-    buttonColor: {default: 'white'},
-    buttonHighlightColor: {default: 'yellow'},
+    buttonColor: {default: '#FAFAFA'},  // Off-white.
+    buttonHighlightColor: {default: '#22D1EE'},  // Light blue.
     model: {default: true}
   },
 


### PR DESCRIPTION

**Description:**


<img width="295" alt="screen shot 2016-07-27 at 10 18 54 am" src="https://cloud.githubusercontent.com/assets/674727/17184981/dd8ab806-53e3-11e6-8ee8-5ffa6ee4c389.png">

**Changes proposed:**
- Off-white rather than complete white.
- Light blue (denoting primary/positive action) rather than flat yellow.


