### PR TITLE
Add Matrix3/4 property type

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -1,4 +1,5 @@
 var coordinates = require('../utils/coordinates');
+var matrices = require('../utils/matrices');
 var debug = require('debug');
 
 var error = debug('core:propertyTypes:warn');
@@ -24,7 +25,17 @@ registerPropertyType('time', 0, intParse);
 registerPropertyType('vec2', {x: 0, y: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec3', {x: 0, y: 0, z: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec4', {x: 0, y: 0, z: 0, w: 0}, vecParse, coordinates.stringify);
-registerPropertyType('matrix4', [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], matrix4Parse, matrix4Stringify);
+registerPropertyType('mat3', [
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+], matrix3Parse, matrices.stringify);
+registerPropertyType('mat4', [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1
+], matrix4Parse, matrices.stringify);
 
 /**
  * Register a parser for re-use such that when someone uses `type` in the schema,
@@ -153,34 +164,10 @@ function vecParse (value) {
   return coordinates.parse(value, this.default);
 }
 
-function matrix4Parse (value) {
-  var defaultValues = this.default;
-  var masterDefaultValues = propertyTypes.matrix4.default;
-  if (Array.isArray(value)) { return beMatrix4Array(value); }
-  if (!value || typeof value !== 'string') { return beMatrix4Array([]); }
-  return beMatrix4Array(value.split(/\s+/).map(trim));
-  function trim (str) { return str.trim(); }
-  function getValue (array, n) {
-    var value;
-    if (array.length > n) {
-      value = parseFloat(array[n], 10);
-      if (!isNaN(value)) { return value; }
-    }
-    if (Array.isArray(defaultValues) && defaultValues.length > n) {
-      value = parseFloat(defaultValues[n], 10);
-      if (!isNaN(value)) { return value; }
-    }
-    return masterDefaultValues[n];
-  }
-  function beMatrix4Array (array) {
-    if (array.length > 16) { array.length = 16; }
-    for (var i = 0; i < 16; i++) {
-      array[i] = getValue(array, i);
-    }
-    return array;
-  }
+function matrix3Parse (value) {
+  return matrices.parseMatrix3(value, this.default);
 }
 
-function matrix4Stringify (value) {
-  return value.join(' ');
+function matrix4Parse (value) {
+  return matrices.parseMatrix4(value, this.default);
 }

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -24,6 +24,7 @@ registerPropertyType('time', 0, intParse);
 registerPropertyType('vec2', {x: 0, y: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec3', {x: 0, y: 0, z: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec4', {x: 0, y: 0, z: 0, w: 0}, vecParse, coordinates.stringify);
+registerPropertyType('matrix4', [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], matrix4Parse, arrayStringify);
 
 /**
  * Register a parser for re-use such that when someone uses `type` in the schema,
@@ -150,4 +151,24 @@ function srcParse (value) {
 
 function vecParse (value) {
   return coordinates.parse(value, this.default);
+}
+
+function matrix4Parse (value) {
+  var defaultValues = propertyTypes.matrix4.default;
+  if (Array.isArray(value)) { return beMatrix4Array(value); }
+  if (!value || typeof value !== 'string') { return beMatrix4Array([]); }
+  return beMatrix4Array(value.split(/\s+/).map(trim));
+  function trim (str) { return str.trim(); }
+  function beMatrix4Array (array) {
+    if (array.length > 16) { array.length = 16; }
+    for (var i = 0; i < 16; i++) {
+      if (i >= array.length) {
+        array[i] = defaultValues[i];
+      } else {
+        var value = parseFloat(array[i], 10);
+        array[i] = isNaN(value) ? defaultValues[i] : value;
+      }
+    }
+    return array;
+  }
 }

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -24,7 +24,7 @@ registerPropertyType('time', 0, intParse);
 registerPropertyType('vec2', {x: 0, y: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec3', {x: 0, y: 0, z: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec4', {x: 0, y: 0, z: 0, w: 0}, vecParse, coordinates.stringify);
-registerPropertyType('matrix4', [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], matrix4Parse, arrayStringify);
+registerPropertyType('matrix4', [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], matrix4Parse, matrix4Stringify);
 
 /**
  * Register a parser for re-use such that when someone uses `type` in the schema,
@@ -179,4 +179,8 @@ function matrix4Parse (value) {
     }
     return array;
   }
+}
+
+function matrix4Stringify (value) {
+  return value.join(' ');
 }

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -154,20 +154,28 @@ function vecParse (value) {
 }
 
 function matrix4Parse (value) {
-  var defaultValues = propertyTypes.matrix4.default;
+  var defaultValues = this.default;
+  var masterDefaultValues = propertyTypes.matrix4.default;
   if (Array.isArray(value)) { return beMatrix4Array(value); }
   if (!value || typeof value !== 'string') { return beMatrix4Array([]); }
   return beMatrix4Array(value.split(/\s+/).map(trim));
   function trim (str) { return str.trim(); }
+  function getValue (array, n) {
+    var value;
+    if (array.length > n) {
+      value = parseFloat(array[n], 10);
+      if (!isNaN(value)) { return value; }
+    }
+    if (Array.isArray(defaultValues) && defaultValues.length > n) {
+      value = parseFloat(defaultValues[n], 10);
+      if (!isNaN(value)) { return value; }
+    }
+    return masterDefaultValues[n];
+  }
   function beMatrix4Array (array) {
     if (array.length > 16) { array.length = 16; }
     for (var i = 0; i < 16; i++) {
-      if (i >= array.length) {
-        array[i] = defaultValues[i];
-      } else {
-        var value = parseFloat(array[i], 10);
-        array[i] = isNaN(value) ? defaultValues[i] : value;
-      }
+      array[i] = getValue(array, i);
     }
     return array;
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -11,6 +11,7 @@ module.exports.device = require('./device');
 module.exports.entity = require('./entity');
 module.exports.forceCanvasResizeSafariMobile = require('./forceCanvasResizeSafariMobile');
 module.exports.material = require('./material');
+module.exports.matrices = require('./matrices');
 module.exports.styleParser = require('./styleParser');
 
 /**

--- a/src/utils/matrices.js
+++ b/src/utils/matrices.js
@@ -67,11 +67,10 @@ function parse (value, defaultMatrix, length) {
  * Example: [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15] to
  *          "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15"
  *
- * @param {array|string}
- * @returns {string}
+ * @param {array} data - column-major matrix array
+ * @returns {string} row-major space separated strings
  */
 function stringify (data) {
-  if (!Array.isArray(data)) { return data; }
   return transpose(data).join(' ');
 }
 module.exports.stringify = stringify;

--- a/src/utils/matrices.js
+++ b/src/utils/matrices.js
@@ -1,0 +1,124 @@
+/* global THREE */
+
+/**
+ * Matrix formats
+ *
+ * End users handle matrix as row-major format while
+ * it's handled as column-major format A-Frame/Three.js inside.
+ *
+ * parse: row-major format input and column-major format output
+ * stringify: column-major format input and row-major format output
+ */
+
+var matrix3Regex = /^\s*(?:(-?\d*\.?\d+)\s+){8}(-?\d*\.?\d+)\s*$/;
+var matrix4Regex = /^\s*(?:(-?\d*\.?\d+)\s+){15}(-?\d*\.?\d+)\s*$/;
+
+/**
+ * Parses column-major matrix3 array from an row-major space separated
+ * strings.
+ * Example: "0 1 2 3 4 5 6 7 8" to [0, 3, 6, 1, 4, 7, 2, 5, 8]
+ *
+ * @param {string} value - row-major matrix space separated strings
+ * @param {array} defaultMatrix - row-major matrix array
+ * @returns {array} column-major matrix array
+ */
+function parseMatrix3 (value, defaultMatrix) {
+  return parse(value, defaultMatrix, 9);
+}
+module.exports.parseMatrix3 = parseMatrix3;
+
+/**
+ * Parses column-major matrix4 array from an row-major space separated
+ * strings.
+ * Example: "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15" to
+ *          [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]
+ *
+ * @param {string} value - row-major matrix space separated strings
+ * @param {array} defaultMatrix - row-major matrix array
+ * @returns {array} column-major matrix array
+ */
+function parseMatrix4 (value, defaultMatrix) {
+  return parse(value, defaultMatrix, 16);
+}
+module.exports.parseMatrix4 = parseMatrix4;
+
+function parse (value, defaultMatrix, length) {
+  var mat = [];
+  var array;
+
+  if (Array.isArray(value)) {
+    array = value;
+  } else if (typeof value === 'string') {
+    array = value.split(/\s+/).map(function (str) { return str.trim(); });
+  } else {
+    return Array.isArray(defaultMatrix)
+             ? transpose(matrixParseFloat(defaultMatrix)) : defaultMatrix;
+  }
+
+  for (var i = 0; i < length; i++) {
+    mat[i] = i < array.length ? array[i] : defaultMatrix && defaultMatrix[i];
+  }
+
+  return transpose(matrixParseFloat(mat));
+}
+
+/**
+ * Stringify row-major matrix from an column-major matrix array.
+ * Example: [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15] to
+ *          "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15"
+ *
+ * @param {array|string}
+ * @returns {string}
+ */
+function stringify (data) {
+  if (!Array.isArray(data)) { return data; }
+  return transpose(data).join(' ');
+}
+module.exports.stringify = stringify;
+
+function isMatrix3 (value) {
+  return matrix3Regex.test(value);
+}
+module.exports.isMatrix3 = isMatrix3;
+
+function isMatrix4 (value) {
+  return matrix4Regex.test(value);
+}
+module.exports.isMatrix4 = isMatrix4;
+
+function matrixParseFloat (mat) {
+  for (var i = 0, il = mat.length; i < il; i++) {
+    mat[i] = parseFloat(mat[i], 10);
+  }
+  return mat;
+}
+
+/**
+ * Transposes matrix array to switch row/column-major format.
+ */
+function transpose (matrix) {
+  var result = [];
+  var rowSize = Math.sqrt(matrix.length);
+
+  for (var i = 0; i < matrix.length; i++) {
+    result[i] = matrix[((i / rowSize) | 0) + ((i % rowSize) * rowSize)];
+  }
+
+  return result;
+}
+
+/**
+ * Converts column-major matrix3 array to three.js Matrix3
+ */
+function toMatrix3 (mat3) {
+  return (new THREE.Matrix3()).fromArray(mat3);
+}
+module.exports.toMatrix3 = toMatrix3;
+
+/**
+ * Converts column-major matrix4 array to three.js Matrix4
+ */
+function toMatrix4 (mat4) {
+  return (new THREE.Matrix4()).fromArray(mat4);
+}
+module.exports.toMatrix4 = toMatrix4;

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -156,26 +156,6 @@ suite('propertyTypes', function () {
     });
   });
 
