### PR TITLE
Workaround for webkit bug where a webgl canvas element is not composited properly

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -1,4 +1,4 @@
-/* global Promise */
+/* global Promise, screen */
 var initMetaTags = require('./metaTags').inject;
 var initWakelock = require('./wakelock');
 var re = require('../a-register-element');
@@ -154,8 +154,8 @@ module.exports = registerElement('a-scene', {
           self.emit('enter-vr', event);
 
           // Lock to landscape orientation on mobile.
-          if (self.isMobile && window.screen.orientation) {
-            window.screen.orientation.lock('landscape');
+          if (self.isMobile && screen.orientation && screen.orientation.lock) {
+            screen.orientation.lock('landscape');
           }
           self.addFullScreenStyles();
 
@@ -189,12 +189,13 @@ module.exports = registerElement('a-scene', {
           var embedded = self.getAttribute('embedded');
           self.removeState('vr-mode');
           // Lock to landscape orientation on mobile.
-          if (self.isMobile && window.screen.orientation) {
-            window.screen.orientation.unlock();
+          if (self.isMobile && screen.orientation && screen.orientation.unlock) {
+            screen.orientation.unlock();
           }
           // Exiting VR in embedded mode, no longer need fullscreen styles.
           if (embedded) { self.removeFullScreenStyles(); }
           self.resize();
+          if (self.isIOS) { utils.forceCanvasResizeSafariMobile(this.canvas); }
           self.emit('exit-vr', {target: self});
         }
         function exitVRFailure (err) {

--- a/src/utils/forceCanvasResizeSafariMobile.js
+++ b/src/utils/forceCanvasResizeSafariMobile.js
@@ -1,0 +1,14 @@
+module.exports = function forceCanvasResizeSafariMobile (canvasEl) {
+  var width = canvasEl.style.width;
+  var height = canvasEl.style.height;
+  // Taken from webvr-polyfill (https://github.com/borismus/webvr-polyfill/blob/85f657cd502ec9417bf26b87c3cb2afa6a70e079/src/util.js#L200)
+  // iOS only workaround for https://bugs.webkit.org/show_bug.cgi?id=152556
+  // By changing the size 1 pixel and restoring the previous value
+  // we trigger a size recalculation cycle.
+  canvasEl.style.width = (parseInt(width, 10) + 1) + 'px';
+  canvasEl.style.height = (parseInt(height, 10) + 1) + 'px';
+  setTimeout(function () {
+    canvasEl.style.width = width;
+    canvasEl.style.height = height;
+  }, 200);
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,6 +8,7 @@ module.exports.coordinates = require('./coordinates');
 module.exports.checkHeadsetConnected = require('./checkHeadsetConnected');
 module.exports.debug = require('./debug');
 module.exports.entity = require('./entity');
+module.exports.forceCanvasResizeSafariMobile = require('./forceCanvasResizeSafariMobile');
 module.exports.material = require('./material');
 module.exports.styleParser = require('./styleParser');
 


### PR DESCRIPTION
Workaround for https://bugs.webkit.org/show_bug.cgi?id=152556 that makes the canvas not have the proper size when changing its dimensions. This fix cover all the cases except when the VR mode is engaged in landscape orientation. An orientation change is needed to readjust the size of the canvas. I've spent a whole day and I could not find a workaround for that last glitch. I propose to live with it and wait for the fix to ship with iOS 10 (the bug above has been marked as fixed in April).