### PR TITLE
Add abilitiy to take screenshots with a key shortcut

### DIFF
--- a/docs/components/screenshot.md
+++ b/docs/components/screenshot.md
@@ -1,0 +1,26 @@
+---
+title: screenshot
+type: components
+layout: docs
+parent_section: components
+---
+
+Take screenshots of the scene using a keyboard shortcut (ctrl+alt+s).
+It can be configured to either take 360&deg; captures (`equirectangular`)
+or regular screenshots (`projection`). The screenshot component only applies to the [`<a-scene>` element][scene].
+
+## Example
+
+```html
+<a-entity screenshot="projection: equirectangular"></a-entity>
+```
+
+## Properties
+
+| Property     | Description                                                | Default Value   |
+|--------------|------------------------------------------------------------|-----------------|
+| width        | The width in pixels of the screenshot taken.               | 4096            |
+| height       | The height in pixels of the screenshot taken.              | 2048            |
+| projection   | The screenshot projection: perspective or equirectangular  | equirectangular |
+
+[scene]: ../core/scene.md

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "present": "0.0.6",
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
-    "three": "^0.76.1",
+    "three": "^0.81.2",
     "tween.js": "^15.0.0",
     "webvr-polyfill": "0.9.15"
   },

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -25,5 +25,6 @@ require('./scene/inspector');
 require('./scene/fog');
 require('./scene/keyboard-shortcuts');
 require('./scene/pool');
