### PR TITLE
Revert "Fix #1732: Don't bubble 'componentchanged' event"

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -210,7 +210,7 @@ Component.prototype = {
       name: this.name,
       newData: this.getData(),
       oldData: oldData
-    }, false);
+    });
   },
 
   /**


### PR DESCRIPTION
The inspector relies on these events bubbling