### PR TITLE
wait for scene load before default camera check (fixes #1723)

### DIFF
--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -15,35 +15,35 @@ module.exports.System = registerSystem('camera', {
   },
 
   /**
-   * Creates a default camera if user has not added one during the initial scene traversal.
+   * Create a default camera if user has not added one during the initial scene traversal.
    *
-   * Default camera height is at human level (~1.8m) and back such that
-   * entities at the origin (0, 0, 0) are well-centered.
+   * Default camera offset height is at average eye level (~1.6m).
    */
   setupDefaultCamera: function () {
     var self = this;
     var sceneEl = this.sceneEl;
     var defaultCameraEl;
-    // setTimeout in case the camera is being set dynamically with a setAttribute.
-    setTimeout(checkForCamera);
-    function checkForCamera () {
+
+    // Wait for all entities to fully load before checking for existence of camera.
+    // Since entities wait for <a-assets> to load, any cameras attaching to the scene
+    // will do so asynchronously.
+    sceneEl.addEventListener('loaded', function checkForCamera () {
       var currentCamera = sceneEl.camera;
       if (currentCamera) {
-        sceneEl.emit('camera-ready', { cameraEl: currentCamera.el });
+        sceneEl.emit('camera-ready', {cameraEl: currentCamera.el});
         return;
       }
       defaultCameraEl = document.createElement('a-entity');
       defaultCameraEl.setAttribute('position', '0 0 0');
       defaultCameraEl.setAttribute(DEFAULT_CAMERA_ATTR, '');
-      defaultCameraEl.setAttribute('camera',
-        {active: true, userHeight: DEFAULT_USER_HEIGHT});
+      defaultCameraEl.setAttribute('camera', {active: true, userHeight: DEFAULT_USER_HEIGHT});
       defaultCameraEl.setAttribute('wasd-controls', '');
       defaultCameraEl.setAttribute('look-controls', '');
       sceneEl.appendChild(defaultCameraEl);
       sceneEl.addEventListener('enter-vr', self.removeDefaultOffset);
       sceneEl.addEventListener('exit-vr', self.addDefaultOffset);
       sceneEl.emit('camera-ready', {cameraEl: defaultCameraEl});
-    }
+    });
   },
 
   /**

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -357,8 +357,6 @@ suite('a-entity', function () {
       var parentEl = entityFactory();
       var el = document.createElement('a-entity');
 
-      parentEl.appendChild(el);
-
       el.addEventListener('loaded', function () {
         parentEl.removeChild(el);
         process.nextTick(function () {
@@ -366,6 +364,8 @@ suite('a-entity', function () {
           done();
         });
       });
+
+      parentEl.appendChild(el);
     });
 
     test('removes itself from scene parent', function (done) {

--- a/tests/systems/camera.test.js
+++ b/tests/systems/camera.test.js
@@ -10,6 +10,41 @@ suite('camera system', function () {
     });
   });
 
+  suite('setupDefaultCamera', function () {
+    test('uses defined camera if defined', function (done) {
+      var assetsEl;
+      var imgEl;  // Image that will never load.
+      var cameraEl;
+      var sceneEl;
+
+      // Create assets.
+      assetsEl = document.createElement('a-assets');
+      imgEl = document.createElement('img');
+      imgEl.setAttribute('src', 'neverloadlalala5.gif');
+      assetsEl.appendChild(imgEl);
+
+      // Create scene.
+      sceneEl = document.createElement('a-scene');
+      sceneEl.appendChild(assetsEl);
+
+      // Create camera.
+      cameraEl = document.createElement('a-entity');
+      cameraEl.setAttribute('camera', '');
+      sceneEl.appendChild(cameraEl);
+
+      sceneEl.addEventListener('loaded', function () {
+        assert.equal(sceneEl.camera.el, cameraEl);
+        done();
+      });
+
+      document.body.appendChild(sceneEl);
+
+      // Trigger scene load through assets. Camera will be waiting for assets.
+      // Add `setTimeout` to mimic asynchrony of asset loading.
+      setTimeout(function () { assetsEl.load(); });
+    });
+  });
+
   suite('setActiveCamera', function () {
     test('sets new active camera on scene', function () {
       var el = this.el;


### PR DESCRIPTION
**Description:**

Found an issue where scene was using default camera despite having a defined one, in the case where the scene has assets.

Caught this in one of my scenes when I had a camera + cursor that wasn't being used, so I saw that the cursor was just hanging in space in a separate camera.

**Changes proposed:**
- Wait for scene load before camera check.
- Remove `nodeready` and `isNode` check in `addToParent` now that I fixed our `document.registerElement`.