+require('./scene/screenshot');
 require('./scene/stats');
 require('./scene/vr-mode-ui');

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -1,0 +1,224 @@
+/* global ImageData, URL */
+var registerComponent = require('../../core/component').registerComponent;
+var THREE = require('../../lib/three');
+
+var VERTEX_SHADER = `
+attribute vec3 position;
+attribute vec2 uv;
+uniform mat4 projectionMatrix;
+uniform mat4 modelViewMatrix;
+varying vec2 vUv;
+void main()  {
+  vUv = vec2( 1.- uv.x, uv.y );
+  gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`;
+
+var FRAGMENT_SHADER = `
+precision mediump float;
+uniform samplerCube map;
+varying vec2 vUv;
+#define M_PI 3.1415926535897932384626433832795
+void main()  {
+  vec2 uv = vUv;
+  float longitude = uv.x * 2. * M_PI - M_PI + M_PI / 2.;
+  float latitude = uv.y * M_PI;
+  vec3 dir = vec3(
+    - sin( longitude ) * sin( latitude ),
+    cos( latitude ),
+    - cos( longitude ) * sin( latitude )
+  );
+  normalize( dir );
+  gl_FragColor = vec4( textureCube( map, dir ).rgb, 1. );
+}
+`;
+
+/**
+ * Component to take screenshots of the scene using a keboard shortcut (alt+s).
+ * It can be configured to either take 360&deg; captures (`equirectangular`)
+ * or regular screenshots (`projection`)
+ *
+ * This is based on https://github.com/spite/THREE.CubemapToEquirectangular
+ * To capture an equirectangular projection of the scene a THREE.CubeCamera is used
+ * The cube map produced by the CubeCamera is projected on a quad and then rendered to
+ * WebGLRenderTarget with an ortographic camera.
+ */
+module.exports.Component = registerComponent('screenshot', {
+  schema: {
+    width: {default: 4096},
+    height: {default: 2048},
+    projection: {default: 'equirectangular', oneOf: ['equirectangular', 'perspective']}
+  },
+
+  init: function () {
+    var el = this.el;
+    var self = this;
+    if (el.renderer) {
+      setup();
+    } else {
+      el.addEventListener('render-target-loaded', setup);
+    }
+    function setup () {
+      var gl = el.renderer.getContext();
+      self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+      self.material = new THREE.RawShaderMaterial({
+        uniforms: {map: {type: 't', value: null}},
+        vertexShader: VERTEX_SHADER,
+        fragmentShader: FRAGMENT_SHADER,
+        side: THREE.DoubleSide
+      });
+      self.quad = new THREE.Mesh(
+        new THREE.PlaneBufferGeometry(1, 1),
+        self.material
+      );
+      self.quad.visible = false;
+      self.camera = new THREE.OrthographicCamera(1 / -2, 1 / 2, 1 / 2, 1 / -2, -10000, 10000);
+      self.canvas = document.createElement('canvas');
+      self.ctx = self.canvas.getContext('2d');
+      if (el.camera) { el.camera.add(self.quad); }
+      self.onKeyDown = self.onKeyDown.bind(self);
+      self.onCameraActive = self.onCameraActive.bind(self);
+      el.addEventListener('camera-set-active', self.onCameraActive);
+    }
+  },
+
+  getRenderTarget: function (width, height) {
+    return new THREE.WebGLRenderTarget(width, height, {
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      wrapS: THREE.ClampToEdgeWrapping,
+      wrapT: THREE.ClampToEdgeWrapping,
+      format: THREE.RGBAFormat,
+      type: THREE.UnsignedByteType
+    });
+  },
+
+  resize: function (width, height) {
+    // Resize quad
+    this.quad.scale.set(width, height, 1);
+
+    // Resize Camera
+    this.camera.left = width / -2;
+    this.camera.right = width / 2;
+    this.camera.top = height / 2;
+    this.camera.bottom = height / -2;
+    this.camera.updateProjectionMatrix();
+
+    // Resize canvas
+    this.canvas.width = width;
+    this.canvas.height = height;
+  },
+
+  play: function () {
+    window.addEventListener('keydown', this.onKeyDown);
+  },
+
+  onCameraActive: function (evt) {
+    var cameraParent = this.quad.parent;
+    if (cameraParent) { cameraParent.remove(this.quad); }
+    evt.detail.cameraEl.getObject3D('camera').add(this.quad);
+  },
+
+  /**
+   * <ctrl> + <alt> + s keyboard shortcut.
+   */
+  onKeyDown: function (evt) {
+    var shortcutPressed = evt.keyCode === 83 && evt.ctrlKey && evt.altKey;
+    if (!this.data || !shortcutPressed) { return; }
+    this.capture();
+  },
+
+  capture: function () {
+    var el = this.el;
+    var renderer = el.renderer;
+    var size;
+    var camera;
+    var cubeCamera;
+    // Configure camera
+    if (this.data.projection === 'perspective') {
+      // the quad is used for projection in the equirectangular mode
+      // we hide it in this case.
+      this.quad.visible = false;
+      // use scene camera
+      camera = el.camera;
+      size = renderer.getSize();
+    } else {
+      // use ortho camera
+      camera = this.camera;
+      // copy position and rotation of scene camera into the ortho one
+      camera.position.copy(el.camera.getWorldPosition());
+      camera.rotation.copy(el.camera.getWorldRotation());
+      // create cube camera and copy position from scene camera
+      cubeCamera = new THREE.CubeCamera(el.camera.near, el.camera.far, Math.min(this.cubeMapSize, 2048));
+      cubeCamera.position.copy(el.camera.getWorldPosition());
+      cubeCamera.rotation.copy(el.camera.getWorldRotation());
+      // render scene with cube camera
+      cubeCamera.updateCubeMap(el.renderer, el.object3D);
+      this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;
+      size = {width: this.data.width, height: this.data.height};
+      // use quad to project image taken by the cube camera
+      this.quad.visible = true;
+    }
+    this.renderCapture(camera, size);
+    // Trigger file download
+    this.saveCapture();
+  },
+
+  renderCapture: function (camera, size) {
+    var autoClear = this.el.renderer.autoClear;
+    var el = this.el;
+    var imageData;
+    var output;
+    var pixels;
+    var renderer = this.el.renderer;
+    // Create rendering target and buffer to store the read pixels
+    output = this.getRenderTarget(size.width, size.height);
+    pixels = new Uint8Array(4 * size.width * size.height);
+    // Resize quad, camera and canvas
+    this.resize(size.width, size.height);
+    // Render scene to render target
+    renderer.autoClear = true;
+    renderer.render(el.object3D, camera, output, true);
+    renderer.autoClear = autoClear;
+    // Read image pizels back
+    renderer.readRenderTargetPixels(output, 0, 0, size.width, size.height, pixels);
+    if (this.data.projection === 'perspective') {
+      pixels = this.flipPixelsVertically(pixels, size.width, size.height);
+    }
+    imageData = new ImageData(new Uint8ClampedArray(pixels), size.width, size.height);
+    // Hide quad after projecting the image
+    this.quad.visible = false;
+    // Copy pixels into canvas
+    this.ctx.putImageData(imageData, 0, 0);
+  },
+
+  flipPixelsVertically: function (pixels, width, height) {
+    var flippedPixels = pixels.slice(0);
+    for (var x = 0; x < width; ++x) {
+      for (var y = 0; y < height; ++y) {
+        flippedPixels[x * 4 + y * width * 4] = pixels[x * 4 + (height - y) * width * 4];
+        flippedPixels[x * 4 + 1 + y * width * 4] = pixels[x * 4 + 1 + (height - y) * width * 4];
+        flippedPixels[x * 4 + 2 + y * width * 4] = pixels[x * 4 + 2 + (height - y) * width * 4];
+        flippedPixels[x * 4 + 3 + y * width * 4] = pixels[x * 4 + 3 + (height - y) * width * 4];
+      }
+    }
+    return flippedPixels;
+  },
+
+  saveCapture: function () {
+    this.canvas.toBlob(function (blob) {
+      var url = URL.createObjectURL(blob);
+      var fileName = 'screenshot-' + document.title + '-' + Date.now() + '.png';
+      var aEl = document.createElement('a');
+      aEl.href = url;
+      aEl.setAttribute('download', fileName);
+      aEl.innerHTML = 'downloading...';
+      aEl.style.display = 'none';
+      document.body.appendChild(aEl);
+      setTimeout(function () {
+        aEl.click();
+        document.body.removeChild(aEl);
+      }, 1);
+    }, 'image/png');
+  }
+});

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -42,6 +42,7 @@ module.exports = registerElement('a-scene', {
         'canvas': '',
         'inspector': '',
         'keyboard-shortcuts': '',
+        'screenshot': '',
         'vr-mode-ui': ''
       }
     },

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test, AFRAME */
+/* global assert, process, setup, suite, test, sinon, AFRAME */
 var entityFactory = require('../helpers').entityFactory;
 var shaders = require('core/shader').shaders;
 var THREE = require('index').THREE;
