### PR TITLE
Use Firefox latest instead of FirefoxNightly for CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-
+addons:
+  firefox: 'latest'
 node_js:
   - '0.12'
 

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "release:push": "npm login && npm publish && git push --follow-tags",
     "start": "npm run dev",
     "test": "karma start ./tests/karma.conf.js",
-    "test:firefox": "karma start ./tests/karma.conf.js --browsers firefox_latest",
+    "test:firefox": "karma start ./tests/karma.conf.js --browsers Firefox",
     "test:chrome": "karma start ./tests/karma.conf.js --browsers Chrome",
-    "test:ci": "TEST_ENV=ci karma start ./tests/karma.conf.js --single-run --browsers firefox_latest",
+    "test:ci": "TEST_ENV=ci karma start ./tests/karma.conf.js --single-run --browsers Firefox",
     "version": "npm run dist"
   },
   "repository": "aframevr/aframe",

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -5,13 +5,7 @@ var karma_conf = {
     debug: true,
     paths: ['src']
   },
-  browsers: ['firefox_latest', 'Chrome'],
-  customLaunchers: {
-    firefox_latest: {
-      base: 'FirefoxNightly',
-      prefs: { /* empty */ }
-    }
-  },
+  browsers: ['Firefox', 'Chrome'],
   client: {
     captureConsole: true,
     mocha: {'ui': 'tdd'}


### PR DESCRIPTION
Firefox nightly in travis does not run tests so let's replace it with `Firefox Latest` 

Firefox latest: Firefox 48.0.0 all checks have passed
https://travis-ci.org/mkungla/aframe/jobs/152856107

Travis default Firefox 31.0.0
https://travis-ci.org/mkungla/aframe/jobs/152852975 some tests fail