### PR TITLE
Address the parentNode === null error in Firefox 

### DIFF
--- a/tests/systems/light.test.js
+++ b/tests/systems/light.test.js
@@ -1,32 +1,32 @@
 /* global assert, process, setup, suite, test */
 var constants = require('constants/');
 var entityFactory = require('../helpers').entityFactory;
+var DEFAULT_LIGHT_ATTR = 'data-aframe-default-light';
 
 suite('light system', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
     el.addEventListener('loaded', function () {
+      var i;
+      var lights = el.sceneEl.querySelectorAll('[light]');
+      // Remove lights to re-test.
+      for (i = 0; i < lights.length; ++i) {
+        el.sceneEl.removeChild(lights[i]);
+      }
       done();
     });
   });
 
   test('adds default lights to scene', function () {
-    var el = this.el;
-    var sceneEl = el.sceneEl;
+    var sceneEl = this.el.sceneEl;
     var i;
-    var lights = sceneEl.querySelectorAll('[light]');
+    var lights;
     var lightsNum = 0;
 
-    // Remove lights to re-test.
-    for (i = 0; i < lights.length; ++i) {
-      sceneEl.removeChild(lights[i]);
-    }
     assert.notOk(document.querySelectorAll('[light]').length);
-
     sceneEl.systems.light.setupDefaultLights();
-    lights = sceneEl.querySelectorAll('a-entity');
+    lights = sceneEl.querySelectorAll('[light]');
 
-    // Remove lights to re-test.
     for (i = 0; i < lights.length; ++i) {
       if (!lights[i].components.light) { continue; }
       lightsNum += 1;
@@ -35,16 +35,34 @@ suite('light system', function () {
     assert.equal(lightsNum, 2);
   });
 
+  test('it does not add default lights to scene if there are used define lights', function (done) {
+    var el = this.el;
+    var lightEl = document.createElement('a-entity');
+    lightEl.setAttribute('light', '');
+
+    assert.notOk(document.querySelectorAll('[light]').length);
+
+    lightEl.addEventListener('loaded', function () {
+      el.sceneEl.systems.light.setupDefaultLights();
+      assert.notOk(document.querySelectorAll('[' + DEFAULT_LIGHT_ATTR + ']').length);
+      done();
+    });
+    el.appendChild(lightEl);
+  });
+
   test('removes default lights when more lights are added', function (done) {
     var el = this.el;
     var lightEl = document.createElement('a-entity');
     lightEl.setAttribute('light', '');
-    el.appendChild(lightEl);
-    process.nextTick(function () {
-      setTimeout(function () {
-        assert.notOk(document.querySelectorAll('[data-aframe-default-light]').length);
-        done();
-      });
+
+    assert.notOk(document.querySelectorAll('[light]').length);
+    el.sceneEl.systems.light.setupDefaultLights();
+    assert.ok(document.querySelectorAll('[' + DEFAULT_LIGHT_ATTR + ']').length);
+
+    lightEl.addEventListener('loaded', function () {
+      assert.notOk(document.querySelectorAll('[' + DEFAULT_LIGHT_ATTR + ']').length);
+      done();
     });
+    el.appendChild(lightEl);
   });
 });


### PR DESCRIPTION
It is due to the use of `MutationObserver` in the `registerElement` polyfill. Default lights are first added to the scene and immediately removed by the light system when the scene lights initialize.  By the time the `attachedCallback` method is called for the default lights `parentNode === null` due to have been removed. The solution is postponing the default light creation until the scene has loaded and prevent the spurious default lights. This also makes the light and camera systems consistent.