### PR TITLE
grab/grabbing cursor on mousedown/mouseup (fixes #1167)

### DIFF
--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -33,6 +33,19 @@
   width: 100%;
 }
 
+.a-canvas:hover {
+  cursor: grab;
+  cursor: -moz-grabbing;
+  cursor: -webkit-grab;
+}
+
+.a-canvas-grabbing,
+.a-canvas:active {
+  cursor: grabbing;
+  cursor: -moz-grabbing;
+  cursor: -webkit-grabbing;
+}
+
 .a-canvas.fullscreen {
   width: 100% !important;
   height: 100% !important;

--- a/tests/components/scene/canvas.test.js
+++ b/tests/components/scene/canvas.test.js
@@ -1,14 +1,52 @@
- /* global assert, process, suite, test */
-'use strict';
+ /* global Event, assert, process, suite, test */
+
+var FULLSCREEN_CLASS = 'fullscreen';
+var GRABBING_CLASS = 'a-canvas-grabbing';
 
 suite('canvas', function () {
   test('adds canvas to a-scene element', function (done) {
-    var el = document.createElement('a-scene');
+    var el = this.sceneEl = document.createElement('a-scene');
     document.body.appendChild(el);
     el.addEventListener('loaded', function () {
       el.setAttribute('canvas', '');
       assert.ok(el.querySelector('canvas'));
       done();
+    });
+  });
+
+  suite('fullscreen', function () {
+    test('adds fullscreen class on enter VR', function () {
+      var el = this.sceneEl;
+      el.emit('enter-vr');
+      assert.ok(el.canvas.classList.contains(FULLSCREEN_CLASS));
+    });
+
+    test('removes fullscreen class on exit VR', function () {
+      var el = this.sceneEl;
+      el.canvas.classList.add(FULLSCREEN_CLASS);
+      el.emit('exit-vr');
+      assert.notOk(el.canvas.classList.contains(FULLSCREEN_CLASS));
+    });
+  });
+
+  suite('grabbing', function () {
+    test('adds grabbing class to document body on mousedown', function (done) {
+      var el = this.sceneEl;
+      el.canvas.dispatchEvent(new Event('mousedown'));
+      process.nextTick(function () {
+        assert.ok(document.body.classList.contains(GRABBING_CLASS));
+        document.body.classList.remove('a-canvas-grabbing');
+        done();
+      });
+    });
+
+    test('removes grabbing class from document body on document body mouseup', function (done) {
+      document.body.classList.add('a-canvas-grabbing');
+      document.body.dispatchEvent(new Event('mouseup'));
+      process.nextTick(function () {
+        assert.notOk(document.body.classList.contains(GRABBING_CLASS));
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
**Description:**

Visually indicate that canvas is draggable.

Or should this be done in look controls? Though perhaps it might be nice for other look controls to not have to duplicate this logic.

![grab](https://cloud.githubusercontent.com/assets/674727/17190859/454196dc-53fc-11e6-8cbf-cf2436d9460a.gif)

**Changes proposed:**
- On canvas mousedown, set grab class.
- On document body mouseup, remove grab class.
- On canvas active and grab class active, set grabbing style.
- Add more canvas tests
- Typos
