### PR TITLE
don't capture event canvas/window mousedown/up in look controls (fixes #1729)

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -98,9 +98,9 @@ module.exports.Component = registerComponent('look-controls', {
     }
 
     // Mouse Events
-    canvasEl.addEventListener('mousedown', this.onMouseDown, false);
-    window.addEventListener('mousemove', this.onMouseMove, false);
-    window.addEventListener('mouseup', this.releaseMouse, false);
+    canvasEl.addEventListener('mousedown', this.onMouseDown);
+    window.addEventListener('mousemove', this.onMouseMove);
+    window.addEventListener('mouseup', this.releaseMouse);
 
     // Touch events
     canvasEl.addEventListener('touchstart', this.onTouchStart);


### PR DESCRIPTION
I believe CodePen was listening to mousedown/click events in order to blur the text editor.

The third arg was a bool `useCapture` that catches the event, and trickles it down.

Though we'd like it to bubble up (default behavior of addEventListener).

Tested on Codepen and a few A-Frame examples.