### PR TITLE
fix typos in requestFullscreen calls (fixes #1962)

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -451,8 +451,9 @@ function getCanvasSize (canvasEl, embedded) {
 
 function requestFullscreen (canvas) {
   var requestFullscreen =
-    canvas.requestFullScreen ||
-    canvas.webkitRequestFullScreen ||
-    canvas.mozRequestFullScreen;
+    canvas.requestFullscreen ||
+    canvas.webkitRequestFullscreen ||
+    canvas.mozRequestFullScreen ||  // The capitalized `S` is not a typo.
+    canvas.msRequestFullscreen;
   requestFullscreen.apply(canvas);
 }


### PR DESCRIPTION
**Description:**

The Fullscreen API is `requestFullscreen`, not `requestFullScreen`/`webkitRequestFullScreen`. Firefox was the only browser that used a capital `S` for its vendor-prefixed implementation. 

**Changes proposed:**
- fixes typo in `requestFullscreen` call for standard/non-vendor-prefixed Fullscreen API call, vendor-prefixed versions of Chrome/Opera, introduces vendor-prefixed version for IE11/Edge.