### PR TITLE
Add wireframe params to Flat and Standard Material

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -63,7 +63,7 @@ A-Frame ships with a few built-in materials.
 
 ### `standard`
 
-The `standard` material is the default material. It uses the physically-based
+The `standard` shader is the default material shader. It uses the physically-based
 [THREE.MeshStandardMaterial][standard].
 
 #### Properties
@@ -94,6 +94,8 @@ These properties are available on top of the base material properties.
 | roughness                     | How rough the material is from `0` to `1`. A rougher material will scatter reflected light in more directions than a smooth material.           | 0.5           |
 | sphericalEnvMap               | Environment spherical texture for reflections. Can either be a selector to an `<img>`, or an inline URL.                                        | None          |
 | width                         | Width of video (in pixels), if defining a video texture.                                                                                        | 640           |
+| wireframe                     | Whether to render just the geometry edges.                                                                                                      | false         |
+| wireframeLinewidth            | Width in px of the rendered line.                                                                                                               | 2             |
 | src                           | Image or video texture map. Can either be a selector to an `<img>` or `<video>`, or an inline URL.                                              | None          |
 
 #### Physically-Based Shading
@@ -168,14 +170,16 @@ such as images or videos. Set `shader` to `flat`:
 
 #### Properties
 
-| Property  | Description                                                                                                                                     | Default Value |
+| Property             | Description                                                                                                                          | Default Value |
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| color     | Base diffuse color.                                                                                                                             | #fff          |
-| fog       | Whether or not material is affected by [fog][fog].                                                                                              | true          |
-| height    | Height of video (in pixels), if defining a video texture.                                                                                       | 360           |
-| repeat    | How many times a texture (defined by `src`) repeats in the X and Y direction.                                                                   | 1 1           |
-| src       | Image or video texture map. Can either be a selector to an `<img>` or `<video>`, or an inline URL.                                              | None          |
-| width     | Width of video (in pixels), if defining a video texture.                                                                                        | 640           |
+| color                | Base diffuse color.                                                                                                                  | #fff          |
+| fog                  | Whether or not material is affected by [fog][fog].                                                                                   | true          |
+| height               | Height of video (in pixels), if defining a video texture.                                                                            | 360           |
+| repeat               | How many times a texture (defined by `src`) repeats in the X and Y direction.                                                        | 1 1           |
+| src                  | Image or video texture map. Can either be a selector to an `<img>` or `<video>`, or an inline URL.                                   | None          |
+| width                | Width of video (in pixels), if defining a video texture.                                                                             | 640           |
+| wireframe            | Whether to render just the geometry edges.                                                                                           | false         |
+| wireframeLinewidth   | Width in px of the rendered line.                                                                                                    | 2             |
 
 ## Textures
 

--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -63,7 +63,7 @@ A-Frame ships with a few built-in materials.
 
 ### `standard`
 
-The `standard` shader is the default material shader. It uses the physically-based
+The `standard` material is the default material. It uses the physically-based
 [THREE.MeshStandardMaterial][standard].
 
 #### Properties

--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -12,7 +12,9 @@ module.exports.Component = registerShader('flat', {
     height: {default: 256},
     repeat: {default: ''},
     src: {default: ''},
-    width: {default: 512}
+    width: { default: 512 },
+    wireframe: { default: false },
+    wireframeLinewidth: {default: 2}
   },
 
   /**
@@ -53,6 +55,8 @@ module.exports.Component = registerShader('flat', {
 function getMaterialData (data) {
   return {
     fog: data.fog,
-    color: new THREE.Color(data.color)
+    color: new THREE.Color(data.color),
+    wireframe: data.wireframe,
+    wireframeLinewidth: data.wireframeLinewidth
   };
 }

--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -12,8 +12,8 @@ module.exports.Component = registerShader('flat', {
     height: {default: 256},
     repeat: {default: ''},
     src: {default: ''},
-    width: { default: 512 },
-    wireframe: { default: false },
+    width: {default: 512},
+    wireframe: {default: false},
     wireframeLinewidth: {default: 2}
   },
 

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -37,7 +37,9 @@ module.exports.Component = registerShader('standard', {
     roughness: {default: 0.5, min: 0.0, max: 1.0},
     sphericalEnvMap: {default: ''},
     src: {default: ''},
-    width: {default: 512}
+    width: {default: 512},
+    wireframe: { default: false },
+    wireframeLinewidth: {default: 2}
   },
 
   /**
@@ -142,7 +144,9 @@ function getMaterialData (data) {
     color: new THREE.Color(data.color),
     fog: data.fog,
     metalness: data.metalness,
-    roughness: data.roughness
+    roughness: data.roughness,
+    wireframe: data.wireframe,
+    wireframeLinewidth: data.wireframeLinewidth
   };
 
   if (data.normalMap) { newData.normalScale = data.normalScale; }

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -38,7 +38,7 @@ module.exports.Component = registerShader('standard', {
     sphericalEnvMap: {default: ''},
     src: {default: ''},
     width: {default: 512},
-    wireframe: { default: false },
+    wireframe: {default: false},
     wireframeLinewidth: {default: 2}
   },
 

--- a/tests/shaders/flat.test.js
+++ b/tests/shaders/flat.test.js
@@ -1,0 +1,28 @@
+/* global assert, process, setup, suite, test */
+var entityFactory = require('../helpers').entityFactory;
+
+suite('flat material', function () {
+  setup(function (done) {
+    var el = this.el = entityFactory();
+    el.setAttribute('material', 'shader: flat');
+    if (el.hasLoaded) { done(); }
+    el.addEventListener('loaded', function () {
+      done();
+    });
+  });
+
+  test('can unset fog', function () {
+    var el = this.el;
+    assert.ok(el.getObject3D('mesh').material.fog);
+    el.setAttribute('material', 'fog', false);
+    assert.notOk(el.getObject3D('mesh').material.fog);
+  });
+
+  test('can use wireframes', function () {
+    var el = this.el;
+    assert.notOk(el.getObject3D('mesh').material.wireframe);
+    el.setAttribute('material', 'wireframe', true);
+    assert.ok(el.getObject3D('mesh').material.wireframe);
+    assert.equal(el.getObject3D('mesh').material.wireframeLinewidth, 2);
+  });
+});

--- a/tests/shaders/standard.test.js
+++ b/tests/shaders/standard.test.js
@@ -88,4 +88,12 @@ suite('standard material', function () {
       done();
     });
   });
+
+  test('can use wireframes', function () {
+    var el = this.el;
+    assert.notOk(el.getObject3D('mesh').material.wireframe);
+    el.setAttribute('material', 'wireframe', true);
+    assert.ok(el.getObject3D('mesh').material.wireframe);
+    assert.equal(el.getObject3D('mesh').material.wireframeLinewidth, 2);
+  });
 });


### PR DESCRIPTION
**Description:**

Moved in a couple more of the THREE.js properties WRT wireframes. 

The default width is set to 2 so that it looks cleaner on VR Headsets

If there are reasons for them not being included that is fine and I just thought it could be useful.

**Changes proposed:**

Allow standard and flat materials to use wireframes.

