### PR TITLE
fix example vertexShader

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -405,7 +405,7 @@ AFRAME.registerShader('hello-world', {
 
   vertexShader: [
     'void main() {',
-    '  gl_Position = projectionMatrix * modelViewMatrix * position;',
+    '  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);',
     '}'
   ].join('\n'),
 


### PR DESCRIPTION
**Description:**

The example vertexShader is failing because `position` is a `vec3`.

**Changes proposed:**
-
- using `vec4(..., 1.0)`
-

