### PR TITLE
Remove parentEl references when entity is detached. (fixes #1444)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -102,7 +102,7 @@ var proto = Object.create(ANode.prototype, {
       if (!this.parentEl || this.isScene) { return; }
       // Remove components.
       Object.keys(this.components).forEach(bind(this.removeComponent, this));
-      this.parentEl.remove(this);
+      this.removeFromParent();
     }
   },
 
@@ -233,6 +233,17 @@ var proto = Object.create(ANode.prototype, {
 
       parentNode.add(this);
       this.attachedToParent = true;  // To prevent multiple attachments to same parent.
+    }
+  },
+
+  /**
+   * Tell parentNode to remove this entity from itself.
+   */
+  removeFromParent: {
+    value: function () {
+      this.parentEl.remove(this);
+      this.parentEl = this.parentNode = null;
+      this.attachedToParent = false;
     }
   },
 

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -103,6 +103,7 @@ var proto = Object.create(ANode.prototype, {
       // Remove components.
       Object.keys(this.components).forEach(bind(this.removeComponent, this));
       this.removeFromParent();
+      ANode.prototype.detachedCallback.call(this);
     }
   },
 

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -72,7 +72,9 @@ module.exports = registerElement('a-node', {
     },
 
     detachedCallback: {
-      value: function () { /* no-op */ }
+      value: function () {
+        this.hasLoaded = false;
+      }
     },
 
     /**

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -23,9 +23,13 @@ module.exports = registerElement('a-node', {
 
     attachedCallback: {
       value: function () {
-        var mixins = this.getAttribute('mixin');
+        var mixins;
+
+        this.hasLoaded = false;
         this.sceneEl = this.closestScene();
         this.emit('nodeready', {}, false);
+
+        mixins = this.getAttribute('mixin');
         if (mixins) { this.updateMixins(mixins); }
       },
       writable: window.debug

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, sinon, setup, suite, teardown, test, HTMLElement, MutationObserver */
+/* global assert, process, sinon, setup, suite, teardown, test, HTMLElement */
 var AEntity = require('core/a-entity');
 var ANode = require('core/a-node');
 var extend = require('utils').extend;
@@ -78,13 +78,18 @@ suite('a-entity', function () {
     var el = document.createElement('a-entity');
     var parentEl = this.el;
     el.object3D = new THREE.Mesh();
+    el.setAttribute('geometry', 'primitive:plane');
     parentEl.appendChild(el);
     el.addEventListener('loaded', afterFirstAttachment);
 
     function afterFirstAttachment () {
+      el.removeEventListener('loaded', afterFirstAttachment);
+
       assert.equal(parentEl.object3D.children[0].uuid, el.object3D.uuid);
       assert.ok(el.parentEl);
       assert.ok(el.parentNode);
+      assert.ok(el.components.geometry);
+      assert.isTrue(el.hasLoaded);
 
       parentEl.removeChild(el);
       process.nextTick(afterDetachment);
@@ -94,16 +99,21 @@ suite('a-entity', function () {
       assert.equal(parentEl.object3D.children.length, 0);
       assert.notOk(el.parentEl);
       assert.notOk(el.parentNode);
+      assert.notOk(el.components.geometry);
+      assert.isFalse(el.hasLoaded);
 
-      var observer = new MutationObserver(afterSecondAttachment);
-      observer.observe(parentEl, {childList: true});
       parentEl.appendChild(el);
+      el.addEventListener('loaded', afterSecondAttachment);
     }
 
     function afterSecondAttachment () {
+      el.removeEventListener('loaded', afterSecondAttachment);
+
       assert.equal(parentEl.object3D.children[0].uuid, el.object3D.uuid);
       assert.ok(el.parentEl);
       assert.ok(el.parentNode);
+      assert.ok(el.components.geometry);
+      assert.isTrue(el.hasLoaded);
 
       done();
     }

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -47,6 +47,8 @@ suite('a-entity', function () {
     parentEl.appendChild(el);
     el.addEventListener('loaded', function () {
       assert.equal(parentEl.object3D.children[0].uuid, el.object3D.uuid);
+      assert.ok(el.parentEl);
+      assert.ok(el.parentNode);
       done();
     });
   });
@@ -361,6 +363,8 @@ suite('a-entity', function () {
         parentEl.removeChild(el);
         process.nextTick(function () {
           assert.equal(parentEl.object3D.children.length, 0);
+          assert.notOk(el.parentEl);
+          assert.notOk(el.parentNode);
           done();
         });
       });

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -74,6 +74,40 @@ suite('a-entity', function () {
     el.removeAttribute('geometry');
   });
 
+  test('can be detached and re-attached safely', function (done) {
+    var el = document.createElement('a-entity');
+    var parentEl = this.el;
+    el.object3D = new THREE.Mesh();
+    parentEl.appendChild(el);
+    el.addEventListener('loaded', afterFirstAttachment);
+
+    function afterFirstAttachment () {
+      assert.equal(parentEl.object3D.children[0].uuid, el.object3D.uuid);
+      assert.ok(el.parentEl);
+      assert.ok(el.parentNode);
+
+      parentEl.removeChild(el);
+      process.nextTick(afterDetachment);
+    }
+
+    function afterDetachment () {
+      assert.equal(parentEl.object3D.children.length, 0);
+      assert.notOk(el.parentEl);
+      assert.notOk(el.parentNode);
+
+      parentEl.appendChild(el);
+      process.nextTick(afterSecondAttachment);
+    }
+
+    function afterSecondAttachment () {
+      assert.equal(parentEl.object3D.children[0].uuid, el.object3D.uuid);
+      assert.ok(el.parentEl);
+      assert.ok(el.parentNode);
+
+      done();
+    }
+  });
+
   suite('attachedCallback', function () {
     test('initializes 3D object', function (done) {
       var el = entityFactory();

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, sinon, setup, suite, teardown, test, HTMLElement */
+/* global assert, process, sinon, setup, suite, teardown, test, HTMLElement, MutationObserver */
 var AEntity = require('core/a-entity');
 var ANode = require('core/a-node');
 var extend = require('utils').extend;
@@ -95,8 +95,9 @@ suite('a-entity', function () {
       assert.notOk(el.parentEl);
       assert.notOk(el.parentNode);
 
+      var observer = new MutationObserver(afterSecondAttachment);
+      observer.observe(parentEl, {childList: true});
       parentEl.appendChild(el);
-      process.nextTick(afterSecondAttachment);
     }
 
     function afterSecondAttachment () {


### PR DESCRIPTION
Failure to remove parentEl references blocks the re-attachment callback
from completing, which prevents the element from being added back to the
scene graph.

Fixes #1444.