### PR TITLE
Raise 'asking a question' to top level in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,10 @@
 
 # Getting Help or Asking a Question
 
-If you're not sure how to do something with A-Frame, please post a question (and any code you've tried so far) to [Stack Overflow under the 'aframe' tag][stackoverflow]. Questions there will automatically create notifications in [Slack](https://aframevr-slack.herokuapp.com), and are easier for others to find – so new developers can
-learn from your questions, too.
+If you're not sure how to do something with A-Frame, please post a question (and any code you've tried so far)
+to [Stack Overflow under the 'aframe' tag][stackoverflow]. Questions there will automatically create
+notifications in [Slack](https://aframevr-slack.herokuapp.com), and are easier for others to find – so new
+developers can learn from your questions, too.
 
 # File an Issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,12 @@
 1. [Invite yourself](https://aframevr-slack.herokuapp.com/) to the A-Frame Slack channel.
 2. [Join the discussion](https://aframevr.slack.com)!
 
-# File an Issue
+# Getting Help or Asking a Question
 
-If you have a question rather than an issue, you can post to [the A-Frame Stack
-Overflow tag][stackoverflow]
+If you're not sure how to do something with A-Frame, please post a question (and any code you've tried so far) to [Stack Overflow under the 'aframe' tag][stackoverflow]. Questions there will automatically create notifications in [Slack](https://aframevr-slack.herokuapp.com), and are easier for others to find – so new developers can
+learn from your questions, too.
+
+# File an Issue
 
 1. Search the [issue tracker](https://github.com/aframevr/aframe/issues) for similar issues.
 2. Specify the version of A-Frame in which the bug occurred.


### PR DESCRIPTION
May be worth creating a top-level header on how/where to ask questions (A: Stack Overflow), rather than having that under the 'File an Issue' header. The distinction of a "question rather than an issue" may not be self-evident.

