### PR TITLE
Issue #1881 - Fix for null src, will not set crossorigin rather than …

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -156,11 +156,13 @@ function setCrossOrigin (mediaEl) {
 
   src = mediaEl.getAttribute('src');
 
-  // Does not have protocol.
-  if (src.indexOf('://') === -1) { return mediaEl; }
+  if (src !== null) {
+    // Does not have protocol.
+    if (src.indexOf('://') === -1) { return mediaEl; }
 
-  // Determine if cross origin is actually needed.
-  if (extractDomain(src) === window.location.host) { return mediaEl; }
+    // Determine if cross origin is actually needed.
+    if (extractDomain(src) === window.location.host) { return mediaEl; }
+  }
 
   warn('Cross-origin element was requested without `crossorigin` set. ' +
        'A-Frame will re-request the asset with `crossorigin` attribute set.', src);

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -107,6 +107,24 @@ suite('a-assets', function () {
       document.body.appendChild(scene);
     });
 
+    test('recreates media elements with crossorigin even if no src set', function (done) {
+      var el = this.el;
+      var scene = this.scene;
+      var img = document.createElement('img');
+
+      img.setAttribute('id', 'myImage');
+      el.setAttribute('timeout', 50);
+      el.appendChild(img);
+
+      el.addEventListener('loaded', function () {
+        assert.ok(el.querySelectorAll('img').length, 1);
+        assert.ok(el.querySelector('#myImage').hasAttribute('crossorigin'));
+        done();
+      });
+
+      document.body.appendChild(scene);
+    });
+
     test('does not recreate media element if not crossorigin', function (done) {
       var el = this.el;
       var scene = this.scene;


### PR DESCRIPTION
**Description:**
Fixing [Issue #1881 ](https://github.com/aframevr/aframe/issues/1881#issuecomment-244658276), where a previous change caused a regression for usage of the dynamic src element.
Now handling when src is not present, where it will return null or an empty string - [https://developer.mozilla.org/en/docs/Web/API/Element/getAttribute](https://developer.mozilla.org/en/docs/Web/API/Element/getAttribute)

**Changes proposed:**
- If src is null, set cross origin instead of throwing error