### PR TITLE
fix component dependencies being initialized with no data (fixes #2033, #1841, #1848)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -369,7 +369,7 @@ var proto = Object.create(ANode.prototype, {
         // Call getAttribute to initialize the data from the DOM.
         self.initComponent(
           componentName,
-          HTMLElement.prototype.getAttribute.call(self, componentName),
+          HTMLElement.prototype.getAttribute.call(self, componentName) || undefined,
           true
         );
       });
@@ -611,7 +611,7 @@ var proto = Object.create(ANode.prototype, {
   setAttribute: {
     value: function (attr, value, componentPropValue) {
       var componentName;
-      var isDebugMode;
+      var isDebugMode = this.sceneEl && this.sceneEl.getAttribute('debug');
 
       componentName = attr.split(MULTIPLE_COMPONENT_DELIMITER)[0];
       if (COMPONENTS[componentName]) {
@@ -622,8 +622,7 @@ var proto = Object.create(ANode.prototype, {
           this.updateComponent(attr, value);
         }
 
-        // On debug mode we write the component state to the DOM attributes.
-        isDebugMode = this.sceneEl && this.sceneEl.getAttribute('debug');
+        // In debug mode, write component data up to the DOM.
         if (isDebugMode) { this.components[attr].flushToDOM(); }
         return;
       }

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -346,16 +346,32 @@ var proto = Object.create(ANode.prototype, {
     writable: window.debug
   },
 
+  /**
+   * Initialize dependencies of a component.
+   *
+   * @param {string} name - Root component name.
+   */
   initComponentDependencies: {
     value: function (name) {
       var self = this;
       var component = COMPONENTS[name];
       var dependencies;
+
+      // Not a component.
       if (!component) { return; }
+
+      // No dependencies.
       dependencies = COMPONENTS[name].dependencies;
       if (!dependencies) { return; }
-      dependencies.forEach(function (component) {
-        self.initComponent(component, undefined, true);
+
+      // Initialize dependencies.
+      dependencies.forEach(function initializeDependency (componentName) {
+        // Call getAttribute to initialize the data from the DOM.
+        self.initComponent(
+          componentName,
+          HTMLElement.prototype.getAttribute.call(self, componentName),
+          true
+        );
       });
     }
   },
@@ -594,16 +610,20 @@ var proto = Object.create(ANode.prototype, {
    */
   setAttribute: {
     value: function (attr, value, componentPropValue) {
-      var isDebugMode = this.sceneEl && this.sceneEl.getAttribute('debug');
-      var componentName = attr.split(MULTIPLE_COMPONENT_DELIMITER)[0];
+      var componentName;
+      var isDebugMode;
+
+      componentName = attr.split(MULTIPLE_COMPONENT_DELIMITER)[0];
       if (COMPONENTS[componentName]) {
-        // Just update one of the component properties
+        // Just update one of the component properties.
         if (typeof value === 'string' && componentPropValue !== undefined) {
           this.updateComponentProperty(attr, value, componentPropValue);
         } else {
           this.updateComponent(attr, value);
         }
-        // On debug mode we write the component state to the DOM attributes
+
+        // On debug mode we write the component state to the DOM attributes.
+        isDebugMode = this.sceneEl && this.sceneEl.getAttribute('debug');
         if (isDebugMode) { this.components[attr].flushToDOM(); }
         return;
       }

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -25,7 +25,6 @@ module.exports = registerElement('a-node', {
       value: function () {
         var mixins;
 
-        this.hasAttached = true;
         this.hasLoaded = false;
         this.sceneEl = this.closestScene();
         this.emit('nodeready', {}, false);

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -25,6 +25,7 @@ module.exports = registerElement('a-node', {
       value: function () {
         var mixins;
 
+        this.hasAttached = true;
         this.hasLoaded = false;
         this.sceneEl = this.closestScene();
         this.emit('nodeready', {}, false);

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -22,7 +22,7 @@ suite('cursor', function () {
   });
 
   suite('init', function () {
-    test('initializes raycasters as dependency', function () {
+    test('initializes raycaster as a dependency', function () {
       assert.ok(this.cursorEl.components.raycaster);
     });
   });
@@ -383,5 +383,19 @@ suite('cursor', function () {
       assert.notOk(cursorEl.is('cursor-fusing'));
       assert.notOk(cursorEl.is('cursor-hovering'));
     });
+  });
+});
+
+suite('cursor + raycaster', function () {
+  test('can use HTML-configured raycaster', function (done) {
+    var parentEl = entityFactory();
+    parentEl.addEventListener('child-attached', function (evt) {
+      var el = evt.detail.el;
+      el.addEventListener('loaded', function () {
+        assert.equal(el.components.raycaster.data.objects, '.clickable');
+        done();
+      });
+    });
+    parentEl.innerHTML = '<a-entity cursor raycaster="objects: .clickable"></a-entity>';
   });
 });

--- a/tests/components/obj-model.test.js
+++ b/tests/components/obj-model.test.js
@@ -12,9 +12,7 @@ suite('obj-model', function () {
     objAsset.setAttribute('src', '/base/tests/assets/crate/crate.obj');
     el = this.el = entityFactory({assets: [mtlAsset, objAsset]});
     if (el.hasLoaded) { done(); }
-    el.addEventListener('loaded', function () {
-      done();
-    });
+    el.addEventListener('loaded', function () { done(); });
   });
 
   test('can load .OBJ only', function (done) {
@@ -60,5 +58,20 @@ suite('obj-model', function () {
       el2.setAttribute('obj-model', {obj: '#obj'});
     });
     el.sceneEl.appendChild(el2);
+  });
+
+  test('can load .OBJ with material', function (done) {
+    var parentEl = this.el;
+    parentEl.addEventListener('child-attached', function (evt) {
+      var el = evt.detail.el;
+      el.addEventListener('model-loaded', function () {
+        var material = el.getObject3D('mesh').children[0].material;
+        assert.equal(material.color.r, 1);
+        assert.equal(material.metalness, 0.123);
+        done();
+      });
+    });
+    parentEl.innerHTML = '<a-entity ' +
+      'obj-model="obj: #obj" material="color: red; metalness: 0.123"></a-entity>';
   });
 });

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -688,6 +688,86 @@ suite('a-entity', function () {
       assert.shallowDeepEqual(el.getAttribute('material'), {});
     });
 
+    test('initializes defined dependency component with setAttributes', function (done) {
+      var el = document.createElement('a-entity');
+
+      registerComponent('root', {
+        dependencies: ['dependency']
+      });
+
+      registerComponent('dependency', {
+        schema: {foo: {type: 'string'}},
+        init: function () {
+          assert.equal(this.data.foo, 'bar');
+          delete components.root;
+          delete components.dependency;
+          done();
+        }
+      });
+
+      // Create entity all at once with defined dependency component and component.
+      el.setAttribute('dependency', 'foo: bar');
+      el.setAttribute('root', '');
+      this.el.appendChild(el);
+    });
+
+    test('initializes defined dependency component with HTML', function (done) {
+      registerComponent('root', {
+        dependencies: ['dependency']
+      });
+
+      registerComponent('dependency', {
+        schema: {foo: {type: 'string'}},
+        init: function () {
+          assert.equal(this.data.foo, 'bar');
+          delete components.root;
+          delete components.dependency;
+          done();
+        }
+      });
+
+      this.el.innerHTML = '<a-entity root dependency="foo: bar">';
+    });
+
+    test('initializes defined dependency component with HTML reverse', function (done) {
+      registerComponent('root', {
+        dependencies: ['dependency']
+      });
+
+      registerComponent('dependency', {
+        schema: {foo: {type: 'string'}},
+        init: function () {
+          assert.equal(this.data.foo, 'bar');
+          delete components.root;
+          delete components.dependency;
+          done();
+        }
+      });
+
+      this.el.innerHTML = '<a-entity dependency="foo: bar" root>';
+    });
+
+    test('can access dependency component data', function (done) {
+      registerComponent('root', {
+        dependencies: ['dependency'],
+
+        init: function () {
+          assert.equal(this.el.components.dependency.data.foo, 'bar');
+          assert.equal(this.el.components.dependency.qux, 'baz');
+          delete components.root;
+          delete components.dependency;
+          done();
+        }
+      });
+
+      registerComponent('dependency', {
+        schema: {foo: {type: 'string'}},
+        init: function () { this.qux = 'baz'; }
+      });
+
+      this.el.innerHTML = '<a-entity dependency="foo: bar" root>';
+    });
+
     test('initializes dependency component and current attribute honored', function () {
       var el = this.el;
       var materialAttribute = 'color: #F0F; transparent: true';
@@ -953,31 +1033,45 @@ suite('a-entity component dependency management', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
     var componentNames = ['codependency', 'dependency', 'nested-dependency', 'test'];
+    var componentProto;
+
     componentNames.forEach(function clearComponent (componentName) {
       components[componentName] = undefined;
     });
 
-    registerComponent('test', extend({}, TestComponent, {
-      dependencies: ['dependency', 'codependency'],
-
-      init: function () {
-        this.el.components.dependency.el;
-      }
+    /**
+     * root
+     *   dependency
+     *     nestedDependency
+     *   codependency
+     */
+    componentProto = extend({}, TestComponent);
+    var RootComponent = registerComponent('root', extend(componentProto, {
+      dependencies: ['dependency', 'codependency']
     }));
-    this.DependencyComponent = registerComponent('dependency', extend({}, TestComponent, {
+    this.rootInit = this.sinon.spy(RootComponent.prototype, 'init');
+
+    componentProto = extend({}, TestComponent);
+    this.DependencyComponent = registerComponent('dependency', extend(componentProto, {
       dependencies: ['nested-dependency']
     }));
-    registerComponent('codependency', extend({}, TestComponent, {
+    this.dependencyInit = this.sinon.spy(this.DependencyComponent.prototype, 'init');
+
+    componentProto = extend({}, TestComponent);
+    var CodependencyComponent = registerComponent('codependency', extend(componentProto, {
       dependencies: []
     }));
-    registerComponent('nested-dependency', TestComponent);
-    el.addEventListener('loaded', function () {
-      done();
-    });
+    this.codependencyInit = this.sinon.spy(CodependencyComponent.prototype, 'init');
+
+    componentProto = extend({}, TestComponent);
+    var NestedDependency = registerComponent('nested-dependency', componentProto);
+    this.nestedDependencyInit = this.sinon.spy(NestedDependency.prototype, 'init');
+
+    el.addEventListener('loaded', function () { done(); });
   });
 
   teardown(function () {
-    components.test = undefined;
+    components.root = undefined;
     components.codependency = undefined;
     components.dependency = undefined;
     components['nested-dependency'] = undefined;
@@ -985,25 +1079,60 @@ suite('a-entity component dependency management', function () {
 
   test('initializes dependency components', function () {
     var el = this.el;
-    el.setAttribute('test', '');
-    assert.ok('test' in el.components);
+    el.setAttribute('root', '');
+    assert.ok('root' in el.components);
     assert.ok('dependency' in el.components);
     assert.ok('codependency' in el.components);
     assert.ok('nested-dependency' in el.components);
   });
 
   test('only initializes each component once', function () {
-    var spy = this.sinon.spy(this.DependencyComponent.prototype, 'init');
-    this.el.setAttribute('test', '');
-    assert.equal(spy.callCount, 1);
+    this.el.setAttribute('root', '');
+    assert.equal(this.rootInit.callCount, 1);
+    assert.equal(this.dependencyInit.callCount, 1);
+    assert.equal(this.codependencyInit.callCount, 1);
+    assert.equal(this.nestedDependencyInit.callCount, 1);
   });
 
   test('initializes dependency components when not yet loaded', function () {
     var el = document.createElement('a-entity');
-    el.setAttribute('test', '');
-    assert.ok('test' in el.components);
+    el.setAttribute('root', '');
+    assert.ok('root' in el.components);
     assert.ok('dependency' in el.components);
     assert.ok('codependency' in el.components);
     assert.ok('nested-dependency' in el.components);
+  });
+
+  test('initializes components (calling .init()) in the correct order', function (done) {
+    var el = helpers.entityFactory();
+    var self = this;
+    el.addEventListener('loaded', function () {
+      sinon.assert.callOrder(
+        self.nestedDependencyInit,
+        self.dependencyInit,
+        self.codependencyInit,
+        self.rootInit
+      );
+      done();
+    });
+    el.setAttribute('root', '');
+  });
+
+  test('initializes components (calling .init()) in the correct order via HTML', function (done) {
+    var parentEl = helpers.entityFactory();
+    var self = this;
+    parentEl.addEventListener('child-attached', function (evt) {
+      var el = evt.detail.el;
+      el.addEventListener('loaded', function () {
+        sinon.assert.callOrder(
+          self.nestedDependencyInit,
+          self.dependencyInit,
+          self.codependencyInit,
+          self.rootInit
+        );
+        done();
+      });
+    });
+    parentEl.innerHTML = '<a-entity root></a-entity>';
   });
 });

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -729,6 +729,27 @@ suite('a-entity', function () {
       this.el.innerHTML = '<a-entity root dependency="foo: bar">';
     });
 
+    test('initializes defined dependency component with null data w/ HTML', function (done) {
+      registerComponent('root', {
+        dependencies: ['dependency'],
+        init: function () {
+          assert.equal(this.el.components.dependency.data.foo, 'bar');
+          delete components.root;
+          delete components.dependency;
+          done();
+        }
+      });
+
+      registerComponent('dependency', {
+        schema: {foo: {default: 'bar'}},
+        init: function () {
+          assert.equal(this.data.foo, 'bar');
+        }
+      });
+
+      this.el.innerHTML = '<a-entity root dependency>';
+    });
+
     test('initializes defined dependency component with HTML reverse', function (done) {
       registerComponent('root', {
         dependencies: ['dependency']


### PR DESCRIPTION
**Description:**

With investigation help from @GavanWilhite.

`initComponent` in `initComponentDependencies` was being called with `undefined` rather than reading data from the DOM. The component later initializes with a null data set because components themselves never fetch data from the DOM; they depend on the entity to pass data to them.

**Changes proposed:**
- Call `initComponent` for dependencies using data from the DOM (`HTMLElement.prototype.getAttribute`).
- Increase confidence of dependency system with tests.
- [x] Specific tests for cursor + raycaster combo.