### PR TITLE
[docs] Updating Fuse Timemout to new syntax in cursor docs

### DIFF
--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -97,7 +97,7 @@ The advantage of fuse-based interactions for VR is that it does not require addi
 To add visual feedback to the cursor in order to display indication when the cursor is clicking or fusing, we can use the [animation system][animation]. When the cursor intersects the entity, it will emit an event, and the animation system will pick up event with the `begin` attribute:
 
 ```html
-<a-entity cursor="fuse: true; timeout: 500"
+<a-entity cursor="fuse: true; fuseTimeout: 500"
           position="0 0 -1"
           geometry="primitive: ring"
           material="color: black; shader: flat">


### PR DESCRIPTION
**Description:**
It seems that you can no longer set the fuse timeout of a cursor using `timeout`. This looks only partially reflected in the docs.
**Changes proposed:**
- Change `timeout` to `fuseTimeout` in the cursor docs

Anyway, Thanks a lot for the great work that you've done on this project ! It's awesome :smiley: 

