### PR TITLE
"var src = src =" should be "var src =" in a-assets.js (fixes #2015)

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -86,7 +86,7 @@ registerElement('a-asset-item', {
     attachedCallback: {
       value: function () {
         var self = this;
-        var src = src = this.getAttribute('src');
+        var src = this.getAttribute('src');
         xhrLoader.load(src, function (textResponse) {
           THREE.Cache.files[src] = textResponse;
           self.data = textResponse;


### PR DESCRIPTION
**Description:**

Fixed typo. #2015

**Changes proposed:**
