### PR TITLE
fix unrendered "Text Geometry Component" link in FAQ

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -112,7 +112,7 @@ texture. There are some components in the ecosystem that enable this:
 There are several possible solutions:
 
 - [Bitmap Font Text Component (recommended)][bmfont-text-component]
-- [Text Geometry Component][text-component]
+- [Text Geometry Component][text-geometry-component]
 - [HTML Shader][html-shader]
 - [Text Wrap Component][text-wrap-component]
 - Use images


### PR DESCRIPTION
Sorry for another PR; I didn't catch this earlier. I would've fixed this along with the other link I fixed in PR #1942.