### PR TITLE
Fix #1630: Add white background highlighting for rStats alarm red text

### DIFF
--- a/vendor/rStats.js
+++ b/vendor/rStats.js
@@ -251,6 +251,7 @@ window.rStats = function rStats ( settings ) {
             var a = ( _def && ( ( _def.below && _value < _def.below ) || ( _def.over && _value > _def.over ) ) );
             _graph.draw( _value, a );
             _dom.style.color = a ? '#b70000' : '#ffffff';
+            _dom.style.backgroundColor = a ? '#ffffff' : null;
         }
 
         function _frame () {


### PR DESCRIPTION
**Description:**
rStats currently displays red text to alarm the user of stats that are less than optimal. This PR attempts to address #1630 ( red text behind the current gray background is hard to read ).

![screen shot 2016-08-29 at 9 15 06 pm](https://cloud.githubusercontent.com/assets/7256178/18075875/b68068e6-6e2d-11e6-873a-cf76f7044c0a.png)


**Changes proposed:**
- When a counter/label enters the alarm state in rStat, a white background highlights the red text to make it more visible and readable.

![rstatcolorchange](https://cloud.githubusercontent.com/assets/7256178/18075808/3d11a18c-6e2d-11e6-82f5-578f531c673a.gif)


