### PR TITLE
add general 'asset' property type to later replace 'src' (fixes #1843)

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -8,6 +8,7 @@ var propertyTypes = module.exports.propertyTypes = {};
 
 // Built-in property types.
 registerPropertyType('array', [], arrayParse, arrayStringify);
+registerPropertyType('asset', '', assetParse);
 registerPropertyType('boolean', false, boolParse);
 registerPropertyType('color', '#FFF', defaultParse, defaultStringify);
 registerPropertyType('int', 0, intParse);
@@ -54,6 +55,27 @@ function arrayParse (value) {
 
 function arrayStringify (value) {
   return value.join(', ');
+}
+
+/**
+ * `src` parser for assets.
+ *
+ * @param {string} value - Can either be `url(<value>)` or a selector to an asset.
+ * @returns {string} Parsed value from `url(<value>)` or src from `<someasset src>`.
+ */
+function assetParse (value) {
+  var parsedUrl = value.match(/\url\((.+)\)/);
+  if (parsedUrl) { return parsedUrl[1]; }
+
+  var el = selectorParse(value);
+  if (el) { return el.getAttribute('src'); }
+
+  if (value.charAt(0) !== '#') {
+    warn('"' + value + '" is not a valid `src` attribute. ' +
+         'Value must be an ID selector (i.e. "#someElement") or wrapped in `url()`.');
+  }
+
+  return '';
 }
 
 function defaultParse (value) {
@@ -105,25 +127,9 @@ function selectorAllStringify (value) {
   return defaultStringify(value);
 }
 
-/**
- * `src` parser for assets.
- *
- * @param {string} value - Can either be `url(<value>)` or a selector to an asset.
- * @returns {string} Parsed value from `url(<value>)` or src from `<someasset src>`.
- */
 function srcParse (value) {
-  var parsedUrl = value.match(/\url\((.+)\)/);
-  if (parsedUrl) { return parsedUrl[1]; }
-
-  var el = selectorParse(value);
-  if (el) { return el.getAttribute('src'); }
-
-  if (value.charAt(0) !== '#') {
-    warn('"' + value + '" is not a valid `src` attribute. ' +
-         'Value must be an ID selector (i.e. "#someElement") or wrapped in `url()`.');
-  }
-
-  return '';
+  warn('`src` property type is deprecated. Use `asset` instead.');
+  return assetParse(value);
 }
 
 function vecParse (value) {

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -5,6 +5,27 @@ var propertyTypes = PropertyTypes.propertyTypes;
 var register = PropertyTypes.registerPropertyType;
 
 suite('propertyTypes', function () {
+  suite('assetParse', function () {
+    var parse = propertyTypes.asset.parse;
+
+    setup(function () {
+      var el = this.el = document.createElement('div');
+      el.setAttribute('id', 'hello');
+      el.setAttribute('src', 'file2.jpg');
+      document.body.appendChild(el);
+    });
+
+    teardown(function () {
+      this.el.parentNode.removeChild(this.el);
+    });
+
+    test('parses src', function () {
+      assert.equal(parse('url(file.jpg)'), 'file.jpg');
+      assert.equal(parse('file.jpg'), '');
+      assert.equal(parse('#hello'), 'file2.jpg');
+    });
+  });
+
   suite('boolean', function () {
     var parse = propertyTypes.boolean.parse;
     var stringify = propertyTypes.boolean.stringify;


### PR DESCRIPTION
**Description:**

General `asset` type, seems a better name, in order to map to `<a-assets>` and asset dialog / stores.

Can possibly have inheriting property types more specific to images, models, sound to tell Inspector which type of asset.

