### PR TITLE
refactor canvas fullscreen, add unit tests for scene enter/exit VR

### DIFF
--- a/src/components/scene/canvas.js
+++ b/src/components/scene/canvas.js
@@ -1,11 +1,12 @@
 var bind = require('../../utils/bind');
-var register = require('../../core/component').registerComponent;
+var registerComponent = require('../../core/component').registerComponent;
 
-module.exports.Component = register('canvas', {
-
+module.exports.Component = registerComponent('canvas', {
   init: function () {
+    var canvasEl;
     var sceneEl = this.el;
-    var canvasEl = document.createElement('canvas');
+
+    canvasEl = document.createElement('canvas');
     canvasEl.classList.add('a-canvas');
     // Mark canvas as provided/injected by A-Frame.
     canvasEl.dataset.aframeCanvas = true;
@@ -20,23 +21,13 @@ module.exports.Component = register('canvas', {
       event.preventDefault();
     });
 
-    // Handle fullscreeen styling
-    sceneEl.addEventListener('enter-vr', addFullscreenClass);
-    sceneEl.addEventListener('exit-vr', removeFullscreenClass);
-
     // Set canvas on scene.
     sceneEl.canvas = canvasEl;
-    sceneEl.emit('render-target-loaded', {
-      target: canvasEl
-    });
+    sceneEl.emit('render-target-loaded', {target: canvasEl});
 
-    function addFullscreenClass (event) {
-      canvasEl.classList.add('fullscreen');
-    }
-
-    function removeFullscreenClass (event) {
-      canvasEl.classList.remove('fullscreen');
-    }
+    // For unknown reasons a syncrhonous resize does not work on desktop when
+    // entering/exiting fullscreen.
+    setTimeout(bind(sceneEl.resize, sceneEl), 0);
 
     function onFullScreenChange () {
       var fullscreenEl =
@@ -47,10 +38,6 @@ module.exports.Component = register('canvas', {
       if (!fullscreenEl) { sceneEl.exitVR(); }
       document.activeElement.blur();
       document.body.focus();
-      // For unkown reasons a syncrhonous resize does
-      // not work on desktop when entering/exiting fullscreen
-      setTimeout(bind(sceneEl.resize, sceneEl), 0);
     }
   }
-
 });

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -12,7 +12,6 @@ var ANode = require('../a-node');
 var initPostMessageAPI = require('./postMessage');
 
 var bind = utils.bind;
-var checkHeadsetConnected = utils.device.checkHeadsetConnected;
 var isIOS = utils.device.isIOS();
 var isMobile = utils.device.isMobile();
 var registerElement = re.registerElement;
@@ -146,14 +145,33 @@ module.exports = registerElement('a-scene', {
       }
     },
 
+    /**
+     * For tests.
+     */
+    checkHeadsetConnected: {
+      value: utils.device.checkHeadsetConnected,
+      writable: window.debug
+    },
+
+    /**
+     * Call `requestPresent` if WebVR or WebVR polyfill.
+     * Call `requestFullscreen` on desktop.
+     * Handle events, states, fullscreen styles.
+     *
+     * @returns {Promise}
+     */
     enterVR: {
       value: function (event) {
         var self = this;
-        if (this.is('vr-mode')) { return; }
-        if (checkHeadsetConnected() || this.isMobile) {
+
+        // Don't enter VR if already in VR.
+        if (this.is('vr-mode')) { return Promise.resolve('Already in VR.'); }
+
+        if (this.checkHeadsetConnected() || this.isMobile) {
           return this.effect.requestPresent().then(enterVRSuccess, enterVRFailure);
         }
         enterVRSuccess();
+        return Promise.resolve();
 
         function enterVRSuccess () {
           self.addState('vr-mode');
@@ -169,7 +187,9 @@ module.exports = registerElement('a-scene', {
           // TODO: 07/16 Chromium builds break when `requestFullscreen`ing on a canvas
           // that we are also `requestPresent`ing. Until then, don't fullscreen if headset
           // connected.
-          if (!self.isMobile && !checkHeadsetConnected()) { requestFullscreen(self.canvas); }
+          if (!self.isMobile && !self.checkHeadsetConnected()) {
+            requestFullscreen(self.canvas);
+          }
           self.resize();
         }
 
@@ -182,28 +202,38 @@ module.exports = registerElement('a-scene', {
         }
       }
     },
-
+     /**
+     * Call `exitPresent` if WebVR or WebVR polyfill.
+     * Handle events, states, fullscreen styles.
+     *
+     * @returns {Promise}
+     */
     exitVR: {
       value: function () {
         var self = this;
-        if (!this.is('vr-mode')) { return Promise.resolve(); }
-        if (checkHeadsetConnected() || this.isMobile) {
+
+        // Don't exit VR if not in VR.
+        if (!this.is('vr-mode')) { return Promise.resolve('Not in VR.'); }
+
+        if (this.checkHeadsetConnected() || this.isMobile) {
           return this.effect.exitPresent().then(exitVRSuccess, exitVRFailure);
         }
         exitVRSuccess();
+        return Promise.resolve();
+
         function exitVRSuccess () {
-          var embedded = self.getAttribute('embedded');
           self.removeState('vr-mode');
           // Lock to landscape orientation on mobile.
           if (self.isMobile && screen.orientation && screen.orientation.unlock) {
             screen.orientation.unlock();
           }
           // Exiting VR in embedded mode, no longer need fullscreen styles.
-          if (embedded) { self.removeFullScreenStyles(); }
+          if (self.hasAttribute('embedded')) { self.removeFullScreenStyles(); }
           self.resize();
           if (self.isIOS) { utils.forceCanvasResizeSafariMobile(this.canvas); }
           self.emit('exit-vr', {target: self});
         }
+
         function exitVRFailure (err) {
           if (err && err.message) {
             throw new Error('Failed to exit VR mode (`exitPresent`): ' + err.message);

--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -47,7 +47,7 @@
 }
 
 // Class is removed when doing <a-scene embedded>.
-.a-canvas.fullscreen {
+a-scene.fullscreen .a-canvas {
   width: 100% !important;
   height: 100% !important;
   top: 0 !important;

--- a/tests/components/scene/canvas.test.js
+++ b/tests/components/scene/canvas.test.js
@@ -1,7 +1,5 @@
  /* global assert, process, suite, test */
 
-var FULLSCREEN_CLASS = 'fullscreen';
-
 suite('canvas', function () {
   test('adds canvas to a-scene element', function (done) {
     var el = this.sceneEl = document.createElement('a-scene');
@@ -10,21 +8,6 @@ suite('canvas', function () {
       el.setAttribute('canvas', '');
       assert.ok(el.querySelector('canvas'));
       done();
-    });
-  });
-
-  suite('fullscreen', function () {
-    test('adds fullscreen class on enter VR', function () {
-      var el = this.sceneEl;
-      el.emit('enter-vr');
-      assert.ok(el.canvas.classList.contains(FULLSCREEN_CLASS));
-    });
-
-    test('removes fullscreen class on exit VR', function () {
-      var el = this.sceneEl;
-      el.canvas.classList.add(FULLSCREEN_CLASS);
-      el.emit('exit-vr');
-      assert.notOk(el.canvas.classList.contains(FULLSCREEN_CLASS));
     });
   });
 });


### PR DESCRIPTION
- Remove duplicated code between scene and canvas component
- Unit test enter / exit VR
- enterVR/exitVR consistently return Promise
