### PR TITLE
unit test look controls

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -1,6 +1,5 @@
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
-var isMobile = require('../utils/').device.isMobile();
 var bind = require('../utils/bind');
 
 var radToDeg = THREE.Math.radToDeg;
@@ -185,7 +184,7 @@ module.exports.Component = registerComponent('look-controls', {
       hmdQuaternion = this.calculateHMDQuaternion();
       hmdEuler.setFromQuaternion(hmdQuaternion, 'YXZ');
 
-      if (isMobile) {
+      if (el.sceneEl.isMobile) {
         // In mobile, allow camera rotation with touch events and sensors.
         rotation = {
           x: radToDeg(hmdEuler.x) + radToDeg(pitchObject.rotation.x),
@@ -229,17 +228,12 @@ module.exports.Component = registerComponent('look-controls', {
    * @member previousRotationY
    */
   calculateDeltaRotation: (function () {
-    var previousRotationX;
-    var previousRotationY;
+    var previousRotationX = 0;
+    var previousRotationY = 0;
     return function () {
       var currentRotationX = radToDeg(this.pitchObject.rotation.x);
       var currentRotationY = radToDeg(this.yawObject.rotation.y);
-      var deltaRotation;
-
-      previousRotationX = previousRotationX || currentRotationX;
-      previousRotationY = previousRotationY || currentRotationY;
-
-      deltaRotation = {
+      var deltaRotation = {
         x: currentRotationX - previousRotationX,
         y: currentRotationY - previousRotationY
       };
@@ -311,6 +305,9 @@ module.exports.Component = registerComponent('look-controls', {
 
   /**
    * Translate mouse drag into rotation.
+   *
+   * Dragging up and down rotates the camera around the X-axis (yaw).
+   * Dragging left and right rotates the camera around the Y-axis (pitch).
    */
   onMouseMove: function (event) {
     var movementX;
@@ -370,7 +367,7 @@ module.exports.Component = registerComponent('look-controls', {
    * Translate touch move to Y-axis rotation.
    */
   onTouchMove: function (event) {
-    var canvas = this.sceneEl.canvas;
+    var canvas = this.el.sceneEl.canvas;
     var deltaY;
     var yawObject = this.yawObject;
 

--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -3,10 +3,25 @@ var THREE = require('../lib/three');
 var isMobile = require('../utils/').device.isMobile();
 var bind = require('../utils/bind');
 
-// To avoid recalculation at every mouse movement tick
-var PI_2 = Math.PI / 2;
 var radToDeg = THREE.Math.radToDeg;
 
+var GRABBING_CLASS = 'a-grabbing';
+var PI_2 = Math.PI / 2;  // Calculate once.
+
+/**
+ * Update entity pose, factoring in mouse drag, touch drag, and HMD sensor data (VRControls).
+ *
+ * @member controls
+ * @member dolly
+ * @member euler
+ * @member mouseDown
+ * @member pitchObject
+ * @member previousHMDPosition
+ * @member previousMouseEvent
+ * @member touchStart
+ * @member touchStarted
+ * @member yawObject
+ */
 module.exports.Component = registerComponent('look-controls', {
   dependencies: ['position', 'rotation'],
 
@@ -26,26 +41,25 @@ module.exports.Component = registerComponent('look-controls', {
     this.bindMethods();
 
     // Enable grab cursor class on canvas.
-    function enableGrabCursor () { sceneEl.canvas.classList.add('a-grab-cursor'); }
     if (!sceneEl.canvas) {
       sceneEl.addEventListener('render-target-loaded', enableGrabCursor);
     } else {
       enableGrabCursor();
     }
+    function enableGrabCursor () { sceneEl.canvas.classList.add('a-grab-cursor'); }
   },
 
   update: function (oldData) {
     var data = this.data;
-    var hmdEnabled = data.hmdEnabled;
-    if (!data.enabled) { return; }
-    if (!hmdEnabled && oldData && hmdEnabled !== oldData.hmdEnabled) {
+
+    // Reset pitch and yaw if disabling HMD.
+    if (oldData && !data.hmdEnabled && data.hmdEnabled !== oldData.hmdEnabled) {
       this.pitchObject.rotation.set(0, 0, 0);
       this.yawObject.rotation.set(0, 0, 0);
     }
+
     this.controls.standing = data.standing;
-    this.controls.update();
-    this.updateOrientation();
-    this.updatePosition();
+    this.updatePose();
   },
 
   play: function () {
@@ -56,25 +70,40 @@ module.exports.Component = registerComponent('look-controls', {
     this.removeEventListeners();
   },
 
+  /**
+   * Update pose on each frame.
+   */
   tick: function (t) {
-    this.update();
+    this.updatePose();
   },
 
   remove: function () {
-    this.pause();
+    this.removeEventListeners();
+  },
+
+  /**
+   * Do actual update of rotation and position of entity.
+   */
+  updatePose: function () {
+    if (!this.data.enabled) { return; }
+    this.controls.update();
+    this.updateOrientation();
+    this.updatePosition();
   },
 
   bindMethods: function () {
     this.onMouseDown = bind(this.onMouseDown, this);
     this.onMouseMove = bind(this.onMouseMove, this);
-    this.releaseMouse = bind(this.releaseMouse, this);
+    this.onMouseUp = bind(this.onMouseUp, this);
     this.onTouchStart = bind(this.onTouchStart, this);
     this.onTouchMove = bind(this.onTouchMove, this);
     this.onTouchEnd = bind(this.onTouchEnd, this);
   },
 
+  /**
+   * Set up states and Object3Ds needed to store rotation data.
+   */
   setupMouseControls: function () {
-    // The canvas where the scene is painted
     this.mouseDown = false;
     this.pitchObject = new THREE.Object3D();
     this.yawObject = new THREE.Object3D();
@@ -82,6 +111,9 @@ module.exports.Component = registerComponent('look-controls', {
     this.yawObject.add(this.pitchObject);
   },
 
+  /**
+   * Set up VR controls that will copy data to the dolly.
+   */
   setupHMDControls: function () {
     this.dolly = new THREE.Object3D();
     this.euler = new THREE.Euler();
@@ -89,66 +121,81 @@ module.exports.Component = registerComponent('look-controls', {
     this.controls.userHeight = 0.0;
   },
 
+  /**
+   * Add mouse and touch event listeners.
+   */
   addEventListeners: function () {
     var sceneEl = this.el.sceneEl;
     var canvasEl = sceneEl.canvas;
 
-    // listen for canvas to load.
+    // Listen for canvas to load.
     if (!canvasEl) {
       sceneEl.addEventListener('render-target-loaded', bind(this.addEventListeners, this));
       return;
     }
 
-    // Mouse Events
+    // Mouse events.
     canvasEl.addEventListener('mousedown', this.onMouseDown, false);
     window.addEventListener('mousemove', this.onMouseMove, false);
-    window.addEventListener('mouseup', this.releaseMouse, false);
+    window.addEventListener('mouseup', this.onMouseUp, false);
 
-    // Touch events
+    // Touch events.
     canvasEl.addEventListener('touchstart', this.onTouchStart);
     window.addEventListener('touchmove', this.onTouchMove);
     window.addEventListener('touchend', this.onTouchEnd);
   },
 
+  /**
+   * Remove mouse and touch event listeners.
+   */
   removeEventListeners: function () {
     var sceneEl = this.el.sceneEl;
     var canvasEl = sceneEl && sceneEl.canvas;
+
     if (!canvasEl) { return; }
 
-    // Mouse Events
+    // Mouse events.
     canvasEl.removeEventListener('mousedown', this.onMouseDown);
     canvasEl.removeEventListener('mousemove', this.onMouseMove);
-    canvasEl.removeEventListener('mouseup', this.releaseMouse);
-    canvasEl.removeEventListener('mouseout', this.releaseMouse);
+    canvasEl.removeEventListener('mouseup', this.onMouseUp);
+    canvasEl.removeEventListener('mouseout', this.onMouseUp);
 
-    // Touch events
+    // Touch events.
     canvasEl.removeEventListener('touchstart', this.onTouchStart);
     canvasEl.removeEventListener('touchmove', this.onTouchMove);
     canvasEl.removeEventListener('touchend', this.onTouchEnd);
   },
 
+  /**
+   * Update orientation for mobile, mouse look, and headset cases.
+   * Mouse-drag only enabled if HMD is not active.
+   */
   updateOrientation: (function () {
     var hmdEuler = new THREE.Euler();
     return function () {
       var currentRotation;
       var deltaRotation;
+      var el = this.el;
+      var hmdQuaternion;
       var pitchObject = this.pitchObject;
-      var yawObject = this.yawObject;
-      var hmdQuaternion = this.calculateHMDQuaternion();
-      var sceneEl = this.el.sceneEl;
       var rotation;
+      var sceneEl = el.sceneEl;
+      var yawObject = this.yawObject;
+
+      hmdQuaternion = this.calculateHMDQuaternion();
       hmdEuler.setFromQuaternion(hmdQuaternion, 'YXZ');
+
       if (isMobile) {
-        // In mobile we allow camera rotation with touch events and sensors
+        // In mobile, allow camera rotation with touch events and sensors.
         rotation = {
           x: radToDeg(hmdEuler.x) + radToDeg(pitchObject.rotation.x),
           y: radToDeg(hmdEuler.y) + radToDeg(yawObject.rotation.y),
           z: radToDeg(hmdEuler.z)
         };
       } else if (!sceneEl.is('vr-mode') || isNullVector(hmdEuler) || !this.data.hmdEnabled) {
-        currentRotation = this.el.getAttribute('rotation');
+        // Mouse-drag only if HMD is not active (disabled, no incoming sensor data).
+        currentRotation = el.getAttribute('rotation');
         deltaRotation = this.calculateDeltaRotation();
-        // Mouse look only if HMD disabled or no info coming from the sensors
         if (this.data.reverseMouseDrag) {
           rotation = {
             x: currentRotation.x - deltaRotation.x,
@@ -163,18 +210,24 @@ module.exports.Component = registerComponent('look-controls', {
           };
         }
       } else {
-        // Mouse rotation ignored with an active headset.
-        // The user head rotation takes priority
+        // HMD. Mouse rotation ignored with active headset, user head rotation takes priority.
         rotation = {
           x: radToDeg(hmdEuler.x),
           y: radToDeg(hmdEuler.y),
           z: radToDeg(hmdEuler.z)
         };
       }
-      this.el.setAttribute('rotation', rotation);
+
+      el.setAttribute('rotation', rotation);
     };
   })(),
 
+  /**
+   * Calculate change in rotation by subtracting previous rotation from current rotation.
+   *
+   * @member previousRotationX
+   * @member previousRotationY
+   */
   calculateDeltaRotation: (function () {
     var previousRotationX;
     var previousRotationY;
@@ -182,18 +235,25 @@ module.exports.Component = registerComponent('look-controls', {
       var currentRotationX = radToDeg(this.pitchObject.rotation.x);
       var currentRotationY = radToDeg(this.yawObject.rotation.y);
       var deltaRotation;
+
       previousRotationX = previousRotationX || currentRotationX;
       previousRotationY = previousRotationY || currentRotationY;
+
       deltaRotation = {
         x: currentRotationX - previousRotationX,
         y: currentRotationY - previousRotationY
       };
+
+      // Store current rotation for next tick.
       previousRotationX = currentRotationX;
       previousRotationY = currentRotationY;
       return deltaRotation;
     };
   })(),
 
+  /**
+   * Grab HMD rotation from the dolly which receives data from VRControls.
+   */
   calculateHMDQuaternion: (function () {
     var hmdQuaternion = new THREE.Quaternion();
     return function () {
@@ -202,20 +262,34 @@ module.exports.Component = registerComponent('look-controls', {
     };
   })(),
 
+  /**
+   * Handle positional tracking for HMDs.
+   *
+   * @member deltaHMDPosition
+   */
   updatePosition: (function () {
     var deltaHMDPosition = new THREE.Vector3();
     return function () {
       var el = this.el;
-      var currentPosition = el.getAttribute('position');
+      var currentPosition;
       var currentHMDPosition;
       var previousHMDPosition = this.previousHMDPosition;
-      var sceneEl = this.el.sceneEl;
+      var sceneEl = el.sceneEl;
+
+      // Not in VR mode.
+      if (!sceneEl.is('vr-mode')) { return; }
+
+      // Calculate change in position.
       currentHMDPosition = this.calculateHMDPosition();
       deltaHMDPosition.copy(currentHMDPosition).sub(previousHMDPosition);
-      if (!sceneEl.is('vr-mode') || isNullVector(deltaHMDPosition)) { return; }
+
+      // Has not moved.
+      if (isNullVector(deltaHMDPosition)) { return; }
+
       previousHMDPosition.copy(currentHMDPosition);
-      // Do nothing if we have not moved.
-      if (!sceneEl.is('vr-mode')) { return; }
+
+      // Set final position by adding change in position to current position.
+      currentPosition = el.getAttribute('position');
       el.setAttribute('position', {
         x: currentPosition.x + deltaHMDPosition.x,
         y: currentPosition.y + deltaHMDPosition.y,
@@ -224,6 +298,9 @@ module.exports.Component = registerComponent('look-controls', {
     };
   })(),
 
+  /**
+   * Get HMD position from VRControls.
+   */
   calculateHMDPosition: function () {
     var dolly = this.dolly;
     var position = new THREE.Vector3();
@@ -232,61 +309,85 @@ module.exports.Component = registerComponent('look-controls', {
     return position;
   },
 
+  /**
+   * Translate mouse drag into rotation.
+   */
   onMouseMove: function (event) {
+    var movementX;
+    var movementY;
     var pitchObject = this.pitchObject;
-    var yawObject = this.yawObject;
     var previousMouseEvent = this.previousMouseEvent;
+    var yawObject = this.yawObject;
 
+    // Not dragging or not enabled.
     if (!this.mouseDown || !this.data.enabled) { return; }
 
-    var movementX = event.movementX || event.mozMovementX;
-    var movementY = event.movementY || event.mozMovementY;
-
+    // Calculate delta.
+    movementX = event.movementX || event.mozMovementX;
+    movementY = event.movementY || event.mozMovementY;
     if (movementX === undefined || movementY === undefined) {
       movementX = event.screenX - previousMouseEvent.screenX;
       movementY = event.screenY - previousMouseEvent.screenY;
     }
     this.previousMouseEvent = event;
 
+    // Calculate rotation.
     yawObject.rotation.y -= movementX * 0.002;
     pitchObject.rotation.x -= movementY * 0.002;
     pitchObject.rotation.x = Math.max(-PI_2, Math.min(PI_2, pitchObject.rotation.x));
   },
 
+  /**
+   * Register mouse down to detect mouse drag.
+   */
   onMouseDown: function (event) {
     this.mouseDown = true;
     this.previousMouseEvent = event;
-    document.body.classList.add('a-grabbing');
+    document.body.classList.add(GRABBING_CLASS);
   },
 
-  releaseMouse: function () {
+  /**
+   * Register mouse up to detect release of mouse drag.
+   */
+  onMouseUp: function () {
     this.mouseDown = false;
-    document.body.classList.remove('a-grabbing');
+    document.body.classList.remove(GRABBING_CLASS);
   },
 
-  onTouchStart: function (e) {
-    if (e.touches.length !== 1) { return; }
+  /**
+   * Register touch down to detect touch drag.
+   */
+  onTouchStart: function (event) {
+    if (event.touches.length !== 1) { return; }
     this.touchStart = {
-      x: e.touches[0].pageX,
-      y: e.touches[0].pageY
+      x: event.touches[0].pageX,
+      y: event.touches[0].pageY
     };
     this.touchStarted = true;
   },
 
-  onTouchMove: function (e) {
+  /**
+   * Translate touch move to Y-axis rotation.
+   */
+  onTouchMove: function (event) {
+    var canvas = this.sceneEl.canvas;
     var deltaY;
     var yawObject = this.yawObject;
+
     if (!this.touchStarted) { return; }
-    deltaY = 2 * Math.PI * (e.touches[0].pageX - this.touchStart.x) /
-            this.el.sceneEl.canvas.clientWidth;
-    // Limits touch orientaion to to yaw (y axis)
+
+    // Limit touch orientaion to to yaw (Y-axis).
+    deltaY = 2 * Math.PI * (event.touches[0].pageX - this.touchStart.x) / canvas.clientWidth;
     yawObject.rotation.y -= deltaY * 0.5;
     this.touchStart = {
-      x: e.touches[0].pageX,
-      y: e.touches[0].pageY
+      x: event.touches[0].pageX,
+      y: event.touches[0].pageY
     };
   },
 
+  /**
+   * Register touch end to detect release of touch drag.
+   */
   onTouchEnd: function () {
     this.touchStarted = false;
   }

--- a/tests/components/look-controls.test.js
+++ b/tests/components/look-controls.test.js
@@ -1,5 +1,4 @@
  /* global Event, assert, process, setup, suite, test */
-
 var CANVAS_GRAB_CLASS = 'a-grab-cursor';
 var GRABBING_CLASS = 'a-grabbing';
 
@@ -17,7 +16,7 @@ suite('look-controls', function () {
       this.sceneEl.canvas.classList.contains(CANVAS_GRAB_CLASS);
     });
 
-    test('adds grabbing class to document body on mousedown', function (done) {
+    test('adds grabbing class to body on mousedown', function (done) {
       var el = this.sceneEl;
       process.nextTick(function () {
         assert.ok(document.body.classList.contains(GRABBING_CLASS));
@@ -27,7 +26,7 @@ suite('look-controls', function () {
       el.canvas.dispatchEvent(new Event('mousedown'));
     });
 
-    test('removes grabbing class from document body on document body mouseup', function (done) {
+    test('removes grabbing class from body on body mouseup', function (done) {
       document.body.classList.add(GRABBING_CLASS);
       process.nextTick(function () {
         assert.notOk(document.body.classList.contains(GRABBING_CLASS));

--- a/tests/core/controls.test.js
+++ b/tests/core/controls.test.js
@@ -1,5 +1,8 @@
 /* global Event, assert, process, setup, suite, test */
 var helpers = require('../helpers');
+var THREE = require('lib/three');
+
+var PI = Math.PI;
 
 suite('position controls on camera with WASD controls (integration unit test)', function () {
   setup(function (done) {
@@ -122,6 +125,319 @@ suite('position controls on camera with WASD controls (integration unit test)', 
         assert.equal(Math.round(newPos.z), position.z);
         done();
       });
+    });
+  });
+});
+
+suite('rotation controls on camera with VRControls (integration unit test)', function () {
+  setup(function (done) {
+    var el = helpers.entityFactory();
+    var self = this;
+
+    function StubVRControls (dolly) {
+      self.dolly = dolly;
+      self.el = el.sceneEl.querySelector('[camera]');  // Default camera.
+      done();  // Done once we get a grip on VRControls created through the default camera.
+    }
+    StubVRControls.prototype.update = function () { /* no-op */ };
+    this.sinon.stub(THREE, 'VRControls', StubVRControls);
+  });
+
+  test('rotates camera around Y', function (done) {
+    var el = this.el;
+    el.sceneEl.addState('vr-mode');
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(0, PI, 0));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(Math.round(rotation.x), 0);
+      assert.equal(Math.round(rotation.y), 180);
+      assert.equal(Math.round(rotation.z), 0);
+      done();
+    });
+  });
+
+  test('rotates camera composing X and Y', function (done) {
+    var el = this.el;
+    el.sceneEl.addState('vr-mode');
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 4, PI, 0));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(Math.round(rotation.x), -45);
+      assert.equal(Math.round(rotation.y), 180);
+      assert.equal(Math.round(rotation.z), 0);
+      done();
+    });
+  });
+
+  test('rotates camera composing X and Y and Z', function (done) {
+    var el = this.el;
+    el.sceneEl.addState('vr-mode');
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 2, PI / 6, PI / 2));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(Math.round(rotation.x), 60);
+      assert.equal(Math.round(rotation.y), 90);
+      assert.equal(Math.round(rotation.z), 180);
+      done();
+    });
+  });
+
+  test('replaces previous rotation', function (done) {
+    var el = this.el;
+    el.sceneEl.addState('vr-mode');
+    el.setAttribute('rotation', {x: -10000, y: -10000, z: -10000});
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 2, PI / 6, PI / 2));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(Math.round(rotation.x), 60);
+      assert.equal(Math.round(rotation.y), 90);
+      assert.equal(Math.round(rotation.z), 180);
+      done();
+    });
+  });
+
+  test('does not rotate camera if not in VR', function (done) {
+    var el = this.el;
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(0, PI, 0));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(rotation.x, 0);
+      assert.equal(rotation.y, 0);
+      assert.equal(rotation.z, 0);
+      done();
+    });
+  });
+});
+
+suite('rotation controls on camera with mouse drag (integration unit test)', function () {
+  setup(function (done) {
+    var el = helpers.entityFactory();
+    var self = this;
+
+    function StubVRControls (dolly) {
+      self.dolly = dolly;
+      self.el = el.sceneEl.querySelector('[camera]');  // Default camera.
+      process.nextTick(function () {
+        done();  // Done once we get a grip on VRControls created through the default camera.
+      });
+    }
+    StubVRControls.prototype.update = function () { /* no-op */ };
+    this.sinon.stub(THREE, 'VRControls', StubVRControls);
+  });
+
+  test('rotates camera on dragging mouse around X', function (done) {
+    var el = this.el;
+    el.sceneEl.canvas.dispatchEvent(new Event('mousedown'));
+
+    process.nextTick(function afterMousedown () {
+      var mouseMoveEvent = new Event('mousemove');
+      mouseMoveEvent.movementX = 1000;
+      mouseMoveEvent.movementY = 1;
+      mouseMoveEvent.screenX = 1000;
+      mouseMoveEvent.screenY = 1000;
+      window.dispatchEvent(mouseMoveEvent);
+      process.nextTick(function afterMousemove () {
+        el.sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.ok(Math.abs(Math.round(rotation.y)) > 0);
+          done();
+        });
+      });
+    });
+  });
+
+  test('rotates camera on dragging mouse along Y', function (done) {
+    var el = this.el;
+    el.sceneEl.canvas.dispatchEvent(new Event('mousedown'));
+
+    process.nextTick(function afterMousedown () {
+      var mouseMoveEvent = new Event('mousemove');
+      mouseMoveEvent.movementX = 1;
+      mouseMoveEvent.movementY = 1000;
+      mouseMoveEvent.screenX = 1000;
+      mouseMoveEvent.screenY = 1000;
+      window.dispatchEvent(mouseMoveEvent);
+      process.nextTick(function afterMousemove () {
+        el.sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.equal(Math.round(rotation.x), -90);
+          done();
+        });
+      });
+    });
+  });
+
+  test('rotates camera dragging mouse on already rotated camera', function (done) {
+    var el = this.el;
+    el.sceneEl.canvas.dispatchEvent(new Event('mousedown'));
+
+    el.setAttribute('rotation', {x: 0, y: -360, z: 0});
+
+    process.nextTick(function afterMousedown () {
+      var mouseMoveEvent = new Event('mousemove');
+      mouseMoveEvent.movementX = 1000;
+      mouseMoveEvent.movementY = 1;
+      mouseMoveEvent.screenX = 1000;
+      mouseMoveEvent.screenY = 1000;
+      window.dispatchEvent(mouseMoveEvent);
+      process.nextTick(function afterMousemove () {
+        el.sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.ok(rotation.y < -360, 'Drag applies delta to current rotation.');
+          done();
+        });
+      });
+    });
+  });
+
+  test('does not rotate camera when dragging in VR with headset', function (done) {
+    var el = this.el;
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(0, PI, 0));
+    el.sceneEl.addState('vr-mode');
+    el.sceneEl.canvas.dispatchEvent(new Event('mousedown'));
+
+    process.nextTick(function afterMousedown () {
+      var mouseMoveEvent = new Event('mousemove');
+      mouseMoveEvent.movementX = 1000;
+      mouseMoveEvent.movementY = 1000;
+      mouseMoveEvent.screenX = 1000;
+      mouseMoveEvent.screenY = 1000;
+      window.dispatchEvent(mouseMoveEvent);
+      process.nextTick(function afterMousemove () {
+        el.sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.equal(Math.round(rotation.x), 0);
+          assert.equal(Math.round(rotation.y), 180, 'Use VR controls rotation');
+          assert.equal(Math.round(rotation.z), 0);
+          done();
+        });
+      });
+    });
+  });
+});
+
+suite('rotation controls on camera with touch drag (integration unit test)', function () {
+  setup(function (done) {
+    var el = helpers.entityFactory();
+    var self = this;
+
+    function StubVRControls (dolly) {
+      self.dolly = dolly;
+      self.el = el.sceneEl.querySelector('[camera]');  // Default camera.
+      process.nextTick(function () {
+        done();  // Done once we get a grip on VRControls created through the default camera.
+      });
+    }
+    StubVRControls.prototype.update = function () { /* no-op */ };
+    this.sinon.stub(THREE, 'VRControls', StubVRControls);
+  });
+
+  test('rotates camera on touch dragging around X', function (done) {
+    var canvas;
+    var el = this.el;
+    var sceneEl = el.sceneEl;
+    var touchStartEvent;
+
+    canvas = sceneEl.canvas;
+    sceneEl.isMobile = true;
+    canvas.clientWidth = 1000;
+
+    // Dispatch touchstart event.
+    touchStartEvent = new Event('touchstart');
+    touchStartEvent.touches = [{pageX: 0, pageY: 0}];
+    canvas.dispatchEvent(touchStartEvent);
+
+    process.nextTick(function afterTouchstart () {
+      var touchMoveEvent = new Event('touchmove');
+      touchMoveEvent.touches = [{pageX: 500, pageY: 0}];
+      window.dispatchEvent(touchMoveEvent);
+      process.nextTick(function afterTouchmove () {
+        sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.ok(Math.abs(Math.round(rotation.y)) > 0);
+          done();
+        });
+      });
+    });
+  });
+
+  test('does not rotate camera on touch dragging along Y', function (done) {
+    var canvas;
+    var el = this.el;
+    var sceneEl = el.sceneEl;
+    var touchStartEvent;
+
+    canvas = sceneEl.canvas;
+    sceneEl.isMobile = true;
+    canvas.clientWidth = 1000;
+
+    // Dispatch touchstart event.
+    touchStartEvent = new Event('touchstart');
+    touchStartEvent.touches = [{pageX: 0, pageY: 0}];
+    canvas.dispatchEvent(touchStartEvent);
+
+    process.nextTick(function afterTouchstart () {
+      var touchMoveEvent = new Event('touchmove');
+      touchMoveEvent.touches = [{pageX: 0, pageY: 500}];
+      window.dispatchEvent(touchMoveEvent);
+      process.nextTick(function afterTouchmove () {
+        sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.equal(Math.round(rotation.x), 0);
+          assert.equal(Math.round(rotation.y), 0);
+          done();
+        });
+      });
+    });
+  });
+});
+
+suite('position controls on camera with VRControls (integration unit test)', function () {
+  setup(function (done) {
+    var el = helpers.entityFactory();
+    var self = this;
+
+    function StubVRControls (dolly) {
+      self.dolly = dolly;
+      self.el = el.sceneEl.querySelector('[camera]');  // Default camera.
+      process.nextTick(function () {
+        done();  // Done once we get a grip on VRControls created through the default camera.
+      });
+    }
+    StubVRControls.prototype.update = function () { /* no-op */ };
+    this.sinon.stub(THREE, 'VRControls', StubVRControls);
+  });
+
+  test('copies matrix to camera in VR mode', function (done) {
+    var el = this.el;
+    var sceneEl = el.sceneEl;
+    var dolly = this.dolly;
+
+    sceneEl.addState('vr-mode');
+    el.components.camera.hasPositionalTracking = true;
+    el.components.camera.removeHeightOffset();
+
+    process.nextTick(function () {
+      var position;
+      dolly.position.set(-1, 2, 3);
+      sceneEl.tick();
+
+      position = el.getAttribute('position');
+      assert.equal(position.x, -1);
+      assert.equal(position.y, 2);
+      assert.equal(position.z, 3);
+      done();
     });
   });
 });


### PR DESCRIPTION
**Description:**

Add unit tests for look-controls coverage. They are more like integration tests because they have no insight into the internals of look-controls. I test on the default camera such that if we ever change how look-controls works or to a different type of component, the tests should still cover everything.

 I have no idea why I need a `process.nextTick` in the tests after calling `sceneEl.tick()` and before calling `getAttribute`. I dug into it and could not find out where the asynchrony was coming from.

**Changes proposed:**
- clean up/comment/docstring look controls
  - don't conflate the component callbacks with methods (i.e., don't call `update` from `tick`, separate out)
- caught and fixed a bug where touch drag would throw `this.sceneEl is undefined`
- add unit tests for hmd (by stubbing VRControls), mouse drag, and touch
