### PR TITLE
Closes #1772 - Fix grammar error in documentation

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -52,7 +52,7 @@ whether you know how to model).
 If you need additional support, [contact us][contact]! We are very interested
 in understanding learning curve difficulties.
 
-## Why does my asset (e.g., image, video, model) not loading?
+## Why does my asset (e.g., image, video, model) not load?
 
 [cors]: https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
 [uploader]: https://aframe.io/aframe/examples/_uploader/


### PR DESCRIPTION
There was a small English grammar error in the FAQ documentation.

Text was: Why does my asset (e.g., image, video, model) not _loading_?
Text is now: Why does my asset (e.g., image, video, model) not _load_?

Closes Issue #1772 