### PR TITLE
Update rstats & Fix for #1630

### DIFF
--- a/src/style/rStats.css
+++ b/src/style/rStats.css
@@ -50,6 +50,19 @@
   margin: 2px 0;
 }
 
+.rs-counter-base.alarm {
+  color: #b70000;
+  text-shadow: 0 0 0 #b70000,
+               0 0 1px #fff,
+               0 0 1px #fff,
+               0 0 2px #fff,
+               0 0 2px #fff,
+               0 0 3px #fff,
+               0 0 3px #fff,
+               0 0 4px #fff,
+               0 0 4px #fff;
+}
+
 .rs-counter-id {
   font-weight: 300;
   -webkit-box-ordinal-group: 0;

--- a/vendor/rStats.js
+++ b/vendor/rStats.js
@@ -194,8 +194,6 @@ window.rStats = function rStats ( settings ) {
             _graph = new Graph( _dom, _id, _def ),
             _started = false;
 
-        _dom.className = 'rs-counter-base';
-
         _spanId.className = 'rs-counter-id';
         _spanId.textContent = ( _def && _def.caption ) ? _def.caption : _id;
 
@@ -250,8 +248,8 @@ window.rStats = function rStats ( settings ) {
             _spanValueText.nodeValue = Math.round( v * 100 ) / 100;
             var a = ( _def && ( ( _def.below && _value < _def.below ) || ( _def.over && _value > _def.over ) ) );
             _graph.draw( _value, a );
-            _dom.style.color = a ? '#b70000' : '#ffffff';
-            _dom.style.backgroundColor = a ? '#ffffff' : null;
+            _dom.className = a ? 'rs-counter-base alarm' : 'rs-counter-base';
+
         }
 
         function _frame () {


### PR DESCRIPTION
**Description:**
Currently the text for counters under the threshold under rstats.js is hard to read (red on gray background). https://github.com/spite/rstats/pull/24 was an attempt to solve this and is now merged into rstats.

This change addresses #1630

**Changes proposed:**
- Update rstats.js with the current version in https://github.com/spite/rstats/blob/master/src/rStats.js

- Add a `.rs-counter-base.alarm` class based off of `.alarm` in https://github.com/spite/rstats/blob/master/demo/rStats.css to add white text-shadow for readability.