### PR TITLE
Light target support. Fixed a bug with spotlight angle. temp fix for a bug with spotlight position.

### DIFF
--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -84,9 +84,10 @@ Spot lights are like point lights in the sense that they affect materials depend
 <a-entity light="type: spot; angle: 45"></a-entity>
 ```
 
-| Property    | Description                                                                                                | Default Value |
-|-------------|------------------------------------------------------------------------------------------------------------|---------------|
-| angle       | Maximum extent of spot light from its direction (in degrees).                                               | 60            |
-| decay       | Amount the light dims along the distance of the light.                                                     | 1.0           |
-| distance    | Distance where intensity becomes 0. If `distance` is `0`, then the point light does not decay with distance. | 0.0           |
-| penumbra  | Percent of the spotlight cone that is attenuated due to penumbra.                                            | 0.0           |
+| Property    | Description                                                                                                    | Default Value |
+|-------------|----------------------------------------------------------------------------------------------------------------|---------------|
+| angle       | Maximum extent of spot light from its direction (in degrees).                                                  | 60            |
+| decay       | Amount the light dims along the distance of the light.                                                         | 1.0           |
+| distance    | Distance where intensity becomes 0. If `distance` is `0`, then the point light does not decay with distance.   | 0.0           |
+| penumbra    | Percent of the spotlight cone that is attenuated due to penumbra.                                              | 0.0           |
+| target      | element the spot should point to. set to null to transform spotlight by orientation, pointing to it's -Z axis. | null          |

--- a/docs/primitives/a-light.md
+++ b/docs/primitives/a-light.md
@@ -33,6 +33,7 @@ The light primitive adjusts the lighting setup of the scene. It is an entity tha
 | intensity    | light.intensity   | 1.0           |
 | penumbra     | light.penumbra    | 0.0           |
 | type         | light.type        | directional   |
+| target       | light.target      | null          |
 
 ## Differences with the Default Lighting
 

--- a/src/extras/primitives/primitives/a-light.js
+++ b/src/extras/primitives/primitives/a-light.js
@@ -13,6 +13,7 @@ registerPrimitive('a-light', {
     distance: 'light.distance',
     intensity: 'light.intensity',
     penumbra: 'light.penumbra',
-    type: 'light.type'
+    type: 'light.type',
+    target: 'light.target'
   }
 });

--- a/tests/components/light.test.js
+++ b/tests/components/light.test.js
@@ -12,42 +12,41 @@ suite('light', function () {
 
   suite('update', function () {
     test('creates light', function () {
-      assert.equal(this.el.object3D.children[0].type, 'DirectionalLight');
+      assert.equal(this.el.getObject3D('light').type, 'DirectionalLight');
     });
 
     test('updates light', function () {
       var el = this.el;
       el.setAttribute('light', 'color: #F0F');
-      assert.shallowDeepEqual(el.object3D.children[0].color,
-                              {r: 1, g: 0, b: 1});
+      assert.shallowDeepEqual(el.getObject3D('light').color, {r: 1, g: 0, b: 1});
     });
 
     test('does not recreate light for basic updates', function () {
       var el = this.el;
-      var uuid = el.object3D.children[0].uuid;
+      var uuid = el.getObject3D('light').uuid;
       el.setAttribute('light', 'color: #F0F');
-      assert.equal(el.object3D.children[0].uuid, uuid);
+      assert.equal(el.getObject3D('light').uuid, uuid);
     });
 
     test('can switch between types of light', function () {
       var el = this.el;
       el.setAttribute('light', 'type: ambient');
-      assert.equal(el.object3D.children[0].type, 'AmbientLight');
+      assert.equal(el.getObject3D('light').type, 'AmbientLight');
     });
 
     test('can update parameters on updated light', function () {
       var el = this.el;
       el.setAttribute('light', 'intensity: 5');
-      assert.equal(el.object3D.children[0].intensity, 5);
+      assert.equal(el.getObject3D('light').intensity, 5);
     });
 
     test('can update spotlight angle', function () {
       var el = this.el;
       el.setAttribute('light', 'type: spot');
       el.setAttribute('light', 'angle', 90);
-      assert.equal(el.object3D.children[0].angle, Math.PI / 2);
+      assert.equal(el.getObject3D('light').angle, Math.PI / 2);
       el.setAttribute('light', 'angle', 180);
-      assert.equal(el.object3D.children[0].angle, Math.PI);
+      assert.equal(el.getObject3D('light').angle, Math.PI);
     });
   });
 
@@ -55,32 +54,32 @@ suite('light', function () {
     test('can get ambient light', function () {
       var el = this.el;
       el.setAttribute('light', 'type: ambient');
-      assert.equal(el.object3D.children[0].type, 'AmbientLight');
+      assert.equal(el.getObject3D('light').type, 'AmbientLight');
     });
 
     test('can get directional light', function () {
       var el = this.el;
       el.setAttribute('light', 'type: directional');
-      assert.equal(el.object3D.children[0].type, 'DirectionalLight');
+      assert.equal(el.getObject3D('light').type, 'DirectionalLight');
     });
 
     test('can get hemisphere light', function () {
       var el = this.el;
       el.setAttribute('light', 'type: hemisphere');
-      assert.equal(el.object3D.children[0].type, 'HemisphereLight');
+      assert.equal(el.getObject3D('light').type, 'HemisphereLight');
     });
 
     test('can get point light', function () {
       var el = this.el;
       el.setAttribute('light', 'type: point');
-      assert.equal(el.object3D.children[0].type, 'PointLight');
+      assert.equal(el.getObject3D('light').type, 'PointLight');
     });
 
     test('can get spot light', function () {
       var el = this.el;
       var light;
       el.setAttribute('light', 'type: spot; angle: 180; penumbra: 0.5');
-      light = el.object3D.children[0];
+      light = el.getObject3D('light');
       assert.equal(light.type, 'SpotLight');
       assert.equal(light.angle, Math.PI);
       assert.equal(light.penumbra, 0.5);
@@ -89,7 +88,7 @@ suite('light', function () {
     test('handles invalid type', function () {
       var el = this.el;
       el.setAttribute('light', 'type: black');
-      assert.equal(el.object3D.children[0].type, 'DirectionalLight');
+      assert.equal(el.getObject3D('light').type, 'DirectionalLight');
     });
   });
 
@@ -121,14 +120,14 @@ suite('light', function () {
 
     test('temp bugfix issue #1624: spotlight object3d position is at spotlight element position', function () {
       var lightEl = this.el;
-      var lightObject = null;
+      var light;
 
       lightEl.setAttribute('light', 'type', 'spot');
-      lightObject = lightEl.getObject3D('light');
+      light = lightEl.getObject3D('light');
 
-      assert.equal(lightEl.object3D.position.x, lightObject.getWorldPosition().x);
-      assert.equal(lightEl.object3D.position.y, lightObject.getWorldPosition().y);
-      assert.equal(lightEl.object3D.position.z, lightObject.getWorldPosition().z);
+      assert.equal(lightEl.object3D.position.x, light.getWorldPosition().x);
+      assert.equal(lightEl.object3D.position.y, light.getWorldPosition().y);
+      assert.equal(lightEl.object3D.position.z, light.getWorldPosition().z);
     });
   });
 
@@ -140,10 +139,9 @@ suite('light', function () {
 
       sceneEl.appendChild(targetEl);
       targetEl.setAttribute('id', 'target');
-
       lightEl.setAttribute('light', 'type: spot; target: #target');
 
-      assert.strictEqual(lightEl.object3D.children[0].target, targetEl.object3D);
+      assert.strictEqual(lightEl.getObject3D('light').target, targetEl.object3D);
     });
 
     test('spotlight: change light target with selector', function () {
@@ -166,19 +164,23 @@ suite('light', function () {
 
     test('spotlight: when created, light target is child object positioned at 0 0 -1', function () {
       var lightEl = this.el;
+      var light, lightTarget;
 
       lightEl.setAttribute('light', 'type: spot');
+      light = lightEl.getObject3D('light');
+      lightTarget = lightEl.getObject3D('light-target');
 
-      assert.equal(lightEl.getObject3D('light').target, lightEl.getObject3D('light-target'));
-      assert.equal(lightEl.getObject3D('light').target.position.x, 0);
-      assert.equal(lightEl.getObject3D('light').target.position.y, 0);
-      assert.equal(lightEl.getObject3D('light').target.position.z, -1);
+      assert.equal(lightTarget.uuid, light.target.uuid);
+      assert.equal(lightTarget.position.x, 0);
+      assert.equal(lightTarget.position.y, 0);
+      assert.equal(lightTarget.position.z, -1);
     });
 
     test('spotlight: when target is changed to null, light target is child object positioned at 0 0 -1', function () {
       var sceneEl = this.el.sceneEl;
       var lightEl = this.el;
       var targetEl = document.createElement('a-entity');
+      var light, lightTarget;
 
       targetEl.setAttribute('id', 'target');
       sceneEl.appendChild(targetEl);
@@ -187,10 +189,13 @@ suite('light', function () {
       lightEl.setAttribute('light', 'target', '#target');
       lightEl.setAttribute('light', 'target', null);
 
-      assert.equal(lightEl.getObject3D('light').target, lightEl.getObject3D('light-target'));
-      assert.equal(lightEl.getObject3D('light').target.position.x, 0);
-      assert.equal(lightEl.getObject3D('light').target.position.y, 0);
-      assert.equal(lightEl.getObject3D('light').target.position.z, -1);
+      light = lightEl.getObject3D('light');
+      lightTarget = lightEl.getObject3D('light-target');
+
+      assert.equal(lightTarget.uuid, light.target.uuid);
+      assert.equal(lightTarget.position.x, 0);
+      assert.equal(lightTarget.position.y, 0);
+      assert.equal(lightTarget.position.z, -1);
     });
 
     test('directional: set light target with selector when light is created', function () {
@@ -203,7 +208,7 @@ suite('light', function () {
 
       lightEl.setAttribute('light', 'type: directional; target: #target');
 
-      assert.strictEqual(lightEl.object3D.children[0].target, targetEl.object3D);
+      assert.strictEqual(lightEl.getObject3D('light').target, targetEl.object3D);
     });
 
     test('directional: change light target with selector', function () {
@@ -221,26 +226,29 @@ suite('light', function () {
       lightEl.setAttribute('light', 'target: #target');
       lightEl.setAttribute('light', 'target: #othertarget');
 
-      assert.strictEqual(lightEl.object3D.children[0].target, othertargetEl.object3D);
+      assert.strictEqual(lightEl.getObject3D('light').target, othertargetEl.object3D);
     });
 
     test('directional: when created, light target is positioned at 0 0 0, but NOT a child', function () {
       var lightEl = this.el;
+      var light;
 
       lightEl.setAttribute('light', 'type: directional');
+      light = lightEl.getObject3D('light');
 
-      assert.typeOf(lightEl.object3D.children[0].target, 'object');
-      assert.equal(lightEl.object3D.children[0].children.length, 0);
+      assert.typeOf(light.target, 'object');
+      assert.equal(light.children.length, 0);
       assert.equal(lightEl.object3D.children.length, 1);
-      assert.equal(lightEl.object3D.children[0].target.position.x, 0);
-      assert.equal(lightEl.object3D.children[0].target.position.y, 0);
-      assert.equal(lightEl.object3D.children[0].target.position.z, 0);
+      assert.equal(light.target.position.x, 0);
+      assert.equal(light.target.position.y, 0);
+      assert.equal(light.target.position.z, 0);
     });
 
     test('directional: when target is changed to null, light target is positioned at 0 0 0, but NOT a child', function () {
       var sceneEl = this.el.sceneEl;
       var lightEl = this.el;
       var targetEl = document.createElement('a-entity');
+      var light;
 
       targetEl.setAttribute('id', 'target');
       sceneEl.appendChild(targetEl);
@@ -248,13 +256,14 @@ suite('light', function () {
       lightEl.setAttribute('light', 'type: directional');
       lightEl.setAttribute('light', 'target', '#target');
       lightEl.setAttribute('light', 'target', null);
+      light = lightEl.getObject3D('light');
 
-      assert.typeOf(lightEl.object3D.children[0].target, 'object');
-      assert.equal(lightEl.object3D.children[0].children.length, 0);
+      assert.typeOf(light.target, 'object');
+      assert.equal(light.children.length, 0);
       assert.equal(lightEl.object3D.children.length, 1);
-      assert.equal(lightEl.object3D.children[0].target.position.x, 0);
-      assert.equal(lightEl.object3D.children[0].target.position.y, 0);
-      assert.equal(lightEl.object3D.children[0].target.position.z, 0);
+      assert.equal(light.target.position.x, 0);
+      assert.equal(light.target.position.y, 0);
+      assert.equal(light.target.position.z, 0);
     });
   });
 });

--- a/tests/components/light.test.js
+++ b/tests/components/light.test.js
@@ -40,6 +40,15 @@ suite('light', function () {
       el.setAttribute('light', 'intensity: 5');
       assert.equal(el.object3D.children[0].intensity, 5);
     });
+
+    test('can update spotlight angle', function () {
+      var el = this.el;
+      el.setAttribute('light', 'type: spot');
+      el.setAttribute('light', 'angle', 90);
+      assert.equal(el.object3D.children[0].angle, Math.PI / 2);
+      el.setAttribute('light', 'angle', 180);
+      assert.equal(el.object3D.children[0].angle, Math.PI);
+    });
   });
 
   suite('getLight', function () {
@@ -108,6 +117,144 @@ suite('light', function () {
       el.components.light.setLight({type: 'spot'});
       assert.notEqual(oldLight, el.components.light.light);
       assert.equal(oldLight.parent, null);
+    });
+
+    test('temp bugfix issue #1624: spotlight object3d position is at spotlight element position', function () {
+      var lightEl = this.el;
+      var lightObject = null;
+
+      lightEl.setAttribute('light', 'type', 'spot');
+      lightObject = lightEl.getObject3D('light');
+
+      assert.equal(lightEl.object3D.position.x, lightObject.getWorldPosition().x);
+      assert.equal(lightEl.object3D.position.y, lightObject.getWorldPosition().y);
+      assert.equal(lightEl.object3D.position.z, lightObject.getWorldPosition().z);
+    });
+  });
+
+  suite('light target', function () {
+    test('spotlight: set light target with selector when light is created', function () {
+      var sceneEl = this.el.sceneEl;
+      var lightEl = this.el;
+      var targetEl = document.createElement('a-entity');
+
+      sceneEl.appendChild(targetEl);
+      targetEl.setAttribute('id', 'target');
+
+      lightEl.setAttribute('light', 'type: spot; target: #target');
+
+      assert.strictEqual(lightEl.object3D.children[0].target, targetEl.object3D);
+    });
+
+    test('spotlight: change light target with selector', function () {
+      var sceneEl = this.el.sceneEl;
+      var lightEl = this.el;
+      var targetEl = document.createElement('a-entity');
+      var othertargetEl = document.createElement('a-entity');
+
+      targetEl.setAttribute('id', 'target');
+      othertargetEl.setAttribute('id', 'othertarget');
+      sceneEl.appendChild(targetEl);
+      sceneEl.appendChild(othertargetEl);
+
+      lightEl.setAttribute('light', 'type: spot');
+      lightEl.setAttribute('light', 'target: #target');
+      lightEl.setAttribute('light', 'target: #othertarget');
+
+      assert.strictEqual(lightEl.getObject3D('light').target, othertargetEl.object3D);
+    });
+
+    test('spotlight: when created, light target is child object positioned at 0 0 -1', function () {
+      var lightEl = this.el;
+
+      lightEl.setAttribute('light', 'type: spot');
+
+      assert.equal(lightEl.getObject3D('light').target, lightEl.getObject3D('light-target'));
+      assert.equal(lightEl.getObject3D('light').target.position.x, 0);
+      assert.equal(lightEl.getObject3D('light').target.position.y, 0);
+      assert.equal(lightEl.getObject3D('light').target.position.z, -1);
+    });
+
+    test('spotlight: when target is changed to null, light target is child object positioned at 0 0 -1', function () {
+      var sceneEl = this.el.sceneEl;
+      var lightEl = this.el;
+      var targetEl = document.createElement('a-entity');
+
+      targetEl.setAttribute('id', 'target');
+      sceneEl.appendChild(targetEl);
+
+      lightEl.setAttribute('light', 'type: spot');
+      lightEl.setAttribute('light', 'target', '#target');
+      lightEl.setAttribute('light', 'target', null);
+
+      assert.equal(lightEl.getObject3D('light').target, lightEl.getObject3D('light-target'));
+      assert.equal(lightEl.getObject3D('light').target.position.x, 0);
+      assert.equal(lightEl.getObject3D('light').target.position.y, 0);
+      assert.equal(lightEl.getObject3D('light').target.position.z, -1);
+    });
+
+    test('directional: set light target with selector when light is created', function () {
+      var sceneEl = this.el.sceneEl;
+      var lightEl = this.el;
+      var targetEl = document.createElement('a-entity');
+
+      sceneEl.appendChild(targetEl);
+      targetEl.setAttribute('id', 'target');
+
+      lightEl.setAttribute('light', 'type: directional; target: #target');
+
+      assert.strictEqual(lightEl.object3D.children[0].target, targetEl.object3D);
+    });
+
+    test('directional: change light target with selector', function () {
+      var sceneEl = this.el.sceneEl;
+      var lightEl = this.el;
+      var targetEl = document.createElement('a-entity');
+      var othertargetEl = document.createElement('a-entity');
+
+      targetEl.setAttribute('id', 'target');
+      othertargetEl.setAttribute('id', 'othertarget');
+      sceneEl.appendChild(targetEl);
+      sceneEl.appendChild(othertargetEl);
+
+      lightEl.setAttribute('light', 'type: directional');
+      lightEl.setAttribute('light', 'target: #target');
+      lightEl.setAttribute('light', 'target: #othertarget');
+
+      assert.strictEqual(lightEl.object3D.children[0].target, othertargetEl.object3D);
+    });
+
+    test('directional: when created, light target is positioned at 0 0 0, but NOT a child', function () {
+      var lightEl = this.el;
+
+      lightEl.setAttribute('light', 'type: directional');
+
+      assert.typeOf(lightEl.object3D.children[0].target, 'object');
+      assert.equal(lightEl.object3D.children[0].children.length, 0);
+      assert.equal(lightEl.object3D.children.length, 1);
+      assert.equal(lightEl.object3D.children[0].target.position.x, 0);
+      assert.equal(lightEl.object3D.children[0].target.position.y, 0);
+      assert.equal(lightEl.object3D.children[0].target.position.z, 0);
+    });
+
+    test('directional: when target is changed to null, light target is positioned at 0 0 0, but NOT a child', function () {
+      var sceneEl = this.el.sceneEl;
+      var lightEl = this.el;
+      var targetEl = document.createElement('a-entity');
+
+      targetEl.setAttribute('id', 'target');
+      sceneEl.appendChild(targetEl);
+
+      lightEl.setAttribute('light', 'type: directional');
+      lightEl.setAttribute('light', 'target', '#target');
+      lightEl.setAttribute('light', 'target', null);
+
+      assert.typeOf(lightEl.object3D.children[0].target, 'object');
+      assert.equal(lightEl.object3D.children[0].children.length, 0);
+      assert.equal(lightEl.object3D.children.length, 1);
+      assert.equal(lightEl.object3D.children[0].target.position.x, 0);
+      assert.equal(lightEl.object3D.children[0].target.position.y, 0);
+      assert.equal(lightEl.object3D.children[0].target.position.z, 0);
     });
   });
 });


### PR DESCRIPTION
spot and directional light have a target, this lets the user set it with a selector.

when no target is set, the target is added to the light itself, with an offset of (0 0 -1), this intuitively let's you control the spotlight direction with it's rotation. (pointing -Z).
haven't done this with directional lights, so not to break anything, when someone sets directional by position offset, pointing to 0 0 0 by default, or to the new target.

a test is here : http://www.frederickdesimpel.be/test/webVR/Aframe/lighttarget/

might need further tests to see if anything strange happens when removing the component.

Also fixed a bug where spotlight angle was only set with degToRad when it is created, further updates were set in radians.