-  suite('matrix4', function () {
-    var parse = propertyTypes.matrix4.parse;
-    var stringify = propertyTypes.matrix4.stringify;
-
-    test('parses matrix4', function () {
-      assert.deepEqual(parse(''), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-      assert.deepEqual(parse({}), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-      assert.deepEqual(parse([]), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-      assert.deepEqual(parse('0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15'), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-      assert.deepEqual(parse('0 1 2 3'), [0, 1, 2, 3, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-      assert.deepEqual(parse('0   1  2 3 4 5   6 7 8 9 10   11  12 13 14 15   16 17 18    19 20'), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-      assert.deepEqual(parse([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-    });
-
-    test('stringifies matrix4', function () {
-      assert.equal(stringify([]), '');
-      assert.equal(stringify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]), '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15');
-    });
-  });
-
   suite('src', function () {
     var parse = propertyTypes.src.parse;
 

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -172,7 +172,7 @@ suite('propertyTypes', function () {
 
     test('stringifies matrix4', function () {
       assert.equal(stringify([]), '');
-      assert.equal(stringify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]), '0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15');
+      assert.equal(stringify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]), '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15');
     });
   });
 

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -156,6 +156,26 @@ suite('propertyTypes', function () {
     });
   });
 
+  suite('matrix4', function () {
+    var parse = propertyTypes.matrix4.parse;
+    var stringify = propertyTypes.matrix4.stringify;
+
+    test('parses matrix4', function () {
+      assert.deepEqual(parse(''), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+      assert.deepEqual(parse({}), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+      assert.deepEqual(parse([]), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+      assert.deepEqual(parse('0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15'), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+      assert.deepEqual(parse('0 1 2 3'), [0, 1, 2, 3, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+      assert.deepEqual(parse('0   1  2 3 4 5   6 7 8 9 10   11  12 13 14 15   16 17 18    19 20'), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+      assert.deepEqual(parse([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    });
+
+    test('stringifies matrix4', function () {
+      assert.equal(stringify([]), '');
+      assert.equal(stringify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]), '0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15');
+    });
+  });
+
   suite('src', function () {
     var parse = propertyTypes.src.parse;
 

--- a/tests/utils/matrices.test.js
+++ b/tests/utils/matrices.test.js
@@ -1,0 +1,91 @@
+/* global assert, suite, test */
+var matrices = require('index').utils.matrices;
+
+suite('utils.matrices', function () {
+  suite('isMatrix3', function () {
+    test('verifies valid matrix3', function () {
+      assert.ok(matrices.isMatrix3('0 1 2 3.4 4 5 -6 7 -8.1'));
+    });
+
+    test('rejects invalid matrix3', function () {
+      assert.ok(!matrices.isMatrix3('0 1 2 3.4 4 5 -6 7'));
+    });
+  });
+
+  suite('parseMatrix3', function () {
+    test('parses string', function () {
+      assert.shallowDeepEqual(
+        matrices.parseMatrix3('0 1 2 3 4 5 6 7 8'),
+        [0, 3, 6, 1, 4, 7, 2, 5, 8]);
+    });
+
+    test('applies defaults to the missing values', function () {
+      var defaultMatrix = [0, -1, 2, 3, 4.1, 5, 6, 7, -8.3];
+      assert.deepEqual(
+        matrices.parseMatrix3('10', defaultMatrix),
+        [10, 3, 6, -1, 4.1, 7, 2, 5, -8.3]);
+    });
+
+    test('parses null', function () {
+      assert.equal(matrices.parseMatrix3(null), undefined);
+    });
+
+    test('parses object with strings', function () {
+      assert.shallowDeepEqual(
+        matrices.parseMatrix3(
+          ['0', '1', '2', '-31', '40.2', '5', '6', '7', '8']),
+        [0, -31, 6, 1, 40.2, 7, 2, 5, 8]);
+    });
+  });
+
+  suite('parseMatrix4', function () {
+    test('parses string', function () {
+      assert.shallowDeepEqual(
+        matrices.parseMatrix4(
+          '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15'),
+        [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]);
+    });
+
+    test('applies defaults to the missing values', function () {
+      var defaultMatrix =
+            [0, 1, 2, -3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13.1, 14, 15];
+      assert.deepEqual(
+        matrices.parseMatrix4('100', defaultMatrix),
+        [100, 4, 8, 12, 1, 5, 9, 13.1, 2, 6, 10, 14, -3, 7, 11, 15]);
+    });
+
+    test('parses null', function () {
+      assert.equal(matrices.parseMatrix4(null), undefined);
+    });
+
+    test('parses object with strings', function () {
+      assert.shallowDeepEqual(
+        matrices.parseMatrix4(
+          ['0', '1', '2', '-31', '4', '5', '60', '7',
+            '8', '9', '10', '11', '12', '13', '14', '15']),
+        [0, 4, 8, 12, 1, 5, 9, 13, 2, 60, 10, 14, -31, 7, 11, 15]);
+    });
+  });
+
+  suite('stringify', function () {
+    test('stringifies a mat3', function () {
+      assert.equal(
+        matrices.stringify(
+          [0, 3, 6, 1, 4, 7, 2, 5, 8]),
+        '0 1 2 3 4 5 6 7 8');
+    });
+
+    test('stringifies a mat4', function () {
+      assert.equal(
+        matrices.stringify(
+          [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]),
+        '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15');
+    });
+
+    test('returns already-stringified string', function () {
+      assert.equal(
+        matrices.stringify('0 1 2 -3 4 5 -6 7 8'),
+        '0 1 2 -3 4 5 -6 7 8');
+    });
+  });
+});

--- a/tests/utils/matrices.test.js
+++ b/tests/utils/matrices.test.js
@@ -81,11 +81,5 @@ suite('utils.matrices', function () {
           [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]),
         '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15');
     });
-
-    test('returns already-stringified string', function () {
-      assert.equal(
-        matrices.stringify('0 1 2 -3 4 5 -6 7 8'),
-        '0 1 2 -3 4 5 -6 7 8');
-    });
   });
 });


### PR DESCRIPTION
Hi, I added Matrix4 property type #2069
Would you review the code because I'm still new to A-Frame.
LMK if there's any issues.

**Description:**

Add 'matrix4' property type.

Default value is
[1, 0, 0, 0,
 0, 1, 0, 0,
 0, 0, 1, 0,
 0, 0, 0, 1]

Input value is assumed as space separated strings.
ex: '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15'

If elements# is greater than 16, it'll be forced to be 16.
If elements# is less than 16, the shortage will be filled with default value.

**Changes proposed:**

