### PR TITLE
use default prop value if given value is empty string (fixes #2059)

### DIFF
--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -119,8 +119,12 @@ module.exports.parseProperties = function (propData, schema, getPartialData, com
  * Deserialize a single property.
  */
 function parseProperty (value, propDefinition) {
-  value = (value === undefined || value === null) ? propDefinition.default : value;
-  return propDefinition.parse(value);
+  // Use default value if value is falsy.
+  if (value === undefined || value === null || value === '') {
+    value = propDefinition.default;
+  }
+  // Invoke property type parser.
+  return propDefinition.parse(value, propDefinition.default);
 }
 module.exports.parseProperty = parseProperty;
 

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -5,7 +5,7 @@ var propertyTypes = PropertyTypes.propertyTypes;
 var register = PropertyTypes.registerPropertyType;
 
 suite('propertyTypes', function () {
-  suite('assetParse', function () {
+  suite('asset', function () {
     var parse = propertyTypes.asset.parse;
 
     setup(function () {
@@ -52,6 +52,17 @@ suite('propertyTypes', function () {
       register('mytype', 5);
       assert.ok('mytype' in propertyTypes);
       assert.equal(propertyTypes.mytype.default, 5);
+    });
+  });
+
+  suite('int', function () {
+    var parse = propertyTypes.int.parse;
+
+    test('parses int', function () {
+      assert.equal(parse('5'), 5);
+      assert.equal(parse(5), 5);
+      assert.equal(parse('4.5'), 4);
+      assert.equal(parse(4.5), 4);
     });
   });
 
@@ -144,7 +155,7 @@ suite('propertyTypes', function () {
     });
   });
 
-  suite('srcParse', function () {
+  suite('src', function () {
     var parse = propertyTypes.src.parse;
 
     setup(function () {

--- a/tests/core/schema.test.js
+++ b/tests/core/schema.test.js
@@ -51,6 +51,14 @@ suite('schema', function () {
       assert.shallowDeepEqual(parsed, {x: 1, y: 2, z: 3});
     });
 
+    test('uses default value if value is falsy', function () {
+      var schemaPropDef = processSchema({type: 'int', default: 2});
+      assert.equal(parseProperty(null, schemaPropDef), 2);
+      assert.equal(parseProperty('', schemaPropDef), 2);
+      assert.equal(parseProperty(undefined, schemaPropDef), 2);
+      assert.equal(parseProperty(0, schemaPropDef), 0);
+    });
+
     test('can parse using inline parse', function () {
       var schemaPropDef = {
         default: 'xyz',


### PR DESCRIPTION
**Description:**

The schema was passing empty strings to the property type parser. For `int` type, this led to `parseInt('', 10)`, which resolved to `NaN`. So for empty strings, we should use the default value.
