### PR TITLE
Issues/1828 tracked controls documentation page

### DIFF
--- a/docs/components/hand-controls.md
+++ b/docs/components/hand-controls.md
@@ -5,8 +5,8 @@ layout: docs
 parent_section: components
 ---
 
-[tracked]: ./components/tracked-controls.md
-[vive]: ./components/vive-controls.md
+[tracked]: ./tracked-controls.md
+[vive]: ./vive-controls.md
 
 The hand-controls gives tracked hands (using a prescribed model) with animated
 gestures. It wraps the [vive-controls component][vive], which wraps the

--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -5,9 +5,13 @@ layout: docs
 parent_section: components
 ---
 
+[handcontrols]: ./hand-controls.md
+[vivecontrols]: ./vive-controls.md
+
 The tracked-controls component interfaces with tracked controllers. 
-Uses the Gamepad API to handle tracked controllers. 
-Selects the appropriate controller, applies pose to the entity, observes buttons state and emits appropriate events.
+It uses the Gamepad API to handle tracked controllers, 
+and is abstracted by the [hand-controls component][handcontrols] & the [vive-controls component][vivecontrols].
+This component elects the appropriate controller, applies pose to the entity, observes buttons state and emits appropriate events.
 
 
 ## Example
@@ -21,18 +25,18 @@ Selects the appropriate controller, applies pose to the entity, observes buttons
 | Property    | Description                                                    | Default Value    |
 |-------------|----------------------------------------------------------------|------------------|
 | controller  | Index of the controller in array returned by the Gamepad API.  | 0                |
-| id          | Selects the controller returned by the Gamepad API.            | 'OpenVR Gamepad' |
+| id          | Selects the controller returned by the Gamepad API.            | OpenVR Gamepad   |
 
 ## Events
 
 | Event Name     | Description                                |
 |----------------|--------------------------------------------|
+| axismove       | Axis changed.                              |
 | buttonchanged  | Any touch or press of a button fires this. |
 | buttondown     | Button pressed.                            |
 | buttonup       | Button released.                           |
 | touchstart     | Touch sensitive button touched.            |
 | touchend       | Touch sensitive button released.           |
-| axismove       | Axis changed.                              |
 
 ### Additional Resources
 

--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -1,0 +1,41 @@
+---
+title: tracked-controls
+type: components
+layout: docs
+parent_section: components
+---
+
+The tracked-controls component interfaces with tracked controllers. 
+Uses the Gamepad API to handle tracked controllers. 
+Selects the appropriate controller, applies pose to the entity, observes buttons state and emits appropriate events.
+
+
+## Example
+
+```html
+<a-entity tracked-controls="controller: 0; id: 'OpenVR Gamepad'"></a-entity>
+```
+
+## Value
+
+| Property             | Description                                        | Default Value        |
+|----------------------|----------------------------------------------------|----------------------|
+| controller           | Index of the controller in array returned by the Gamepad API.  | 0                |
+| id                   | Selects the controller returned by the Gamepad API.            | 'OpenVR Gamepad' |
+
+## Events
+
+| Event Name   | Description             |
+| ----------   | -----------             |
+| buttonchanged  | Any touch or press of a button fires this. |
+| buttondown     | Button pressed.    |
+| buttonup       | Button released.    |
+| touchstart     | Touch sensitive button touched.    |
+| touchend       | Touch sensitive button released.   |
+| axismove   | Axis changed.  |
+
+### Additional Resources
+
+- [Gamepad API][gamepadAPI] - W3C Gamepad API
+
+[gamepadAPI]: https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API

--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -17,7 +17,7 @@ This component elects the appropriate controller, applies pose to the entity, ob
 ## Example
 
 ```html
-<a-entity tracked-controls="controller: 0; id: 'OpenVR Gamepad'"></a-entity>
+<a-entity tracked-controls="controller: 0; id: OpenVR Gamepad"></a-entity>
 ```
 
 ## Value

--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -18,24 +18,26 @@ Selects the appropriate controller, applies pose to the entity, observes buttons
 
 ## Value
 
-| Property             | Description                                        | Default Value        |
-|----------------------|----------------------------------------------------|----------------------|
-| controller           | Index of the controller in array returned by the Gamepad API.  | 0                |
-| id                   | Selects the controller returned by the Gamepad API.            | 'OpenVR Gamepad' |
+| Property    | Description                                                    | Default Value    |
+|-------------|----------------------------------------------------------------|------------------|
+| controller  | Index of the controller in array returned by the Gamepad API.  | 0                |
+| id          | Selects the controller returned by the Gamepad API.            | 'OpenVR Gamepad' |
 
 ## Events
 
-| Event Name   | Description             |
-| ----------   | -----------             |
+| Event Name     | Description                                |
+|----------------|--------------------------------------------|
 | buttonchanged  | Any touch or press of a button fires this. |
-| buttondown     | Button pressed.    |
-| buttonup       | Button released.    |
-| touchstart     | Touch sensitive button touched.    |
-| touchend       | Touch sensitive button released.   |
-| axismove   | Axis changed.  |
+| buttondown     | Button pressed.                            |
+| buttonup       | Button released.                           |
+| touchstart     | Touch sensitive button touched.            |
+| touchend       | Touch sensitive button released.           |
+| axismove       | Axis changed.                              |
 
 ### Additional Resources
 
 - [Gamepad API][gamepadAPI] - W3C Gamepad API
+- [OpenVR][openVR] - OpenVR Documentation
 
 [gamepadAPI]: https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API
+[openVR]: https://github.com/ValveSoftware/openvr/wiki/API-Documentation


### PR DESCRIPTION
**Description:**
In current documentation, 0.3.0+, as of 2016/08/20, the linked Tracked-Controls does not exist, and so the reader gets a 404.
Additionally, within Hand-Controls, the path for both the nonexistent TC and the present Vive-Controls is incorrect
For [Issue 1828](https://github.com/aframevr/aframe/issues/1828)

**Changes proposed:**
- New file, tracked-controls.md
- Change to path in hand-controls.md to reference files in current folder
