### PR TITLE
Add browserify env to .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -68,7 +68,7 @@
 
     // Environments
     "browser"       : true,     // Web Browser (window, document, etc)
-    "browserify"    : false,    // Browserify (node.js code in the browser)
+    "browserify"    : true,     // Browserify (node.js code in the browser)
     "couch"         : false,    // CouchDB
     "devel"         : true,     // Development/debugging (alert, confirm, etc)
     "dojo"          : false,    // Dojo Toolkit


### PR DESCRIPTION
Nit that's been bugging me, in both Sublime and Atom I have JSHint plugins configured that automatically apply the nearest .jshintrc. In A-Frame's case there's nothing to indicate that `require()` and `module.exports` are allowed, so they're flagged:

![screen shot 2016-08-19 at 11 34 19 pm](https://cloud.githubusercontent.com/assets/1848368/17828631/a4c837e8-6665-11e6-9345-3df55229248c.png)
