### PR TITLE
Add support for mat3 and mat4 properties.

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -24,6 +24,21 @@ registerPropertyType('time', 0, intParse);
 registerPropertyType('vec2', {x: 0, y: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec3', {x: 0, y: 0, z: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec4', {x: 0, y: 0, z: 0, w: 0}, vecParse, coordinates.stringify);
+registerPropertyType('mat2', [
+  1, 0,
+  0, 1
+], matParse, matStringify);
+registerPropertyType('mat3', [
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+], matParse, matStringify);
+registerPropertyType('mat4', [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1
+], matParse, matStringify);
 
 /**
  * Register a parser for re-use such that when someone uses `type` in the schema,
@@ -150,4 +165,39 @@ function srcParse (value) {
 
 function vecParse (value) {
   return coordinates.parse(value, this.default);
+}
+
+/**
+ * Parses a string of the form "n1 n2, n3 n4", returning an array in column-major format.
+ * @param  {string} value
+ * @return {Array<Number>}
+ */
+function matParse (value) {
+  if (!value) { return this.default; }
+  var rows = arrayParse(value).map(function (row) {
+    return row.trim().replace(/\s+/g, ' ').split(' ').map(Number);
+  });
+  // Flatten.
+  return [].concat.apply([], rows);
+}
+
+function matStringify (value) {
+  var n = Math.sqrt(value.length);
+  if (n % 1 !== 0) {
+    warn('Invalid matrix dimensions.');
+    return '';
+  }
+
+  // Group matrix values into rows.
+  var rows = [];
+  for (var i = 0; i < n; i++) {
+    var row = [];
+    for (var j = 0; j < n; j++) {
+      row.push(value[i * n + j]);
+    }
+    rows.push(row.join(' '));
+  }
+
+  // Add comma-delimiter to rows.
+  return arrayStringify(rows);
 }

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -24,10 +24,6 @@ registerPropertyType('time', 0, intParse);
 registerPropertyType('vec2', {x: 0, y: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec3', {x: 0, y: 0, z: 0}, vecParse, coordinates.stringify);
 registerPropertyType('vec4', {x: 0, y: 0, z: 0, w: 0}, vecParse, coordinates.stringify);
-registerPropertyType('mat2', [
-  1, 0,
-  0, 1
-], matParse, matStringify);
 registerPropertyType('mat3', [
   1, 0, 0,
   0, 1, 0,
@@ -177,8 +173,15 @@ function matParse (value) {
   var rows = arrayParse(value).map(function (row) {
     return row.trim().replace(/\s+/g, ' ').split(' ').map(Number);
   });
-  // Flatten.
-  return [].concat.apply([], rows);
+
+  // Convert to column-major format.
+  var elements = [];
+  for (var i = 0; i < rows.length; i++) {
+    for (var j = 0; j < rows[i].length; j++) {
+      elements.push(rows[j][i]);
+    }
+  }
+  return elements;
 }
 
 function matStringify (value) {
@@ -193,7 +196,7 @@ function matStringify (value) {
   for (var i = 0; i < n; i++) {
     var row = [];
     for (var j = 0; j < n; j++) {
-      row.push(value[i * n + j]);
+      row.push(value[i + j * n]);
     }
     rows.push(row.join(' '));
   }

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -176,4 +176,45 @@ suite('propertyTypes', function () {
       assert.equal(parse('#hello'), 'file2.jpg');
     });
   });
+
+  suite('matrix', function () {
+    var parse = propertyTypes.mat4.parse;
+    var stringify = propertyTypes.mat4.stringify;
+
+    test('parses matrices', function () {
+      assert.deepEqual(parse('2 0 0 0, 0 2 0 0, 0 0 2 0, 0 0 0 2'), [
+        2, 0, 0, 0,
+        0, 2, 0, 0,
+        0, 0, 2, 0,
+        0, 0, 0, 2
+      ]);
+      assert.deepEqual(parse('1 2 3, 4 5 6, 7 8 9'), [
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9
+      ]);
+      assert.deepEqual(parse('1 2, 3 4'), [
+        1, 2,
+        3, 4
+      ]);
+    });
+
+    test('stringifies matrices', function () {
+      assert.equal(stringify([
+        2, 0, 0, 0,
+        0, 2, 0, 0,
+        0, 0, 2, 0,
+        0, 0, 0, 2
+      ]), '2 0 0 0, 0 2 0 0, 0 0 2 0, 0 0 0 2');
+      assert.equal(stringify([
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9
+      ]), '1 2 3, 4 5 6, 7 8 9');
+      assert.equal(stringify([
+        1, 2,
+        3, 4
+      ]), '1 2, 3 4');
+    });
+  });
 });

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -177,44 +177,36 @@ suite('propertyTypes', function () {
     });
   });
 
-  suite('matrix', function () {
+  suite.only('matrix', function () {
     var parse = propertyTypes.mat4.parse;
     var stringify = propertyTypes.mat4.stringify;
 
     test('parses matrices', function () {
-      assert.deepEqual(parse('2 0 0 0, 0 2 0 0, 0 0 2 0, 0 0 0 2'), [
-        2, 0, 0, 0,
-        0, 2, 0, 0,
-        0, 0, 2, 0,
-        0, 0, 0, 2
+      assert.deepEqual(parse('1 2 3 4, 5 6 7 8, 9 10 11 12, 13 14 15 16'), [
+        1, 5, 9, 13,
+        2, 6, 10, 14,
+        3, 7, 11, 15,
+        4, 8, 12, 16
       ]);
       assert.deepEqual(parse('1 2 3, 4 5 6, 7 8 9'), [
-        1, 2, 3,
-        4, 5, 6,
-        7, 8, 9
-      ]);
-      assert.deepEqual(parse('1 2, 3 4'), [
-        1, 2,
-        3, 4
+        1, 4, 7,
+        2, 5, 8,
+        3, 6, 9
       ]);
     });
 
     test('stringifies matrices', function () {
       assert.equal(stringify([
-        2, 0, 0, 0,
-        0, 2, 0, 0,
-        0, 0, 2, 0,
-        0, 0, 0, 2
-      ]), '2 0 0 0, 0 2 0 0, 0 0 2 0, 0 0 0 2');
+        1, 5, 9, 13,
+        2, 6, 10, 14,
+        3, 7, 11, 15,
+        4, 8, 12, 16
+      ]), '1 2 3 4, 5 6 7 8, 9 10 11 12, 13 14 15 16');
       assert.equal(stringify([
-        1, 2, 3,
-        4, 5, 6,
-        7, 8, 9
+        1, 4, 7,
+        2, 5, 8,
+        3, 6, 9
       ]), '1 2 3, 4 5 6, 7 8 9');
-      assert.equal(stringify([
-        1, 2,
-        3, 4
-      ]), '1 2, 3 4');
     });
   });
 });


### PR DESCRIPTION
Uses row-major format when serialized (for readability) but column-major format when parsed (for compatibility with THREE.Matrix4.fromArray).

For example, these are equivalent:

```js
"n1 n2 n3, n4 n5 n6, n7 n8 n9"
[n1, n4, n7, n2, n5, n8, n3, n6, n9]
```

Fixes #2069.