### PR TITLE
getAttribute -> getDefinedAttribute, getComputedAttribute -> getAttribute (fixes #1590)

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -189,12 +189,12 @@ entity.getAttribute('data-position');
 // >> "0 1 1"
 ```
 
-### `getDefinedAttribute (componentName)`
+### `getDOMAttribute (componentName)`
 
-`getDefinedAttribute` retrieves only parsed component data that is explicitly
+`getDOMAttribute` retrieves only parsed component data that is explicitly
 defined in the DOM or via `setAttribute`. If `componentName` is the name of a
-registered component, `getDefinedAttribute` will return only the component data
-defined in the HTML as a parsed object. `getDefinedAttribute` for components is
+registered component, `getDOMAttribute` will return only the component data
+defined in the HTML as a parsed object. `getDOMAttribute` for components is
 the partial form of `getAttribute` since the returned component data does not
 include applied mixins or default values:
 
@@ -203,16 +203,16 @@ Compare the output of the above example of [`getAttribute`](#getAttribute):
 ```js
 // <a-entity geometry="primitive: box; width: 3">
 
-entity.getDefinedAttribute('geometry');
+entity.getDOMAttribute('geometry');
 // >> { primitive: "box", width: 3 }
 
-entity.getDefinedAttribute('geometry').primitive;
+entity.getDOMAttribute('geometry').primitive;
 // >> "box"
 
-entity.getDefinedAttribute('geometry').height;
+entity.getDOMAttribute('geometry').height;
 // >> undefined
 
-entity.getDefinedAttribute('position');
+entity.getDOMAttribute('position');
 // >> undefined
 ```
 

--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -159,24 +159,28 @@ entity.emit('sink', null, false);
 `flushToDOM` will manually serialize all of the entity's components' data and update the DOM.
 Read more about [component-to-DOM serialization][component-to-dom-serialization].
 
-### `getAttribute (attr)`
+### `getAttribute (componentName)`
 
-`getAttribute` can be used to retrieve parsed component data. If `attr` is the name of a registered component, `getAttribute` will return only the component data defined in the HTML as a parsed object. `getAttribute` for components is the partial form of `getComputedAttribute` since the returned component data does not include applied mixins or default values:
+`getAttribute` retrieves parsed component data (including mixins and defaults).
 
 ```js
 // <a-entity geometry="primitive: box; width: 3">
 
 entity.getAttribute('geometry');
-// >> { primitive: "box", width: 3 }
+// >> {primitive: "box", depth: 2, height: 2, translate: "0 0 0", width: 3, ...}
 
 entity.getAttribute('geometry').primitive;
 // >> "box"
 
 entity.getAttribute('geometry').height;
-// >> undefined
+// >> 2
+
+entity.getAttribute('position');
+// >> {x: 0, y: 0, z: 0}
 ```
 
-If `attr` is not the name of a registered component, `getAttribute` will behave as it normally would:
+If `componentName` is not the name of a registered component, `getAttribute`
+will behave as it normally would:
 
 ```js
 // <a-entity data-position="0 1 1">
@@ -185,26 +189,32 @@ entity.getAttribute('data-position');
 // >> "0 1 1"
 ```
 
-### `getComputedAttribute (attr)`
+### `getDefinedAttribute (componentName)`
 
-`getComputedAttribute` is similar to `getAttribute`, but it will return *all* of the component's properties for multi-property components. It can be thought of as an analog to [`getComputedStyle`](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle), which in CSS returns all CSS properties after applying stylesheets and computations. `getComputedAttribute` will return all component properties after applying mixins and default values.
+`getDefinedAttribute` retrieves only parsed component data that is explicitly
+defined in the DOM or via `setAttribute`. If `componentName` is the name of a
+registered component, `getDefinedAttribute` will return only the component data
+defined in the HTML as a parsed object. `getDefinedAttribute` for components is
+the partial form of `getAttribute` since the returned component data does not
+include applied mixins or default values:
 
 Compare the output of the above example of [`getAttribute`](#getAttribute):
 
 ```js
 // <a-entity geometry="primitive: box; width: 3">
 
-entity.getComputedAttribute('geometry');
-// >> { primitive: "box", depth: 2, height: 2, translate: "0 0 0", width: 3, ... }
+entity.getDefinedAttribute('geometry');
+// >> { primitive: "box", width: 3 }
 
-entity.getComputedAttribute('geometry').primitive;
+entity.getDefinedAttribute('geometry').primitive;
 // >> "box"
 
-entity.getComputedAttribute('geometry').height;
-// >> 2
-```
+entity.getDefinedAttribute('geometry').height;
+// >> undefined
 
-More often we will want to use `getComputedAttribute` to inspect the component's data. Though sometimes we might want to use `getAttribute` to discern which properties were explicitly defined.
+entity.getDefinedAttribute('position');
+// >> undefined
+```
 
 ### `getObject3D (type)`
 

--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -110,7 +110,7 @@ module.exports.Component = registerComponent('camera', {
     var userHeightOffset = this.data.userHeight;
 
     oldOffset = oldOffset || 0;
-    currentPosition = el.getComputedAttribute('position') || {x: 0, y: 0, z: 0};
+    currentPosition = el.getAttribute('position') || {x: 0, y: 0, z: 0};
     el.setAttribute('position', {
       x: currentPosition.x,
       y: currentPosition.y - oldOffset + userHeightOffset,

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -69,7 +69,7 @@ module.exports.Component = registerComponent('geometry', {
     toMesh = toEl.getObject3D('mesh');
     if (!toMesh) {
       toMesh = toEl.getOrCreateObject3D('mesh', THREE.Mesh);
-      toEl.setAttribute('material', el.getComputedAttribute('material'));
+      toEl.setAttribute('material', el.getAttribute('material'));
       return;
     }
 

--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -145,7 +145,7 @@ module.exports.Component = registerComponent('look-controls', {
           z: radToDeg(hmdEuler.z)
         };
       } else if (!sceneEl.is('vr-mode') || isNullVector(hmdEuler) || !this.data.hmdEnabled) {
-        currentRotation = this.el.getComputedAttribute('rotation');
+        currentRotation = this.el.getAttribute('rotation');
         deltaRotation = this.calculateDeltaRotation();
         // Mouse look only if HMD disabled or no info coming from the sensors
         rotation = {
@@ -197,7 +197,7 @@ module.exports.Component = registerComponent('look-controls', {
     var deltaHMDPosition = new THREE.Vector3();
     return function () {
       var el = this.el;
-      var currentPosition = el.getComputedAttribute('position');
+      var currentPosition = el.getAttribute('position');
       var currentHMDPosition;
       var previousHMDPosition = this.previousHMDPosition;
       var sceneEl = this.el.sceneEl;

--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -57,7 +57,7 @@ module.exports.Component = registerComponent('wasd-controls', {
 
     // Get movement vector and translate position.
     movementVector = this.getMovementVector(delta);
-    position = el.getComputedAttribute('position');
+    position = el.getAttribute('position');
     el.setAttribute('position', {
       x: position.x + movementVector.x,
       y: position.y + movementVector.y,
@@ -132,7 +132,7 @@ module.exports.Component = registerComponent('wasd-controls', {
     var rotationEuler = new THREE.Euler(0, 0, 0, 'YXZ');
 
     return function (delta) {
-      var rotation = this.el.getComputedAttribute('rotation');
+      var rotation = this.el.getAttribute('rotation');
       var velocity = this.velocity;
 
       directionVector.copy(velocity);

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -117,7 +117,7 @@ var proto = Object.create(ANode.prototype, {
         this.updateComponents();
         return;
       }
-      this.updateComponent(attrName, this.getDefinedAttribute(attrName));
+      this.updateComponent(attrName, this.getDOMAttribute(attrName));
     }
   },
 
@@ -412,7 +412,7 @@ var proto = Object.create(ANode.prototype, {
        * Update component with given name.
        */
       function updateComponent (name) {
-        var attrValue = self.getDefinedAttribute(name);
+        var attrValue = self.getDOMAttribute(name);
         delete elComponents[name];
         self.updateComponent(name, attrValue);
       }
@@ -646,7 +646,7 @@ var proto = Object.create(ANode.prototype, {
   },
 
   /**
-   * `getAttribute` used to be `getDefinedAttribute` and `getComputedAttribute` used to be
+   * `getAttribute` used to be `getDOMAttribute` and `getComputedAttribute` used to be
    * what `getAttribute` is now. Now legacy code.
    *
    * @param {string} attr
@@ -669,7 +669,7 @@ var proto = Object.create(ANode.prototype, {
    * @param {string} attr
    * @returns {object|string} Object if component, else string.
    */
-  getDefinedAttribute: {
+  getDOMAttribute: {
     value: function (attr) {
       // If cached value exists, return partial component data.
       var component = this.components[attr];

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -8,6 +8,7 @@ var bind = utils.bind;
 
 var AEntity;
 var debug = utils.debug('core:a-entity:debug');
+var warn = utils.debug('core:a-entity:warn');
 
 var MULTIPLE_COMPONENT_DELIMITER = '__';
 
@@ -116,7 +117,7 @@ var proto = Object.create(ANode.prototype, {
         this.updateComponents();
         return;
       }
-      this.updateComponent(attrName, this.getAttribute(attrName));
+      this.updateComponent(attrName, this.getDefinedAttribute(attrName));
     }
   },
 
@@ -411,7 +412,7 @@ var proto = Object.create(ANode.prototype, {
        * Update component with given name.
        */
       function updateComponent (name) {
-        var attrValue = self.getAttribute(name);
+        var attrValue = self.getDefinedAttribute(name);
         delete elComponents[name];
         self.updateComponent(name, attrValue);
       }
@@ -626,6 +627,39 @@ var proto = Object.create(ANode.prototype, {
   },
 
   /**
+   * If `attr` is a component, returns ALL component data including applied mixins and
+   * defaults.
+   *
+   * If `attr` is not a component, fall back to HTML getAttribute.
+   *
+   * @param {string} attr
+   * @returns {object|string} Object if component, else string.
+   */
+  getAttribute: {
+    value: function (attr) {
+      // If component, return component data.
+      var component = this.components[attr];
+      if (component) { return component.getData(); }
+      return HTMLElement.prototype.getAttribute.call(this, attr);
+    },
+    writable: window.debug
+  },
+
+  /**
+   * `getAttribute` used to be `getDefinedAttribute` and `getComputedAttribute` used to be
+   * what `getAttribute` is now. Now legacy code.
+   *
+   * @param {string} attr
+   * @returns {object|string} Object if component, else string.
+   */
+  getComputedAttribute: {
+    value: function (attr) {
+      warn('`getComputedAttribute` is deprecated. Use `getAttribute` instead.');
+      return this.getAttribute(attr);
+    }
+  },
+
+  /**
    * If `attr` is a component, returns JUST the component data defined on the entity.
    * Like a partial version of `getComputedAttribute` as returned component data
    * does not include applied mixins or defaults.
@@ -635,7 +669,7 @@ var proto = Object.create(ANode.prototype, {
    * @param {string} attr
    * @returns {object|string} Object if component, else string.
    */
-  getAttribute: {
+  getDefinedAttribute: {
     value: function (attr) {
       // If cached value exists, return partial component data.
       var component = this.components[attr];
@@ -643,24 +677,6 @@ var proto = Object.create(ANode.prototype, {
       return HTMLElement.prototype.getAttribute.call(this, attr);
     },
     writable: window.debug
-  },
-
-  /**
-   * If `attr` is a component, returns ALL component data including applied mixins and
-   * defaults.
-   *
-   * If `attr` is not a component, fall back to HTML getAttribute.
-   *
-   * @param {string} attr
-   * @returns {object|string} Object if component, else string.
-   */
-  getComputedAttribute: {
-    value: function (attr) {
-      // If component, return component data.
-      var component = this.components[attr];
-      if (component) { return component.getData(); }
-      return HTMLElement.prototype.getAttribute.call(this, attr);
-    }
   },
 
   addState: {

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -16,6 +16,7 @@ var checkHeadsetConnected = utils.checkHeadsetConnected;
 var registerElement = re.registerElement;
 var isIOS = utils.isIOS();
 var isMobile = utils.isMobile();
+var warn = utils.debug('core:a-scene:warn');
 
 /**
  * Scene element, holds all entities.
@@ -225,14 +226,25 @@ module.exports = registerElement('a-scene', {
     },
 
     /**
-     * Wraps Entity.getComputedAttribute to take into account for systems.
-     * If system exists, then return system data rather than possible component data.
+     * `getAttribute` used to be `getDefinedAttribute` and `getComputedAttribute` used to be
+     * what `getAttribute` is now. Now legacy code.
      */
     getComputedAttribute: {
       value: function (attr) {
+        warn('`getComputedAttribute` is deprecated. Use `getAttribute` instead.');
+        this.getAttribute(attr);
+      }
+    },
+
+    /**
+     * Wraps Entity.getDefinedAttribute to take into account for systems.
+     * If system exists, then return system data rather than possible component data.
+     */
+    getDefinedAttribute: {
+      value: function (attr) {
         var system = this.systems[attr];
         if (system) { return system.data; }
-        return AEntity.prototype.getComputedAttribute.call(this, attr);
+        return AEntity.prototype.getDefinedAttribute.call(this, attr);
       }
     },
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -226,7 +226,7 @@ module.exports = registerElement('a-scene', {
     },
 
     /**
-     * `getAttribute` used to be `getDefinedAttribute` and `getComputedAttribute` used to be
+     * `getAttribute` used to be `getDOMAttribute` and `getComputedAttribute` used to be
      * what `getAttribute` is now. Now legacy code.
      */
     getComputedAttribute: {
@@ -237,14 +237,14 @@ module.exports = registerElement('a-scene', {
     },
 
     /**
-     * Wraps Entity.getDefinedAttribute to take into account for systems.
+     * Wraps Entity.getDOMAttribute to take into account for systems.
      * If system exists, then return system data rather than possible component data.
      */
-    getDefinedAttribute: {
+    getDOMAttribute: {
       value: function (attr) {
         var system = this.systems[attr];
         if (system) { return system.data; }
-        return AEntity.prototype.getDefinedAttribute.call(this, attr);
+        return AEntity.prototype.getDOMAttribute.call(this, attr);
       }
     },
 

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -84,7 +84,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
             // Set component properties individually to not overwrite user-defined components.
             if (componentData instanceof Object) {
               var component = components[componentName];
-              var attrValues = self.getDefinedAttribute(componentName) || {};
+              var attrValues = self.getDOMAttribute(componentName) || {};
               var data = component.parse(attrValues);
 
               // Check if component property already defined.

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -84,7 +84,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
             // Set component properties individually to not overwrite user-defined components.
             if (componentData instanceof Object) {
               var component = components[componentName];
-              var attrValues = self.getAttribute(componentName) || {};
+              var attrValues = self.getDefinedAttribute(componentName) || {};
               var data = component.parse(attrValues);
 
               // Check if component property already defined.

--- a/src/utils/entity.js
+++ b/src/utils/entity.js
@@ -7,9 +7,9 @@ module.exports.getComponentProperty = function (el, name, delimiter) {
   delimiter = delimiter || '.';
   if (name.indexOf(delimiter) !== -1) {
     splitName = name.split(delimiter);
-    return el.getComputedAttribute(splitName[0])[splitName[1]];
+    return el.getAttribute(splitName[0])[splitName[1]];
   }
-  return el.getComputedAttribute(name);
+  return el.getAttribute(name);
 };
 
 /**

--- a/tests/components/position.test.js
+++ b/tests/components/position.test.js
@@ -19,7 +19,7 @@ suite('position', function () {
 
   suite('schema', function () {
     test('can get position', function () {
-      assert.shallowDeepEqual(this.el.getComputedAttribute('position'), {
+      assert.shallowDeepEqual(this.el.getAttribute('position'), {
         x: 0, y: 0, z: 0
       });
     });

--- a/tests/components/rotation.test.js
+++ b/tests/components/rotation.test.js
@@ -20,7 +20,7 @@ suite('rotation', function () {
 
   suite('schema', function () {
     test('can get rotation', function () {
-      assert.shallowDeepEqual(this.el.getComputedAttribute('rotation'), {
+      assert.shallowDeepEqual(this.el.getAttribute('rotation'), {
         x: 0, y: 0, z: 0
       });
     });

--- a/tests/components/scale.test.js
+++ b/tests/components/scale.test.js
@@ -19,7 +19,7 @@ suite('scale', function () {
 
   suite('schema', function () {
     test('can get scale', function () {
-      assert.shallowDeepEqual(this.el.getComputedAttribute('scale'), {
+      assert.shallowDeepEqual(this.el.getAttribute('scale'), {
         x: 1, y: 1, z: 1
       });
     });

--- a/tests/core/a-animation.test.js
+++ b/tests/core/a-animation.test.js
@@ -154,20 +154,20 @@ suite('a-animation', function () {
     });
 
     test('start value', function () {
-      assert.equal(this.el.getComputedAttribute('light').intensity, 0);
+      assert.equal(this.el.getAttribute('light').intensity, 0);
     });
 
     test('between value', function () {
       var intensity;
       this.animationEl.tween.update(this.startTime + 500);
-      intensity = this.el.getComputedAttribute('light').intensity;
+      intensity = this.el.getAttribute('light').intensity;
       assert.isAbove(intensity, 0);
       assert.isBelow(intensity, 1);
     });
 
     test('finish value', function () {
       this.animationEl.tween.update(this.startTime + 1000);
-      assert.equal(this.el.getComputedAttribute('light').intensity, 1);
+      assert.equal(this.el.getAttribute('light').intensity, 1);
     });
   });
 
@@ -644,20 +644,20 @@ suite('a-animation', function () {
     });
 
     test('start value', function () {
-      assert.equal(this.el.getComputedAttribute(attribute), '#ff0000');
+      assert.equal(this.el.getAttribute(attribute), '#ff0000');
     });
 
     test('between value', function () {
       var color;
       this.animationEl.tween.update(this.startTime + 500);
-      color = this.el.getComputedAttribute(attribute);
+      color = this.el.getAttribute(attribute);
       assert.isAbove(color, '#0000ff');
       assert.isBelow(color, '#ff0000');
     });
 
     test('finish value', function () {
       this.animationEl.tween.update(this.startTime + 1000);
-      assert.equal(this.el.getComputedAttribute(attribute), '#0000ff');
+      assert.equal(this.el.getAttribute(attribute), '#0000ff');
     });
   });
 

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -265,7 +265,7 @@ suite('a-entity', function () {
       var el = this.el;
       var material;
       el.setAttribute('material', 'color: #F0F; metalness: 0.75');
-      material = el.getAttribute('material');
+      material = el.getDefinedAttribute('material');
       assert.equal(material.color, '#F0F');
       assert.equal(material.metalness, 0.75);
     });
@@ -275,7 +275,7 @@ suite('a-entity', function () {
       var material;
       var value = {color: '#F0F', metalness: 0.75};
       el.setAttribute('material', value);
-      material = el.getAttribute('material');
+      material = el.getDefinedAttribute('material');
       assert.equal(material.color, '#F0F');
       assert.equal(material.metalness, 0.75);
     });
@@ -286,7 +286,7 @@ suite('a-entity', function () {
       var value = {color: '#000'};
       el.setAttribute('material', 'color: #F0F; roughness: 0.25');
       el.setAttribute('material', value);
-      material = el.getAttribute('material');
+      material = el.getDefinedAttribute('material');
       assert.equal(material.color, '#000');
       assert.equal(material.roughness, undefined);
     });
@@ -294,16 +294,16 @@ suite('a-entity', function () {
     test('can set a single component via a single attribute', function () {
       var el = this.el;
       el.setAttribute('material', 'color', '#F0F');
-      assert.equal(el.getAttribute('material').color, '#F0F');
+      assert.equal(el.getDefinedAttribute('material').color, '#F0F');
     });
 
     test('can update a single component attribute', function () {
       var el = this.el;
       var material;
       el.setAttribute('material', 'color: #F0F; roughness: 0.25');
-      assert.equal(el.getAttribute('material').roughness, 0.25);
+      assert.equal(el.getDefinedAttribute('material').roughness, 0.25);
       el.setAttribute('material', 'roughness', 0.75);
-      material = el.getAttribute('material');
+      material = el.getDefinedAttribute('material');
       assert.equal(material.color, '#F0F');
       assert.equal(material.roughness, 0.75);
     });
@@ -320,11 +320,11 @@ suite('a-entity', function () {
       var position;
 
       el.setAttribute('position', '10 20 30');
-      position = el.getAttribute('position');
+      position = el.getDefinedAttribute('position');
       assert.deepEqual(position, {x: 10, y: 20, z: 30});
 
       el.setAttribute('position', {x: 30, y: 20, z: 10});
-      position = el.getAttribute('position');
+      position = el.getDefinedAttribute('position');
       assert.deepEqual(position, {x: 30, y: 20, z: 10});
     });
 
@@ -445,12 +445,12 @@ suite('a-entity', function () {
     });
   });
 
-  suite('getAttribute', function () {
+  suite('getDefinedAttribute', function () {
     test('returns parsed component data', function () {
       var componentData;
       var el = this.el;
       el.setAttribute('geometry', 'primitive: box; width: 5');
-      componentData = el.getAttribute('geometry');
+      componentData = el.getDefinedAttribute('geometry');
       assert.equal(componentData.width, 5);
       assert.notOk('height' in componentData);
     });
@@ -458,26 +458,26 @@ suite('a-entity', function () {
     test('returns empty object if component is at defaults', function () {
       var el = this.el;
       el.setAttribute('material', '');
-      assert.shallowDeepEqual(el.getAttribute('material'), {});
+      assert.shallowDeepEqual(el.getDefinedAttribute('material'), {});
     });
 
     test('returns null for a default component if it is not set', function () {
       var el = this.el;
-      assert.shallowDeepEqual(el.getAttribute('position'), null);
+      assert.shallowDeepEqual(el.getDefinedAttribute('position'), null);
     });
 
     test('returns parsed data if default component is set', function () {
       var el = this.el;
       var position = {x: 5, y: 6, z: 6};
       el.setAttribute('position', position);
-      assert.shallowDeepEqual(el.getAttribute('position'), position);
+      assert.shallowDeepEqual(el.getDefinedAttribute('position'), position);
     });
 
     test('returns partial component data', function () {
       var componentData;
       var el = this.el;
       el.setAttribute('geometry', 'primitive: box; width: 5');
-      componentData = el.getAttribute('geometry');
+      componentData = el.getDefinedAttribute('geometry');
       assert.equal(componentData.width, 5);
       assert.notOk('height' in componentData);
     });
@@ -485,24 +485,24 @@ suite('a-entity', function () {
     test('falls back to HTML getAttribute if not a component', function () {
       var el = this.el;
       el.setAttribute('class', 'pied piper');
-      assert.equal(el.getAttribute('class'), 'pied piper');
+      assert.equal(el.getDefinedAttribute('class'), 'pied piper');
     });
 
     test('retrieves data from a multiple component', function () {
       var el = this.el;
       el.setAttribute('sound__1', {'src': 'url(mysoundfile.mp3)', autoplay: true});
       el.setAttribute('sound__2', {'src': 'url(mysoundfile.mp3)', autoplay: false});
-      assert.ok(el.getAttribute('sound__1'));
-      assert.ok(el.getAttribute('sound__2'));
-      assert.notOk(el.getAttribute('sound'));
-      assert.equal(el.getAttribute('sound__1').autoplay, true);
+      assert.ok(el.getDefinedAttribute('sound__1'));
+      assert.ok(el.getDefinedAttribute('sound__2'));
+      assert.notOk(el.getDefinedAttribute('sound'));
+      assert.equal(el.getDefinedAttribute('sound__1').autoplay, true);
     });
 
     test('retrieves default value for single property component when ' +
          'the element attribute is set to empty string', function () {
       var sceneEl = this.el.sceneEl;
       sceneEl.setAttribute('debug', '');
-      assert.equal(sceneEl.getAttribute('debug'), true);
+      assert.equal(sceneEl.getDefinedAttribute('debug'), true);
     });
   });
 
@@ -583,12 +583,12 @@ suite('a-entity', function () {
     });
   });
 
-  suite('getComputedAttribute', function () {
+  suite('getAttribute', function () {
     test('returns full component data', function () {
       var componentData;
       var el = this.el;
       el.setAttribute('geometry', 'primitive: box; width: 5');
-      componentData = el.getComputedAttribute('geometry');
+      componentData = el.getAttribute('geometry');
       assert.equal(componentData.primitive, 'box');
       assert.equal(componentData.width, 5);
       assert.ok('height' in componentData);
@@ -597,7 +597,7 @@ suite('a-entity', function () {
     test('returns default value on a default component not set', function () {
       var el = this.el;
       var defaultPosition = {x: 0, y: 0, z: 0};
-      var elPosition = el.getComputedAttribute('position');
+      var elPosition = el.getAttribute('position');
       assert.shallowDeepEqual(elPosition, defaultPosition);
     });
 
@@ -605,7 +605,7 @@ suite('a-entity', function () {
       var componentData;
       var el = this.el;
       el.setAttribute('sound__test', 'src: url(mysoundfile.mp3)');
-      componentData = el.getComputedAttribute('sound__test');
+      componentData = el.getAttribute('sound__test');
       assert.equal(componentData.src, 'mysoundfile.mp3');
       assert.equal(componentData.autoplay, false);
       assert.ok('loop' in componentData);
@@ -614,7 +614,7 @@ suite('a-entity', function () {
     test('falls back to HTML getAttribute if not a component', function () {
       var el = this.el;
       el.setAttribute('class', 'pied piper');
-      assert.equal(el.getComputedAttribute('class'), 'pied piper');
+      assert.equal(el.getAttribute('class'), 'pied piper');
     });
   });
 
@@ -649,7 +649,7 @@ suite('a-entity', function () {
       var el = this.el;
       assert.ok('position' in el.components);
       el.removeAttribute('position');
-      assert.equal(el.getAttribute('position'), null);
+      assert.equal(el.getDefinedAttribute('position'), null);
       assert.ok('position' in el.components);
     });
 
@@ -787,7 +787,7 @@ suite('a-entity', function () {
       mixinFactory(mixinId, {material: 'shader: flat'});
       el.setAttribute('mixin', mixinId);
       el.setAttribute('material', 'color: red');
-      assert.shallowDeepEqual(el.getComputedAttribute('material'), {shader: 'flat', color: 'red'});
+      assert.shallowDeepEqual(el.getAttribute('material'), {shader: 'flat', color: 'red'});
     });
 
     test('merges component properties from mixin', function (done) {
@@ -796,7 +796,7 @@ suite('a-entity', function () {
       process.nextTick(function () {
         el.setAttribute('mixin', 'box');
         el.setAttribute('geometry', {depth: 5, height: 5, width: 5});
-        assert.shallowDeepEqual(el.getComputedAttribute('geometry'), {
+        assert.shallowDeepEqual(el.getAttribute('geometry'), {
           depth: 5,
           height: 5,
           primitive: 'box',
@@ -811,7 +811,7 @@ suite('a-entity', function () {
       var mixinId = 'position';
       mixinFactory(mixinId, {position: '1 2 3'});
       el.setAttribute('mixin', mixinId);
-      assert.shallowDeepEqual(el.getComputedAttribute('position'), {x: 1, y: 2, z: 3});
+      assert.shallowDeepEqual(el.getAttribute('position'), {x: 1, y: 2, z: 3});
     });
 
     test('does not override defined property', function () {
@@ -819,7 +819,7 @@ suite('a-entity', function () {
       el.setAttribute('material', {color: 'red'});
       mixinFactory('blue', {material: 'color: blue'});
       el.setAttribute('mixin', 'blue');
-      assert.shallowDeepEqual(el.getComputedAttribute('material').color, 'red');
+      assert.shallowDeepEqual(el.getAttribute('material').color, 'red');
     });
   });
 });

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -265,7 +265,7 @@ suite('a-entity', function () {
       var el = this.el;
       var material;
       el.setAttribute('material', 'color: #F0F; metalness: 0.75');
-      material = el.getDefinedAttribute('material');
+      material = el.getDOMAttribute('material');
       assert.equal(material.color, '#F0F');
       assert.equal(material.metalness, 0.75);
     });
@@ -275,7 +275,7 @@ suite('a-entity', function () {
       var material;
       var value = {color: '#F0F', metalness: 0.75};
       el.setAttribute('material', value);
-      material = el.getDefinedAttribute('material');
+      material = el.getDOMAttribute('material');
       assert.equal(material.color, '#F0F');
       assert.equal(material.metalness, 0.75);
     });
@@ -286,7 +286,7 @@ suite('a-entity', function () {
       var value = {color: '#000'};
       el.setAttribute('material', 'color: #F0F; roughness: 0.25');
       el.setAttribute('material', value);
-      material = el.getDefinedAttribute('material');
+      material = el.getDOMAttribute('material');
       assert.equal(material.color, '#000');
       assert.equal(material.roughness, undefined);
     });
@@ -294,16 +294,16 @@ suite('a-entity', function () {
     test('can set a single component via a single attribute', function () {
       var el = this.el;
       el.setAttribute('material', 'color', '#F0F');
-      assert.equal(el.getDefinedAttribute('material').color, '#F0F');
+      assert.equal(el.getDOMAttribute('material').color, '#F0F');
     });
 
     test('can update a single component attribute', function () {
       var el = this.el;
       var material;
       el.setAttribute('material', 'color: #F0F; roughness: 0.25');
-      assert.equal(el.getDefinedAttribute('material').roughness, 0.25);
+      assert.equal(el.getDOMAttribute('material').roughness, 0.25);
       el.setAttribute('material', 'roughness', 0.75);
-      material = el.getDefinedAttribute('material');
+      material = el.getDOMAttribute('material');
       assert.equal(material.color, '#F0F');
       assert.equal(material.roughness, 0.75);
     });
@@ -320,11 +320,11 @@ suite('a-entity', function () {
       var position;
 
       el.setAttribute('position', '10 20 30');
-      position = el.getDefinedAttribute('position');
+      position = el.getDOMAttribute('position');
       assert.deepEqual(position, {x: 10, y: 20, z: 30});
 
       el.setAttribute('position', {x: 30, y: 20, z: 10});
-      position = el.getDefinedAttribute('position');
+      position = el.getDOMAttribute('position');
       assert.deepEqual(position, {x: 30, y: 20, z: 10});
     });
 
@@ -445,12 +445,12 @@ suite('a-entity', function () {
     });
   });
 
-  suite('getDefinedAttribute', function () {
+  suite('getDOMAttribute', function () {
     test('returns parsed component data', function () {
       var componentData;
       var el = this.el;
       el.setAttribute('geometry', 'primitive: box; width: 5');
-      componentData = el.getDefinedAttribute('geometry');
+      componentData = el.getDOMAttribute('geometry');
       assert.equal(componentData.width, 5);
       assert.notOk('height' in componentData);
     });
@@ -458,26 +458,26 @@ suite('a-entity', function () {
     test('returns empty object if component is at defaults', function () {
       var el = this.el;
       el.setAttribute('material', '');
-      assert.shallowDeepEqual(el.getDefinedAttribute('material'), {});
+      assert.shallowDeepEqual(el.getDOMAttribute('material'), {});
     });
 
     test('returns null for a default component if it is not set', function () {
       var el = this.el;
-      assert.shallowDeepEqual(el.getDefinedAttribute('position'), null);
+      assert.shallowDeepEqual(el.getDOMAttribute('position'), null);
     });
 
     test('returns parsed data if default component is set', function () {
       var el = this.el;
       var position = {x: 5, y: 6, z: 6};
       el.setAttribute('position', position);
-      assert.shallowDeepEqual(el.getDefinedAttribute('position'), position);
+      assert.shallowDeepEqual(el.getDOMAttribute('position'), position);
     });
 
     test('returns partial component data', function () {
       var componentData;
       var el = this.el;
       el.setAttribute('geometry', 'primitive: box; width: 5');
-      componentData = el.getDefinedAttribute('geometry');
+      componentData = el.getDOMAttribute('geometry');
       assert.equal(componentData.width, 5);
       assert.notOk('height' in componentData);
     });
@@ -485,24 +485,24 @@ suite('a-entity', function () {
     test('falls back to HTML getAttribute if not a component', function () {
       var el = this.el;
       el.setAttribute('class', 'pied piper');
-      assert.equal(el.getDefinedAttribute('class'), 'pied piper');
+      assert.equal(el.getDOMAttribute('class'), 'pied piper');
     });
 
     test('retrieves data from a multiple component', function () {
       var el = this.el;
       el.setAttribute('sound__1', {'src': 'url(mysoundfile.mp3)', autoplay: true});
       el.setAttribute('sound__2', {'src': 'url(mysoundfile.mp3)', autoplay: false});
-      assert.ok(el.getDefinedAttribute('sound__1'));
-      assert.ok(el.getDefinedAttribute('sound__2'));
-      assert.notOk(el.getDefinedAttribute('sound'));
-      assert.equal(el.getDefinedAttribute('sound__1').autoplay, true);
+      assert.ok(el.getDOMAttribute('sound__1'));
+      assert.ok(el.getDOMAttribute('sound__2'));
+      assert.notOk(el.getDOMAttribute('sound'));
+      assert.equal(el.getDOMAttribute('sound__1').autoplay, true);
     });
 
     test('retrieves default value for single property component when ' +
          'the element attribute is set to empty string', function () {
       var sceneEl = this.el.sceneEl;
       sceneEl.setAttribute('debug', '');
-      assert.equal(sceneEl.getDefinedAttribute('debug'), true);
+      assert.equal(sceneEl.getDOMAttribute('debug'), true);
     });
   });
 
@@ -649,7 +649,7 @@ suite('a-entity', function () {
       var el = this.el;
       assert.ok('position' in el.components);
       el.removeAttribute('position');
-      assert.equal(el.getDefinedAttribute('position'), null);
+      assert.equal(el.getDOMAttribute('position'), null);
       assert.ok('position' in el.components);
     });
 

--- a/tests/core/a-mixin.test.js
+++ b/tests/core/a-mixin.test.js
@@ -23,10 +23,10 @@ suite('a-mixin', function () {
     this.assetsEl.appendChild(mixinEl);
 
     mixinEl.addEventListener('loaded', function () {
-      assert.equal(el.getComputedAttribute('geometry').primitive, 'ring');
+      assert.equal(el.getAttribute('geometry').primitive, 'ring');
       mixinEl.setAttribute('geometry', 'primitive: circle');
       process.nextTick(function () {
-        assert.equal(el.getComputedAttribute('geometry').primitive, 'circle');
+        assert.equal(el.getAttribute('geometry').primitive, 'circle');
         done();
       });
     });
@@ -43,7 +43,7 @@ suite('a-mixin', function () {
     this.assetsEl.appendChild(mixinEl);
 
     mixinEl.addEventListener('loaded', function () {
-      var geometry = el.getComputedAttribute('geometry');
+      var geometry = el.getAttribute('geometry');
       assert.equal(geometry.buffer, false);
       assert.equal(geometry.primitive, 'ring');
       done();

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -88,7 +88,7 @@ suite('a-scene (without renderer)', function () {
 
       sceneEl.initSystem('test');
       assert.equal(sceneEl.getAttribute('test'), 'system');
-      assert.equal(sceneEl.getComputedAttribute('test'), 'system');
+      assert.equal(sceneEl.getAttribute('test'), 'system');
     });
 
     test('does not initialize component on setAttribute', function () {

--- a/tests/extras/primitives/primitives.test.js
+++ b/tests/extras/primitives/primitives.test.js
@@ -75,7 +75,7 @@ suite('registerPrimitive', function () {
     entity.children[0].addEventListener('loaded', function () {
       var material = entity.children[0].getAttribute('material');
       assert.equal(material.color, 'red');
-      assert.equal(material.fog, 'false');
+      assert.equal(material.fog, false);
       done();
     });
   });

--- a/tests/extras/primitives/primitives/a-camera.test.js
+++ b/tests/extras/primitives/primitives/a-camera.test.js
@@ -14,7 +14,7 @@ suite('a-camera', function () {
   suite('active camera', function () {
     test('is the active camera when applied', function (done) {
       var camera = this.camera;
-      assert.ok(camera.getComputedAttribute('camera').active);
+      assert.ok(camera.getAttribute('camera').active);
       done();
     });
   });

--- a/tests/extras/primitives/primitives/a-torus.test.js
+++ b/tests/extras/primitives/primitives/a-torus.test.js
@@ -14,7 +14,7 @@ suite('a-torus', function () {
   });
 
   test('has default position when created', function () {
-    assert.deepEqual(this.torusEl.getComputedAttribute('position'), {x: 0, y: 0, z: 0});
+    assert.deepEqual(this.torusEl.getAttribute('position'), {x: 0, y: 0, z: 0});
   });
 
   test('sets geometry.primitive', function () {


### PR DESCRIPTION
**Description:**

I'd expect that `getAttribute` returns full component data. 99% of the time we're grabbing component data, we want the computed component data, not just what is defined in the attribute. Since everyone knows DOM's `getAttribute` rather than A-Frame's `getComputedAttribute`, this is the method they'll reach for first. Since `getAttribute` currently returns only *defined* data, it is confusing when `el.getAttribute('position')` returns `null`.

**Changes proposed:**
- Old `getAttribute` is now an explicit `getDefinedAttribute`
- Old `getComputedAttribute` is now `getAttribute`
- [x] docs