### PR TITLE
move <a-assets> inside of <a-scene>

### DIFF
--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -112,7 +112,7 @@ To play with an example of a cursor with visual feedback, check out the [Cursor 
 
 [animation]: ../core/animations.md
 [camera]: ./camera.md
-[cursor-codepen]: http://codepen.io/team/mozvr/pen/RrxgwE
+[cursor-codepen]: http://codepen.io/anon/pen/dpmpJP
 [geometry]: ./geometry.md
 [material]: ./material.md
 [raycaster]: ./raycaster.md


### PR DESCRIPTION
**Description:**
`<a-assets>` should move into `<a-scene>`, or it will show the error:

> aframe.js:60419Uncaught Error: <a-assets> must be a child of a <a-scene>

outside of CodePen.

**Changes proposed:**
move `<a-assets>` inside of `<a-scene>`, and update the demo link.