### PR TITLE
make cursor mouseleave with multiple objects more reliable (fixes #1882)

### DIFF
--- a/examples/test/cursor/index.html
+++ b/examples/test/cursor/index.html
@@ -25,24 +25,36 @@
 
       <a-entity position="0 .6 4">
         <a-camera>
-          <a-entity cursor
+          <a-entity raycaster="far: 30; objects: .intersectable"
+                    cursor
                     geometry="primitive: ring; radiusOuter: 0.015;
                               radiusInner: 0.01; segmentsTheta: 32"
                     material="color: #283644; shader: flat"
-                    raycaster="far: 30"
                     position="0 0 -0.75"></a-entity>
         </a-camera>
       </a-entity>
 
       <a-entity position="-3.5 1 0">
-        <a-entity mixin="red cube">
+        <a-entity mixin="red cube"
+                  class="intersectable">
           <a-animation begin="click" attribute="position" from="0 0 0"
                        to="0 0 -10" dur="2000" fill="both"></a-animation>
         </a-entity>
       </a-entity>
 
+      <a-entity position="0 1 1">
+        <a-entity id="invisibleCube"
+                  mixin="cube"
+                  material="color: grey; opacity: 0.3; transparent: true"
+                  scale="1 1 0.1">
+          <a-animation begin="click" attribute="rotation" to="0 360 0"
+                       easing="linear" dur="2000" fill="backwards"></a-animation>
+        </a-entity>
+      </a-entity>
+
       <a-entity position="0 1 0">
         <a-entity id="foregroundCube"
+                  class="intersectable"
                   mixin="green cube"
                   sound__1="on: click; src: #blip1;"
                   sound__2="on: mouseenter; src: #blip2;">
@@ -53,6 +65,7 @@
 
       <a-entity position="0 1 -3">
         <a-entity id="backgroundCube"
+                  class="intersectable"
                   mixin="green cube">
           <a-animation begin="click" attribute="rotation" to="0 360 0"
                        easing="linear" dur="2000" fill="backwards"></a-animation>
@@ -60,14 +73,15 @@
       </a-entity>
 
       <a-entity position="3.5 1 0" rotation="0 45 0">
-        <a-entity mixin="blue cube">
+        <a-entity mixin="blue cube"
+                  class="intersectable">
           <a-animation begin="click" fill="forwards" repeat="1"
                        direction="alternate" attribute="position" from="0 0 0"
                        to="15 0 0" dur="2000"></a-animation>
         </a-entity>
       </a-entity>
 
-      <a-entity mixin="yellow cube" position="0 3 -3" class="clickable"
+      <a-entity mixin="yellow cube" position="0 3 -3" class="intersectable clickable"
                 rotation="0 45 0" scale=".5 .5 .5"></a-entity>
     </a-scene>
 
@@ -100,11 +114,42 @@
 
         // testing mouseenter and mouseleave
         var foregroundCube = document.querySelector('#foregroundCube');
-        foregroundCube.addEventListener('mouseenter', function () {
+        foregroundCube.addEventListener('mouseenter', function (evt) {
           foregroundCube.setAttribute('mixin','cube cube-hovered')
         })
-        foregroundCube.addEventListener('mouseleave', function () {
+        foregroundCube.addEventListener('mouseleave', function (evt) {
           foregroundCube.setAttribute('mixin','green cube')
+        })
+        foregroundCube.addEventListener('mousedown', function (evt) {
+          foregroundCube.setAttribute('mixin','cube cube-selected')
+        })
+        foregroundCube.addEventListener('mouseup', function (evt) {
+          foregroundCube.setAttribute('mixin','cube cube-hovered')
+        })
+        foregroundCube.addEventListener('click', function (evt) {
+          var scene = document.querySelector('a-scene');
+          var clickRing = document.createElement('a-entity');
+          clickRing.id = 'clickRing-'+new Date().getTime();
+          clickRing.setAttribute('material','color: magenta; transparent: true; opacity: 0.6');
+          clickRing.setAttribute('geometry','primitive: ring; radius-inner: 0.5; radius-outer: 0.6');
+          clickRing.setAttribute('position',evt.detail.intersection.point);
+          var opacityAnimation = document.createElement('a-animation');
+          opacityAnimation.setAttribute('attribute','material.opacity');
+          opacityAnimation.setAttribute('to',0);
+          opacityAnimation.setAttribute('duration','250');
+          opacityAnimation.setAttribute('easing','ease-out-quad');
+          var scaleAnimation = document.createElement('a-animation');
+          scaleAnimation.setAttribute('attribute','scale');
+          scaleAnimation.setAttribute('to','3 3 3');
+          scaleAnimation.setAttribute('duration','250');
+          scaleAnimation.setAttribute('easing','ease-out-quad');
+          var onAnimationEnd = function () {
+            scene.removeChild(document.querySelector('#'+clickRing.id))
+          }
+          scaleAnimation.addEventListener('animationend', onAnimationEnd.bind(this))
+          clickRing.appendChild(opacityAnimation);
+          clickRing.appendChild(scaleAnimation);
+          scene.appendChild(clickRing);
         })
       })();
     </script>

--- a/examples/test/cursor/index.html
+++ b/examples/test/cursor/index.html
@@ -42,9 +42,18 @@
       </a-entity>
 
       <a-entity position="0 1 0">
-        <a-entity mixin="green cube"
+        <a-entity id="foregroundCube"
+                  mixin="green cube"
                   sound__1="on: click; src: #blip1;"
                   sound__2="on: mouseenter; src: #blip2;">
+          <a-animation begin="click" attribute="rotation" to="0 360 0"
+                       easing="linear" dur="2000" fill="backwards"></a-animation>
+        </a-entity>
+      </a-entity>
+
+      <a-entity position="0 1 -3">
+        <a-entity id="backgroundCube"
+                  mixin="green cube">
           <a-animation begin="click" attribute="rotation" to="0 360 0"
                        easing="linear" dur="2000" fill="backwards"></a-animation>
         </a-entity>
@@ -58,7 +67,7 @@
         </a-entity>
       </a-entity>
 
-      <a-entity mixin="yellow cube" position="0 3 0" class="clickable"
+      <a-entity mixin="yellow cube" position="0 3 -3" class="clickable"
                 rotation="0 45 0" scale=".5 .5 .5"></a-entity>
     </a-scene>
 
@@ -88,6 +97,15 @@
             window.top.postMessage({type: 'navigate', data: {url: href}}, '*');
           })
         }
