### PR TITLE
[docs] Added trigger events for Vive controls

### DIFF
--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -40,5 +40,5 @@ buttons (trigger, grip, menu, system) and trackpad.
 | systemup     | System button released. |
 | trackpadup   | Trackpad pressed.       |
 | trackpaddown | Trackpad released.      |
-| triggerup   | Trigger pressed.        |
+| triggerup    | Trigger pressed.        |
 | triggerdown  | Trigger released.       |

--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -40,5 +40,5 @@ buttons (trigger, grip, menu, system) and trackpad.
 | systemup     | System button released. |
 | trackpadup   | Trackpad pressed.       |
 | trackpaddown | Trackpad released.      |
-| trigger up   | Trigger pressed.        |
+| triggerup   | Trigger pressed.        |
 | triggerdown  | Trigger released.       |

--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -40,3 +40,5 @@ buttons (trigger, grip, menu, system) and trackpad.
 | systemup     | System button released. |
 | trackpadup   | Trackpad pressed.       |
 | trackpaddown | Trackpad released.      |
+| trigger up   | Trigger pressed.        |
+| triggerdown  | Trigger released.       |


### PR DESCRIPTION
**Description:**
I noticed that the documentation for Vive controls were missing the `triggerup` and `triggerdown` events. 

**Changes proposed:**
Updated docs with missing events.