### PR TITLE
Fix #798: Add 'aframe-injected' attribute to elements injected by aframe

### DIFF
--- a/src/components/scene/vr-mode-ui.js
+++ b/src/components/scene/vr-mode-ui.js
@@ -1,4 +1,5 @@
 var registerComponent = require('../../core/component').registerComponent;
+var constants = require('../../constants/');
 var utils = require('../../utils/');
 
 var ENTER_VR_CLASS = 'a-enter-vr';
@@ -111,8 +112,10 @@ function createEnterVRButton (enterVRHandler) {
   // Create elements.
   wrapper = document.createElement('div');
   wrapper.classList.add(ENTER_VR_CLASS);
+  wrapper.setAttribute(constants.AFRAME_INJECTED, '');
   vrButton = document.createElement('button');
   vrButton.className = ENTER_VR_BTN_CLASS;
+  vrButton.setAttribute(constants.AFRAME_INJECTED, '');
 
   // Insert elements.
   wrapper.appendChild(vrButton);
@@ -128,8 +131,10 @@ function createOrientationModal (exitVRHandler) {
   var modal = document.createElement('div');
   modal.className = ORIENTATION_MODAL_CLASS;
   modal.classList.add(HIDDEN_CLASS);
+  modal.setAttribute(constants.AFRAME_INJECTED, '');
 
   var exit = document.createElement('button');
+  exit.setAttribute(constants.AFRAME_INJECTED, '');
   exit.innerHTML = 'Exit VR';
 
   // Exit VR on close.

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,4 @@
 module.exports = {
+  AFRAME_INJECTED: 'aframe-injected',
   animation: require('./animation')
 };

--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -1,5 +1,5 @@
 var ANode = require('./a-node');
-var constants = require('../constants/animation');
+var animationConstants = require('../constants/animation');
 var coordinates = require('../utils/').coordinates;
 var parseProperty = require('./schema').parseProperty;
 var registerElement = require('./a-register-element').registerElement;
@@ -8,11 +8,11 @@ var THREE = require('../lib/three');
 var utils = require('../utils/');
 
 var getComponentProperty = utils.entity.getComponentProperty;
-var DEFAULTS = constants.defaults;
-var DIRECTIONS = constants.directions;
-var EASING_FUNCTIONS = constants.easingFunctions;
-var FILLS = constants.fills;
-var REPEATS = constants.repeats;
+var DEFAULTS = animationConstants.defaults;
+var DIRECTIONS = animationConstants.directions;
+var EASING_FUNCTIONS = animationConstants.easingFunctions;
+var FILLS = animationConstants.fills;
+var REPEATS = animationConstants.repeats;
 var isCoordinate = coordinates.isCoordinate;
 
 /**

--- a/src/core/scene/metaTags.js
+++ b/src/core/scene/metaTags.js
@@ -1,3 +1,4 @@
+var constants = require('../../constants/');
 var extend = require('../../utils').extend;
 
 var MOBILE_HEAD_TAGS = module.exports.MOBILE_HEAD_TAGS = [
@@ -73,5 +74,6 @@ module.exports.inject = function injectHeadTags (scene) {
 function createTag (tagObj) {
   if (!tagObj || !tagObj.tagName) { return; }
   var meta = document.createElement(tagObj.tagName);
+  meta.setAttribute(constants.AFRAME_INJECTED, '');
   return extend(meta, tagObj.attributes);
 }

--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -1,4 +1,5 @@
 var registerSystem = require('../core/system').registerSystem;
+var constants = require('../constants/');
 
 var DEFAULT_CAMERA_ATTR = 'data-aframe-default-camera';
 var DEFAULT_USER_HEIGHT = 1.6;
@@ -39,6 +40,7 @@ module.exports.System = registerSystem('camera', {
       defaultCameraEl.setAttribute('camera', {active: true, userHeight: DEFAULT_USER_HEIGHT});
       defaultCameraEl.setAttribute('wasd-controls', '');
       defaultCameraEl.setAttribute('look-controls', '');
+      defaultCameraEl.setAttribute(constants.AFRAME_INJECTED, '');
       sceneEl.appendChild(defaultCameraEl);
       sceneEl.addEventListener('enter-vr', self.removeDefaultOffset);
       sceneEl.addEventListener('exit-vr', self.addDefaultOffset);

--- a/src/systems/light.js
+++ b/src/systems/light.js
@@ -1,4 +1,5 @@
 var registerSystem = require('../core/system').registerSystem;
+var constants = require('../constants/');
 
 var DEFAULT_LIGHT_ATTR = 'data-aframe-default-light';
 
@@ -47,11 +48,13 @@ module.exports.System = registerSystem('light', {
 
     ambientLight.setAttribute('light', {color: '#BBB', type: 'ambient'});
     ambientLight.setAttribute(DEFAULT_LIGHT_ATTR, '');
+    ambientLight.setAttribute(constants.AFRAME_INJECTED, '');
     sceneEl.appendChild(ambientLight);
 
     directionalLight.setAttribute('light', {color: '#FFF', intensity: 0.6});
     directionalLight.setAttribute('position', {x: -0.5, y: 1, z: 1});
     directionalLight.setAttribute(DEFAULT_LIGHT_ATTR, '');
+    directionalLight.setAttribute(constants.AFRAME_INJECTED, '');
     sceneEl.appendChild(directionalLight);
 
     this.defaultLightsEnabled = true;

--- a/tests/core/scene/meta-tags.test.js
+++ b/tests/core/scene/meta-tags.test.js
@@ -2,6 +2,7 @@
 var helpers = require('../../helpers');
 var initMetaTags = require('core/scene/metaTags').inject;
 var metaTags = require('core/scene/metaTags');
+var constants = require('constants/');
 
 suite('metaTags', function () {
   setup(function (done) {
@@ -49,12 +50,15 @@ suite('metaTags', function () {
     webAppCapableMetaTag = document.querySelector('meta[name="mobile-web-app-capable"]');
 
     assert.ok(appleMobileWebAppCapableMetaTag);
+    assert.ok(appleMobileWebAppCapableMetaTag.hasAttribute(constants.AFRAME_INJECTED));
     assert.equal(appleMobileWebAppCapableMetaTag.content, 'yes');
 
     assert.ok(viewportMetaTag);
+    assert.ok(viewportMetaTag.hasAttribute(constants.AFRAME_INJECTED));
     assert.equal(viewportMetaTag.content, metaTags.MOBILE_HEAD_TAGS[0].attributes.content);
 
     assert.ok(webAppCapableMetaTag);
+    assert.ok(webAppCapableMetaTag.hasAttribute(constants.AFRAME_INJECTED));
     assert.equal(webAppCapableMetaTag.content, 'yes');
   });
 });

--- a/tests/systems/light.test.js
+++ b/tests/systems/light.test.js
@@ -1,4 +1,5 @@
 /* global assert, process, setup, suite, test */
+var constants = require('constants/');
 var entityFactory = require('../helpers').entityFactory;
 
 suite('light system', function () {
@@ -24,10 +25,12 @@ suite('light system', function () {
 
     sceneEl.systems.light.setupDefaultLights();
     lights = sceneEl.querySelectorAll('a-entity');
+
     // Remove lights to re-test.
     for (i = 0; i < lights.length; ++i) {
       if (!lights[i].components.light) { continue; }
       lightsNum += 1;
+      assert.ok(lights[i].hasAttribute(constants.AFRAME_INJECTED));
     }
     assert.equal(lightsNum, 2);
   });


### PR DESCRIPTION
re: https://github.com/aframevr/aframe/issues/798

Added as an attribute to not muddle the CSS classes, while still able to select with QSA.  This also adds to only `a-` elements as well as the `<video>` created by `material.js`.  

Purposely did not add to meta tag, the original canvas, or the `vr-mode-ui` elements as they're simply for VR mode in/out.

Let me know what you think of this.