### PR TITLE
Fixed a mistake in docs for position component

### DIFF
--- a/docs/components/position.md
+++ b/docs/components/position.md
@@ -22,7 +22,7 @@ A-Frame uses a right-handed coordinate system where the negative Z axis extends 
 | Axis | Description                                                  | Default Value |
 |------|--------------------------------------------------------------|---------------|
 | x    | Negative X axis extends left. Positive X Axis extends right. | 0             |
-| y    | Negative Y axis extends up. Positive Y Axis extends down.    | 0             |
+| y    | Negative Y axis extends down. Positive Y Axis extends up.    | 0             |
 | z    | Negative Z axis extends in. Positive Z Axis extends out.     | 0             |
 
 ## Relative Positioning


### PR DESCRIPTION
**Description:**
Issue #1628 

Documentation suggests, that: 

> Positive Y Axis extends down

It's the other way around.

**Changes proposed:**
Literally this:
` Negative Y axis extends down. Positive Y Axis extends up.`