### PR TITLE
batch components and use only one setAttribute call when initializing primitives (fixes #1900, #1609)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -286,6 +286,7 @@ module.exports.registerComponent = function (name, definition) {
   components[name] = {
     Component: NewComponent,
     dependencies: NewComponent.prototype.dependencies,
+    isSingleProp: isSingleProp(NewComponent.prototype.schema),
     multiple: NewComponent.prototype.multiple,
     parse: NewComponent.prototype.parse,
     parseAttrValueForCache: NewComponent.prototype.parseAttrValueForCache,

--- a/src/utils/entity.js
+++ b/src/utils/entity.js
@@ -1,4 +1,15 @@
 /**
+ * Split a delimited component property string (e.g., `material.color`) to an object
+ * containing `component` name and `property` name. If there is no delimiter, just return the
+ * string back.
+ */
+module.exports.getComponentPropertyPath = function (str, delimiter) {
+  delimiter = delimiter || '.';
+  if (str.indexOf(delimiter) === -1) { return str; }
+  return str.split(delimiter);
+};
+
+/**
  * Get component property using encoded component name + component property name with a
  * delimiter.
  */


### PR DESCRIPTION
**Description:**

Also makes primitives work with mixins.

The data gathering and batch works as like:

- Default components
- Mixins
- Mappings
- Defined components

And then a single `setAttribute` is called for each component (using the current `setAttribute(name, obj)`).