### PR TITLE
allow torus knot to be floats again, doc torusknot p/q (fixes #1777)

### DIFF
--- a/docs/components/geometry.md
+++ b/docs/components/geometry.md
@@ -290,8 +290,8 @@ coprime the result will be a torus link:
 | radiusTubular   | Radius of the tubes of the torus knot.                                                                          | 0.2           |
 | segmentsRadial  | Number of segments along the circumference of the tube ends. A higher number means the tube will be more round. | 36            |
 | segmentsTubular | Number of segments along the circumference of the tube face. A higher number means the tube will be more round. | 32            |
-| p               | Number that helps define the pretzel shape.                                                                     | 2             |
-| q               | Number that helps define the pretzel shape.                                                                     | 3             |
+| p               | How many times the geometry winds around its axis of rotational symmetry.                                       | 2             |
+| q               | How many times the geometry winds around a circle in the interior of the torus.                                 | 3             |
 
 ## Register a Custom Geometry
 

--- a/src/geometries/torusKnot.js
+++ b/src/geometries/torusKnot.js
@@ -3,8 +3,8 @@ var THREE = require('../lib/three');
 
 registerGeometry('torusKnot', {
   schema: {
-    p: {default: 2, min: 1, type: 'int'},
-    q: {default: 3, min: 1, type: 'int'},
+    p: {default: 2, min: 1},
+    q: {default: 3, min: 1},
     radius: {default: 1, min: 0},
     radiusTubular: {default: 0.2, min: 0},
     segmentsRadial: {default: 36, min: 3, type: 'int'},


### PR DESCRIPTION
It's defined as ints in the three.js docs, but you can interpolate these values still as floats.