### PR TITLE
don't remove camera height offset on mobile/cardboard (fixes #1715)

### DIFF
--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -59,16 +59,25 @@ module.exports.Component = registerComponent('camera', {
     });
   },
 
+  /**
+   * Remove the height offset (called when entering VR) since WebVR API gives absolute
+   * position.
+   * Does not apply for mobile.
+   */
   removeHeightOffset: function () {
-    var el = this.el;
-    // Remove default camera if present.
-    var userHeightOffset = this.userHeightOffset;
     var currentPosition;
+    var el = this.el;
+    var headsetConnected;
+    var sceneEl = el.sceneEl;
+    var userHeightOffset = this.userHeightOffset;
+
     // Checking this.headsetConnected to make the value injectable for unit tests.
-    var headsetConnected = this.headsetConnected || checkHeadsetConnected();
+    headsetConnected = this.headsetConnected || checkHeadsetConnected();
+
     // If there's not a headset connected we keep the offset.
     // Necessary for fullscreen mode with no headset.
-    if (!userHeightOffset || !headsetConnected) { return; }
+    if (sceneEl.isMobile || !userHeightOffset || !headsetConnected) { return; }
+
     this.userHeightOffset = undefined;
     currentPosition = el.getAttribute('position') || {x: 0, y: 0, z: 0};
     el.setAttribute('position', {

--- a/tests/components/camera.test.js
+++ b/tests/components/camera.test.js
@@ -87,5 +87,17 @@ suite('camera', function () {
       sceneEl.emit('enter-vr');
       assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 1.6, z: 0});
     });
+
+    test('does not remove the default offset when entering VR on mobile', function () {
+      var sceneEl = this.el.sceneEl;
+      var cameraEl = this.el;
+
+      sceneEl.isMobile = true;
+      cameraEl.components.camera.headsetConnected = true;
+
+      assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 1.6, z: 0});
+      sceneEl.emit('enter-vr');
+      assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 1.6, z: 0});
+    });
   });
 });


### PR DESCRIPTION
add isMobile check

Fixes https://github.com/aframevr/aframe/issues/1612 where COLLADA model seemed to move after entering VR on mobile.

Fixes cases where camera would clip through the ground on mobile after entering VR
