### PR TITLE
Removes assignment to CustomEvent.target

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -25,7 +25,6 @@ module.exports.fireEvent = function (el, name, data) {
   data.detail = data.detail || {};
   data.detail.target = data.detail.target || el;
   var evt = new CustomEvent(name, data);
-  evt.target = el;
   el.dispatchEvent(evt);
 };
 


### PR DESCRIPTION
**Description:**
`CustomEvent#target` is a read only property.
The removed line yielded an error when using strict mode.

**Changes proposed:**
- Remove assignment to `CustomEvent#target`