### PR TITLE
fix primitive bugs: missing material mappings and failed object cloning

### DIFF
--- a/src/extras/primitives/getMeshMixin.js
+++ b/src/extras/primitives/getMeshMixin.js
@@ -1,15 +1,19 @@
 /**
  * Common mesh defaults, mappings, and transforms.
  */
+var components = require('../../core/component').components;
 var shaders = require('../../core/shader').shaders;
 var utils = require('../../utils/');
 
 var materialMappings = {};
-Object.keys(shaders.standard.schema).forEach(function addMapping (prop) {
+Object.keys(components.material.schema).forEach(addMapping);
+Object.keys(shaders.standard.schema).forEach(addMapping);
+
+function addMapping (prop) {
   // To hyphenated.
   var htmlAttrName = prop.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
   materialMappings[htmlAttrName] = 'material.' + prop;
-});
+}
 
 module.exports = function getMeshMixin () {
   return {

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -48,7 +48,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
           var self = this;
 
           // Gather component data from default components.
-          initialComponents = utils.extend({}, this.defaultComponentsFromPrimitive);
+          initialComponents = JSON.parse(JSON.stringify(this.defaultComponentsFromPrimitive));
 
           // Gather component data from mixins.
           mixins = this.getAttribute('mixin');

--- a/tests/extras/primitives/primitives/meshPrimitives.test.js
+++ b/tests/extras/primitives/primitives/meshPrimitives.test.js
@@ -38,8 +38,10 @@ suite('meshPrimitives', function () {
     el.addEventListener('loaded', function () {
       el.setAttribute('color', 'red');
       el.setAttribute('depth', 5);
+      el.setAttribute('side', 'back');
       process.nextTick(function () {
         assert.equal(el.getAttribute('material').color, 'red');
+        assert.equal(el.getAttribute('material').side, 'back');
         assert.equal(el.getAttribute('geometry').depth, 5);
       });
       done();


### PR DESCRIPTION
**Description:**

**Changes proposed:**
- Standard material props were in the mapping, but not core material props like `side`.
- Fix primitive not cloning the default components properly causing primitives to affect each other.

