### PR TITLE
travis cache node_modules/ for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,7 @@ branches:
 
 after_success:
     - npm run codecov
+
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
- Speeds up builds
- Prevents the frequent case of npm install crapping out during builds