### PR TITLE
have entities wait on assets in order to make use of xhrloader cache

### DIFF
--- a/docs/core/asset-management-system.md
+++ b/docs/core/asset-management-system.md
@@ -6,29 +6,31 @@ parent_section: core
 order: 9
 ---
 
+A-Frame has an asset management system that allows us to place all of our
+assets in one place and to preload and cache assets for better performance.
+
 Games and rich 3D experiences traditionally preload many of their assets, such
 as models or textures, before rendering their scenes. This makes sure that
 assets aren't missing visually, and this is benenficial for performance to
-ensure scenes don't try to fetch assets while rendering. A-Frame has an asset
-management system that allows us to place all of our assets in one place and to
-preload and cache assets for better performance.
+ensure scenes don't try to fetch assets while rendering.
 
 Assets are placed within `<a-assets>`, and `<a-assets>` is placed within
 `<a-scene>`. Assets include:
 
-- `<a-asset-item>` - Miscellaneous assets such as 3D models
-- `<a-mixin>` - Reusable [mixins][mixins]
+- `<a-asset-item>` - Miscellaneous assets such as 3D models and materials
 - `<audio>` - Sound files
 - `<img>` - Image textures
 - `<video>` - Video textures
 
-Then the scene will block until all of these assets are fetched (or error out) before playing.
+The scene and all entities will block until all of these types of assets are
+fetched (or error out) before playing.
 
 <!--toc-->
 
 ## Example
 
-We can define all of our assets in `<a-assets>` and point to those assets from our entities using selectors:
+We can define all of our assets in `<a-assets>` and point to those assets from
+our entities using selectors:
 
 ```html
 <a-scene>
@@ -36,32 +38,47 @@ We can define all of our assets in `<a-assets>` and point to those assets from o
   <a-assets>
     <a-asset-item id="horse-obj" src="horse.obj"></a-asset-item>
     <a-asset-item id="horse-mtl" src="horse.mtl"></a-asset-item>
-
     <a-mixin id="giant" scale="5 5 5"></a-mixin>
-
-    <audio src="neigh.mp3"></a-mixin>
-
+    <audio id="neigh" src="neigh.mp3"></a-mixin>
     <img id="advertisement" src="ad.png">
-
     <video id="kentucky-derby" src="derby.mp4">
   </a-assets>
 
   <!-- Scene. -->
-  <a-entity mixin="giant" obj-model="obj: #horse-obj; mtl: #horse-mtl"></a-entity>
+  <a-plane src="advertisement"></a-plane>
+  <a-sound src="#neigh"></a-sound>
   <a-entity geometry="primitive: plane" material="src: #kentucky-derby"></a-entity>
-  <a-entity geometry="primitive: plane" material="src: #advertisement></a-entity>
+  <a-entity mixin="giant" obj-model="obj: #horse-obj; mtl: #horse-mtl"></a-entity>
 </a-scene>
 ```
 
-Then the scene will wait for all of the assets for rendering.
+The scene and all of its entities will wait for all of the assets (up until the
+timeout) before initializing and rendering.
 
 ## Cross-Origin Resources
 
-Loading assets from a different domain requires [cross-origin resource sharing (CORS) headers][cors]. Else we have to serve the asset ourselves.
+[cors]: https://wikipedia.org/wiki/Cross-origin_resource_sharing
 
-For some options, all resources hosted on [GitHub Pages][ghpages] are served with CORS headers. We highly recommend GitHub Pages as a simple deployment platform. Alternatively, we could also upload assets using the [A-Frame + Uploadcare Uploader][uploader], a service that will help serve our assets CORS'd.
+Loading assets from a different domain requires [cross-origin resource sharing
+(CORS) headers][cors]. Else we have to serve the asset ourselves.
 
-Given that CORS headers are set, if fetching a texture from a different origin or domain such as from an image hosting service or a CDN, then we should specify the `crossorigin` attribute on the `<img>`, `<video>`, or `<canvas>` element used to create a texture. [CORS][corsimage] security mechanisms in the browser generally disallow reading raw data from media elements from other domains if not explicitly allowed:
+[ghpages]: https://pages.github.com/
+[uploader]: https://aframe.io/aframe/examples/_uploader/
+
+For some options, all resources hosted on [GitHub Pages][ghpages] are served
+with CORS headers. We highly recommend GitHub Pages as a simple deployment
+platform. Alternatively, we could also upload assets using the [A-Frame +
+Uploadcare Uploader][uploader], a service that will help serve our assets
+CORS'd.
+
+[corsimage]: https://developer.mozilla.org/docs/Web/HTML/CORS_enabled_image
+
+Given that CORS headers are set, if fetching a texture from a different origin
+or domain such as from an image hosting service or a CDN, then we should
+specify the `crossorigin` attribute on the `<img>`, `<video>`, or `<canvas>`
+element used to create a texture. [CORS][corsimage] security mechanisms in the
+browser generally disallow reading raw data from media elements from other
+domains if not explicitly allowed:
 
 ```html
 <a-scene>
@@ -95,14 +112,19 @@ Audio and video assets will only block the scene if `autoplay` is set or if `pre
 
 ## Setting a Timeout
 