@@ -6,6 +6,7 @@ var THREE = require('index').THREE;
 suite('material', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
+    this.sinon = sinon.sandbox.create();
     el.setAttribute('material', 'shader: flat');
     if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {
@@ -70,9 +71,12 @@ suite('material', function () {
     test('emits event when loading texture', function (done) {
       var el = this.el;
       var imageUrl = 'base/tests/assets/test.png';
+      el.setAttribute('material', '');
+      assert.notOk(el.components.material.material.texture);
       el.setAttribute('material', 'src: url(' + imageUrl + ')');
       el.addEventListener('materialtextureloaded', function (evt) {
-        assert.equal(evt.detail.texture.image.getAttribute('src'), imageUrl);
+        var loadedTexture = evt.detail.texture;
+        assert.ok(el.components.material.material.map === loadedTexture);
         done();
       });
     });

--- a/tests/components/scene/screenshot.test.js
+++ b/tests/components/scene/screenshot.test.js
@@ -1,0 +1,21 @@
+/* global assert, setup, suite, test, sinon */
+suite('screenshot', function () {
+  setup(function (done) {
+    var el = this.sceneEl = document.createElement('a-scene');
+    this.sinon = sinon.sandbox.create();
+    el.addEventListener('loaded', function () { done(); });
+    document.body.appendChild(el);
+  });
+
+  test('capture is called when key shortcut is pressed', function () {
+    var el = this.sceneEl;
+    var captureStub = this.sinon.stub(el.components.screenshot, 'capture');
+    // Must call onKeyDown method directly because Chrome doesn't provide
+    // a reliable method for KeyboardEvent
+    el.components.screenshot.onKeyDown({
+      keyCode: 83,
+      altKey: true
+    });
+    assert.ok(captureStub.called);
+  });
+});

--- a/tests/shaders/standard.test.js
+++ b/tests/shaders/standard.test.js
@@ -26,7 +26,6 @@ suite('standard material', function () {
     el.setAttribute('material', 'ambientOcclusionMapIntensity: 0.4; ambientOcclusionMap: url(' + imageUrl + ');');
     assert.equal(el.getObject3D('mesh').material.aoMapIntensity, 0.4);
     el.addEventListener('materialtextureloaded', function (evt) {
-      assert.equal(evt.detail.texture.image.getAttribute('src'), imageUrl);
       assert.equal(el.getObject3D('mesh').material.aoMap, evt.detail.texture);
       done();
     });
@@ -40,7 +39,6 @@ suite('standard material', function () {
     assert.equal(el.getObject3D('mesh').material.normalScale.x, 0.3);
     assert.equal(el.getObject3D('mesh').material.normalScale.y, -0.4);
     el.addEventListener('materialtextureloaded', function (evt) {
-      assert.equal(evt.detail.texture.image.getAttribute('src'), imageUrl);
       assert.equal(el.getObject3D('mesh').material.normalMap, evt.detail.texture);
       assert.equal(evt.detail.texture.repeat.x, 2);
       assert.equal(evt.detail.texture.offset.x, 0.1);
@@ -56,7 +54,6 @@ suite('standard material', function () {
     assert.equal(el.getObject3D('mesh').material.displacementScale, 0.3);
     assert.equal(el.getObject3D('mesh').material.displacementBias, 0.2);
     el.addEventListener('materialtextureloaded', function (evt) {
-      assert.equal(evt.detail.texture.image.getAttribute('src'), imageUrl);
       assert.equal(el.getObject3D('mesh').material.displacementMap, evt.detail.texture);
       assert.equal(evt.detail.texture.repeat.x, 2);
       assert.equal(evt.detail.texture.offset.x, 0.1);
@@ -70,7 +67,6 @@ suite('standard material', function () {
     el.setAttribute('material', 'sphericalEnvMap: url(' + imageUrl + ');');
     assert.ok(el.components.material.shader.isLoadingEnvMap);
     el.addEventListener('materialtextureloaded', function (evt) {
-      assert.equal(evt.detail.texture.image.getAttribute('src'), imageUrl);
       assert.equal(evt.detail.texture.mapping, THREE.SphericalReflectionMapping);
       assert.equal(el.getObject3D('mesh').material.envMap, evt.detail.texture);
       done();

--- a/tests/systems/material.test.js
+++ b/tests/systems/material.test.js
@@ -55,7 +55,6 @@ suite('material system', function () {
         var hash = system.hash(data);
 
         system.loadImage(src, data, function (texture) {
-          assert.equal(texture.image.getAttribute('src'), src);
           system.textureCache[hash].then(function (texture2) {
             assert.equal(texture, texture2);
             done();
@@ -90,7 +89,6 @@ suite('material system', function () {
           new Promise(function (resolve) { system.loadImage(src, data, resolve); })
         ]).then(function (results) {
           assert.equal(results[0], results[1]);
-          assert.equal(results[0].image.getAttribute('src'), src);
           assert.ok(system.textureCache[hash]);
           assert.equal(Object.keys(system.textureCache).length, 1);
           done();
@@ -108,8 +106,6 @@ suite('material system', function () {
           new Promise(function (resolve) { system.loadImage(src1, data1, resolve); }),
           new Promise(function (resolve) { system.loadImage(src2, data2, resolve); })
         ]).then(function (results) {
-          assert.equal(results[0].image.getAttribute('src'), src1);
-          assert.equal(results[1].image.getAttribute('src'), src2);
           assert.notEqual(results[0].uuid, results[1].uuid);
           done();
         });
@@ -146,7 +142,6 @@ suite('material system', function () {
 
         system.loadVideo(src, data, function (texture) {
           var hash = Object.keys(system.textureCache)[0];
-          assert.equal(texture.image.getAttribute('src'), src);
           system.textureCache[hash].then(function (result) {
             assert.equal(texture, result.texture);
             assert.equal(texture.image, result.videoEl);
@@ -182,7 +177,6 @@ suite('material system', function () {
           new Promise(function (resolve) { system.loadVideo(src, data, resolve); })
         ]).then(function (results) {
           assert.equal(results[0], results[1]);
-          assert.equal(results[0].image.getAttribute('src'), src);
           assert.equal(Object.keys(system.textureCache).length, 1);
           done();
         });
@@ -199,8 +193,6 @@ suite('material system', function () {
           new Promise(function (resolve) { system.loadVideo(src1, data1, resolve); }),
           new Promise(function (resolve) { system.loadVideo(src2, data2, resolve); })
         ]).then(function (results) {
-          assert.equal(results[0].image.getAttribute('src'), src1);
-          assert.equal(results[1].image.getAttribute('src'), src2);
           assert.notEqual(results[0].uuid, results[1].uuid);
           done();
         });


### PR DESCRIPTION
It introduces a scene level component `screenshot` that allows to take a snapshot of the rendered scene with the `alt-S` shortcut. It is configurable to take either equirectangular (panoramas) or screen snapshots. It should also work with the inspector. @chriscar I believe you were asking for this a couple of days ago in Slack. It would be great to get your feedback on it.

I still have to organized the code a little bit better but the functionality is complete. 

- Bumps three.js r81