### PR TITLE
remove dist step from travis, keep build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - CI_ACTION="npm run test:ci"
     - CI_ACTION="npm run lint"
     - CI_ACTION="npm run build"
-    - CI_ACTION="npm run dist"
 
 branches:
   only:


### PR DESCRIPTION
**Description:**

Testing `npm run dist` was redundant to `npm run build`.

