### PR TITLE
Update a-camera.md

### DIFF
--- a/docs/primitives/a-camera.md
+++ b/docs/primitives/a-camera.md
@@ -48,7 +48,7 @@ override the set position:
 
 When we use the camera primitive, A-Frame will not prescribe a default camera.
 
-Note the default camera is positioned at `0 1.8 4` whereas the camera primitive
+Note the default camera is positioned at `0 1.6 0` whereas the camera primitive
 will be positioned at `0 0 0`. In the example below, we would see a box:
 
 ```html


### PR DESCRIPTION
**Description:**

**Changes proposed:**
-
-
-

CHANGELOG.md says "Default camera is now positioned at 0, 1.6, 0 rather than 0, 1.8, -4. In VR mode, the 1.6m height offset as defined by camera.userHeight is removed. (#1474, #1718)"

but in v0.3 doc, still v0.2 value of Default camera position (0, 1.8, -4).

My English is so poor~Sorry