### PR TITLE
add asset-specific property types: map, model, audio (fixes #1329)

### DIFF
--- a/src/components/blend-character-model.js
+++ b/src/components/blend-character-model.js
@@ -6,7 +6,7 @@ var THREE = require('../lib/three');
  * Loads a model with skeletal animation blending.
  */
 module.exports.Component = registerComponent('blend-character-model', {
-  schema: {type: 'src'},
+  schema: {type: 'asset'},
 
   init: function () {
     this.model = null;

--- a/src/components/collada-model.js
+++ b/src/components/collada-model.js
@@ -2,9 +2,7 @@ var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
 
 module.exports.Component = registerComponent('collada-model', {
-  schema: {
-    type: 'src'
-  },
+  schema: {type: 'asset'},
 
   init: function () {
     this.model = null;

--- a/src/components/obj-model.js
+++ b/src/components/obj-model.js
@@ -8,8 +8,8 @@ module.exports.Component = registerComponent('obj-model', {
   dependencies: ['material'],
 
   schema: {
-    mtl: {type: 'src'},
-    obj: {type: 'src'}
+    mtl: {type: 'model'},
+    obj: {type: 'model'}
   },
 
   init: function () {

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -14,7 +14,7 @@ module.exports.Component = registerComponent('sound', {
     loop: {default: false},
     on: {default: ''},
     poolSize: {default: 1},
-    src: {type: 'src'},
+    src: {type: 'audio'},
     volume: {default: 1}
   },
 

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -7,12 +7,15 @@ var warn = debug('core:propertyTypes:warn');
 var propertyTypes = module.exports.propertyTypes = {};
 
 // Built-in property types.
+registerPropertyType('audio', '', assetParse);
 registerPropertyType('array', [], arrayParse, arrayStringify);
 registerPropertyType('asset', '', assetParse);
 registerPropertyType('boolean', false, boolParse);
 registerPropertyType('color', '#FFF', defaultParse, defaultStringify);
 registerPropertyType('int', 0, intParse);
 registerPropertyType('number', 0, numberParse);
+registerPropertyType('map', '', assetParse);
+registerPropertyType('model', '', assetParse);
 registerPropertyType('selector', '', selectorParse, selectorStringify);
 registerPropertyType('selectorAll', '', selectorAllParse, selectorAllStringify);
 registerPropertyType('src', '', srcParse);
@@ -61,21 +64,23 @@ function arrayStringify (value) {
  * `src` parser for assets.
  *
  * @param {string} value - Can either be `url(<value>)` or a selector to an asset.
- * @returns {string} Parsed value from `url(<value>)` or src from `<someasset src>`.
+ * @returns {string|Element} Parsed value from `url(<value>)`, src from `<someasset src>`, or
+ *   canvas.
  */
 function assetParse (value) {
+  var el;
   var parsedUrl = value.match(/\url\((.+)\)/);
+
   if (parsedUrl) { return parsedUrl[1]; }
 
-  var el = selectorParse(value);
-  if (el) { return el.getAttribute('src'); }
+  el = selectorParse(value);
+  if (!el) { return ''; }
 
-  if (value.charAt(0) !== '#') {
-    warn('"' + value + '" is not a valid `src` attribute. ' +
-         'Value must be an ID selector (i.e. "#someElement") or wrapped in `url()`.');
+  if (el.tagName === 'CANVAS') {
+    return el;
+  } else {
+    return el.getAttribute('src');
   }
-
-  return '';
 }
 
 function defaultParse (value) {

--- a/src/core/shader.js
+++ b/src/core/shader.js
@@ -5,13 +5,17 @@ var shaders = module.exports.shaders = {};  // Keep track of registered shaders.
 var shaderNames = module.exports.shaderNames = [];  // Keep track of the names of registered shaders.
 var THREE = require('../lib/three');
 
+// A-Frame properties to three.js uniform types.
 var propertyToThreeMapping = {
+  array: 'v3',
+  color: 'v3',
+  int: 'i',
   number: 'f',
+  map: 't',
   time: 'f',
-  vec4: 'v4',
-  vec3: 'v3',
   vec2: 'v2',
-  color: 'v3'
+  vec3: 'v3',
+  vec4: 'v4'
 };
 
 /**

--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -11,7 +11,7 @@ module.exports.Component = registerShader('flat', {
     fog: {default: true},
     height: {default: 256},
     repeat: {default: ''},
-    src: {default: ''},
+    src: {type: 'map'},
     width: {default: 512},
     wireframe: {default: false},
     wireframeLinewidth: {default: 2}

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -10,14 +10,14 @@ var texturePromises = {};
  */
 module.exports.Component = registerShader('standard', {
   schema: {
-    ambientOcclusionMap: {default: ''},
+    ambientOcclusionMap: {type: 'map'},
     ambientOcclusionMapIntensity: {default: 1},
     ambientOcclusionTextureOffset: {default: ''},
     ambientOcclusionTextureRepeat: {default: ''},
 
     color: {type: 'color'},
 
-    displacementMap: {default: ''},
+    displacementMap: {type: 'map'},
     displacementScale: {default: 1},
     displacementBias: {default: 0.5},
     displacementTextureOffset: {default: ''},
@@ -28,15 +28,15 @@ module.exports.Component = registerShader('standard', {
     height: {default: 256},
     metalness: {default: 0.0, min: 0.0, max: 1.0},
 
-    normalMap: {default: ''},
+    normalMap: {type: 'map'},
     normalScale: {type: 'vec2', default: '1 1'},
     normalTextureOffset: {default: ''},
     normalTextureRepeat: {default: ''},
 
     repeat: {default: ''},
     roughness: {default: 0.5, min: 0.0, max: 1.0},
-    sphericalEnvMap: {default: ''},
-    src: {default: ''},
+    sphericalEnvMap: {type: 'map'},
+    src: {type: 'map'},
     width: {default: 512},
     wireframe: {default: false},
     wireframeLinewidth: {default: 2}
@@ -97,7 +97,7 @@ module.exports.Component = registerShader('standard', {
 
     // if a spherical env map is defined then use it.
     if (sphericalEnvMap) {
-      this.el.sceneEl.systems.material.loadTexture(sphericalEnvMap, { src: sphericalEnvMap }, function textureLoaded (texture) {
+      this.el.sceneEl.systems.material.loadTexture(sphericalEnvMap, {src: sphericalEnvMap}, function textureLoaded (texture) {
         self.isLoadingEnvMap = false;
         texture.mapping = THREE.SphericalReflectionMapping;
         material.envMap = texture;

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -35,10 +35,16 @@ module.exports.System = registerSystem('material', {
    */
   loadTexture: function (src, data, cb) {
     var self = this;
-    utils.srcLoader.validateSrc(src, loadImageCb, loadVideoCb, loadCanvasCb);
+
+    // Canvas.
+    if (src.tagName === 'CANVAS') {
+      this.loadCanvas(src, data, cb);
+      return;
+    }
+
+    utils.srcLoader.validateSrc(src, loadImageCb, loadVideoCb);
     function loadImageCb (src) { self.loadImage(src, data, cb); }
     function loadVideoCb (src) { self.loadVideo(src, data, cb); }
-    function loadCanvasCb (src) { self.loadCanvas(src, data, cb); }
   },
 
   /**

--- a/src/utils/src-loader.js
+++ b/src/utils/src-loader.js
@@ -5,8 +5,8 @@ var warn = debug('utils:src-loader:warn');
 
 /**
  * Validates a texture, either as a selector or as a URL.
- * Detects whether `src` is pointing to an image, video, or canvas, and invokes the
- * appropriate callback.
+ * Detects whether `src` is pointing to an image or video and invokes the appropriate
+ * callback.
  *
  * If `src` is selector, check if it's valid, return the el in the callback.
  * An el is returned so that it can be reused for texture loading.
@@ -16,36 +16,15 @@ var warn = debug('utils:src-loader:warn');
  * @params {string} src - A selector or a URL. URLs must be wrapped by `url()`.
  * @params {function} isImageCb - callback if texture is an image.
  * @params {function} isVideoCb - callback if texture is a video.
- * @params {function} isCanvasCb - callback if texture is a canvas.
  */
-function validateSrc (src, isImageCb, isVideoCb, isCanvasCb) {
-  var textureEl;
-  var isImage;
-  var isVideo;
-  var isCanvas;
-  var url = parseUrl(src);
-
-  // src is a url.
-  if (url) {
-    validateImageUrl(url, function isAnImageUrl (isImage) {
-      if (!isImage) { isVideoCb(url); return; }
-      isImageCb(url);
-    });
-    return;
-  }
-
-  // src is a query selector.
-  textureEl = validateAndGetQuerySelector(src);
-  if (!textureEl) { return; }
-  isImage = textureEl && textureEl.tagName === 'IMG';
-  isVideo = textureEl && textureEl.tagName === 'VIDEO';
-  isCanvas = textureEl && textureEl.tagName === 'CANVAS';
-  if (isImage) { return isImageCb(textureEl); }
-  if (isVideo) { return isVideoCb(textureEl); }
-  if (isCanvas) { return isCanvasCb(textureEl); }
-
-  // src is a valid selector but doesn't match with a <img>, <video>, or <canvas> element.
-  warn('"%s" does not point to a valid <img>, <video>, or <canvas> element', src);
+function validateSrc (src, isImageCb, isVideoCb) {
+  validateImageUrl(src, function isAnImageUrl (isImage) {
+    if (isImage) {
+      isImageCb(src);
+      return;
+    }
+    isVideoCb(src);
+  });
 }
 
 /**
@@ -80,7 +59,8 @@ function validateCubemapSrc (src, cb) {
   }
   if (urls) {
     for (i = 1; i < 7; i++) {
-      validateSrc(urls[i], isImageCb);
+      // TODO: cubemap property type.
+      validateSrc(parseUrl(urls[i]), isImageCb);
     }
     return;
   }


### PR DESCRIPTION
**Description:**

Add new property types: `map`, `model`, `audio`.

**Changes proposed:**
- Convert some existing components to use the new property types (e.g., `asset` and `map).
- Add them to property type mappings in A-Frame's API for wrapping ShaderMaterial, but I'm convinced we should kill that #2047.
- Move canvas texture loading outside of the funky `src` validation code, have property type return the canvas, and pass it straight to three.js.
