### PR TITLE
warning message if aframe script tag is not before <a-scene> (fixes #2000)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,12 @@
+var debug = require('./utils/debug');
+var error = debug('A-Frame:warn');
+var info = debug('A-Frame:info');
+
+if (document.currentScript && document.currentScript.parentNode !== document.head) {
+  error('Put the A-Frame <script> tag in the <head> of the HTML before <a-scene> to ensure everything for A-Frame is properly registered before they are used in the <body>.');
+  info('Also make sure that any component <script> tags are included after A-Frame, but still before <a-scene>.');
+}
+
 // Polyfill `Promise`.
 window.Promise = window.Promise || require('promise-polyfill');
 


### PR DESCRIPTION
One of the top pitfalls.