-If some assets are taking an extremely long time to load, we may want to set an appropriate timeout such that the user isn't waiting all day. When the timeout is reached, then the scene will start playing regardless of whether all the assets have loaded.
+We can set a timeout that when reached, the scene will begin rendering and
+entities will begin initializing regardless of whether all the assets have
+loaded. The default timeout is 3 seconds. To set a different timeout, we just
+pass in the number of milliseconds to the `timeout` attribute:
 
-The default timeout is 3 seconds. To set a different timeout, we just pass in the number of milliseconds to the `timeout` attribute:
+If some assets are taking a long time to load, we may want to set an
+appropriate timeout such that the user isn't waiting all day in case their
+network is slow.
 
 ```html
 <a-scene>
   <a-assets timeout="10000">
-    <!-- You got until the count of 10 to load, else the show will go on without you. -->
+    <!-- You got until the count of 10 to load else the show will go on without you. -->
     <img src="bigimage.png">
   </a-asset>
 </a-scene>
@@ -110,7 +132,8 @@ The default timeout is 3 seconds. To set a different timeout, we just pass in th
 
 ## Events
 
-Since `<a-assets>` and `<a-asset-item>` are *nodes* in A-Frame, they will emit the `loaded` event when they say they have finished loading.
+Since `<a-assets>` and `<a-asset-item>` are *nodes* in A-Frame, they will emit
+the `loaded` event when they say they have finished loading.
 
 ### <a-assets>
 
@@ -119,15 +142,28 @@ Since `<a-assets>` and `<a-asset-item>` are *nodes* in A-Frame, they will emit t
 | loaded     | All assets were loaded, or assets timed out. |
 | timeout    | Assets timed out.                            |
 
-### <a-asset-item>
+## Load Progress on Individual Assets
+
+### `<a-asset-item>`
 
 | Event Name | Description                           |
 |------------|---------------------------------------|
 | loaded     | Asset pointed to by `src` was loaded. |
 
-## `HTMLMediaElement`
+### `<img>`
 
-Audio and video assets are [`HTMLMediaElement`][mediael]s. The browser triggers particular events on these elements; noted here for convenience:
+Images are a standard DOM element so we can listen to the standard DOM events.
+
+| Event Name | Description       |
+|------------|-------------------|
+| loaded     | Image was loaded. |
+
+### `HTMLMediaElement`
+
+[mediael]: https://developer.mozilla.org/docs/Web/API/HTMLMediaElement
+
+Audio and video assets are [`HTMLMediaElement`][mediael]s. The browser triggers
+particular events on these elements; noted here for convenience:
 
 | Event Name | Description                           |
 |------------|---------------------------------------|
@@ -135,11 +171,30 @@ Audio and video assets are [`HTMLMediaElement`][mediael]s. The browser triggers 
 | loadeddata | Progress.                             |
 | progress   | Progress.                             |
 
-A-Frame uses these progress events, comparing how much time was buffered with the duration of the asset, in order to detect when the asset has been loaded.
+A-Frame uses these progress events, comparing how much time was buffered with
+the duration of the asset, in order to detect when the asset has been loaded.
 
-[cors]: https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
-[corsimage]: https://developer.mozilla.org/docs/Web/HTML/CORS_enabled_image
-[ghpages]: https://pages.github.com/
-[mediael]: https://developer.mozilla.org/docs/Web/API/HTMLMediaElement
-[mixins]: ./mixins.md
-[uploader]: https://aframe.io/aframe/examples/_uploader/
+## How It Works Internally
+
+Every element in A-Frame inherits from `<a-node>`, the `AFRAME.ANode`
+prototype. `ANode` controls load and initialization order. For an element to
+initialize (whether it is `<a-assets>`, `<a-asset-item>`, `<a-scene>`, or
+`<a-entity>`), all of its children must have already initialized. Nodes
+initialize bottom up.
+
+`<a-assets>` is an `ANode`, and it waits for all of its children to load before
+it loads. And since `<a-assets>` is a child of `<a-scene>`, the scene
+effectively must wait for all assets to load. We also added extra load logic to
+`<a-entity>` such that they explicitly wait for `<a-assets>` to load if it is
+defined.
+
+`<a-asset-item>` uses `THREE.XHRLoader` to fetch files. The data returned is
+stored in `THREE.Cache`. Every three.js loader inherits from `THREE.XHRLoader`,
+whether they are a `ColladaLoader`, `OBJLoader`, `ImageLoader`, etc. And they
+all have access and are aware of the central `THREE.Cache`. If a file has
+already been fetched, it won't be fetched again.
+
+Thus, since we block entity initialization on assets, by the time entities
+load, all assets will have been already fetched. As long as `<a-asset-item>`s
+are defined, and the entity is fetching files using some form
+`THREE.XHRLoader`, then caching will automatically work.

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -83,9 +83,9 @@ registerElement('a-asset-item', {
     attachedCallback: {
       value: function () {
         var self = this;
-        var src = this.getAttribute('src');
-
+        var src = src = this.getAttribute('src');
         xhrLoader.load(src, function (textResponse) {
+          THREE.Cache.files[src] = textResponse;
           self.data = textResponse;
           ANode.prototype.load.call(self);
         });

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -68,8 +68,27 @@ var proto = Object.create(ANode.prototype, {
    */
   attachedCallback: {
     value: function () {
+      var assetsEl;  // Asset management system element.
+      var sceneEl = this.sceneEl;
+      var self = this;  // Component.
+
       this.addToParent();
+
+      // Don't .load() scene on attachedCallback.
       if (this.isScene) { return; }
+
+      // Gracefully not error when outside of <a-scene> (e.g., tests).
+      if (!sceneEl) {
+        this.load();
+        return;
+      }
+
+      // Wait for asset management system to finish before loading.
+      assetsEl = sceneEl.querySelector('a-assets');
+      if (assetsEl && !assetsEl.hasLoaded) {
+        assetsEl.addEventListener('loaded', function () { self.load(); });
+        return;
+      }
       this.load();
     }
   },

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1,6 +1,6 @@
 /* global assert, process, sinon, setup, suite, teardown, test, HTMLElement */
-'use strict';
 var AEntity = require('core/a-entity');
+var ANode = require('core/a-node');
 var extend = require('utils').extend;
 var registerComponent = require('core/component').registerComponent;
 var components = require('core/component').components;
@@ -129,6 +129,31 @@ suite('a-entity', function () {
         done();
       });
       this.el.sceneEl.appendChild(el);
+    });
+
+    test('waits for <a-assets>', function (done) {
+      var assetsEl;
+      var el;
+      var img;
+      var sceneEl;
+
+      // Create DOM.
+      sceneEl = document.createElement('a-scene');
+      assetsEl = document.createElement('a-assets');
+      img = document.createElement('img');
+      img.setAttribute('src', 'willneverload.jpg');
+      el = document.createElement('a-entity');
+      assetsEl.appendChild(img);
+      sceneEl.appendChild(assetsEl);
+      sceneEl.appendChild(el);
+      document.body.appendChild(sceneEl);
+
+      el.addEventListener('loaded', function () {
+        assert.ok(assetsEl.hasLoaded);
+        assert.ok(el.hasLoaded);
+        done();
+      });
+      ANode.prototype.load.call(assetsEl);
     });
   });
 
@@ -439,14 +464,13 @@ suite('a-entity', function () {
       entity.appendChild(animationChild);
       entity.appendChild(entityChild1);
       entity.appendChild(entityChild2);
-      document.body.appendChild(entity);
-
       entity.addEventListener('loaded', function () {
         var childEntities = entity.getChildEntities();
         assert.equal(childEntities.length, 2);
         assert.equal(childEntities.indexOf(animationChild), -1);
         done();
       });
+      document.body.appendChild(entity);
     });
   });
 


### PR DESCRIPTION
**Description:**

Entities were not waiting for assets to load This caused duplicate asset fetching if an asset was defined in `<a-assets>` and an entity was also fetching an asset through a component.

This makes entities wait for `<a-assets>` (if exists) to load. This ensures all `<a-asset-item>`s have been fetched and made into the `THREE.Cache` used by `THREE.XHRLoader`. Subsequent fetches from loaders (e.g., `ColladaLoader`, `OBJLoader`, `MTLLoader`) will automatically pull from the cache.

Depended on https://github.com/aframevr/aframe/pull/1689, which has been merged.

**Changes proposed:**
- Entity wait for `<a-assets>` to load if exists.
- Update asset system documentation.