### PR TITLE
Changed geometry-gallery thetaLength from 350 to 360

### DIFF
--- a/examples/test/geometry-gallery/index.html
+++ b/examples/test/geometry-gallery/index.html
@@ -15,12 +15,12 @@
                            width: .125"></a-mixin>
         <a-mixin id="circle"
                  geometry="primitive: circle; radius: .2;
-                           segments: 100; thetaStart: 0; thetaLength: 350">
+                           segments: 100; thetaStart: 0; thetaLength: 360">
         </a-mixin>
         <a-mixin id="cylinder"
                  geometry="primitive: cylinder; radius: 0.2; height: .5;
                            segmentsRadial: 50; segmentsHeight: 50:
-                           openEnded: true; thetaStart: 0; thetaLength: 350">
+                           openEnded: true; thetaStart: 0; thetaLength: 360">
         </a-mixin>
         <a-mixin id="ring"
                   geometry="primitive: ring; radiusInner: .3; radiusOuter: .5;


### PR DESCRIPTION
**Description:**
The current `geometry-gallery` example uses `thetaLength: 350` for circle and cylinder makes them looks like broken:
<img width="444" alt="screenshot 2016-08-12 21 19 17" src="https://cloud.githubusercontent.com/assets/782511/17634402/bd88b37c-60d2-11e6-9ef3-860885e9efac.png">

I've just changed them to `360`:
<img width="409" alt="screenshot 2016-08-12 21 19 36" src="https://cloud.githubusercontent.com/assets/782511/17634440/e5be79d0-60d2-11e6-995e-645f6df9d26c.png">


