### PR TITLE
Fix #1762: Implement faster bind function

### DIFF
--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -1,6 +1,7 @@
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
 var utils = require('../utils/');
+var bind = utils.bind;
 
 var checkHeadsetConnected = utils.checkHeadsetConnected;
 
@@ -34,8 +35,8 @@ module.exports.Component = registerComponent('camera', {
     el.setObject3D('camera', camera);
 
     // Add listeners to save and restore camera pose if headset is present.
-    this.onEnterVR = this.onEnterVR.bind(this);
-    this.onExitVR = this.onExitVR.bind(this);
+    this.onEnterVR = bind(this.onEnterVR, this);
+    this.onExitVR = bind(this.onExitVR, this);
     sceneEl.addEventListener('enter-vr', this.onEnterVR);
     sceneEl.addEventListener('exit-vr', this.onExitVR);
   },

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -1,5 +1,6 @@
 var registerComponent = require('../core/component').registerComponent;
 var utils = require('../utils/');
+var bind = utils.bind;
 
 var EVENTS = {
   CLICK: 'click',
@@ -42,16 +43,16 @@ module.exports.Component = registerComponent('cursor', {
 
     // Wait for canvas to load.
     if (!canvas) {
-      cursorEl.sceneEl.addEventListener('render-target-loaded', this.init.bind(this));
+      cursorEl.sceneEl.addEventListener('render-target-loaded', bind(this.init, this));
       return;
     }
 
     // Attach event listeners.
-    canvas.addEventListener('mousedown', this.onMouseDown.bind(this));
-    canvas.addEventListener('mouseup', this.onMouseUp.bind(this));
-    cursorEl.addEventListener('raycaster-intersection', this.onIntersection.bind(this));
+    canvas.addEventListener('mousedown', bind(this.onMouseDown, this));
+    canvas.addEventListener('mouseup', bind(this.onMouseUp, this));
+    cursorEl.addEventListener('raycaster-intersection', bind(this.onIntersection, this));
     cursorEl.addEventListener('raycaster-intersection-cleared',
-                              this.onIntersectionCleared.bind(this));
+                              bind(this.onIntersectionCleared, this));
   },
 
   /**

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -1,3 +1,4 @@
+var bind = require('../utils/bind');
 var diff = require('../utils').diff;
 var debug = require('../utils/debug');
 var registerComponent = require('../core/component').registerComponent;
@@ -76,7 +77,7 @@ module.exports.Component = registerComponent('light', {
               if (value.hasLoaded) {
                 self.onSetTarget(value);
               } else {
-                value.addEventListener('loaded', self.onSetTarget.bind(self, value));
+                value.addEventListener('loaded', bind(self.onSetTarget, self, value));
               }
             }
             break;
@@ -147,7 +148,7 @@ module.exports.Component = registerComponent('light', {
           if (target.hasLoaded) {
             this.onSetTarget(target);
           } else {
-            target.addEventListener('loaded', this.onSetTarget.bind(this, target));
+            target.addEventListener('loaded', bind(this.onSetTarget, this, target));
           }
         }
         return light;
@@ -168,7 +169,7 @@ module.exports.Component = registerComponent('light', {
           if (target.hasLoaded) {
             this.onSetTarget(target);
           } else {
-            target.addEventListener('loaded', this.onSetTarget.bind(this, target));
+            target.addEventListener('loaded', bind(this.onSetTarget, this, target));
           }
         }
         return light;

--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -1,6 +1,7 @@
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
 var isMobile = require('../utils/').isMobile();
+var bind = require('../utils/bind');
 
 // To avoid recalculation at every mouse movement tick
 var PI_2 = Math.PI / 2;
@@ -63,12 +64,12 @@ module.exports.Component = registerComponent('look-controls', {
   },
 
   bindMethods: function () {
-    this.onMouseDown = this.onMouseDown.bind(this);
-    this.onMouseMove = this.onMouseMove.bind(this);
-    this.releaseMouse = this.releaseMouse.bind(this);
-    this.onTouchStart = this.onTouchStart.bind(this);
-    this.onTouchMove = this.onTouchMove.bind(this);
-    this.onTouchEnd = this.onTouchEnd.bind(this);
+    this.onMouseDown = bind(this.onMouseDown, this);
+    this.onMouseMove = bind(this.onMouseMove, this);
+    this.releaseMouse = bind(this.releaseMouse, this);
+    this.onTouchStart = bind(this.onTouchStart, this);
+    this.onTouchMove = bind(this.onTouchMove, this);
+    this.onTouchEnd = bind(this.onTouchEnd, this);
   },
 
   setupMouseControls: function () {
@@ -93,7 +94,7 @@ module.exports.Component = registerComponent('look-controls', {
 
     // listen for canvas to load.
     if (!canvasEl) {
-      sceneEl.addEventListener('render-target-loaded', this.addEventListeners.bind(this));
+      sceneEl.addEventListener('render-target-loaded', bind(this.addEventListeners, this));
       return;
     }
 

--- a/src/components/scene/canvas.js
+++ b/src/components/scene/canvas.js
@@ -1,3 +1,4 @@
+var bind = require('../../utils/bind');
 var register = require('../../core/component').registerComponent;
 
 module.exports.Component = register('canvas', {
@@ -48,7 +49,7 @@ module.exports.Component = register('canvas', {
       document.body.focus();
       // For unkown reasons a syncrhonous resize does
       // not work on desktop when entering/exiting fullscreen
-      setTimeout(sceneEl.resize.bind(sceneEl), 0);
+      setTimeout(bind(sceneEl.resize, sceneEl), 0);
     }
   }
 

--- a/src/components/scene/stats.js
+++ b/src/components/scene/stats.js
@@ -1,5 +1,6 @@
 var registerComponent = require('../../core/component').registerComponent;
 var RStats = require('../../../vendor/rStats');
+var bind = require('../../utils/bind');
 require('../../../vendor/rStats.extras');
 require('../../lib/rStatsAframe');
 
@@ -18,8 +19,8 @@ module.exports.Component = registerComponent('stats', {
     this.stats = createStats(scene);
     this.statsEl = document.querySelector('.rs-base');
 
-    this.hideBound = this.hide.bind(this);
-    this.showBound = this.show.bind(this);
+    this.hideBound = bind(this.hide, this);
+    this.showBound = bind(this.show, this);
 
     scene.addEventListener('enter-vr', this.hideBound);
     scene.addEventListener('exit-vr', this.showBound);

--- a/src/components/scene/vr-mode-ui.js
+++ b/src/components/scene/vr-mode-ui.js
@@ -1,6 +1,7 @@
 var registerComponent = require('../../core/component').registerComponent;
 var constants = require('../../constants/');
 var utils = require('../../utils/');
+var bind = utils.bind;
 
 var ENTER_VR_CLASS = 'a-enter-vr';
 var ENTER_VR_BTN_CLASS = 'a-enter-vr-button';
@@ -23,15 +24,15 @@ module.exports.Component = registerComponent('vr-mode-ui', {
 
     if (utils.getUrlParameter('ui') === 'false') { return; }
 
-    this.enterVR = sceneEl.enterVR.bind(sceneEl);
-    this.exitVR = sceneEl.exitVR.bind(sceneEl);
+    this.enterVR = bind(sceneEl.enterVR, sceneEl);
+    this.exitVR = bind(sceneEl.exitVR, sceneEl);
     this.insideLoader = false;
     this.enterVREl = null;
     this.orientationModalEl = null;
 
     // Hide/show VR UI when entering/exiting VR mode.
-    sceneEl.addEventListener('enter-vr', this.updateEnterVRInterface.bind(this));
-    sceneEl.addEventListener('exit-vr', this.updateEnterVRInterface.bind(this));
+    sceneEl.addEventListener('enter-vr', bind(this.updateEnterVRInterface, this));
+    sceneEl.addEventListener('exit-vr', bind(this.updateEnterVRInterface, this));
 
     window.addEventListener('message', function (event) {
       if (event.data.type === 'loaderReady') {
@@ -41,7 +42,7 @@ module.exports.Component = registerComponent('vr-mode-ui', {
     });
 
     // Modal that tells the user to change orientation if in portrait.
-    window.addEventListener('orientationchange', this.toggleOrientationModalIfNeeded.bind(this));
+    window.addEventListener('orientationchange', bind(this.toggleOrientationModalIfNeeded, this));
   },
 
   update: function () {

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -1,5 +1,6 @@
-var debug = require('../utils/debug');
 var registerComponent = require('../core/component').registerComponent;
+var debug = require('../utils/debug');
+var bind = require('../utils/bind');
 var THREE = require('../lib/three');
 
 var warn = debug('components:sound:warn');
@@ -22,7 +23,7 @@ module.exports.Component = registerComponent('sound', {
     this.listener = null;
     this.audioLoader = new THREE.AudioLoader();
     this.sound = null;
-    this.playSound = this.playSound.bind(this);
+    this.playSound = bind(this.playSound, this);
   },
 
   update: function (oldData) {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -1,4 +1,5 @@
 var registerComponent = require('../core/component').registerComponent;
+var bind = require('../utils/bind');
 
 var VIVE_CONTROLLER_MODEL_OBJ_URL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.obj';
 var VIVE_CONTROLLER_MODEL_OBJ_MTL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.mtl';
@@ -38,10 +39,10 @@ module.exports.Component = registerComponent('vive-controls', {
   init: function () {
     var self = this;
     this.animationActive = 'pointing';
-    this.onButtonChanged = this.onButtonChanged.bind(this);
+    this.onButtonChanged = bind(this.onButtonChanged, this);
     this.onButtonDown = function (evt) { self.onButtonEvent(evt.detail.id, 'down'); };
     this.onButtonUp = function (evt) { self.onButtonEvent(evt.detail.id, 'up'); };
-    this.onModelLoaded = this.onModelLoaded.bind(this);
+    this.onModelLoaded = bind(this.onModelLoaded, this);
   },
 
   play: function () {

--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -1,4 +1,5 @@
 var registerComponent = require('../core/component').registerComponent;
+var bind = require('../utils/bind');
 var shouldCaptureKeyEvent = require('../utils/').shouldCaptureKeyEvent;
 var THREE = require('../lib/three');
 
@@ -25,11 +26,11 @@ module.exports.Component = registerComponent('wasd-controls', {
     this.velocity = new THREE.Vector3();
     // To keep track of the pressed keys
     this.keys = {};
-    this.onBlur = this.onBlur.bind(this);
-    this.onFocus = this.onFocus.bind(this);
-    this.onVisibilityChange = this.onVisibilityChange.bind(this);
-    this.onKeyDown = this.onKeyDown.bind(this);
-    this.onKeyUp = this.onKeyUp.bind(this);
+    this.onBlur = bind(this.onBlur, this);
+    this.onFocus = bind(this.onFocus, this);
+    this.onVisibilityChange = bind(this.onVisibilityChange, this);
+    this.onKeyDown = bind(this.onKeyDown, this);
+    this.onKeyUp = bind(this.onKeyUp, this);
     this.attachVisibilityEventListeners();
   },
 

--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -6,6 +6,7 @@ var registerElement = require('./a-register-element').registerElement;
 var TWEEN = require('tween.js');
 var THREE = require('../lib/three');
 var utils = require('../utils/');
+var bind = utils.bind;
 
 var getComponentProperty = utils.entity.getComponentProperty;
 var DEFAULTS = animationConstants.defaults;
@@ -134,7 +135,7 @@ module.exports.AAnimation = registerElement('a-animation', {
           .onUpdate(function () {
             self.partialSetAttribute(this);
           })
-          .onComplete(self.onCompleted.bind(self));
+          .onComplete(bind(self.onCompleted, self));
       }
     },
 
@@ -257,10 +258,10 @@ module.exports.AAnimation = registerElement('a-animation', {
      */
     bindMethods: {
       value: function () {
-        this.start = this.start.bind(this);
-        this.stop = this.stop.bind(this);
-        this.onStateAdded = this.onStateAdded.bind(this);
-        this.onStateRemoved = this.onStateRemoved.bind(this);
+        this.start = bind(this.start, this);
+        this.stop = bind(this.stop, this);
+        this.onStateAdded = bind(this.onStateAdded, this);
+        this.onStateRemoved = bind(this.onStateRemoved, this);
       }
     },
 

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -1,4 +1,5 @@
 var ANode = require('./a-node');
+var bind = require('../utils/bind');
 var debug = require('../utils/debug');
 var registerElement = require('./a-register-element').registerElement;
 var THREE = require('../lib/three');
@@ -50,7 +51,7 @@ module.exports = registerElement('a-assets', {
         }
 
         // Trigger loaded for scene to start rendering.
-        Promise.all(loaded).then(this.load.bind(this));
+        Promise.all(loaded).then(bind(this.load, this));
 
         // Timeout to start loading anyways.
         timeout = parseInt(this.getAttribute('timeout'), 10) || 3000;

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -4,6 +4,7 @@ var components = require('./component').components;
 var registerElement = require('./a-register-element').registerElement;
 var THREE = require('../lib/three');
 var utils = require('../utils/');
+var bind = utils.bind;
 
 var AEntity;
 var debug = utils.debug('core:a-entity:debug');
@@ -100,7 +101,7 @@ var proto = Object.create(ANode.prototype, {
     value: function () {
       if (!this.parentEl || this.isScene) { return; }
       // Remove components.
-      Object.keys(this.components).forEach(this.removeComponent.bind(this));
+      Object.keys(this.components).forEach(bind(this.removeComponent, this));
       this.parentEl.remove(this);
     }
   },
@@ -654,7 +655,7 @@ var proto = Object.create(ANode.prototype, {
     value: function (state) {
       if (this.is(state)) { return; }
       this.states.push(state);
-      this.mapStateMixins(state, this.registerMixin.bind(this));
+      this.mapStateMixins(state, bind(this.registerMixin, this));
       this.emit('stateadded', {state: state});
     }
   },
@@ -664,7 +665,7 @@ var proto = Object.create(ANode.prototype, {
       var stateIndex = this.states.indexOf(state);
       if (stateIndex === -1) { return; }
       this.states.splice(stateIndex, 1);
-      this.mapStateMixins(state, this.unregisterMixin.bind(this));
+      this.mapStateMixins(state, bind(this.unregisterMixin, this));
       this.emit('stateremoved', {state: state});
     }
   },

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -1,6 +1,7 @@
 /* global HTMLElement, MutationObserver */
 var registerElement = require('./a-register-element').registerElement;
 var utils = require('../utils/');
+var bind = utils.bind;
 
 /**
  * Base class for A-Frame that manages loading of objects.
@@ -120,8 +121,8 @@ module.exports = registerElement('a-node', {
         // To determine what listeners will be removed
         var diff = oldMixinsIds.filter(function (i) { return newMixinsIds.indexOf(i) < 0; });
         this.mixinEls = [];
-        diff.forEach(this.unregisterMixin.bind(this));
-        newMixinsIds.forEach(this.registerMixin.bind(this));
+        diff.forEach(bind(this.unregisterMixin, this));
+        newMixinsIds.forEach(bind(this.registerMixin, this));
       }
     },
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -11,6 +11,7 @@ var AEntity = require('../a-entity');
 var ANode = require('../a-node');
 var initPostMessageAPI = require('./postMessage');
 
+var bind = utils.bind;
 var checkHeadsetConnected = utils.checkHeadsetConnected;
 var registerElement = re.registerElement;
 var isIOS = utils.isIOS();
@@ -49,7 +50,7 @@ module.exports = registerElement('a-scene', {
         this.isMobile = isMobile;
         this.isScene = true;
         this.object3D = new THREE.Scene();
-        this.render = this.render.bind(this);
+        this.render = bind(this.render, this);
         this.systems = {};
         this.time = 0;
 
@@ -93,7 +94,7 @@ module.exports = registerElement('a-scene', {
 
     attachedCallback: {
       value: function () {
-        var resize = this.resize.bind(this);
+        var resize = bind(this.resize, this);
         initMetaTags(this);
         initWakelock(this);
         this.initSystems();
@@ -107,7 +108,7 @@ module.exports = registerElement('a-scene', {
 
     initSystems: {
       value: function () {
-        Object.keys(systems).forEach(this.initSystem.bind(this));
+        Object.keys(systems).forEach(bind(this.initSystem, this));
       }
     },
 

--- a/src/core/scene/postMessage.js
+++ b/src/core/scene/postMessage.js
@@ -1,3 +1,4 @@
+var bind = require('../../utils/bind');
 var isIframed = require('../../utils/').isIframed;
 
 /**
@@ -8,7 +9,7 @@ module.exports = function initPostMessageAPI (scene) {
   // Handles fullscreen behavior when inside an iframe.
   if (!isIframed()) { return; }
   // postMessage API handler
-  window.addEventListener('message', postMessageAPIHandler.bind(scene));
+  window.addEventListener('message', bind(postMessageAPIHandler, scene));
 };
 
 function postMessageAPIHandler (event) {

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -3,6 +3,7 @@ var components = require('../../core/component').components;
 var registerElement = require('../../core/a-register-element').registerElement;
 var utils = require('../../utils/');
 
+var bind = utils.bind;
 var debug = utils.debug;
 var setComponentProperty = utils.entity.setComponentProperty;
 var log = debug('extras:primitives:debug');
@@ -128,7 +129,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
       getTransformedValue: {
         value: function (attr, value) {
           if (!this.transforms || !this.transforms[attr]) { return value; }
-          return this.transforms[attr].bind(this)(value);
+          return bind(this.transforms[attr], this)(value);
         }
       }
     })

--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -1,3 +1,4 @@
+var bind = require('../utils/bind');
 var constants = require('../constants/');
 var registerSystem = require('../core/system').registerSystem;
 
@@ -15,7 +16,7 @@ module.exports.System = registerSystem('camera', {
     // Wait for all entities to fully load before checking for existence of camera.
     // Since entities wait for <a-assets> to load, any cameras attaching to the scene
     // will do so asynchronously.
-    this.sceneEl.addEventListener('loaded', this.setupDefaultCamera.bind(this));
+    this.sceneEl.addEventListener('loaded', bind(this.setupDefaultCamera, this));
   },
 
   /**

--- a/src/systems/light.js
+++ b/src/systems/light.js
@@ -1,4 +1,5 @@
 var registerSystem = require('../core/system').registerSystem;
+var bind = require('../utils/bind');
 var constants = require('../constants/');
 
 var DEFAULT_LIGHT_ATTR = 'data-aframe-default-light';
@@ -19,7 +20,7 @@ module.exports.System = registerSystem('light', {
     // Wait for all entities to fully load before checking for existence of lights.
     // Since entities wait for <a-assets> to load, any lights attaching to the scene
     // will do so asynchronously.
-    this.sceneEl.addEventListener('loaded', this.setupDefaultLights.bind(this));
+    this.sceneEl.addEventListener('loaded', bind(this.setupDefaultLights, this));
   },
 
   /**

--- a/src/utils/bind.js
+++ b/src/utils/bind.js
@@ -1,0 +1,15 @@
+/**
+ * Faster version of Function.prototype.bind
+ * @param {Function} fn - Function to wrap.
+ * @param {Object} ctx - What to bind as context.
+ * @param {...*} arguments - Arguments to pass through.
+ */
+module.exports = function bind (fn, ctx/* , arg1, arg2 */) {
+  return (function (prependedArgs) {
+    return function bound () {
+      // Concat the bound function arguments with those passed to original bind
+      var args = prependedArgs.concat(Array.prototype.slice.call(arguments, 0));
+      return fn.apply(ctx, args);
+    };
+  })(Array.prototype.slice.call(arguments, 2));
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,6 +4,7 @@
 var deepAssign = require('deep-assign');
 var objectAssign = require('object-assign');
 
+module.exports.bind = require('./bind');
 module.exports.coordinates = require('./coordinates');
 module.exports.checkHeadsetConnected = require('./checkHeadsetConnected');
 module.exports.debug = require('./debug');

--- a/tests/utils/bind.test.js
+++ b/tests/utils/bind.test.js
@@ -1,0 +1,47 @@
+/* global assert, suite, test */
+var bind = require('utils/bind');
+
+suite('utils.bind', function () {
+  test('utils.bind binds to object', function () {
+    var obj = {
+      propName: 'aframe',
+      getProp: function (arg) {
+        return this.propName;
+      }
+    };
+    assert.equal(obj.getProp(), bind(obj.getProp, obj)());
+  });
+
+  test('utils.bind binds properly when called by other object', function () {
+    var obj = {
+      propName: 'aframe',
+      getProp: function (arg) {
+        return this.propName;
+      },
+      getPropByCallback: function (cb) {
+        return cb();
+      }
+    };
+    var obj2 = {
+      propName: 'webvr'
+    };
+    var bound = bind(obj.getProp, obj2);
+    assert.equal(obj2.propName, bound());
+    assert.equal(obj2.propName, obj.getPropByCallback(bound));
+  });
+
+  test('utils.bind accepts and handles additional arguments properly', function () {
+    var firstArg = 'awesome';
+    var secondArg = {};
+    var obj = {
+      propName: 'aframe',
+      getPropertyByCallback: function (arg1, arg2, arg3) {
+        assert.equal(arg1, firstArg);
+        assert.equal(arg2, secondArg);
+        assert.equal(arg3, obj.propName);
+      }
+    };
+    var bound = bind(obj.getPropertyByCallback, obj, firstArg, secondArg);
+    bound(obj.propName);
+  });
+});


### PR DESCRIPTION
One idea I had and have seen before is, instead of `this.blah, this` all the time, doing `'blah', this` and assuming that `this` holds the function if the first argument is a string. i.e:

```
module.exports.bind = function (fn, ctx) {
  if(typeof fn === 'string') fn = ctx[fn];
  return function bound () {
    return fn.apply(ctx, arguments);
  };
};

bind('onKeyUp', this);
```