### PR TITLE
remove event.preventDefault in look-controls canvas mousedown (fixes #1729)

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -247,7 +247,6 @@ module.exports.Component = registerComponent('look-controls', {
     this.mouseDown = true;
     this.previousMouseEvent = event;
     document.body.classList.add('a-grabbing');
-    event.preventDefault();
   },
 
   releaseMouse: function () {


### PR DESCRIPTION
**Description:**

https://codepen.io/ngokevin/pen/AXNZwV

Allow CodePen to listen to click of the scene to blur their text editor.

