### PR TITLE
[WIP] system share component registration/constructor/prototype (fixes #1947)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -14,14 +14,16 @@ var MULTIPLE_COMPONENT_DELIMITER = '__';
 
 /**
  * Entity is a container object that components are plugged into to comprise everything in
- * the scene. In A-Frame, they inherently have position, rotation, and scale.
+ * the scene. In A-Frame, they inherently have position, rotation, and scale. The entity
+ * handles component lifecycle.
  *
  * To be able to take components, the scene element inherits from the entity definition.
+ * Since systems are similar to components, the entity also handles system lifecycle.
  *
- * @member {object} components - entity's currently initialized components.
+ * @member {object} components - Entity's currently initialized components.
  * @member {object} object3D - three.js object.
  * @member {array} states
- * @member {boolean} isPlaying - false if dynamic behavior of the entity is paused.
+ * @member {boolean} isPlaying - `false` if dynamic behavior of the entity is paused.
  */
 var proto = Object.create(ANode.prototype, {
   defaultComponents: {

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -328,7 +328,7 @@ var proto = Object.create(ANode.prototype, {
                         'components of type `' + componentName +
                         '`. There can only be one component of this type per entity.');
       }
-      component = this.components[attrName] = new COMPONENTS[componentName].Component(
+      component = this.components[attrName] = new COMPONENTS[componentName].Constructor(
         this, data, componentId);
       if (this.isPlaying) { component.play(); }
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -54,6 +54,7 @@ module.exports = registerElement('a-scene', {
         this.isScene = true;
         this.object3D = new THREE.Scene();
         this.render = bind(this.render, this);
+        this.sceneEl = this;
         this.systems = {};
         this.time = 0;
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -2,7 +2,6 @@
 var initMetaTags = require('./metaTags').inject;
 var initWakelock = require('./wakelock');
 var re = require('../a-register-element');
-var systems = require('../system').systems;
 var THREE = require('../../lib/three');
 var TWEEN = require('tween.js');
 var utils = require('../../utils/');
@@ -19,7 +18,7 @@ var registerElement = re.registerElement;
 var warn = utils.debug('core:a-scene:warn');
 
 /**
- * Scene element, holds all entities.
+ * Scene element. Holds all entities.
  *
  * @member {number} animationFrameID
  * @member {array} behaviors - Component instances that have registered themselves to be
@@ -101,28 +100,11 @@ module.exports = registerElement('a-scene', {
         var resize = bind(this.resize, this);
         initMetaTags(this);
         initWakelock(this);
-        this.initSystems();
-
         window.addEventListener('load', resize);
         window.addEventListener('resize', resize);
         this.play();
       },
       writable: window.debug
-    },
-
-    initSystems: {
-      value: function () {
-        Object.keys(systems).forEach(bind(this.initSystem, this));
-      }
-    },
-
-    initSystem: {
-      value: function (name) {
-        var system;
-        if (this.systems[name]) { return; }
-        system = this.systems[name] = new systems[name](this);
-        system.init();
-      }
     },
 
     /**
@@ -137,7 +119,7 @@ module.exports = registerElement('a-scene', {
 
     /**
      * @param {object} behavior - Generally a component. Must implement a .update() method to
-     *        be called on every tick.
+     *   be called on every tick.
      */
     addBehavior: {
       value: function (behavior) {
@@ -216,18 +198,6 @@ module.exports = registerElement('a-scene', {
     },
 
     /**
-     * Wraps Entity.getAttribute to take into account for systems.
-     * If system exists, then return system data rather than possible component data.
-     */
-    getAttribute: {
-      value: function (attr) {
-        var system = this.systems[attr];
-        if (system) { return system.data; }
-        return AEntity.prototype.getAttribute.call(this, attr);
-      }
-    },
-
-    /**
      * `getAttribute` used to be `getDOMAttribute` and `getComputedAttribute` used to be
      * what `getAttribute` is now. Now legacy code.
      */
@@ -235,34 +205,6 @@ module.exports = registerElement('a-scene', {
       value: function (attr) {
         warn('`getComputedAttribute` is deprecated. Use `getAttribute` instead.');
         this.getAttribute(attr);
-      }
-    },
-
-    /**
-     * Wraps Entity.getDOMAttribute to take into account for systems.
-     * If system exists, then return system data rather than possible component data.
-     */
-    getDOMAttribute: {
-      value: function (attr) {
-        var system = this.systems[attr];
-        if (system) { return system.data; }
-        return AEntity.prototype.getDOMAttribute.call(this, attr);
-      }
-    },
-
-    /**
-     * Wraps Entity.setAttribute to take into account for systems.
-     * If system exists, then skip component initialization checks and do a normal
-     * setAttribute.
-     */
-    setAttribute: {
-      value: function (attr, value, componentPropValue) {
-        var system = this.systems[attr];
-        if (system) {
-          ANode.prototype.setAttribute.call(this, attr, value);
-          return;
-        }
-        AEntity.prototype.setAttribute.call(this, attr, value, componentPropValue);
       }
     },
 
@@ -390,19 +332,13 @@ module.exports = registerElement('a-scene', {
      */
     tick: {
       value: function (time, timeDelta) {
-        var systems = this.systems;
-
         // Animations.
         TWEEN.update(time);
-        // Components.
-        this.behaviors.forEach(function (component) {
+
+        // Components (and systems).
+        this.behaviors.forEach(function runTick (component) {
           if (!component.el.isPlaying) { return; }
           component.tick(time, timeDelta);
-        });
-        // Systems.
-        Object.keys(systems).forEach(function (key) {
-          if (!systems[key].tick) { return; }
-          systems[key].tick(time, timeDelta);
         });
       }
     },

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -45,7 +45,8 @@ module.exports.registerSystem = function (name, definition) {
   NewSystem = function (el, attrName, id) {
     System.call(this, el, attrName, id);
   };
-  NewSystem.prototype = utils.createPrototype(name, definition, System, 'system', systems);
+  NewSystem.prototype = utils.createPrototype(name, definition, System.prototype, 'system',
+                                              systems);
   entry = componentModule.registerComponentConstructor(name, NewSystem, systems);
 
   // Initialize systems for already-running scenes.

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -186,7 +186,7 @@ module.exports.createPrototype = function (moduleName, definition, BasePrototype
   var proto = {};
 
   // Format definition object to prototype object.
-  Object.keys(definition).forEach(function (key) {
+  Object.keys(definition).forEach(function convertToPrototype (key) {
     proto[key] = {
       value: definition[key],
       writable: true

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -171,5 +171,37 @@ module.exports.findAllScenes = function (el) {
   return matchingElements;
 };
 
+/**
+ * Helper for registering extendable A-Frame modules (e.g, components, systems).
+ *
+ * @param {string} moduleName - Name of instance of the module.
+ * @param {object} definition - Module prototype definition as plain JavaScript object.
+ * @param {string} moduleType - Type of module, used to generate error messages.
+ * @param {object} registeredModules - Object containing registered modules of the type.
+
+ * @returns {object} Prototype object.
+ */
+module.exports.createPrototype = function (moduleName, definition, BasePrototype, moduleType,
+                                           registeredModules) {
+  var proto = {};
+
+  // Format definition object to prototype object.
+  Object.keys(definition).forEach(function (key) {
+    proto[key] = {
+      value: definition[key],
+      writable: true
+    };
+  });
+
+  // Check if already registered.
+  if (registeredModules[moduleName]) {
+    throw new Error('The %type `' + moduleName + '` has been already registered. ' +
+                    'Check that you are not loading two versions of the same %type' +
+                    'or two different %type of the same name.'.replace(/%type/g, moduleType));
+  }
+
+  return Object.create(BasePrototype, proto);
+};
+
 // Must be at bottom to avoid circular dependency.
 module.exports.srcLoader = require('./src-loader');

--- a/tests/core/system.test.js
+++ b/tests/core/system.test.js
@@ -3,10 +3,6 @@ var components = require('core/component').components;
 var systems = require('core/system').systems;
 var registerSystem = require('core/system').registerSystem;
 
-var TestSystem = {
-  init: function () {}
-};
-
 suite('System', function () {
   suite('standard systems', function () {
     test('are registered', function () {
@@ -21,7 +17,7 @@ suite('System', function () {
 
     test('can be registered', function () {
       assert.notOk('TestSystem' in systems);
-      registerSystem('test', TestSystem);
+      registerSystem('test', {init: function () {}});
       assert.ok('test' in systems);
     });
   });
@@ -32,18 +28,17 @@ suite('System', function () {
       delete systems.test;
     });
 
-    test('initializes data for single-prop schema', function () {
+    test.only('initializes data for single-prop schema', function () {
       var sceneEl = document.createElement('a-scene');
       var system;
       var TestSystem;
 
-      AFRAME.registerSystem('test', {
+      TestSystem = AFRAME.registerSystem('test', {
         schema: {default: ''}
       });
-      TestSystem = systems.test;
 
       sceneEl.setAttribute('test', 'candy');
-      system = new TestSystem(sceneEl);
+      system = new TestSystem(sceneEl, 'candy', '');
       assert.equal(system.data, 'candy');
     });
 
@@ -52,16 +47,15 @@ suite('System', function () {
       var system;
       var TestSystem;
 
-      AFRAME.registerSystem('test', {
+      TestSystem = AFRAME.registerSystem('test', {
         schema: {
           a: {type: 'number'},
           b: {type: 'string'}
         }
       });
-      TestSystem = systems.test;
 
       sceneEl.setAttribute('test', 'a: 50; b: horses');
-      system = new TestSystem(sceneEl);
+      system = new TestSystem(sceneEl, 'test', '');
       assert.equal(system.data.a, 50);
       assert.equal(system.data.b, 'horses');
     });
@@ -71,15 +65,14 @@ suite('System', function () {
       var system;
       var TestSystem;
 
-      AFRAME.registerSystem('test', {
+      TestSystem = AFRAME.registerSystem('test', {
         schema: {
           a: {default: 50},
           b: {default: 'horses'}
         }
       });
-      TestSystem = systems.test;
 
-      system = new TestSystem(sceneEl);
+      system = new TestSystem(sceneEl, 'test', '');
       assert.equal(system.data.a, 50);
       assert.equal(system.data.b, 'horses');
     });
@@ -89,10 +82,9 @@ suite('System', function () {
       var system;
       var TestSystem;
 
-      AFRAME.registerSystem('test', {schema: {}});
-      TestSystem = systems.test;
+      TestSystem = AFRAME.registerSystem('test', {schema: {}});
 
-      system = new TestSystem(sceneEl);
+      system = new TestSystem(sceneEl, 'test', '');
       assert.notOk(system.data);
     });
   });


### PR DESCRIPTION
**Description:**

This enables system updates, play, and pause.

**Changes proposed:**
- Reuse code between components and systems.
- Refactor functions out of `AFRAME.registerComponent` to be agnostic enough to use with systems (or other types of modules) as well
- `AFRAME.components[myComponent].Component` -> `AFRAME.components[myComponent].Constructor`...follow this pattern for registerable modules.
- [ ] Have Entity handle System initialization / updates just as it does with components (if the entity is the scene).
- [ ] Update geometry/material constructors to use the new functions for DRY.