### PR TITLE
Typo in example code

### DIFF
--- a/docs/core/asset-management-system.md
+++ b/docs/core/asset-management-system.md
@@ -39,7 +39,7 @@ our entities using selectors:
     <a-asset-item id="horse-obj" src="horse.obj"></a-asset-item>
     <a-asset-item id="horse-mtl" src="horse.mtl"></a-asset-item>
     <a-mixin id="giant" scale="5 5 5"></a-mixin>
-    <audio id="neigh" src="neigh.mp3"></a-mixin>
+    <audio id="neigh" src="neigh.mp3">
     <img id="advertisement" src="ad.png">
     <video id="kentucky-derby" src="derby.mp4">
   </a-assets>


### PR DESCRIPTION
**Description:**
Fixed a typo in example code

**Changes proposed:**
- removed a `</a-mixin>` that shouldn't be there