### PR TITLE
Add the new standard shader details to the documentation.

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -70,17 +70,31 @@ The `standard` material is the default material. It uses the physically-based
 
 These properties are available on top of the base material properties.
 
-| Property  | Description                                                                                                                                     | Default Value |
-|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| color     | Base diffuse color.                                                                                                                             | #fff          |
-| height    | Height of video (in pixels), if defining a video texture.                                                                                       | 360           |
-| envMap    | Environment cubemap texture for reflections. Can be a selector to <a-cubemap> or a comma-separated list of URLs.                                | None          |
-| fog       | Whether or not material is affected by [fog][fog].                                                                                              | true          |
-| metalness | How metallic the material is from `0` to `1`.                                                                                                   | 0.5           |
-| repeat    | How many times a texture (defined by `src`) repeats in the X and Y direction.                                                                   | 1 1           |
-| roughness | How rough the material is from `0` to `1`. A rougher material will scatter reflected light in more directions than a smooth material.           | 0.5           |
-| width     | Width of video (in pixels), if defining a video texture.                                                                                        | 640           |
-| src       | Image or video texture map. Can either be a selector to an `<img>` or `<video>`, or an inline URL.                                              | None          |
+| Property                      | Description                                                                                                                                     | Default Value |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| ambientOcclusionMap           | Ambient occlusion map. Used to add shadows to the mesh. Can either be a selector to an `<img>` an inline URL.                                   | None          |
+| ambientOcclusionMapIntensity  | The intensity of the ambient occlusion map, a number betwwen 0 and 1.                                                                           | 1             |
+| ambientOcclusionTextureRepeat | How many times the ambient occlusion texture repeats in the X and Y direction.                                                                  | 1 1           |
+| ambientOcclusionTextureOffset | How the ambient occlusion texture is offset in the x y direction.                                                                               | 0 0           |
+| color                         | Base diffuse color.                                                                                                                             | #fff          |
+| displacementMap               | Displacement map. Used to distort a mesh. Can either be a selector to an `<img>` an inline URL.                                                 | None          |
+| displacementMapScale          | The intensity of the displacement map effect                                                                                                    | 1             |
+| displacementMapBias           | The zero point of the displacement map.                                                                                                         | 0.5           |
+| displacementTextureRepeat     | How many times the displacement texture repeats in the X and Y direction.                                                                       | 1 1           |
+| displacementTextureOffset     | How the displacement texture is offset in the x y direction.                                                                                    | 0 0           |
+| height                        | Height of video (in pixels), if defining a video texture.                                                                                       | 360           |
+| envMap                        | Environment cubemap texture for reflections. Can be a selector to <a-cubemap> or a comma-separated list of URLs.                                | None          |
+| fog                           | Whether or not material is affected by [fog][fog].                                                                                              | true          |
+| metalness                     | How metallic the material is from `0` to `1`.                                                                                                   | 0.5           |
+| normalMap                     | Normal map. Used to add the illusion of complex detail. Can either be a selector to an `<img>` an inline URL.                                   | None          |
+| normalMapScale                | Scale of the effect of the normal map in the X and Y directions.                                                                                | 1 1           |
+| normalTextureRepeat           | How many times the normal texture repeats in the X and Y direction.                                                                             | 1 1           |
+| normalTextureOffset           | How the normal texture is offset in the x y direction.                                                                                          | 0 0           |
+| repeat                        | How many times a texture (defined by `src`) repeats in the X and Y direction.                                                                   | 1 1           |
+| roughness                     | How rough the material is from `0` to `1`. A rougher material will scatter reflected light in more directions than a smooth material.           | 0.5           |
+| sphericalEnvMap               | Environment spherical texture for reflections. Can either be a selector to an `<img>`, or an inline URL.                                        | None          |
+| width                         | Width of video (in pixels), if defining a video texture.                                                                                        | 640           |
+| src                           | Image or video texture map. Can either be a selector to an `<img>` or `<video>`, or an inline URL.                                              | None          |
 
 #### Physically-Based Shading
 
@@ -102,13 +116,25 @@ For example, for a tree bark material, as an estimation, we might set:
 </a-entity>
 ```
 
+#### Distortion Maps
+
+There are three properties which give the illusion of complex geometry:
+
+* Ambient Occlusion Maps - Applies a texture to the image which add shadows.
+* Displacement Maps - These maps distorts a simpler model at a high resolution allowing additional service detail. This will affect the mesh's silhouette but can be expensive.
+* Normal Maps - This image defines the angle of the surface at that point. Giving the appearance of complex geometry without distorting the model. This does not change the geometry but it is cheap.
+
 #### Environment Maps
 
-The `envMap` property defines what environment the material reflects.  Unlike
-textures, the `envMap` property takes a cubemap, six images put together to
+The `envMap` and `sphericalEnvMap` properties define what environment
+the material reflects. The clarity of the environment reflection depends
+on the `metalness`, and `roughness` properties.
+
+The `sphericalEnvMap` property takes a single sperical mapped
+texture. Of the kind you would assign to a `<a-sky>`.
+
+Unlike textures, the `envMap` property takes a cubemap, six images put together to
 form a cube. The cubemap is wrapped around the mesh and applied as a texture.
-The clarity of the environment depends on the `metalness`, and `roughness`
-properties.
 
 For example:
 

--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -73,7 +73,7 @@ These properties are available on top of the base material properties.
 | Property                      | Description                                                                                                                                     | Default Value |
 |-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | ambientOcclusionMap           | Ambient occlusion map. Used to add shadows to the mesh. Can either be a selector to an `<img>` an inline URL.                                   | None          |
-| ambientOcclusionMapIntensity  | The intensity of the ambient occlusion map, a number betwwen 0 and 1.                                                                           | 1             |
+| ambientOcclusionMapIntensity  | The intensity of the ambient occlusion map, a number between 0 and 1.                                                                           | 1             |
 | ambientOcclusionTextureRepeat | How many times the ambient occlusion texture repeats in the X and Y direction.                                                                  | 1 1           |
 | ambientOcclusionTextureOffset | How the ambient occlusion texture is offset in the x y direction.                                                                               | 0 0           |
 | color                         | Base diffuse color.                                                                                                                             | #fff          |
@@ -130,7 +130,7 @@ The `envMap` and `sphericalEnvMap` properties define what environment
 the material reflects. The clarity of the environment reflection depends
 on the `metalness`, and `roughness` properties.
 
-The `sphericalEnvMap` property takes a single sperical mapped
+The `sphericalEnvMap` property takes a single spherical mapped
 texture. Of the kind you would assign to a `<a-sky>`.
 
 Unlike textures, the `envMap` property takes a cubemap, six images put together to

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -19,7 +19,7 @@ module.exports.Component = registerShader('standard', {
 
     displacementMap: {default: ''},
     displacementScale: {default: 1},
-    displacementBias: {default: 1},
+    displacementBias: {default: 0.5},
     displacementTextureOffset: {default: ''},
     displacementTextureRepeat: {default: ''},
     envMap: {default: ''},


### PR DESCRIPTION
**Description:** Updates the docs with details about the new properties of the Standard Shader

**Changes proposed:**
- Add details for spherical environment maps
- Add details about the different types of distortion maps
- Update the default value of the displacement bias to something more sensible.

