### PR TITLE
Replace alarm white background with improved white text shadow in rStats.js

### DIFF
--- a/vendor/rStats.js
+++ b/vendor/rStats.js
@@ -251,7 +251,7 @@ window.rStats = function rStats ( settings ) {
             var a = ( _def && ( ( _def.below && _value < _def.below ) || ( _def.over && _value > _def.over ) ) );
             _graph.draw( _value, a );
             _dom.style.color = a ? '#b70000' : '#ffffff';
-            _dom.style.backgroundColor = a ? '#ffffff' : null;
+            _dom.style.textShadow = a ? '0px 0px 0px #b70000, 0px 0px 1px #ffffff, 0px 0px 1px #ffffff, 0px 0px 2px #ffffff, 0px 0px 2px #ffffff, 0px 0px 3px #ffffff, 0px 0px 3px #ffffff, 0px 0px 4px #ffffff, 0px 0px 4px #ffffff' : null;
         }
 
         function _frame () {


### PR DESCRIPTION
**Description:**
Currently, rStats displays a large white background behind counters under the alarm state. This was added for visibility in #1874, however it's aggressive compared to the rest of the rStat dashboard.

![rstatcolorchange](https://cloud.githubusercontent.com/assets/7256178/18153870/0ca84576-6fb5-11e6-9bb0-e093bb13bcbe.gif)


**Changes proposed:**
- When a counter/label enters the alarm state, a white text shadow highlights the red text to make it more readible and visible without being as intrusive as a wide white background. The text shadow makes use of 9 levels of shadow to form a composite & dense coloring around the red text.

- This solution was discussed in #1630.

![rstatcolorchange7](https://cloud.githubusercontent.com/assets/7256178/18153888/2130d260-6fb5-11e6-8b6c-b259a4e403b2.gif)

