### PR TITLE
Fix hand-controls events being attached twice (fixes #1704)

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -5,7 +5,7 @@ var RIGHT_HAND_MODEL_URL = 'https://media.aframe.io/controllers/hands/rightHand.
 /**
 *
 * Hand Controls component
-* HAndle events coming from the vive-controls
+* Handle events coming from the vive-controls
 * Translate button events to hand related actions:
 * gripclose, gripopen, thumbup, thumbdown, pointup, pointdown
 * Load a hand model with gestures that are applied based
@@ -24,14 +24,13 @@ module.exports.Component = registerComponent('hand-controls', {
     this.onTrackpadUp = function () { self.handleButton('trackpad', 'up'); };
     this.onTriggerDown = function () { self.handleButton('trigger', 'down'); };
     this.onTriggerUp = function () { self.handleButton('trigger', 'up'); };
-    this.addEventListeners();
   },
 
   play: function () {
     this.addEventListeners();
   },
 
-  stop: function () {
+  pause: function () {
     this.removeEventListeners();
   },
 


### PR DESCRIPTION
**Description:** The hand-controls component is adding events twice, once during a manual "addEventListeners()" call in init() and a second time when play() is automatically called after update(). Additionally, a few other changes were made based on [@ngokevin's comment on the issue](https://github.com/aframevr/aframe/issues/1704).

**Changes proposed:**
- Remove "addEventListeners()" call in init()
- Rename "stop()" to "pause()"
- ~~Move addEventListeners/removeEventListeners into pause() and play()~~
- Fix typo in component docstring ("HAndle" -> "Handle")