### PR TITLE
Fix #1865 - Check window.performance.getEntriesByName presence for stats

### DIFF
--- a/src/lib/rStatsAframe.js
+++ b/src/lib/rStatsAframe.js
@@ -16,7 +16,9 @@ window.aframeStats = function (scene) {
 
   function _update () {
     _rS('te').set(getEntityCount());
-    _rS('lt').set(window.performance.getEntriesByName('render-started')[0].startTime.toFixed(0));
+    if (window.performance.getEntriesByName) {
+      _rS('lt').set(window.performance.getEntriesByName('render-started')[0].startTime.toFixed(0));
+    }
   }
 
   function getEntityCount () {


### PR DESCRIPTION
Fix issue that causing Safari stats to fail.