### PR TITLE
lax the asset parser, remove no longer needed primitives.transform (fixes #2038)

### DIFF
--- a/docs/core/component.md
+++ b/docs/core/component.md
@@ -233,13 +233,13 @@ types:
 | Property Type   | Description                                                                                                       | Default Value            |
 | --------------- | -------------                                                                                                     | -------------            |
 | array           | Comma-separated values to array (e.g., `"1, 2, 3" to ['1', '2', '3'].                                             | []                       |
+| asset           | Parse URL out of `url(<url>)`. If a selector, call `querySelector` and `getAttribute('src')`. Can take a string.  | ''                       |
 | boolean         | Convert to boolean (i.e., `"false"` to false, everything else truthy).                                            | false                    |
 | color           | Currently does no parsing. Used by the A-Frame Inspector for widgets.                                             | #FFF                     |
 | int             | Calls `parseInt` (e.g., `"124.5"` to `124`).                                                                      | 0                        |
 | number          | Calls `parseFloat` (e.g., `"124.5" to `124.5').                                                                   | 0                        |
 | selector        | Calls `querySelector` (e.g., `"#box" to `<a-entity id="box">`).                                                   | null                     |
 | selectorAll     | Calls `querySelectorAll` and converts `NodeList` to `Array` (e.g., `".boxes"` to [<a-entity class="boxes", ...]), | null                     |
-| src             | Parses URL out of `url(<url>)` or if it is a selector, calls `querySelector` and `getAttribute('src')`.           | ''                       |
 | string          | Does no parsing.                                                                                                  | ''                       |
 | vec2            | Parses two numbers into an `{x, y}` object (e.g., `1 -2` to `{x: 1, y: -2}`.                                      | {x: 0, y: 0}             |
 | vec3            | Parses three numbers into an `{x, y, z}` object (e.g., `1 -2 3` to `{x: 1, y: -2, z: 3}`.                         | {x: 0, y: 0, z: 0}       |

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -61,26 +61,37 @@ function arrayStringify (value) {
 }
 
 /**
- * `src` parser for assets.
+ * For general assets.
  *
- * @param {string} value - Can either be `url(<value>)` or a selector to an asset.
- * @returns {string|Element} Parsed value from `url(<value>)`, src from `<someasset src>`, or
- *   canvas.
+ * @param {string} value - Can either be `url(<value>)`, an ID selector to an asset, or
+ *   just string.
+ * @returns {string} Parsed value from `url(<value>)`, src from `<someasset src>`, or
+ *   just string.
  */
 function assetParse (value) {
   var el;
-  var parsedUrl = value.match(/\url\((.+)\)/);
+  var parsedUrl;
 
+  // Wrapped `url()` in case of data URI.
+  parsedUrl = value.match(/\url\((.+)\)/);
   if (parsedUrl) { return parsedUrl[1]; }
 
-  el = selectorParse(value);
-  if (!el) { return ''; }
-
-  if (el.tagName === 'CANVAS') {
-    return el;
-  } else {
-    return el.getAttribute('src');
+  // ID.
+  if (value.charAt(0) === '#') {
+    el = selectorParse(value);
+    if (el) {
+      if (el.tagName === 'CANVAS') {
+        return el;
+      } else {
+        return el.getAttribute('src');
+      }
+    }
+    warn('"' + value + '" asset not found.');
+    return;
   }
+
+  // Non-wrapped url().
+  return value;
 }
 
 function defaultParse (value) {

--- a/src/extras/primitives/getMeshMixin.js
+++ b/src/extras/primitives/getMeshMixin.js
@@ -13,19 +13,7 @@ Object.keys(shaders.standard.schema).forEach(function addMapping (prop) {
 
 module.exports = function getMeshMixin () {
   return {
-    defaultComponents: {
-      material: {}
-    },
-
-    mappings: utils.extend({}, materialMappings),
-
-    transforms: {
-      src: function (value) {
-        // Selector.
-        if (value[0] === '#') { return value; }
-        // Inline url().
-        return 'url(' + value + ')';
-      }
-    }
+    defaultComponents: {material: {}},
+    mappings: utils.extend({}, materialMappings)
   };
 };

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -3,7 +3,6 @@ var components = require('../../core/component').components;
 var registerElement = require('../../core/a-register-element').registerElement;
 var utils = require('../../utils/');
 
-var bind = utils.bind;
 var debug = utils.debug;
 var setComponentProperty = utils.entity.setComponentProperty;
 var log = debug('extras:primitives:debug');
@@ -113,21 +112,8 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
 
           if (!attr || !componentName) { return; }
 
-          // Run transform.
-          value = this.getTransformedValue(attr, value);
-
           // Set value.
           setComponentProperty(this, componentName, value);
-        }
-      },
-
-      /**
-       * Calls defined transform function on value if any.
-       */
-      getTransformedValue: {
-        value: function (attr, value) {
-          if (!this.transforms || !this.transforms[attr]) { return value; }
-          return bind(this.transforms[attr], this)(value);
         }
       }
     })

--- a/src/extras/primitives/primitives/a-obj-model.js
+++ b/src/extras/primitives/primitives/a-obj-model.js
@@ -6,9 +6,5 @@ registerPrimitive('a-obj-model', utils.extendDeep({}, meshMixin, {
   mappings: {
     src: 'obj-model.obj',
     mtl: 'obj-model.mtl'
-  },
-
-  transforms: {
-    mtl: meshMixin.transforms.src
   }
 }));

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -19,10 +19,11 @@ suite('propertyTypes', function () {
       this.el.parentNode.removeChild(this.el);
     });
 
-    test('parses src', function () {
+    test('parses asset', function () {
       assert.equal(parse('url(file.jpg)'), 'file.jpg');
-      assert.equal(parse('file.jpg'), '');
+      assert.equal(parse('file.jpg'), 'file.jpg');
       assert.equal(parse('#hello'), 'file2.jpg');
+      assert.equal(parse('#where'), null);
     });
   });
 
@@ -171,7 +172,7 @@ suite('propertyTypes', function () {
 
     test('parses src', function () {
       assert.equal(parse('url(file.jpg)'), 'file.jpg');
-      assert.equal(parse('file.jpg'), '');
+      assert.equal(parse('file.jpg'), 'file.jpg');
       assert.equal(parse('#hello'), 'file2.jpg');
     });
   });

--- a/tests/extras/primitives/primitives.test.js
+++ b/tests/extras/primitives/primitives.test.js
@@ -73,25 +73,6 @@ suite('registerPrimitive', function () {
       });
     });
   });
-
-  test('transforms', function (done) {
-    primitiveFactory({
-      mappings: {
-        opacity: 'material.opacity'
-      },
-      transforms: {
-        opacity: function (value) {
-          return value * 2;
-        }
-      }
-    }, function (el) {
-      el.setAttribute('opacity', '.25');
-      process.nextTick(function () {
-        assert.equal(el.getAttribute('material').opacity, 0.5);
-        done();
-      });
-    });
-  });
 });
 
 suite('registerPrimitive (using innerHTML)', function () {


### PR DESCRIPTION
**Description:**

Allows URL properties to be just a string, for a more lenient API. Keep `url()` as a solution to escape semicolons or for data URIs. Lets us remove the primitives transform API. 