### PR TITLE
Lowers the default of segmentRadials to improve performance. The anim…

### DIFF
--- a/src/geometries/torusKnot.js
+++ b/src/geometries/torusKnot.js
@@ -7,7 +7,7 @@ registerGeometry('torusKnot', {
     q: {default: 3, min: 1, type: 'int'},
     radius: {default: 1, min: 0},
     radiusTubular: {default: 0.2, min: 0},
-    segmentsRadial: {default: 36, min: 3, type: 'int'},
+    segmentsRadial: {default: 8, min: 3, type: 'int'},
     segmentsTubular: {default: 100, min: 3, type: 'int'}
   },
 


### PR DESCRIPTION
**Description:**

The commit https://github.com/aframevr/aframe/commit/5728bf51b40b3a2eb3c86aa61e245bfc72dfae87 fixed a typo that effectively made the `segmenstRadial` default === 36 instead of 8 which is the `THREE` default for the `torusKnot` geometry. A value of 36 affects the performance of the `geometry-gallery` and `animation` examples. `animation` is 5x slower with a value of 36 vs 8. This PR sets the default to the `THREE` value of 8. 