### PR TITLE
Add runtime env variable to load inspector from master in developmen

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "main": "dist/aframe.js",
   "scripts": {
     "browserify": "browserify src/index.js -s 'AFRAME' -p browserify-derequire",
-    "build": "mkdirp build/ && npm run browserify -- --debug -o build/aframe.js",
+    "build": "mkdirp build/ && npm run browserify -- --debug -t [envify --INSPECTOR_VERSION dev] -o build/aframe.js",
     "codecov": "codecov",
-    "dev": "npm run build && node ./scripts/budo",
+    "dev": "npm run build && cross-env INSPECTOR_VERSION=dev node ./scripts/budo -t envify",
     "dist": "npm run dist:min && npm run dist:max",
-    "dist:max": "npm run browserify -s -- --debug | exorcist dist/aframe.js.map > dist/aframe.js",
-    "dist:min": "npm run browserify -s -- --debug -p [minifyify --map aframe.min.js.map --output dist/aframe.min.js.map] -o dist/aframe.min.js",
+    "dist:max": "npm run browserify -s -- --debug -t [envify --INSPECTOR_VERSION dev] | exorcist dist/aframe.js.map > dist/aframe.js",
+    "dist:min": "npm run browserify -s -- --debug -t [envify --INSPECTOR_VERSION dev] -p [minifyify --map aframe.min.js.map --output dist/aframe.min.js.map] -o dist/aframe.min.js",
     "dist:release": "npm run dist:release:min && npm run dist:release:max",
     "dist:release:max": "npm run browserify -s -- --debug | exorcist dist/aframe-v0.3.0.js.map > dist/aframe-v0.3.0.js",
     "dist:release:min": "npm run browserify -s -- --debug -p [minifyify --map aframe-v0.3.0.min.js.map --output dist/aframe-v0.3.0.min.js.map] -o dist/aframe-v0.3.0.min.js",
@@ -52,6 +52,7 @@
     "chai": "^3.5.0",
     "chai-shallow-deep-equal": "^1.4.0",
     "codecov": "^1.0.1",
+    "envify": "^3.4.1",
     "exorcist": "^0.4.0",
     "ghpages": "0.0.8",
     "husky": "^0.11.7",
@@ -84,7 +85,8 @@
   "link": true,
   "browserify": {
     "transform": [
-      "browserify-css"
+      "browserify-css",
+      "envify"
     ]
   },
   "semistandard": {

--- a/src/components/scene/inspector.js
+++ b/src/components/scene/inspector.js
@@ -4,7 +4,9 @@ var bind = require('../../utils/bind');
 var pkg = require('../../../package');
 var registerComponent = require('../../core/component').registerComponent;
 
-var INSPECTOR_URL = pkg.homepage + 'releases/' + pkg.version + '/aframe-inspector.min.js';
+var INSPECTOR_DEV_URL = 'https://aframe.io/aframe-inspector/build/aframe-inspector.js';
+var INSPECTOR_RELEASE_URL = pkg.homepage + 'releases/' + pkg.version + '/aframe-inspector.min.js';
+var INSPECTOR_URL = process.env.INSPECTOR_VERSION === 'dev' ? INSPECTOR_DEV_URL : INSPECTOR_RELEASE_URL;
 var LOADING_MESSAGE = 'Loading Inspector';
 
 module.exports.Component = registerComponent('inspector', {


### PR DESCRIPTION
The build commands are getting messy. Ideas to clean them up are more than welcome.

Budo is also messy. I could not pass `-t [envify --BUILD_TYPE development]` as an argument. Whatever parser budo is using splits the string in substrings using the space as separator. It took my a while to understand what was going on. At the end I used `cross-env` to be able to set an environment variable so I can just pass `-t envify` to budo.