### PR TITLE
Fix 1535: Don't set camera position for Null vector

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -2,6 +2,7 @@ var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
 var isMobile = require('../utils/').isMobile();
 var bind = require('../utils/bind');
+var isNullVector = require('../utils/coordinates').isNullVector;
 
 // To avoid recalculation at every mouse movement tick
 var PI_2 = Math.PI / 2;
@@ -282,7 +283,3 @@ module.exports.Component = registerComponent('look-controls', {
     this.touchStarted = false;
   }
 });
-
-function isNullVector (vector) {
-  return vector.x === 0 && vector.y === 0 && vector.z === 0;
-}

--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -1,3 +1,4 @@
+var isNullVector = require('../utils/coordinates').isNullVector;
 var KEYCODE_TO_CODE = require('../constants').keyboardevent.KEYCODE_TO_CODE;
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
@@ -57,6 +58,8 @@ module.exports.Component = registerComponent('wasd-controls', {
 
     // Get movement vector and translate position.
     movementVector = this.getMovementVector(delta);
+    if (isNullVector(movementVector)) { return; }
+
     position = el.getComputedAttribute('position');
     el.setAttribute('position', {
       x: position.x + movementVector.x,

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -70,3 +70,10 @@ function vecParseFloat (vec) {
 module.exports.toVector3 = function (vec3) {
   return new THREE.Vector3(vec3.x, vec3.y, vec3.z);
 };
+
+/**
+ * @returns {bool}
+ */
+module.exports.isNullVector = function (vector) {
+  return vector.x === 0 && vector.y === 0 && vector.z === 0;
+};


### PR DESCRIPTION
Took a stab at #1535 ; reuses existing function, avoids unnecessary processing.