+
+        // testing mouseenter and mouseleave
+        var foregroundCube = document.querySelector('#foregroundCube');
+        foregroundCube.addEventListener('mouseenter', function () {
+          foregroundCube.setAttribute('mixin','cube cube-hovered')
+        })
+        foregroundCube.addEventListener('mouseleave', function () {
+          foregroundCube.setAttribute('mixin','green cube')
+        })
       })();
     </script>
   </body>

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -89,10 +89,7 @@ module.exports.Component = registerComponent('cursor', {
     // Set intersected entity if not already intersecting.
     if (this.intersectedEl === intersectedEl) { return; }
 
-    if (this.intersectedEl) {
-      this.leaveCurrentIntersection();
-    }
-
+    if (this.intersectedEl) { this.clearCurrentIntersection(); }
     this.intersectedEl = intersectedEl;
 
     // Hovering.
@@ -120,10 +117,10 @@ module.exports.Component = registerComponent('cursor', {
     // ignore if the event didn't occur on the current intersection
     if (intersectedEl !== this.intersectedEl) { return; }
 
-    this.leaveCurrentIntersection(intersectedEl);
+    this.clearCurrentIntersection(intersectedEl);
   },
 
-  leaveCurrentIntersection: function () {
+  clearCurrentIntersection: function () {
     var cursorEl = this.el;
 
     // No longer hovering (or fusing).

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -88,6 +88,11 @@ module.exports.Component = registerComponent('cursor', {
 
     // Set intersected entity if not already intersecting.
     if (this.intersectedEl === intersectedEl) { return; }
+
+    if (this.intersectedEl) {
+      this.leaveCurrentIntersection();
+    }
+
     this.intersectedEl = intersectedEl;
 
     // Hovering.
@@ -108,14 +113,21 @@ module.exports.Component = registerComponent('cursor', {
    * Handle intersection cleared.
    */
   onIntersectionCleared: function (evt) {
-    var cursorEl = this.el;
     var intersectedEl = evt.detail.el;
 
-    // Not intersecting.
     if (!intersectedEl || !this.intersectedEl) { return; }
 
+    // ignore if the event didn't occur on the current intersection
+    if (intersectedEl !== this.intersectedEl) { return; }
+
+    this.leaveCurrentIntersection(intersectedEl);
+  },
+
+  leaveCurrentIntersection: function () {
+    var cursorEl = this.el;
+
     // No longer hovering (or fusing).
-    intersectedEl.removeState(STATES.HOVERED);
+    this.intersectedEl.removeState(STATES.HOVERED);
     cursorEl.removeState(STATES.HOVERING);
     cursorEl.removeState(STATES.FUSING);
     this.twoWayEmit(EVENTS.MOUSELEAVE);

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -70,7 +70,7 @@ module.exports.Component = registerComponent('cursor', {
    * - Currently-intersected entity is the same as the one when mousedown was triggered,
    *   in case user mousedowned one entity, dragged to another, and mouseupped.
    */
-  onMouseUp: function () {
+  onMouseUp: function (evt) {
     this.twoWayEmit(EVENTS.MOUSEUP);
     if (this.data.fuse || !this.intersectedEl ||
         this.mouseDownEl !== this.intersectedEl) { return; }
@@ -85,6 +85,8 @@ module.exports.Component = registerComponent('cursor', {
     var cursorEl = this.el;
     var data = this.data;
     var intersectedEl = evt.detail.els[0];  // Grab the closest.
+    var intersection = evt.detail.intersections[0];
+    this.intersection = intersection;
 
     // Set intersected entity if not already intersecting.
     if (this.intersectedEl === intersectedEl) { return; }
@@ -141,8 +143,10 @@ module.exports.Component = registerComponent('cursor', {
    */
   twoWayEmit: function (evtName) {
     var intersectedEl = this.intersectedEl;
-    this.el.emit(evtName, {intersectedEl: this.intersectedEl});
+    var cursorPayload = { intersectedEl: this.intersectedEl, intersection: this.intersection };
+    var intersectedElPayload = { cursorEl: this.el, intersection: this.intersection };
+    this.el.emit(evtName, cursorPayload);
     if (!intersectedEl) { return; }
-    intersectedEl.emit(evtName, {cursorEl: this.el});
+    intersectedEl.emit(evtName, intersectedElPayload);
   }
 });

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -143,10 +143,10 @@ module.exports.Component = registerComponent('cursor', {
    */
   twoWayEmit: function (evtName) {
     var intersectedEl = this.intersectedEl;
-    var cursorPayload = { intersectedEl: this.intersectedEl, intersection: this.intersection };
-    var intersectedElPayload = { cursorEl: this.el, intersection: this.intersection };
-    this.el.emit(evtName, cursorPayload);
+    var cursorEvtDetail = { intersectedEl: this.intersectedEl, intersection: this.intersection };
+    var intersectedElEvtDetail = { cursorEl: this.el, intersection: this.intersection };
+    this.el.emit(evtName, cursorEvtDetail);
     if (!intersectedEl) { return; }
-    intersectedEl.emit(evtName, intersectedElPayload);
+    intersectedEl.emit(evtName, intersectedElEvtDetail);
   }
 });


### PR DESCRIPTION
**Description:**
A fix to the cursor.js component to ensure that `mouseenter` and `mouseleave` events fire reliably when multiple objects intersect the cursor's raycaster. 
 
**Changes proposed:**
- created a new function called `leaveCurrentIntersection` to handle triggering leave events, resetting the fuse timer, etc.
- leaveCurrentIntersection is now triggered in the `onIntersection` function if a current intersection already exists
- leaveCurrentIntersection is triggered in `onIntersectionCleared` only if the event is fired on the currently intersected element
- added test cases to the Cursor test example 

