### PR TITLE
Support for non-QWERTY keyboard layouts (ZQSD, AWSD, Dvorak, ...)

### DIFF
--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -1,5 +1,6 @@
 var registerComponent = require('../core/component').registerComponent;
 var shouldCaptureKeyEvent = require('../utils/').shouldCaptureKeyEvent;
+var KEYCODE_TO_CODE = require('../constants').keyboardevent.KEYCODE_TO_CODE;
 var THREE = require('../lib/three');
 
 var MAX_DELTA = 0.2;
@@ -64,12 +65,12 @@ module.exports.Component = registerComponent('wasd-controls', {
 
     if (data.enabled) {
       if (data.adEnabled) {
-        if (keys[65]) { velocity[adAxis] -= adSign * acceleration * delta; } // Left
-        if (keys[68]) { velocity[adAxis] += adSign * acceleration * delta; } // Right
+        if (keys.KeyA || keys.ArrowLeft) { velocity[adAxis] -= adSign * acceleration * delta; }
+        if (keys.KeyD || keys.ArrowRight) { velocity[adAxis] += adSign * acceleration * delta; }
       }
       if (data.wsEnabled) {
-        if (keys[87]) { velocity[wsAxis] -= wsSign * acceleration * delta; } // Up
-        if (keys[83]) { velocity[wsAxis] += wsSign * acceleration * delta; } // Down
+        if (keys.KeyW || keys.ArrowUp) { velocity[wsAxis] -= wsSign * acceleration * delta; }
+        if (keys.KeyS || keys.ArrowDown) { velocity[wsAxis] += wsSign * acceleration * delta; }
       }
     }
 
@@ -143,12 +144,14 @@ module.exports.Component = registerComponent('wasd-controls', {
 
   onKeyDown: function (event) {
     if (!shouldCaptureKeyEvent(event)) { return; }
-    this.keys[event.keyCode] = true;
+    var code = event.code || KEYCODE_TO_CODE[event.keyCode];
+    this.keys[code] = true;
   },
 
   onKeyUp: function (event) {
     if (!shouldCaptureKeyEvent(event)) { return; }
-    this.keys[event.keyCode] = false;
+    var code = event.code || KEYCODE_TO_CODE[event.keyCode];
+    this.keys[code] = false;
   },
 
   getMovementVector: (function (delta) {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   AFRAME_INJECTED: 'aframe-injected',
-  animation: require('./animation')
+  animation: require('./animation'),
+  keyboardevent: require('./keyboardevent')
 };

--- a/src/constants/keyboardevent.js
+++ b/src/constants/keyboardevent.js
@@ -1,0 +1,13 @@
+module.exports = {
+  // Tiny KeyboardEvent.code polyfill.
+  KEYCODE_TO_CODE: {
+    '38': 'ArrowUp',
+    '37': 'ArrowLeft',
+    '40': 'ArrowDown',
+    '39': 'ArrowRight',
+    '87': 'KeyW',
+    '65': 'KeyA',
+    '83': 'KeyS',
+    '68': 'KeyD'
+  }
+};


### PR DESCRIPTION
Uses `event.code` in browsers that implement it, which is layout-agnostic and should consistently correspond to the physical locations of the WASD keys, not their letter-equivalents.

Also adds <kbd>←</kbd><kbd>→</kbd><kbd>↑</kbd><kbd>↓</kbd> for good measure.

Would understand if we don't want to merge this while #1248 is still open, but this seems like a nice-to-have for users outside the U.S.

Fixes #333, #1409, and #1490.