### PR TITLE
Fix #1862 - Ensure inspector is destroyed upon test completion

### DIFF
--- a/tests/components/scene/inspector.test.js
+++ b/tests/components/scene/inspector.test.js
@@ -1,8 +1,12 @@
 /* global assert, setup, suite, teardown, test */
 
 suite('inspector', function () {
+  var SCRIPT_SELECTOR = 'script[data-name=aframe-inspector]';
+
   setup(function (done) {
     var el = this.sceneEl = document.createElement('a-scene');
+    // Set a fake URL so the inspector doesn't interfere with other tests
+    el.setAttribute('inspector', 'url: fake.js');
     document.body.appendChild(el);
 
     el.addEventListener('loaded', function () { done(); });
@@ -10,13 +14,16 @@ suite('inspector', function () {
 
   teardown(function () {
     var el = this.sceneEl;
+    var script = document.querySelector(SCRIPT_SELECTOR);
+
     el.parentNode.removeChild(el);
+    script.parentNode.removeChild(script);
   });
 
   test('adds inspector SCRIPT element to page', function () {
     var el = this.sceneEl;
 
-    // Have to call method directly because Chrome doesn't provide
+    // Must call onKeydown method directly because Chrome doesn't provide
     // a reliable method for KeyboardEvent
     el.components.inspector.onKeydown({
       keyCode: 73,
@@ -24,6 +31,6 @@ suite('inspector', function () {
       altKey: true
     });
 
-    assert.equal(document.querySelectorAll('script[data-name=aframe-inspector]').length, 1);
+    assert.ok(document.querySelector(SCRIPT_SELECTOR));
   });
 });


### PR DESCRIPTION
Appears to fix transient test failures.