### PR TITLE
count all relevant entities for aframe stats

### DIFF
--- a/src/lib/rStatsAframe.js
+++ b/src/lib/rStatsAframe.js
@@ -15,29 +15,16 @@ window.aframeStats = function (scene) {
   } ];
 
   function _update () {
-    _rS('te').set(getEntitiesCount());
+    _rS('te').set(getEntityCount());
     _rS('lt').set(window.performance.getEntriesByName('render-started')[0].startTime.toFixed(0));
   }
 
-  function getEntitiesCount () {
-    var aframeElements = getAllTagMatches(_scene, /^a-/i);
-    var assetEl = _scene.querySelector('a-assets');
-    var count;
-
-    aframeElements.filter(function (el) {
-      return el.tagName !== 'a-animation';
+  function getEntityCount () {
+    var elements = _scene.querySelectorAll('*');
+    Array.prototype.slice.call(elements).filter(function (el) {
+      return el.isEntity;
     });
-    count = aframeElements.length;
-    if (assetEl) {
-      count -= getAllTagMatches(assetEl, /^a-/i).length + 1;
-    }
-    return count;
-  }
-
-  function getAllTagMatches (element, regEx) {
-    return Array.prototype.slice.call(element.querySelectorAll('*')).filter(function (el) {
-      return el.tagName.match(regEx);
-    });
+    return elements.length;
   }
 
   function _start () {}

--- a/src/lib/rStatsAframe.js
+++ b/src/lib/rStatsAframe.js
@@ -15,8 +15,29 @@ window.aframeStats = function (scene) {
   } ];
 
   function _update () {
-    _rS('te').set(_scene.querySelectorAll('a-entity').length);
+    _rS('te').set(getEntitiesCount());
     _rS('lt').set(window.performance.getEntriesByName('render-started')[0].startTime.toFixed(0));
+  }
+
+  function getEntitiesCount () {
+    var aframeElements = getAllTagMatches(_scene, /^a-/i);
+    var assetEl = _scene.querySelector('a-assets');
+    var count;
+
+    aframeElements.filter(function (el) {
+      return el.tagName !== 'a-animation';
+    });
+    count = aframeElements.length;
+    if (assetEl) {
+      count -= getAllTagMatches(assetEl, /^a-/i).length + 1;
+    }
+    return count;
+  }
+
+  function getAllTagMatches (element, regEx) {
+    return Array.prototype.slice.call(element.querySelectorAll('*')).filter(function (el) {
+      return el.tagName.match(regEx);
+    });
   }
 
   function _start () {}


### PR DESCRIPTION
**Description:**
Only literal a-entity elements were counted for aframe stats

**Changes proposed:**
counts all <a-*> elements excluding a-animations,  a-assets and it's children.

Not sure yet how and if this stat is updated when children are parsed / attached.
An alternative is to keep track of entities being created.
An addition could be to give stats on the different kinds of entities.

code review please if this is good programming / performance, ...