### PR TITLE
closestScene already checks current node so don't duplicate check

### DIFF
--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -23,7 +23,7 @@ module.exports = registerElement('a-node', {
     attachedCallback: {
       value: function () {
         var mixins = this.getAttribute('mixin');
-        this.sceneEl = this.isScene ? this : this.closestScene();
+        this.sceneEl = this.closestScene();
         this.emit('nodeready', {}, false);
         if (mixins) { this.updateMixins(mixins); }
       },


### PR DESCRIPTION
Tiny cleanup; `closestScene` starts with the current node so no need to repeat it with the ternary.