### PR TITLE
Fix material update referencing the sceneEl when it has not loaded

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -57,7 +57,6 @@ module.exports.Component = registerComponent('material', {
   },
 
   updateBehavior: function () {
-    var scene = this.el.sceneEl;
     var schema = this.schema;
     var self = this;
     var tickProperties = {};
@@ -68,16 +67,13 @@ module.exports.Component = registerComponent('material', {
       self.shader.update(tickProperties);
     };
     var keys = Object.keys(schema);
+    this.tick = undefined;
     keys.forEach(function (key) {
       if (schema[key].type === 'time') {
         self.tick = tick;
         tickProperties[key] = true;
-        scene.addBehavior(self);
       }
     });
-    if (Object.keys(tickProperties).length === 0) {
-      scene.removeBehavior(this);
-    }
   },
 
   updateShader: function (shaderName) {


### PR DESCRIPTION
This bug was unveiled by the inspector. The material update method was triggering a `sceneEl.addBehaviour(self)`. If the entity has not loaded there's no reference to `sceneEl`. It turns that that call was also unnecessary since the `play` / `pause` methods will take care of adding / removing the behavior when appropriate. I made sure that the sky shader example still works since it uses a property with `time` type. This is an example that reproduces the bug ![bug](https://d3vv6lp55qjaqc.cloudfront.net/items/2M3E3G3K2u0m0W0F0o0I/Image%202016-11-20%20at%208.47.28%20PM.png?X-CloudApp-Visitor-Id=9d04ec9f60e3cd874a1089e40fcaad60&v=8d11f4b3)

