### PR TITLE
rename media repo to assets

### DIFF
--- a/examples/showcase/tracked-controls/components/ground.js
+++ b/examples/showcase/tracked-controls/components/ground.js
@@ -7,7 +7,7 @@ AFRAME.registerComponent('ground', {
   init: function () {
     var objectLoader;
     var object3D = this.el.object3D;
-    var MODEL_URL = 'https://media.aframe.io/link-traversal/models/ground.json';
+    var MODEL_URL = 'https://aframevr.github.io/assets/link-traversal/models/ground.json';
     if (this.objectLoader) { return; }
     objectLoader = this.objectLoader = new THREE.ObjectLoader();
     objectLoader.crossOrigin = '';

--- a/examples/showcase/wikipedia/index.html
+++ b/examples/showcase/wikipedia/index.html
@@ -96,8 +96,8 @@ cite,dfn{font-style:inherit} q{quotes:'"' '"' "'" "'"} blockquote{overflow:hidde
 <td colspan="2" style="text-align:center">
 <a-scene class="ascene" debug="" embedded style="margin: auto">
     <a-assets>
-      <a-asset-item id="crate-obj" src="https://media.aframe.io/wikipedia/model.obj"></a-asset-item>
-      <a-asset-item id="crate-mtl" src="https://media.aframe.io/wikipedia/model.mtl"></a-asset-item>
+      <a-asset-item id="crate-obj" src="https://aframevr.github.io/assets/wikipedia/model.obj"></a-asset-item>
+      <a-asset-item id="crate-mtl" src="https://aframevr.github.io/assets/wikipedia/model.mtl"></a-asset-item>
     </a-assets>
     <a-entity id="sky" geometry="primitive: sphere; radius: 2000;"
               material="shader: sky; sunPosition: 10 18 0;side: back"></a-entity>

--- a/examples/showcase/wikipedia/indexMobile.html
+++ b/examples/showcase/wikipedia/indexMobile.html
@@ -245,8 +245,8 @@ url(https://en.wikipedia.org/w/load.php?modules=mobile.toc.images&image=toc&form
 <td colspan="2" style="text-align:center">
 <a-scene class="ascene" debug="true" embedded style="margin: auto">
     <a-assets>
-      <a-asset-item id="crate-obj" src="https://media.aframe.io/wikipedia/model.obj"></a-asset-item>
-      <a-asset-item id="crate-mtl" src="https://media.aframe.io/wikipedia/model.mtl"></a-asset-item>
+      <a-asset-item id="crate-obj" src="https://aframevr.github.io/assets/wikipedia/model.obj"></a-asset-item>
+      <a-asset-item id="crate-mtl" src="https://aframevr.github.io/assets/wikipedia/model.mtl"></a-asset-item>
     </a-assets>
     <a-entity id="sky" geometry="primitive: sphere; radius: 2000;"
               material="shader: sky; sunPosition: 10 18 0;side: back"></a-entity>

--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -1,6 +1,7 @@
 var registerComponent = require('../core/component').registerComponent;
-var LEFT_HAND_MODEL_URL = 'https://media.aframe.io/controllers/hands/leftHand.json';
-var RIGHT_HAND_MODEL_URL = 'https://media.aframe.io/controllers/hands/rightHand.json';
+
+var LEFT_HAND_MODEL_URL = 'https://aframevr.github.io/assets/controllers/hands/leftHand.json';
+var RIGHT_HAND_MODEL_URL = 'https://aframevr.github.io/assets/controllers/hands/rightHand.json';
 
 /**
 *

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -1,6 +1,8 @@
 var registerComponent = require('../core/component').registerComponent;
-var VIVE_CONTROLLER_MODEL_OBJ_URL = 'https://media.aframe.io/controllers/vive/vr_controller_vive.obj';
-var VIVE_CONTROLLER_MODEL_OBJ_MTL = 'https://media.aframe.io/controllers/vive/vr_controller_vive.mtl';
+
+var VIVE_CONTROLLER_MODEL_OBJ_URL = 'https://aframevr.github.io/assets/controllers/vive/vr_controller_vive.obj';
+var VIVE_CONTROLLER_MODEL_OBJ_MTL = 'https://aframevr.github.io/assets/controllers/vive/vr_controller_vive.mtl';
+
 /**
  * Vive Controls Component
  * Interfaces with vive controls and maps Gamepad events to


### PR DESCRIPTION
**Description:**

Use aframevr.github.io/assets (formerly named `media`) instead of media.aframe.io (Custom GitHub Pages domain).

