### PR TITLE
reduce buffer scale to 0.5 for iOS safari < 10 (fixes #1714)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,12 @@ window.WebVRConfig = window.WebVRConfig || {
   MOUSE_KEYBOARD_CONTROLS_DISABLED: true
 };
 
+// Workaround for iOS Safari canvas sizing issues in stereo (webvr-polyfill/issues/102).
+// Should be fixed in iOS 10.
+if (/(iphone|ipod|ipad).*os.*(7|8|9)/i.test(navigator.userAgent)) {
+  window.WebVRConfig.BUFFER_SCALE = 1 / window.devicePixelRatio;
+}
+
 // WebVR polyfill
 require('webvr-polyfill');
 


### PR DESCRIPTION
**Description:**

Workaround for [Webkit bug on iOS Safari < 10](https://bugs.webkit.org/show_bug.cgi?id=152556).

### Before

Upon Entering VR from landscape without orientation change:

![img_3576](https://cloud.githubusercontent.com/assets/674727/17687932/92352120-632e-11e6-8168-ae6259ed4bb6.PNG)

### After

Stereo now sized correctly, at the cost of decreased resolution. With the version check, this should automatically be addressed once people upgrade to iOS 10 as the Webkit patch rolls out.

![img_3575](https://cloud.githubusercontent.com/assets/674727/17687931/92350a14-632e-11e6-9d0e-278b66cab73f.PNG)


