### PR TITLE
Fix for the low display resolution on Android when going into VR mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "style-attr": "^1.0.2",
     "three": "^0.76.1",
     "tween.js": "^15.0.0",
-    "webvr-polyfill": "borismus/webvr-polyfill#5fdd44b"
+    "webvr-polyfill": "0.9.15"
   },
   "devDependencies": {
     "browserify": "^11.0.1",

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -266,7 +266,11 @@ module.exports = registerElement('a-scene', {
         var embedded = this.getAttribute('embedded') && !this.is('vr-mode');
         var size;
         // Possible camera or canvas not injected yet.
-        if (!camera || !canvas) { return; }
+        // ON MOBILE the webvr-polyfill relies on the fullscreen API to enter
+        // VR mode. The canvas is resized by VREffect following the values returned
+        // by getEyeParameters. We don't want to overwrite the size with the
+        // windows width and height.
+        if (!camera || !canvas || this.is('vr-mode') && isMobile) { return; }
         // Update camera.
         size = getCanvasSize(canvas, embedded);
         camera.aspect = size.width / size.height;

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,7 @@ window.WebVRConfig = window.WebVRConfig || {
   CARDBOARD_UI_DISABLED: true,
   ROTATE_INSTRUCTIONS_DISABLED: true,
   TOUCH_PANNER_DISABLED: true,
-  MOUSE_KEYBOARD_CONTROLS_DISABLED: true,
-  BUFFER_SCALE: 1 / window.devicePixelRatio
+  MOUSE_KEYBOARD_CONTROLS_DISABLED: true
 };
 
 // WebVR polyfill

--- a/vendor/VREffect.js
+++ b/vendor/VREffect.js
@@ -11,34 +11,37 @@
 
 THREE.VREffect = function ( renderer, onError ) {
 
-	var vrHMD;
-	var isDeprecatedAPI = false;
+	var isWebVR1 = true;
+
+	var vrDisplay, vrDisplays;
 	var eyeTranslationL = new THREE.Vector3();
 	var eyeTranslationR = new THREE.Vector3();
 	var renderRectL, renderRectR;
 	var eyeFOVL, eyeFOVR;
 
-	function gotVRDevices( devices ) {
+	function gotVRDisplays( displays ) {
 
-		for ( var i = 0; i < devices.length; i ++ ) {
+		vrDisplays = displays;
 
-			if ( 'VRDisplay' in window && devices[ i ] instanceof VRDisplay ) {
+		for ( var i = 0; i < displays.length; i ++ ) {
 
-				vrHMD = devices[ i ];
-				isDeprecatedAPI = false;
+			if ( 'VRDisplay' in window && displays[ i ] instanceof VRDisplay ) {
+
+				vrDisplay = displays[ i ];
+				isWebVR1 = true;
 				break; // We keep the first we encounter
 
-			} else if ( 'HMDVRDevice' in window && devices[ i ] instanceof HMDVRDevice ) {
+			} else if ( 'HMDVRDevice' in window && displays[ i ] instanceof HMDVRDevice ) {
 
-				vrHMD = devices[ i ];
-				isDeprecatedAPI = true;
+				vrDisplay = displays[ i ];
+				isWebVR1 = false;
 				break; // We keep the first we encounter
 
 			}
 
 		}
 
-		if ( vrHMD === undefined ) {
+		if ( vrDisplay === undefined ) {
 
 			if ( onError ) onError( 'HMD not available' );
 
@@ -48,43 +51,55 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	if ( navigator.getVRDisplays ) {
 
-		navigator.getVRDisplays().then( gotVRDevices );
+		navigator.getVRDisplays().then( gotVRDisplays );
 
 	} else if ( navigator.getVRDevices ) {
 
 		// Deprecated API.
-		navigator.getVRDevices().then( gotVRDevices );
+		navigator.getVRDevices().then( gotVRDisplays );
 
 	}
 
 	//
 
+	this.isPresenting = false;
 	this.scale = 1;
 
-	var isPresenting = false;
+	var scope = this;
 
 	var rendererSize = renderer.getSize();
 	var rendererPixelRatio = renderer.getPixelRatio();
+
+	this.getVRDisplay = function () {
+
+		return vrDisplay;
+
+	};
+
+	this.getVRDisplays = function () {
+
+		return vrDisplays;
+
+	};
 
 	this.setSize = function ( width, height ) {
 
 		rendererSize = { width: width, height: height };
 
-		if ( isPresenting ) {
+		if ( scope.isPresenting ) {
 
-			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
+			var eyeParamsL = vrDisplay.getEyeParameters( 'left' );
 			renderer.setPixelRatio( 1 );
 
-			if ( isDeprecatedAPI ) {
-
-				renderer.setSize( eyeParamsL.renderRect.width * 2, eyeParamsL.renderRect.height, false );
-
-			} else {
+			if ( isWebVR1 ) {
 
 				renderer.setSize( eyeParamsL.renderWidth * 2, eyeParamsL.renderHeight, false );
 
-			}
+			} else {
 
+				renderer.setSize( eyeParamsL.renderRect.width * 2, eyeParamsL.renderRect.height, false );
+
+			}
 
 		} else {
 
@@ -98,105 +113,124 @@ THREE.VREffect = function ( renderer, onError ) {
 	// fullscreen
 
 	var canvas = renderer.domElement;
-	var fullscreenchange = canvas.mozRequestFullScreen ? 'mozfullscreenchange' : 'webkitfullscreenchange';
+	var requestFullscreen;
+	var exitFullscreen;
+	var fullscreenElement;
+	var leftBounds = [ 0.0, 0.0, 0.5, 1.0 ];
+	var rightBounds = [ 0.5, 0.0, 0.5, 1.0 ];
 
-	document.addEventListener( fullscreenchange, function () {
+	function onFullscreenChange () {
 
-		isPresenting = vrHMD !== undefined && ( vrHMD.isPresenting || ( isDeprecatedAPI && ( document.mozFullScreenElement || document.webkitFullscreenElement ) !== undefined ) );
+		var wasPresenting = scope.isPresenting;
+		scope.isPresenting = vrDisplay !== undefined && ( vrDisplay.isPresenting || ( ! isWebVR1 && document[ fullscreenElement ] instanceof window.HTMLElement ) );
 
-		if ( isPresenting ) {
+		if ( scope.isPresenting ) {
 
-			rendererPixelRatio = renderer.getPixelRatio();
-			rendererSize = renderer.getSize();
-
-			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
+			var eyeParamsL = vrDisplay.getEyeParameters( 'left' );
 			var eyeWidth, eyeHeight;
 
-			if ( isDeprecatedAPI ) {
-
-				eyeWidth = eyeParamsL.renderRect.width;
-				eyeHeight = eyeParamsL.renderRect.height;
-
-			} else {
+			if ( isWebVR1 ) {
 
 				eyeWidth = eyeParamsL.renderWidth;
 				eyeHeight = eyeParamsL.renderHeight;
 
+				if ( vrDisplay.getLayers ) {
+
+					var layers = vrDisplay.getLayers();
+					if (layers.length) {
+
+						leftBounds = layers[0].leftBounds || [ 0.0, 0.0, 0.5, 1.0 ];
+						rightBounds = layers[0].rightBounds || [ 0.5, 0.0, 0.5, 1.0 ];
+
+					}
+				}
+
+			} else {
+
+				eyeWidth = eyeParamsL.renderRect.width;
+				eyeHeight = eyeParamsL.renderRect.height;
+
 			}
 
-			renderer.setPixelRatio( 1 );
-			renderer.setSize( eyeWidth * 2, eyeHeight, false );
+			if ( !wasPresenting ) {
 
-		} else {
+				rendererPixelRatio = renderer.getPixelRatio();
+				rendererSize = renderer.getSize();
 
-			renderer.setPixelRatio( rendererPixelRatio );
-			renderer.setSize( rendererSize.width, rendererSize.height );
+				renderer.setPixelRatio( 1 );
+				renderer.setSize( eyeWidth * 2, eyeHeight, false );
 
-		}
+			}
 
-	}, false );
-
-	window.addEventListener( 'vrdisplaypresentchange', function () {
-
-		isPresenting = vrHMD && vrHMD.isPresenting;
-
-		if ( isPresenting ) {
-
-			rendererPixelRatio = renderer.getPixelRatio();
-			rendererSize = renderer.getSize();
-
-			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
-			renderer.setPixelRatio( 1 );
-			renderer.setSize( eyeParamsL.renderWidth * 2, eyeParamsL.renderHeight, false );
-
-		} else {
+		} else if ( wasPresenting ) {
 
 			renderer.setPixelRatio( rendererPixelRatio );
 			renderer.setSize( rendererSize.width, rendererSize.height );
 
 		}
 
-	}, false );
+	}
+
+	if ( canvas.requestFullscreen ) {
+
+		requestFullscreen = 'requestFullscreen';
+		fullscreenElement = 'fullscreenElement';
+		exitFullscreen = 'exitFullscreen';
+		document.addEventListener( 'fullscreenchange', onFullscreenChange, false );
+
+	} else if ( canvas.mozRequestFullScreen ) {
+
+		requestFullscreen = 'mozRequestFullScreen';
+		fullscreenElement = 'mozFullScreenElement';
+		exitFullscreen = 'mozCancelFullScreen';
+		document.addEventListener( 'mozfullscreenchange', onFullscreenChange, false );
+
+	} else {
+
+		requestFullscreen = 'webkitRequestFullscreen';
+		fullscreenElement = 'webkitFullscreenElement';
+		exitFullscreen = 'webkitExitFullscreen';
+		document.addEventListener( 'webkitfullscreenchange', onFullscreenChange, false );
+
+	}
+
+	window.addEventListener( 'vrdisplaypresentchange', onFullscreenChange, false );
 
 	this.setFullScreen = function ( boolean ) {
 
 		return new Promise( function ( resolve, reject ) {
 
-			if ( vrHMD === undefined ) {
+			if ( vrDisplay === undefined ) {
 
 				reject( new Error( 'No VR hardware found.' ) );
 				return;
 
 			}
-			if ( isPresenting === boolean ) {
+
+			if ( scope.isPresenting === boolean ) {
 
 				resolve();
 				return;
 
 			}
 
-			if ( ! isDeprecatedAPI ) {
+			if ( isWebVR1 ) {
 
 				if ( boolean ) {
 
-					resolve( vrHMD.requestPresent( [ { source: canvas } ] ) );
+					resolve( vrDisplay.requestPresent( [ { source: canvas } ] ) );
 
 				} else {
 
-					resolve( vrHMD.exitPresent() );
+					resolve( vrDisplay.exitPresent() );
 
 				}
 
 			} else {
 
-				if ( canvas.mozRequestFullScreen ) {
+				if ( canvas[ requestFullscreen ] ) {
 
-					canvas.mozRequestFullScreen( { vrDisplay: vrHMD } );
-					resolve();
-
-				} else if ( canvas.webkitRequestFullscreen ) {
-
-					canvas.webkitRequestFullscreen( { vrDisplay: vrHMD } );
+					canvas[ boolean ? requestFullscreen : exitFullscreen ]( { vrDisplay: vrDisplay } );
 					resolve();
 
 				} else {
@@ -224,6 +258,46 @@ THREE.VREffect = function ( renderer, onError ) {
 
 	};
 
+	this.requestAnimationFrame = function ( f ) {
+
+		if ( isWebVR1 && vrDisplay !== undefined ) {
+
+			return vrDisplay.requestAnimationFrame( f );
+
+		} else {
+
+			return window.requestAnimationFrame( f );
+
+		}
+
+	};
+
+	this.cancelAnimationFrame = function ( h ) {
+
+		if ( isWebVR1 && vrDisplay !== undefined ) {
+
+			vrDisplay.cancelAnimationFrame( h );
+
+		} else {
+
+			window.cancelAnimationFrame( h );
+
+		}
+
+	};
+
+	this.submitFrame = function () {
+
+		if ( isWebVR1 && vrDisplay !== undefined && scope.isPresenting ) {
+
+			vrDisplay.submitFrame();
+
+		}
+
+	};
+
+	this.autoSubmitFrame = true;
+
 	// render
 
 	var cameraL = new THREE.PerspectiveCamera();
@@ -232,9 +306,9 @@ THREE.VREffect = function ( renderer, onError ) {
 	var cameraR = new THREE.PerspectiveCamera();
 	cameraR.layers.enable( 2 );
 
-	this.render = function ( scene, camera ) {
+	this.render = function ( scene, camera, renderTarget, forceClear ) {
 
-		if ( vrHMD && isPresenting ) {
+		if ( vrDisplay && scope.isPresenting ) {
 
 			var autoUpdate = scene.autoUpdate;
 
@@ -245,10 +319,10 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			var eyeParamsL = vrHMD.getEyeParameters( 'left' );
-			var eyeParamsR = vrHMD.getEyeParameters( 'right' );
+			var eyeParamsL = vrDisplay.getEyeParameters( 'left' );
+			var eyeParamsR = vrDisplay.getEyeParameters( 'right' );
 
-			if ( ! isDeprecatedAPI ) {
+			if ( isWebVR1 ) {
 
 				eyeTranslationL.fromArray( eyeParamsL.offset );
 				eyeTranslationR.fromArray( eyeParamsR.offset );
@@ -274,11 +348,31 @@ THREE.VREffect = function ( renderer, onError ) {
 			// When rendering we don't care what the recommended size is, only what the actual size
 			// of the backbuffer is.
 			var size = renderer.getSize();
-			renderRectL = { x: 0, y: 0, width: size.width / 2, height: size.height };
-			renderRectR = { x: size.width / 2, y: 0, width: size.width / 2, height: size.height };
+			renderRectL = {
+				x: Math.round( size.width * leftBounds[ 0 ] ),
+				y: Math.round( size.height * leftBounds[ 1 ] ),
+				width: Math.round( size.width * leftBounds[ 2 ] ),
+				height:  Math.round(size.height * leftBounds[ 3 ] )
+			};
+			renderRectR = {
+				x: Math.round( size.width * rightBounds[ 0 ] ),
+				y: Math.round( size.height * rightBounds[ 1 ] ),
+				width: Math.round( size.width * rightBounds[ 2 ] ),
+				height:  Math.round(size.height * rightBounds[ 3 ] )
+			};
 
-			renderer.setScissorTest( true );
-			renderer.clear();
+			if (renderTarget) {
+
+				renderer.setRenderTarget(renderTarget);
+				renderTarget.scissorTest = true;
+
+			} else  {
+
+				renderer.setScissorTest( true );
+
+			}
+
+			if ( renderer.autoClear || forceClear ) renderer.clear();
 
 			if ( camera.parent === null ) camera.updateMatrixWorld();
 
@@ -294,16 +388,45 @@ THREE.VREffect = function ( renderer, onError ) {
 
 
 			// render left eye
-			renderer.setViewport( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
-			renderer.setScissor( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
-			renderer.render( scene, cameraL );
+			if ( renderTarget ) {
+
+				renderTarget.viewport.set(renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height);
+				renderTarget.scissor.set(renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height);
+
+			} else {
+
+				renderer.setViewport( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
+				renderer.setScissor( renderRectL.x, renderRectL.y, renderRectL.width, renderRectL.height );
+
+			}
+			renderer.render( scene, cameraL, renderTarget, forceClear );
 
 			// render right eye
-			renderer.setViewport( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
-			renderer.setScissor( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
-			renderer.render( scene, cameraR );
+			if (renderTarget) {
 
-			renderer.setScissorTest( false );
+				renderTarget.viewport.set(renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height);
+  				renderTarget.scissor.set(renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height);
+
+			} else {
+
+				renderer.setViewport( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
+				renderer.setScissor( renderRectR.x, renderRectR.y, renderRectR.width, renderRectR.height );
+
+			}
+			renderer.render( scene, cameraR, renderTarget, forceClear );
+
+			if (renderTarget) {
+
+				renderTarget.viewport.set( 0, 0, size.width, size.height );
+				renderTarget.scissor.set( 0, 0, size.width, size.height );
+				renderTarget.scissorTest = false;
+				renderer.setRenderTarget( null );
+
+			} else {
+
+				renderer.setScissorTest( false );
+
+			}
 
 			if ( autoUpdate ) {
 
@@ -311,9 +434,9 @@ THREE.VREffect = function ( renderer, onError ) {
 
 			}
 
-			if ( ! isDeprecatedAPI ) {
+			if ( scope.autoSubmitFrame ) {
 
-				vrHMD.submitFrame();
+				scope.submitFrame();
 
 			}
 
@@ -323,7 +446,7 @@ THREE.VREffect = function ( renderer, onError ) {
 
 		// Regular render mode if not HMD
 
-		renderer.render( scene, camera );
+		renderer.render( scene, camera, renderTarget, forceClear );
 
 	};
 


### PR DESCRIPTION
**Description:**

a-scene `resize` method is attached to the resize event on the windows element. The resize event is triggered when entering/exiting fullscreen. The polyfill on mobile uses fullscreen to enter VR mode and the the `resize` method was replacing the renderer size set by VREffect (based on the getEyeParameters API) with the window height and width using the pixelRatio === 1 set by VREffect when entering VR.

**Changes proposed:**
1. the `resize` method returns if we're in mobile + VR mode. This way the renderer size set by VREffect is not replaced anymore.
2. Bumps the webvr-polyfill to the latest version.
3. Bumps three.js VREffect to avoid a problem when using the undefined renderRect value returned by the polyfilled `getEyeParameters` API. 


