### PR TITLE
[WIP] Initialize primitive mappings with one setAttribute() per component.

### DIFF
--- a/src/utils/entity.js
+++ b/src/utils/entity.js
@@ -13,16 +13,25 @@ module.exports.getComponentProperty = function (el, name, delimiter) {
 };
 
 /**
+ * Convert an encoded component + component property name, encoded with a delimiter, to a path in
+ * array syntax.
+ */
+var getComponentPropertyPath = module.exports.getComponentPropertyPath = function (name, delimiter) {
+  delimiter = delimiter || '.';
+  return name.split(delimiter);
+};
+
+/**
  * Set component property using encoded component name + component property name with a
  * delimiter.
  */
 module.exports.setComponentProperty = function (el, name, value, delimiter) {
-  var splitName;
-  delimiter = delimiter || '.';
-  if (name.indexOf(delimiter) !== -1) {
-    splitName = name.split(delimiter);
-    el.setAttribute(splitName[0], splitName[1], value);
-    return;
+  var propertyPath = getComponentPropertyPath(name, delimiter);
+  if (propertyPath.length === 1) {
+    el.setAttribute(propertyPath[1], value);
+  } else if (propertyPath.length === 2) {
+    el.setAttribute(propertyPath[0], propertyPath[1], value);
+  } else {
+    throw new Error('Invalid property name: "%s"', name);
   }
-  el.setAttribute(name, value);
 };


### PR DESCRIPTION
Fixes #1900.

This is orthogonal to the `setAttribute` API changes @ngokevin suggests, although that sounds valuable independently. Tests aren't currently passing, and I'm not sure if this is too risky for v0.4.0, but here's the work in progress.