### PR TITLE
a-node getChildren shorter array syntax

### DIFF
--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -109,11 +109,7 @@ module.exports = registerElement('a-node', {
 
     getChildren: {
       value: function () {
-        var children = [];
-        for (var i = 0; i < this.children.length; i++) {
-          children.push(this.children[i]);
-        }
-        return children;
+        return Array.prototype.slice.call(this.children, 0);
       }
     },
 


### PR DESCRIPTION
Much shorter than a `for` loop.

This is the third or fourth usage of `A.p.s.call` -- should we consider a `ANode.prototype.query` method for querying children and returning an `Array` as a standard?