### PR TITLE
update primitive standard material mapping + docs (fixes #2013)

### DIFF
--- a/docs/primitives/a-box.md
+++ b/docs/primitives/a-box.md
@@ -23,20 +23,34 @@ The box primitive, formerly called `<a-cube>`, creates shapes such as boxes, cub
 
 ## Attributes
 
-| Attribute       | Component Mapping       | Default Value |
-| --------        | -----------------       | ------------- |
-| color           | material.color          | #FFF          |
-| depth           | geometry.depth          | 1             |
-| height          | geometry.height         | 1             |
-| metalness       | material.metalness      | 0             |
-| opacity         | material.opacity        | 1             |
-| repeat          | material.repeat         | None          |
-| roughness       | material.roughness      | 0.5           |
-| segments-depth  | geometry.segmentsDepth  | 1             |
-| segments-height | geometry.segmentsHeight | 1             |
-| segments-width  | geometry.segmentsWidth  | 1             |
-| shader          | material.shader         | standard      |
-| side            | material.side           | front         |
-| src             | material.src            | None          |
-| transparent     | material.transparent    | false         |
-| width           | geometry.width          | 1             |
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| depth                            | geometry.depth                         | 1             |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| segments-depth                   | geometry.segmentsDepth                 | 1             |
+| segments-height                  | geometry.segmentsHeight                | 1             |
+| segments-width                   | geometry.segmentsWidth                 | 1             |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-circle.md
+++ b/docs/primitives/a-circle.md
@@ -26,21 +26,37 @@ component with the type set to `circle`.
 
 ## Attributes
 
-| Attribute    | Component Mapping    | Default Value |
-| --------     | -----------------    | ------------- |
-| color        | material.color       | #FFF          |
-| metalness    | material.metalness   | None          |
-| opacity      | material.opacity     | 1             |
-| radius       | geometry.radius      | 1             |
-| repeat       | material.repeat      | None          |
-| roughness    | material.roughness   | 0.5           |
-| segments     | geometry.segments    | 32            |
-| shader       | material.shader      | standard      |
-| side         | material.side        | front         |
-| src          | material.src         | None          |
-| theta-length | geometry.thetaLength | 360           |
-| theta-start  | geometry.thetaStart  | 0             |
-| transparent  | material.transparent | None          |
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| radius                           | geometry.radius                        | 1             |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| segments                         | geometry.segments                      | 32            |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| theta-length                     | geometry.thetaLength                   | 360           |
+| theta-start                      | geometry.thetaStart                    | 0             |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
 
 ## Parallelizing to the Ground
 

--- a/docs/primitives/a-cone.md
+++ b/docs/primitives/a-cone.md
@@ -23,22 +23,38 @@ The cone primitive creates a cone shape. It is an entity that prescribes the [ge
 
 ## Attributes
 
-| Attribute       | Component Mapping       | Default Value |
-| --------        | -----------------       | ------------- |
-| color           | material.color          | #FFF          |
-| height          | geometry.height         | 1             |
-| metalness       | material.metalness      | 0             |
-| opacity         | material.opacity        | 1             |
-| open-ended      | geometry.openEnded      | false         |
-| radius-bottom   | geometry.radiusBottom   | 1             |
-| radius-top      | geometry.radiusTop      | 0.8           |
-| repeat          | material.repeat         | None          |
-| roughness       | material.roughness      | 0.5           |
-| segments-height | geometry.segmentsHeight | 18            |
-| segments-radial | geometry.segmentsRadial | 36            |
-| shader          | material.shader         | standard      |
-| side            | material.side           | front         |
-| src             | material.src            | None          |
-| theta-length    | geometry.thetaLength    | 360           |
-| theta-start     | geometry.thetaStart     | 0             |
-| transparent     | material.transparent    | false         |
+
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| open-ended                       | geometry.openEnded                     | false         |
+| radius-bottom                    | geometry.radiusBottom                  | 1             |
+| radius-top                       | geometry.radiusTop                     | 0.8           |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| segments-height                  | geometry.segmentsHeight                | 18            |
+| segments-radial                  | geometry.segmentsRadial                | 36            |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| theta-length                     | geometry.thetaLength                   | 360           |
+| theta-start                      | geometry.thetaStart                    | 0             |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-cylinder.md
+++ b/docs/primitives/a-cylinder.md
@@ -27,21 +27,37 @@ The cylinder primitive is versatile and can actually be used to create various s
 
 ## Attributes
 
-| Attribute       | Component Mapping       | Default Value |
-| --------        | -----------------       | ------------- |
-| color           | material.color          | #FFF          |
-| height          | geometry.height         | 1             |
-| metalness       | material.metalness      | 0             |
-| opacity         | material.opacity        | 1             |
-| open-ended      | geometry.openEnded      | false         |
-| radius          | geometry.radius         | 1             |
-| repeat          | material.repeat         | None          |
-| roughness       | material.roughness      | 0.5           |
-| segments-height | geometry.segmentsHeight | 18            |
-| segments-radial | geometry.segmentsRadial | 36            |
-| shader          | material.shader         | standard      |
-| side            | material.side           | front         |
-| src             | material.src            | None          |
-| theta-length    | geometry.thetaLength    | 360           |
-| theta-start     | geometry.thetaStart     | 0             |
-| transparent     | material.transparent    | false         |
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| open-ended                       | geometry.openEnded                     | false         |
+| radius-bottom                    | geometry.radiusBottom                  | 1             |
+| radius-top                       | geometry.radiusTop                     | 0.8           |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| segments-height                  | geometry.segmentsHeight                | 18            |
+| segments-radial                  | geometry.segmentsRadial                | 36            |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| theta-length                     | geometry.thetaLength                   | 360           |
+| theta-start                      | geometry.thetaStart                    | 0             |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-isocahedron.md
+++ b/docs/primitives/a-isocahedron.md
@@ -1,5 +1,5 @@
 ---
-title: <a-dodecahedron>
+title: <a-octahedron>
 type: primitives
 layout: docs
 parent_section: primitives
@@ -8,7 +8,7 @@ parent_section: primitives
 ## Example
 
 ```html
-<a-dodecahedron color="#FF926B" radius="5"></a-dodecahedron>
+<a-isoacahedron color="#FF926B" radius="5"></a-isocahedron>
 ```
 
 ## Attributes
@@ -20,6 +20,7 @@ parent_section: primitives
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
 | color                            | material.color                         | #FFF          |
+| detail                           | geometry.detail                        | 0             |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
@@ -33,17 +34,11 @@ parent_section: primitives
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| open-ended                       | geometry.openEnded                     | false         |
-| radius-bottom                    | geometry.radiusBottom                  | 1             |
-| radius-top                       | geometry.radiusTop                     | 0.8           |
+| radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
-| segments-height                  | geometry.segmentsHeight                | 18            |
-| segments-radial                  | geometry.segmentsRadial                | 36            |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
-| theta-length                     | geometry.thetaLength                   | 360           |
-| theta-start                      | geometry.thetaStart                    | 0             |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-octahedron.md
+++ b/docs/primitives/a-octahedron.md
@@ -13,15 +13,32 @@ parent_section: primitives
 
 ## Attributes
 
-| Attribute   | Component Mapping    | Default Value |
-| --------    | -----------------    | ------------- |
-| color       | material.color       | #FFF          |
-| metalness   | material.metalness   | 0             |
-| opacity     | material.opacity     | 1             |
-| radius      | geometry.radius      | 1             |
-| repeat      | material.repeat      | None          |
-| roughness   | material.roughness   | 0.5           |
-| shader      | material.shader      | standard      |
-| side        | material.side        | front         |
-| src         | material.src         | None          |
-| transparent | material.transparent | false         |
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| detail                           | geometry.detail                        | 0             |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| radius                           | geometry.radius                        | 1             |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-plane.md
+++ b/docs/primitives/a-plane.md
@@ -26,21 +26,35 @@ component with the type set to `plane`.
 
 ## Attributes
 
-| Attribute       | Component Mapping       | Default Value |
-| --------        | -----------------       | ------------- |
-| color           | material.color          | #FFF          |
-| height          | geometry.height         | 1             |
-| metalness       | material.metalness      | 0             |
-| opacity         | material.opacity        | 1             |
-| repeat          | material.repeat         | None          |
-| roughness       | material.roughness      | 0.5           |
-| segments-height | geometry.segmentsHeight | 1             |
-| segments-width  | geometry.segmentsWidth  | 1             |
-| shader          | material.shader         | standard      |
-| side            | material.side           | front         |
-| src             | material.src            | None          |
-| transparent     | material.transparent    | false         |
-| width           | geometry.width          | 1             |
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| segments-height                  | geometry.segmentsHeight                | 1             |
+| segments-width                   | geometry.segmentsWidth                 | 1             |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
 
 ## Parallelizing to the Ground
 

--- a/docs/primitives/a-ring.md
+++ b/docs/primitives/a-ring.md
@@ -23,20 +23,36 @@ The ring primitive creates a ring or disc shape. It is an entity that prescribes
 
 ## Attributes
 
-| Attribute      | Component Mapping      | Default Value |
-| --------       | -----------------      | ------------- |
-| color          | material.color         | #FFF          |
-| metalness      | material.metalness     | None          |
-| opacity        | material.opacity       | 1             |
-| radius-inner   | geometry.radiusInner   | 0.8           |
-| radius-outer   | geometry.radiusOuter   | 1.2           |
-| repeat         | material.repeat        | None          |
-| roughness      | material.roughness     | 0.5           |
-| segments-phi   | geometry.segmentsPhi   | 10            |
-| segments-theta | geometry.segmentsTheta | 32            |
-| shader         | material.shader        | standard      |
-| side           | material.side          | front         |
-| src            | material.src           | None          |
-| theta-length   | geometry.thetaLength   | 360           |
-| theta-start    | geometry.thetaStart    | 0             |
-| transparent    | material.transparent   | None          |
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| radius-inner                     | geometry.radiusInner                   | 0.8           |
+| radius-outer                     | geometry.radiusOuter                   | 1.2           |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| segments-phi                     | geometry.segmentsPhi                   | 10            |
+| segments-theta                   | geometry.segmentsTheta                 | 32            |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| theta-length                     | geometry.thetaLength                   | 360           |
+| theta-start                      | geometry.thetaStart                    | 0             |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-sphere.md
+++ b/docs/primitives/a-sphere.md
@@ -15,21 +15,37 @@ The sphere primitive creates a spherical or polyhedron shapes. It wraps an entit
 
 ## Attributes
 
-| Attribute       | Component Mapping       | Default Value |
-| --------        | -----------------       | ------------- |
-| color           | material.color          | #FFF          |
-| metalness       | material.metalness      | 0             |
-| opacity         | material.opacity        | 1             |
-| phi-length      | geometry.phiLength      | 360           |
-| phi-start       | geometry.phiStart       | 0             |
-| radius          | geometry.radius         | 1             |
-| repeat          | material.repeat         | None          |
-| roughness       | material.roughness      | 0.5           |
-| segments-height | geometry.segmentsHeight | 18            |
-| segments-width  | geometry.segmentsWidth  | 36            |
-| shader          | material.shader         | standard      |
-| side            | material.side           | front         |
-| src             | material.src            | None          |
-| theta-length    | geometry.thetaLength    | 180           |
-| theta-start     | geometry.thetaStart     | 0             |
-| transparent     | material.transparent    | false         |
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| phi-length                       | geometry.phiLength                     | 360           |
+| phi-start                        | geometry.phiStart                      | 0             |
+| radius                           | geometry.radius                        | 1             |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| segments-height                  | geometry.segmentsHeight                | 18            |
+| segments-width                   | geometry.segmentsWidth                 | 36            |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| theta-length                     | geometry.thetaLength                   | 180           |
+| theta-start                      | geometry.thetaStart                    | 0             |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-tetrahedron.md
+++ b/docs/primitives/a-tetrahedron.md
@@ -13,15 +13,32 @@ parent_section: primitives
 
 ## Attributes
 
-| Attribute   | Component Mapping    | Default Value |
-| --------    | -----------------    | ------------- |
-| color       | material.color       | #FFF          |
-| metalness   | material.metalness   | 0             |
-| opacity     | material.opacity     | 1             |
-| radius      | geometry.radius      | 1             |
-| repeat      | material.repeat      | None          |
-| roughness   | material.roughness   | 0.5           |
-| shader      | material.shader      | standard      |
-| side        | material.side        | front         |
-| src         | material.src         | None          |
-| transparent | material.transparent | false         |
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| detail                           | geometry.detail                        | 0             |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| radius                           | geometry.radius                        | 1             |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-torus-knot.md
+++ b/docs/primitives/a-torus-knot.md
@@ -5,6 +5,8 @@ layout: docs
 parent_section: primitives
 ---
 
+[geometry]: ../components/geometry.md
+
 The torus knot primitive creates pretzel shapes using the [geometry][geometry]
 component with the type set to `torusKnot`.
 
@@ -16,22 +18,36 @@ component with the type set to `torusKnot`.
 
 ## Attributes
 
-| Attribute        | Component Mapping        | Default Value |
-| --------         | -----------------        | ------------- |
-| color            | material.color           | #FFF          |
-| metalness        | material.metalness       | 0             |
-| opacity          | material.opacity         | 1             |
-| p                | geometry.p               | 2             |
-| q                | geometry.q               | 3             |
-| radius           | geometry.radius          | 1             |
-| radius-tubular   | geometry.radiusTubular   | 0.2           |
-| repeat           | material.repeat          | None          |
-| roughness        | material.roughness       | 0.5           |
-| segments-radial  | geometry.segmentsRadial  | 36            |
-| segments-tubular | geometry.segmentsTubular | 100           |
-| shader           | material.shader          | standard      |
-| side             | material.side            | front         |
-| src              | material.src             | None          |
-| transparent      | material.transparent     | false         |
-
-[geometry]: ../components/geometry.md
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| color                            | material.color                         | #FFF          |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| p                                | geometry.p                             | 2             |
+| q                                | geometry.q                             | 3             |
+| radius                           | geometry.radius                        | 1             |
+| radius-tubular                   | geometry.radiusTubular                 | 0.2           |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| segments-radial                  | geometry.segmentsRadial                | 8             |
+| segments-tubular                 | geometry.segmentsTubular               | 100           |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-torus.md
+++ b/docs/primitives/a-torus.md
@@ -5,6 +5,8 @@ layout: docs
 parent_section: primitives
 ---
 
+[geometry]: ../components/geometry.md
+
 The torus primitive creates donut or tube shapes using the [geometry][geometry]
 component with the type set to `torus`.
 
@@ -16,21 +18,35 @@ component with the type set to `torus`.
 
 ## Attributes
 
-| Attribute        | Component Mapping        | Default Value |
-| --------         | -----------------        | ------------- |
-| arc              | geometry.arc             | 360           |
-| color            | material.color           | #FFF          |
-| metalness        | material.metalness       | 0             |
-| opacity          | material.opacity         | 1             |
-| radius           | geometry.radius          | 1             |
-| radius-tubular   | geometry.radiusTubular   | 0.2           |
-| repeat           | material.repeat          | None          |
-| roughness        | material.roughness       | 0.5           |
-| segments-radial  | geometry.segmentsRadial  | 0             |
-| segments-tubular | geometry.segmentsTubular | 32            |
-| shader           | material.shader          | standard      |
-| side             | material.side            | front         |
-| src              | material.src             | None          |
-| transparent      | material.transparent     | false         |
-
-[geometry]: ../components/geometry.md
+| Attribute                        | Component Mapping                      | Default Value |
+| --------                         | -----------------                      | ------------- |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| arc                              | geometry.arc                           | 360           |
+| color                            | material.color                         | #FFF          |
+| displacement-bias                | material.displacementBias              | 0.5           |
+| displacement-map                 | material.displacementMap               | None          |
+| displacement-scale               | material.displacementScale             | 1             |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| env-map                          | material.envMap                        | None          |
+| fog                              | material.fog                           | true          |
+| height                           | material.height                        | 256           |
+| metalness                        | material.metalness                     | 0             |
+| normal-map                       | material.normalMap                     | None          |
+| normal-scale                     | material.normalScale                   | 1 1           |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| radius                           | geometry.radius                        | 1             |
+| radius-tubular                   | geometry.radiusTubular                 | 0.2           |
+| repeat                           | material.repeat                        | 1 1           |
+| roughness                        | material.roughness                     | 0.5           |
+| segments-radial                  | geometry.segmentsRadial                | 36            |
+| segments-tubular                 | geometry.segmentsTubular               | 32            |
+| spherical-env-map                | material.sphericalEnvMap               | None          |
+| src                              | material.src                           | None          |
+| width                            | material.width                         | 512           |
+| wireframe                        | material.wireframe                     | false         |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/scripts/primitive-docs/index.html
+++ b/scripts/primitive-docs/index.html
@@ -28,7 +28,7 @@ geometryNames.forEach(function (geometryName) {
     rows[unCamelCase(property)] = '|' + [
       unCamelCase(property),
       'geometry.' + property,
-      geometry.schema[property].default
+      geometry.schema[property].stringify(geometry.schema[property].default)
     ].join('|') + '|';
   });
 
@@ -43,7 +43,7 @@ geometryNames.forEach(function (geometryName) {
       mapping,
       (materialProp.default === undefined || materialProp.default === null ||
        materialProp.default === '') ?
-        'None' : materialProp.default
+        'None' : materialProp.stringify(materialProp.default)
     ].join('|') + '|';
   });
 

--- a/src/extras/primitives/getMeshMixin.js
+++ b/src/extras/primitives/getMeshMixin.js
@@ -1,23 +1,23 @@
 /**
  * Common mesh defaults, mappings, and transforms.
  */
+var shaders = require('../../core/shader').shaders;
+var utils = require('../../utils/');
+
+var materialMappings = {};
+Object.keys(shaders.standard.schema).forEach(function addMapping (prop) {
+  // To hyphenated.
+  var htmlAttrName = prop.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+  materialMappings[htmlAttrName] = 'material.' + prop;
+});
+
 module.exports = function getMeshMixin () {
   return {
     defaultComponents: {
       material: {}
     },
 
-    mappings: {
-      color: 'material.color',
-      metalness: 'material.metalness',
-      opacity: 'material.opacity',
-      repeat: 'material.repeat',
-      roughness: 'material.roughness',
-      shader: 'material.shader',
-      side: 'material.side',
-      src: 'material.src',
-      transparent: 'material.transparent'
-    },
+    mappings: utils.extend({}, materialMappings),
 
     transforms: {
       src: function (value) {

--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -5,7 +5,7 @@ var utils = require('../utils/');
 /**
  * Flat shader using THREE.MeshBasicMaterial.
  */
-module.exports.Component = registerShader('flat', {
+module.exports.Shader = registerShader('flat', {
   schema: {
     color: {type: 'color'},
     fog: {default: true},

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -8,7 +8,7 @@ var texturePromises = {};
 /**
  * Standard (physically-based) shader using THREE.MeshStandardMaterial.
  */
-module.exports.Component = registerShader('standard', {
+module.exports.Shader = registerShader('standard', {
   schema: {
     ambientOcclusionMap: {type: 'map'},
     ambientOcclusionMapIntensity: {default: 1},


### PR DESCRIPTION
- Automate material mappings.
- Use the primitive doc generator to update docs.