### PR TITLE
Entity: first attach the object3d then emit the child-attached event.

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -212,8 +212,8 @@ var proto = Object.create(ANode.prototype, {
       if (!el.object3D) {
         throw new Error("Trying to add an element that doesn't have an `object3D`");
       }
-      this.emit('child-attached', { el: el });
       this.object3D.add(el.object3D);
+      this.emit('child-attached', { el: el });
     }
   },
 


### PR DESCRIPTION
**Description:**
Saw this when looking for info for the docs.

I might be wrong, but wouldn't it make more sense that the object3D is already present when the event is fired?

**Changes proposed:**
first attach the object3d then emit the child-attached event.
