### PR TITLE
addToParent was invoked twice: In the load and attachedCallback methods

### DIFF
--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -43,25 +43,10 @@ module.exports.AAnimation = registerElement('a-animation', {
 
     attachedCallback: {
       value: function () {
-        var self = this;
-        var el = this.el = this.parentNode;
-
-        init();
-
-        function init () {
-          if (!el.isPlaying) {
-            el.addEventListener('play', init);
-            return;
-          }
-          if (!el.hasLoaded) {
-            el.addEventListener('loaded', init);
-            return;
-          }
-
-          self.handleMixinUpdate();
-          self.update();
-          self.load();
-        }
+        this.el = this.parentNode;
+        this.handleMixinUpdate();
+        this.update();
+        this.load();
       }
     },
 
@@ -172,7 +157,7 @@ module.exports.AAnimation = registerElement('a-animation', {
         var begin = data.begin;
         var end = data.end;
         // Cancel previous event listeners
-        if (this.evt) this.removeEventListeners(this.evt);
+        if (this.evt) { this.removeEventListeners(this.evt); }
         // Store new event name.
         this.evt = { begin: begin, end: end };
         // Add new event listeners
@@ -214,6 +199,12 @@ module.exports.AAnimation = registerElement('a-animation', {
 
     start: {
       value: function () {
+        var self = this;
+        // Postpone animation start until the entity has loaded
+        if (!this.el.hasLoaded) {
+          this.el.addEventListener('loaded', function () { self.start(); });
+          return;
+        }
         if (this.isRunning || !this.el.isPlaying) { return; }
         this.tween = this.getTween();
         this.isRunning = true;

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -241,23 +241,12 @@ var proto = Object.create(ANode.prototype, {
 
       if (this.hasLoaded) { return; }
 
-      // Attach to parent object3D.
-      this.addToParent();
-
-      // Scene load.
-      function sceneLoadCallback () { self.updateComponents(); }
-      if (this.isScene) {
-        ANode.prototype.load.call(this, sceneLoadCallback);
-        return;
-      }
-
+      ANode.prototype.load.call(this, entityLoadCallback);
       // Entity load.
       function entityLoadCallback () {
         self.updateComponents();
-        // self.parentNode should work but that is null during this cb for unknown (#1483).
-        if (self.parentEl.isPlaying) { self.play(); }
+        if (self.isScene || self.parentEl.isPlaying) { self.play(); }
       }
-      ANode.prototype.load.call(this, entityLoadCallback, isEntity);
     },
     writable: window.debug
   },
@@ -734,10 +723,6 @@ function isComponentMixedIn (name, mixinEls) {
     if (inMixin) { break; }
   }
   return inMixin;
-}
-
-function isEntity (el) {
-  return el.isEntity;
 }
 
 AEntity = registerElement('a-entity', {


### PR DESCRIPTION
This fixes the error of `parentEl === null`  seen on console in some of the demo like anime-ui.

This removes also what I believe is unnecessary sceneEl specific code since the same logic (updating components) is run for every entity (scene is just another entity).
