### PR TITLE
Tracked controls still update the pose if a mesh is not present

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -33,8 +33,8 @@ module.exports.Component = registerComponent('tracked-controls', {
 
   tick: function (time, delta) {
     var mesh = this.el.getObject3D('mesh');
-    if (!mesh) { return; }
-    if (mesh.update) { mesh.update(delta / 1000); }
+    // Update mesh animations.
+    if (mesh && mesh.update) { mesh.update(delta / 1000); }
     this.updatePose();
     this.updateButtons();
   },

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -1,0 +1,25 @@
+/* global assert, process, setup, suite, test */
+var entityFactory = require('../helpers').entityFactory;
+
+suite('tracked-controls', function () {
+  setup(function (done) {
+    var el = this.el = entityFactory();
+    el.setAttribute('tracked-controls', '');
+    el.addEventListener('loaded', function () {
+      done();
+    });
+  });
+
+  suite('tick', function () {
+    test('pose and buttons update if mesh is not defined', function () {
+      var el = this.el;
+      var trackedControls = el.components['tracked-controls'];
+      var updateButtonsSpy = this.sinon.spy(trackedControls, 'updateButtons');
+      var updatePoseSpy = this.sinon.spy(trackedControls, 'updatePose');
+      assert.equal(el.getObject3D('mesh'), undefined);
+      trackedControls.tick();
+      assert.ok(updatePoseSpy.called);
+      assert.ok(updateButtonsSpy.called);
+    });
+  });
+});


### PR DESCRIPTION
The tick method was returning if a mesh is not defined. `tracked-controls` should work with any entity with and without a mesh defined.