### PR TITLE
add codecov config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,20 @@
+coverage:
+  precision: 2
+  round: down
+  range: 70...100
+
+  status:
+    # Learn more at https://codecov.io/docs#yaml_default_commit_status
+    project:
+      default:
+        target: 70
+        threshold: null
+        branches: null
+    patch:
+      default:
+        target: 1
+        threshold: null
+        branches: null
+    changes: false
+
+comment: off


### PR DESCRIPTION
- Disable comments in favor of using the Travis CI statuses. To reduce noise.
- Remove failure threshold if a PR decreases overall coverage.