### PR TITLE
set BUFFER_SCALE: 1 for webvr-polyfill to fix res (fixes #1735)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ window.Promise = window.Promise || require('promise-polyfill');
 window.hasNativeWebVRImplementation = !!navigator.getVRDisplays || !!navigator.getVRDevices;
 
 window.WebVRConfig = window.WebVRConfig || {
+  BUFFER_SCALE: 1,
   CARDBOARD_UI_DISABLED: true,
   ROTATE_INSTRUCTIONS_DISABLED: true,
   TOUCH_PANNER_DISABLED: true,


### PR DESCRIPTION
**Description:**

Set `BUFFER_SCALE` to 1 to get full mobile resolution.


### Anime UI

#### 0.2.0

![](https://cloud.githubusercontent.com/assets/674727/17494244/b5823d32-5d68-11e6-8783-47898ccbcce1.PNG)

#### Master

![img_3570](https://cloud.githubusercontent.com/assets/674727/17533536/08116588-5e3a-11e6-9b09-c2baebfeee6c.PNG)

#### This PR

![img_3569](https://cloud.githubusercontent.com/assets/674727/17533533/080d9c50-5e3a-11e6-8dca-41fe03cae1f1.PNG)

### Composite

#### Master

![img_3571](https://cloud.githubusercontent.com/assets/674727/17533534/080fe046-5e3a-11e6-96a6-d730cf79a03d.PNG)

#### This PR

![img_3572](https://cloud.githubusercontent.com/assets/674727/17533535/08100210-5e3a-11e6-920b-727a92ad0d2d.PNG)

**Tested:**

- [x] iPhone 6 Safari
- [ ] iPhone 6 Firefox
- [ ] Nexus 6 Chrome