### PR TITLE
Issue #1881 src not set throws error for dynamic src

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -156,8 +156,8 @@ function setCrossOrigin (mediaEl) {
 
   src = mediaEl.getAttribute('src');
 
-  // Does not have protocol.
-  if (src.indexOf('://') === -1) { return mediaEl; }
+  // Does not have src or src does not have protocol.
+  if (src === null || src.indexOf('://') === -1) { return mediaEl; }
 
   // Determine if cross origin is actually needed.
   if (extractDomain(src) === window.location.host) { return mediaEl; }

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -107,6 +107,26 @@ suite('a-assets', function () {
       document.body.appendChild(scene);
     });
 
+    test('does not recreate media element if no src set', function (done) {
+      var el = this.el;
+      var scene = this.scene;
+      var img = document.createElement('img');
+      var cloneSpy = this.sinon.spy(img, 'cloneNode');
+
+      img.setAttribute('id', 'myImage');
+      el.setAttribute('timeout', 50);
+      el.appendChild(img);
+
+      el.addEventListener('loaded', function () {
+        assert.ok(el.querySelectorAll('img').length, 1);
+        assert.notOk(el.querySelector('#myImage').hasAttribute('crossorigin'));
+        assert.notOk(cloneSpy.called);
+        done();
+      });
+
+      document.body.appendChild(scene);
+    });
+
     test('does not recreate media element if not crossorigin', function (done) {
       var el = this.el;
       var scene = this.scene;


### PR DESCRIPTION
**Description:**
Fixing [Issue #1881 ](https://github.com/aframevr/aframe/issues/1881#issuecomment-244658276), where a previous change caused a regression for usage of the dynamic src element.
Now handling when src is not present, where it will return null or an empty string - [https://developer.mozilla.org/en/docs/Web/API/Element/getAttribute](https://developer.mozilla.org/en/docs/Web/API/Element/getAttribute)

**Changes proposed:**
- If src is null, return the media element, like if it does not have the protocol set