### PR TITLE
Fix #1373, #1293 - Update video docs with regard to webkit-playsinline

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -83,7 +83,9 @@ Because of an [iOS platform restriction][iosvideo] in order to get inline video
 Inline video support on iOS 10 may change this. On certain Android devices or
 browsers, we must:
 
-- Require user interaction to trigger the video (such as a click or tap event).
+[android-touch-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=178297
+
+- Require user interaction to trigger the video (such as a click or tap event). See [Chromium Bug 178297][android-touch-bug].
 
 We will try to create a video boilerplate that has all the configurations to
 work on mobile devices.

--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -76,8 +76,8 @@ Mobile browsers have limitations with displaying inline video.
 Because of an [iOS platform restriction][iosvideo] in order to get inline video
 (with or without autoplay), we must:
 
-- Set the `<meta name="apple-mobile-web-app-capable" content="yes">` metatag.
-- Set the `webkit-playsinline` attribute to the video element.
+- Set the `<meta name="apple-mobile-web-app-capable" content="yes">` meta tag (will be injected if missing).
+- Set the `webkit-playsinline` attribute to the video element (is automatically added to all videos).
 - Pin the webpage to the iOS homescreen.
 
 Inline video support on iOS 10 may change this. On certain Android devices or

--- a/docs/primitives/a-video.md
+++ b/docs/primitives/a-video.md
@@ -46,5 +46,5 @@ The video primitive displays a video on a flat plane as a texture. It is an enti
 iOS has a lot of restrictions on playing videos in the browser. To play an inline video texture, we must:
 
 - Set the `<meta name="apple-mobile-web-app-capable" content="yes">` meta tag (will be injected if missing).
-- Set the `webkit-playsinline` attribute to the video element.
+- Set the `webkit-playsinline` attribute to the video element (is automatically added to all videos).
 - Pin the webpage to the iOS homescreen.

--- a/docs/primitives/a-video.md
+++ b/docs/primitives/a-video.md
@@ -48,3 +48,10 @@ iOS has a lot of restrictions on playing videos in the browser. To play an inlin
 - Set the `<meta name="apple-mobile-web-app-capable" content="yes">` meta tag (will be injected if missing).
 - Set the `webkit-playsinline` attribute to the video element (is automatically added to all videos).
 - Pin the webpage to the iOS homescreen.
+
+Inline video support on iOS 10 may change this. On certain Android devices or
+browsers, we must:
+
+[android-touch-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=178297
+
+- Require user interaction to trigger the video (such as a click or tap event). See [Chromium Bug 178297][android-touch-bug].

--- a/docs/primitives/a-videosphere.md
+++ b/docs/primitives/a-videosphere.md
@@ -47,3 +47,10 @@ iOS has a lot of restrictions on playing videos in the browser. To play an inlin
 - Set the `<meta name="apple-mobile-web-app-capable" content="yes">` meta tag (will be injected if missing).
 - Set the `webkit-playsinline` attribute to the video element (is automatically added to all videos).
 - Pin the webpage to the iOS homescreen.
+
+Inline video support on iOS 10 may change this. On certain Android devices or
+browsers, we must:
+
+[android-touch-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=178297
+
+- Require user interaction to trigger the video (such as a click or tap event). See [Chromium Bug 178297][android-touch-bug]

--- a/docs/primitives/a-videosphere.md
+++ b/docs/primitives/a-videosphere.md
@@ -45,5 +45,5 @@ In order to be seamless, videos should be [equirectangular](https://en.wikipedia
 iOS has a lot of restrictions on playing videos in the browser. To play an inline video texture, we must:
 
 - Set the `<meta name="apple-mobile-web-app-capable" content="yes">` meta tag (will be injected if missing).
-- Set the `webkit-playsinline` attribute to the video element.
+- Set the `webkit-playsinline` attribute to the video element (is automatically added to all videos).
 - Pin the webpage to the iOS homescreen.


### PR DESCRIPTION
Like the `apple-mobile-web-app-capable` point, adding note that this attribute is automatically added by A-Frame so users don't think they need to add it.