### PR TITLE
hook primitives into the core entity init process (fixes #2104)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -30,6 +30,9 @@ var Component = module.exports.Component = function (el, attr, id) {
   this.id = id;
   this.attrName = this.name + (id ? '__' + id : '');
   this.updateCachedAttrValue(attr);
+
+  if (!el.hasLoaded) { return; }
+  this.updateProperties(this.attrValue);
 };
 
 Component.prototype = {
@@ -272,8 +275,6 @@ module.exports.registerComponent = function (name, definition) {
   }
   NewComponent = function (el, attr, id) {
     Component.call(this, el, attr, id);
-    if (!el.hasLoaded) { return; }
-    this.updateProperties(this.attrValue);
   };
 
   NewComponent.prototype = Object.create(Component.prototype, proto);

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -53,7 +53,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
             mixins.forEach(function applyMixin (mixinId) {
               var mixinComponents = self.sceneEl.querySelector('#' + mixinId).componentCache;
               Object.keys(mixinComponents).forEach(function setComponent (name) {
-                data[name] = utils.extendDeep(data[name], mixinComponents[name]);
+                data[name] = utils.extendDeep(data[name] || {}, mixinComponents[name]);
               });
             });
           }

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -1,11 +1,11 @@
 var AEntity = require('../../core/a-entity');
-var components = require('../../core/component').components;
 var registerElement = require('../../core/a-register-element').registerElement;
 var utils = require('../../utils/');
 
 var debug = utils.debug;
 var setComponentProperty = utils.entity.setComponentProperty;
 var log = debug('extras:primitives:debug');
+var warn = debug('extras:primitives:warn');
 
 var primitives = module.exports.primitives = {};
 
@@ -15,7 +15,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
 
   // Deprecation warning for defaultAttributes usage.
   if (definition.defaultAttributes) {
-    console.warn("The 'defaultAttributes' object is deprecated. Use 'defaultComponents' instead.");
+    warn("The 'defaultAttributes' object is deprecated. Use 'defaultComponents' instead.");
   }
 
   var primitive = registerElement(name, {
@@ -26,21 +26,17 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
       deprecated: {value: definition.deprecated || null},
       deprecatedMappings: {value: definition.deprecatedMappings || {}},
       mappings: {value: definition.mappings || {}},
-      transforms: {value: definition.transforms || {}},
 
       createdCallback: {
         value: function () {
-          if (definition.deprecated) {
-            console.warn(definition.deprecated);
-          }
+          if (definition.deprecated) { console.warn(definition.deprecated); }
         }
       },
 
-      attachedCallback: {
+      getExtraComponents: {
         value: function () {
           var attr;
-          var Component;
-          var initialComponents;
+          var data;
           var i;
           var mapping;
           var mixins;
@@ -48,52 +44,36 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
           var self = this;
 
           // Gather component data from default components.
-          initialComponents = utils.clone(this.defaultComponentsFromPrimitive);
+          data = utils.clone(this.defaultComponentsFromPrimitive);
 
-          // Gather component data from mixins.
+          // Factor in mixins to overwrite default components.
           mixins = this.getAttribute('mixin');
           if (mixins) {
             mixins = mixins.trim().split(' ');
-            mixins.forEach(function (mixinId) {
+            mixins.forEach(function applyMixin (mixinId) {
               var mixinComponents = self.sceneEl.querySelector('#' + mixinId).componentCache;
               Object.keys(mixinComponents).forEach(function setComponent (name) {
-                initialComponents[name] = utils.extendDeep(
-                  initialComponents[name], mixinComponents[name]);
+                data[name] = utils.extendDeep(data[name], mixinComponents[name]);
               });
             });
           }
 
+          // Gather component data from mappings.
           for (i = 0; i < this.attributes.length; i++) {
             attr = this.attributes[i];
-
-            // Gather component data from mappings.
             mapping = this.mappings[attr.name];
             if (mapping) {
               path = utils.entity.getComponentPropertyPath(mapping);
               if (path.constructor === Array) {
-                initialComponents[path[0]][path[1]] = attr.value;
+                data[path[0]][path[1]] = attr.value;
               } else {
-                initialComponents[path] = attr.value;
+                data[path] = attr.value;
               }
               continue;
             }
-
-            // Gather component data from components.
-            if (components[attr.name]) {
-              Component = components[attr.name];
-              if (Component.isSingleProp) {
-                initialComponents[attr.name] = attr.value;
-              } else {
-                initialComponents[attr.name] = utils.extendDeep(
-                  initialComponents[attr.name] || {}, Component.parse(attr.value || {}));
-              }
-            }
           }
 
-          // Set components.
-          Object.keys(initialComponents).forEach(function initComponent (componentName) {
-            self.setAttribute(componentName, initialComponents[componentName]);
-          });
+          return data;
         }
       },
 


### PR DESCRIPTION
**Description:**

The root issue was the dependencies were not being initialized for primitives because primitives were trying to do `setAttribute` on `attachedCallback`, but at that time `Entity.load` had not been called yet, so dependencies were being blocked from initializing on `el.hasLoaded`.

I initially tried keep them more-or-less separate and give primitives their own `load` method, but it  got messy fast and it became much easier to have the `Entity` prototype have knowledge of the extra data supplied by primitives (through `defaultComponents` and `mappings`). Thus I made primitives implement a method called `getInitialComponents` which the Entity can pull from. 

As an extra bonus, this also means primitives no longer have to duplicate some of the Entity data building process. Primitives only have to worry about default components + mappings, and the entity handles the other data sources.

I made `getInitialComponents` a method rather than having primitives set a property because when an instance of a primitive was setting the property, it would overwrite that property used by other instances sharing the same prototype.

**Changes proposed:**
- Primitives implement `getInitialComponents`.
- `Entity.updateComponents` includes `getInitialComponents`, merging it on the level of DOM components

