### PR TITLE
Fix unused definition in docs/introduction/index.md

### DIFF
--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -83,7 +83,7 @@ The existing web ecosystem of tools were built on top of the notion of
 manipulating plain HTML and are thus compatible with A-Frame.
 
 [integrationimage]: https://cloud.githubusercontent.com/assets/674727/20290346/5f3f10b6-aa94-11e6-9d71-94c3e4350d08.png
-![Works with Everything](https://cloud.githubusercontent.com/assets/674727/20290346/5f3f10b6-aa94-11e6-9d71-94c3e4350d08.png)
+![Works with Everything][integrationimage]
 
 ### Entity-Component-System
 


### PR DESCRIPTION
**Description:**

I've run into this error on the latest master branch.

    $ npm run test:docs

    > aframe@0.4.0 test:docs C:\Users\takahiro\Documents\aframe
    > node scripts/docs-link-check.js

    docs/introduction/index.md
        Link definition not being used: integrationimage

    npm ERR! Windows_NT 10.0.14393
    npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "run" "test:docs"
    npm ERR! node v4.6.0
    npm ERR! npm  v2.15.9
    npm ERR! code ELIFECYCLE
    npm ERR! aframe@0.4.0 test:docs: `node scripts/docs-link-check.js`
    npm ERR! Exit status 1
    npm ERR!
    npm ERR! Failed at the aframe@0.4.0 test:docs script 'node scripts/docs-link-check.js'.
    npm ERR! This is most likely a problem with the aframe package,
    npm ERR! not with npm itself.
    npm ERR! Tell the author that this fails on your system:
    npm ERR!     node scripts/docs-link-check.js
    npm ERR! You can get information on how to open an issue for this project with:
    npm ERR!     npm bugs aframe
    npm ERR! Or if that isn't available, you can get their info via:
    npm ERR!
    npm ERR!     npm owner ls aframe
    npm ERR! There is likely additional logging output above.

    npm ERR! Please include the following file with any support request:
    npm ERR!     C:\Users\takahiro\Documents\aframe\npm-debug.log


It seems #2085 causes this issue so I've fixed.
