### PR TITLE
make loadedData public for <a-assets>,  download percentage of xhr+mediaElements

### DIFF
--- a/examples/test/asset-progress/index.html
+++ b/examples/test/asset-progress/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Asset Progress</title>
+    <meta name="description" content="Asset Progress — A-Frame">
+    <script src="../../../dist/aframe.js"></script>
+    <style>
+      #progressOverlay {
+        background: #333;
+        color: #FAFAFA;
+        height: 100px;
+        left: 0;
+        padding-left: 10px;
+        position: fixed;
+        top: 0;
+        width: 200px;
+        z-index: 99999;
+      }
+    </style>
+  </head>
+  <body>
+    <a-scene>
+      <a-assets timeout="99999">
+        <video id="video" src="https://ucarecdn.com/bcece0a8-86ce-460e-856b-40dac4875f15/"
+               autoplay loop crossorigin></video>
+      </a-assets>
+    </a-scene>
+
+    <div id="progressOverlay">
+      <p id="percent"></p>
+      <p id="bytes"></p>
+    </div>
+
+    <script>
+      var assetsEl = document.querySelector('a-assets');
+      var bytesEl = document.querySelector('#bytes');
+      var percentEl = document.querySelector('#percent');
+      assetsEl.addEventListener('progress', function (evt) {
+        percentEl.innerHTML = evt.detail.percent + '%';
+        bytesEl.innerHTML = evt.detail.loadedBytes + ' / ' + evt.detail.totalBytes + 'MB';
+      });
+    </script>
+  </body>
+</html>

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -88,9 +88,9 @@ module.exports = registerElement('a-assets', {
       value: function () {
         var loaded = 0;
         var total = 0;
-        for (var assetId in this.progress) {
-          loaded += this.progress[assetId].loaded;
-          total += this.progress[assetId].total;
+        for (var src in this.progress) {
+          loaded += this.progress[src].loaded;
+          total += this.progress[src].total;
         }
         this.loadedBytes = loaded;
         this.totalBytes = total;

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -62,6 +62,7 @@ module.exports = registerElement('a-assets', {
 
         // Progress checker.
         this.progressInterval = setInterval(function updateProgress () {
+          self.calculateProgressPercent();
           self.emit('progress', {
             percent: self.percent,
             loadedBytes: self.loadedBytes,
@@ -94,8 +95,8 @@ module.exports = registerElement('a-assets', {
         }
         this.loadedBytes = loaded;
         this.totalBytes = total;
-        this.progress = Math.round(loaded * 100 / total);
-        return this.progress;
+        this.percent = Math.round(loaded * 100 / total);
+        return this.percent;
       }
     },
 
@@ -182,12 +183,12 @@ function mediaElementLoaded (el) {
     Use of `preload` is recommended. `autoplay` would start playing before scene starts.
     Check for opt-out.
    */
-  autoplay = el.getAttribute('autoplay');
+  autoplay = el.hasAttribute('autoplay');
   preload = el.getAttribute('preload');
   if (!(preload === 'auto' || preload === '') && !autoplay) { return; }
 
   // If media specifies preload, wait until media is completely buffered.
-  assetsEl = this.parentNode;
+  assetsEl = el.parentNode;
   return new Promise(function (resolve, reject) {
     if (el.readyState === 4) { return resolve(); }  // Already loaded.
     if (el.error) { return reject(); }  // Error.

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -4,8 +4,7 @@ var THREE = require('lib/three');
 // Empty src will not trigger load events in Chrome.
 // Use data URI where a load event is needed.
 var IMG_SRC = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-
-var XHR_SRC = 'base/src/README.md';
+// var XHR_SRC = 'base/src/README.md';
 
 suite('a-assets', function () {
   setup(function () {
@@ -189,19 +188,6 @@ suite('a-asset-item', function () {
     var el = this.assetsEl = document.createElement('a-assets');
     var scene = this.sceneEl = document.createElement('a-scene');
     scene.appendChild(el);
-  });
-
-  test('emits progress event', function (done) {
-    var assetItem = document.createElement('a-asset-item');
-    assetItem.setAttribute('src', XHR_SRC);
-    assetItem.addEventListener('progress', function (evt) {
-      assert.ok(evt.detail.loadedBytes !== undefined);
-      assert.ok(evt.detail.totalBytes !== undefined);
-      assert.ok(evt.detail.xhr !== undefined);
-      done();
-    });
-    this.assetsEl.appendChild(assetItem);
-    document.body.appendChild(this.sceneEl);
   });
 
   test('emits error event', function (done) {


### PR DESCRIPTION
**Description:**
ISSUE:
 I’ve tried to utilize a combination of assets on my scene which has lead me down the path of buffering and optimization in order to achieve a relatively smooth experience.

Specifically, I’ve tried to attach a 300mb .mp4 to a <a-videosphere/>, and even though the rest of the assets don’t present much of an issue, the video will freeze and hit download bumps every so often.

The conclusion: download all assets before starting the scene.

assets.js checks that all mediaElements have a combination of autoplay and preload=“auto” before buffering, but also, there is no way of monitoring the progress of the download of ALL assets (img, a-asset-item, mediaElements).

**Changes proposed:**
The goal is to have a progress bar that feeds from easily-accessible data.

I decided to make a global object that holds individual loaded/total combinations per asset and triggers a function that adds up all these values to estimate a percentage of progress.

To the current structure of assets.js, I added a few lines that do the following:
- I created the global object assetsElement
- within createdCallback in registerElement(‘a-assets’) I added this.loadedData = 0; which makes progress updates easily accessible
- I add any xhr items to assetsElement
- created a new callback to the xhrLoaded which updates values to assetsElement object for any <a-asset-item>
- I removed the validation for the existence of autoplay in mediaElementLoaded(el), instead, it only checks if preload==‘none’
- in function checkProgress() I add new mediaElements to assetsElement object
-  in checkProgress(), after running through the buffer cycle,  assetsElement loaded value is updated for each mediaElement key
- Both in the xhrLoaded and the mediaElementLoaded the function assetsProgress() is used to add up all the loaded and total values of assetsElement, it returns a percentage which is used to update loadedData in the parentNode (<a-assets>).
- Finally, both the xhrLoaded and mediaElementLoaded emit(‘progress’) to the parentNode (<a-assets>)

USAGE:
- preload=“auto” for any media elements (img, video) will add it to the percentage tally. xhr's are added by default.
- the value of loadedData can be grabbed as follow:
  var loadingAssets = document.querySelector('a-assets');
  loadingAssets.addEventListener("progress",function(evt){
  if(this.hasLoaded){
      console.log(this.loadedData)
  }
  });

PROBLEMS:
- The only way to buffer audio files is by adding autoplay, which starts playing all the audio files at once from the beginning.  For now, I’ve left all audios with preload=“none” and no autoplay
- image file sizes should be accessible as well, just to be consistent.
