### PR TITLE
fix derived node prototype methods being called before base node prototype methods

### DIFF
--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -16,7 +16,8 @@ module.exports = registerElement('a-node', {
         this.isNode = true;
         this.mixinEls = [];
         this.mixinObservers = {};
-      }
+      },
+      writable: window.debug
     },
 
     attachedCallback: {
@@ -25,7 +26,8 @@ module.exports = registerElement('a-node', {
         this.sceneEl = this.isScene ? this : this.closestScene();
         this.emit('nodeready', {}, false);
         if (mixins) { this.updateMixins(mixins); }
-      }
+      },
+      writable: window.debug
     },
 
     attributeChangedCallback: {

--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -7,28 +7,27 @@
   `ANode` and `AEntity`.  It's a pass through in any other case.
 
   It wraps some of the prototype methods of the created element to make sure
-  that the corresponding functions in the base classes (`AEntity` and `ANode`)
-  are also invoked. The method in the base class is always called before the one
-  in the derived object.
+  that the corresponding functions in the base prototypes (`AEntity` and `ANode`)
+  are also invoked. The method in the base prototype is always called before the one
+  in the derived prototype.
 */
 
 // Polyfill `document.registerElement`.
 require('document-register-element');
 
-var registerElement = document.registerElement;
-
+var ANode;  // Must declare before AEntity. Initialized at the bottom.
+var AEntity;
 var knownTags = module.exports.knownTags = {};
 
-var addTagName = function (tagName) {
+function addTagName (tagName) {
   knownTags[tagName.toLowerCase()] = true;
-};
+}
 
 /**
- * Returns whether the element type is one of our known registered ones
+ * Return whether the element type is one of our known registered ones.
  *
- * @param   {string} node The name of the tag to register
- * @returns {boolean} Whether the tag name matches that of our registered
- *                    custom elements
+ * @param {string} node - The name of the tag to register.
+ * @returns {boolean} Whether the tag name matches that of our registered custom elements.
  */
 module.exports.isNode = function (node) {
   return node.tagName.toLowerCase() in knownTags || node.isNode;
@@ -47,23 +46,23 @@ module.exports.registerElement = function (tagName, obj) {
 
   if (isANode || isAEntity) { addTagName(tagName); }
 
-  // Does the element inherit from `ANode`?
+  // Wrap if element inherits from `ANode`.
   if (isANode) {
     newObj = wrapANodeMethods(obj.prototype);
     newObj = {prototype: Object.create(proto, newObj)};
   }
 
-  // Does the element inherit from `AEntity`?
+  // Wrap if element inherits from `AEntity`.
   if (isAEntity) {
     newObj = wrapAEntityMethods(obj.prototype);
     newObj = {prototype: Object.create(proto, newObj)};
   }
 
-  return registerElement.call(document, tagName, newObj);
+  return document.registerElement(tagName, newObj);
 };
 
 /**
- * This wraps some of the obj methods to call those on `ANode` base clase.
+ * Wrap some obj methods to call those on `ANode` base prototype.
  *
  * @param {object} obj - Object that contains the methods that will be wrapped.
  * @return {object} An object with the same properties as the input parameter but
@@ -76,13 +75,13 @@ function wrapANodeMethods (obj) {
     'attributeChangedCallback',
     'createdCallback'
   ];
-  wrapMethods(newObj, ANodeMethods, ANode.prototype, obj);
+  wrapMethods(newObj, ANodeMethods, obj, ANode.prototype);
   copyProperties(obj, newObj);
   return newObj;
 }
 
 /**
- * This wraps some of the obj methods to call those on `AEntity` base class.
+ * This wraps some of the obj methods to call those on `AEntity` base prototype.
  *
  * @param {object} obj - The objects that contains the methods that will be wrapped.
  * @return {object} - An object with the same properties as the input parameter but
@@ -96,11 +95,12 @@ function wrapAEntityMethods (obj) {
     'createdCallback'
   ];
   var AEntityMethods = [
-    'attributeChangedCallback',
     'attachedCallback',
+    'attributeChangedCallback',
     'createdCallback',
     'detachedCallback'
   ];
+
   wrapMethods(newObj, ANodeMethods, obj, ANode.prototype);
   wrapMethods(newObj, AEntityMethods, obj, AEntity.prototype);
   // Copies the remaining properties into the new object.
@@ -109,8 +109,8 @@ function wrapAEntityMethods (obj) {
 }
 
 /**
- * Wraps a list a methods to ensure that those in the base class are called
- * through the derived one.
+ * Wrap a list a methods to ensure that those in the base prototype are called
+ * before the derived one.
  *
  * @param {object} targetObj - Object that will contain the wrapped methods.
  * @param {array} methodList - List of methods from the derivedObj that will be wrapped.
@@ -122,9 +122,10 @@ function wrapMethods (targetObj, methodList, derivedObj, baseObj) {
     wrapMethod(targetObj, methodName, derivedObj, baseObj);
   });
 }
+module.exports.wrapMethods = wrapMethods;
 
 /**
- * Wraps one method to ensure that the one in the base class is called before
+ * Wrap one method to ensure that the one in the base prototype is called before
  * the one in the derived one.
  *
  * @param {object} obj - Object that will contain the wrapped method.
@@ -135,16 +136,21 @@ function wrapMethods (targetObj, methodList, derivedObj, baseObj) {
 function wrapMethod (obj, methodName, derivedObj, baseObj) {
   var derivedMethod = derivedObj[methodName];
   var baseMethod = baseObj[methodName];
+
+  // Derived prototype does not define method, no need to wrap.
   if (!derivedMethod || !baseMethod) { return; }
-  // The derived class doesn't override the one in the base one
+
+  // Derived prototype doesn't override the one in the base one, no need to wrap.
   if (derivedMethod === baseMethod) { return; }
-  // Wrapper
-  // The base method is called before the one in the derived class
-  var wrapperMethod = function () {
-    baseMethod.apply(this, arguments);
-    return derivedMethod.apply(this, arguments);
+
+  // Wrap to ensure the base method is called before the one in the derived prototype.
+  obj[methodName] = {
+    value: function wrappedMethod () {
+      baseMethod.apply(this, arguments);
+      return derivedMethod.apply(this, arguments);
+    },
+    writable: window.debug
   };
-  obj[methodName] = {value: wrapperMethod, writable: window.debug};
 }
 
 /**
@@ -165,5 +171,5 @@ function copyProperties (source, destination) {
   });
 }
 
-var ANode = require('./a-node');
-var AEntity = require('./a-entity');
+ANode = require('./a-node');
+AEntity = require('./a-entity');

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -34,6 +34,12 @@ suite('a-entity', function () {
     components.test = undefined;
   });
 
+  test('createdCallback', function () {
+    var el = this.el;
+    assert.ok(el.isNode);
+    assert.ok(el.isEntity);
+  });
+
   test('adds itself to parent when attached', function (done) {
     var el = document.createElement('a-entity');
     var parentEl = this.el;

--- a/tests/core/a-register-element.test.js
+++ b/tests/core/a-register-element.test.js
@@ -1,0 +1,96 @@
+/* global HTMLElement, assert, suite, test */
+var AEntity = require('core/a-entity.js');
+var ANode = require('core/a-node.js');
+var registerElement = require('core/a-register-element').registerElement;
+var wrapMethods = require('core/a-register-element').wrapMethods;
+
+suite('a-register-element', function () {
+  suite('registerElement', function () {
+    test('wraps node createdCallback', function (done) {
+      var nodeCreatedSpy = this.sinon.spy(ANode.prototype, 'createdCallback');
+      registerElement('a-test-node', {
+        prototype: Object.create(ANode.prototype, {
+          createdCallback: {
+            value: function () {
+              assert.ok(nodeCreatedSpy.called);
+              done();
+            }
+          }
+        })
+      });
+      document.createElement('a-test-node');
+    });
+
+    test('wraps node attachedCallback', function (done) {
+      var nodeAttachedSpy = this.sinon.spy(ANode.prototype, 'attachedCallback');
+      registerElement('a-test-node-2', {
+        prototype: Object.create(ANode.prototype, {
+          attachedCallback: {
+            value: function () {
+              assert.ok(nodeAttachedSpy.called);
+              done();
+            }
+          }
+        })
+      });
+      document.body.appendChild(document.createElement('a-test-node-2'));
+    });
+
+    test('wraps entity createdCallback', function (done) {
+      var entityCreatedSpy = this.sinon.spy(AEntity.prototype, 'createdCallback');
+      registerElement('a-test-entity', {
+        prototype: Object.create(AEntity.prototype, {
+          createdCallback: {
+            value: function () {
+              assert.ok(entityCreatedSpy.called);
+              done();
+            }
+          }
+        })
+      });
+      document.createElement('a-test-entity');
+    });
+
+    test('wraps entity attachedCallback', function (done) {
+      var entityAttachedSpy = this.sinon.spy(AEntity.prototype, 'attachedCallback');
+      registerElement('a-test-entity-2', {
+        prototype: Object.create(AEntity.prototype, {
+          attachedCallback: {
+            value: function () {
+              assert.ok(entityAttachedSpy.called);
+              done();
+            }
+          }
+        })
+      });
+      document.body.appendChild(document.createElement('a-test-entity-2'));
+    });
+  });
+
+  suite('wrapMethods', function () {
+    test('wraps to call base prototype method before derived prototype method', function () {
+      var BasePrototype;
+      var DerivedPrototype;
+      var checkIn = [];
+      var WrappedDerivedPrototype;
+
+      // Create prototypes;
+      BasePrototype = Object.create(HTMLElement.prototype, {
+        createdCallback: { value: function () { checkIn.push(0); } }
+      });
+      DerivedPrototype = Object.create(BasePrototype, {
+        createdCallback: { value: function () { checkIn.push(1); } }
+      });
+
+      // Wrap.
+      WrappedDerivedPrototype = {};
+      wrapMethods(WrappedDerivedPrototype, ['createdCallback'], DerivedPrototype,
+                  BasePrototype);
+
+      // Check Base (0) before Derived (1).
+      WrappedDerivedPrototype.createdCallback.value();
+      assert.equal(checkIn[0], 0);
+      assert.equal(checkIn[1], 1);
+    });
+  });
+});


### PR DESCRIPTION
**Description:**

## The Change That Fixes Everything

The order is `(target, methods, derivedPrototype, basePrototype)`. It was reversed.

```
-  wrapMethods(newObj, ANodeMethods, ANode.prototype, obj);
+  wrapMethods(newObj, ANodeMethods, obj, ANode.prototype);
```

**Changes proposed:**
- Fix method wrapping to call base before derived as intended.
- Tests.
- Cleaned comments while understanding the code.

Later, it would make sense to reverse the order of the arguments. Base first since we intend to call it first. Then derived.