### PR TITLE
Resolve #2039, fix typo and adjust example code

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -94,6 +94,13 @@ with CORS headers. We recommend GitHub Pages as a simple deployment platform.
 Or you could also upload assets using the [A-Frame + Uploadcare
 Uploader][uploader], a service that serves files with CORS headers set.
 
+## Why is the HTML/DOM not updating in A-Frame?
+
+[debug]: https://aframe.io/docs/0.3.0/components/debug.html
+
+For performance reasons, A-Frame does not update the DOM with component data.
+Use the [debug component][debug] to enable component-to-DOM serialization.
+
 ## Why does my video not play on mobile?
 
 [iosvideo]: https://developer.apple.com/library/iad/documentation/UserExperience/Conceptual/iAdJSProgGuide/PlayingVideosinAds/PlayingVideosinAds.html

--- a/docs/primitives/index.md
+++ b/docs/primitives/index.md
@@ -84,7 +84,7 @@ To create a wide red box using the primitives API, we could write:
 Which ends up expanding to:
 
 ```html
-<a-box color="red" width="3" geometry="primitive: box; width: 3" material="color: red"></a-box>
+<a-entity geometry="primitive: box; width: 3" material="color: red"></a-box>
 ```
 
 Under the hood, we see that primitives *extend* `<a-entity>` as a custom
@@ -150,5 +150,5 @@ AFRAME.registerPrimitive('a-ocean', {
 Then we'd be able to create oceans using basic HTML syntax with little configuration needed:
 
 ```html
-<a-ocean color="aqua" height="100" width="100"></a-ocean>
+<a-ocean color="aqua" depth="100" width="100"></a-ocean>
 ```


### PR DESCRIPTION
**Description:**
- Added FAQ per open issue request
- Fixed a typo in a code example
- Adjusted the a-ocean component property from "height" to "depth" since "height" does not have any effect (only width and depth affect the X & Z axes; Y axis is not adjustable by the component).
