### PR TITLE
Modify the begin attribute of a-animation

### DIFF
--- a/docs/guides/building-with-components.md
+++ b/docs/guides/building-with-components.md
@@ -53,7 +53,7 @@ This is the starting point for our scene:
     <a-cursor id="cursor">
       <a-animation begin="click" easing="ease-in" attribute="scale"
                    fill="backwards" from="0.1 0.1 0.1" to="1 1 1" dur="150"></a-animation>
-      <a-animation begin="fusing" easing="ease-in" attribute="scale"
+      <a-animation begin="cursor-fusing" easing="ease-in" attribute="scale"
                    from="1 1 1" to="0.1 0.1 0.1" dur="1500"></a-animation>
     </a-cursor>
   </a-camera>


### PR DESCRIPTION
**Description:**

**Changes proposed:**
-
-
-

"fusing" doesn't work, while "cursor-fusing" does, as mentioned in the cursor docs