### PR TITLE
Fix deprecation warnings within the examples

### DIFF
--- a/examples/test/raycaster/components/intersect-color-change.js
+++ b/examples/test/raycaster/components/intersect-color-change.js
@@ -6,14 +6,14 @@
 AFRAME.registerComponent('intersect-color-change', {
   init: function () {
     var el = this.el;
-    var material = el.getComputedAttribute('material');
+    var material = el.getAttribute('material');
     var initialColor = material.color;
     var initialOpacity = material.opacity;
 
     // Set color using raycaster parent color.
     el.addEventListener('raycaster-intersected', function (evt) {
       var raycasterEl = evt.detail.el;
-      var fingerColor = raycasterEl.parentNode.getComputedAttribute('material').color;
+      var fingerColor = raycasterEl.parentNode.getAttribute('material').color;
       el.setAttribute('material', 'color', fingerColor);
       el.setAttribute('material', 'opacity', 1.0);
     });

--- a/examples/test/raycaster/components/raycaster-helper.js
+++ b/examples/test/raycaster/components/raycaster-helper.js
@@ -11,14 +11,14 @@ AFRAME.registerComponent('raycaster-helper', {
     var el = this.el;
     var geometry = new THREE.Geometry();
     var material = new THREE.LineBasicMaterial({
-      color: el.getComputedAttribute('material').color
+      color: el.getAttribute('material').color
     });
     var raycaster = el.components.raycaster.raycaster;
     var length = raycaster.far === Infinity ? 1000 : raycaster.far;
 
     geometry.vertices.push(originVector,
                            raycaster.ray.direction.clone().multiplyScalar(length));
-    material.opacity = el.getComputedAttribute('material').opacity;
+    material.opacity = el.getAttribute('material').opacity;
     material.transparent = true;
     el.setObject3D('line', new THREE.Line(geometry, material));
   }

--- a/examples/test/shaders/index.html
+++ b/examples/test/shaders/index.html
@@ -22,7 +22,7 @@
 
             if (evt.detail.name !== 'rotation') { return; }
 
-            sunPosition = orbitEl.getComputedAttribute('rotation');
+            sunPosition = orbitEl.getAttribute('rotation');
 
             if(sunPosition === null) { return; }
 

--- a/examples/test/visibility/index.html
+++ b/examples/test/visibility/index.html
@@ -66,7 +66,7 @@
               break;
             }
             case greenCylinder: {
-              var oldVisible = greenCylinder.getComputedAttribute('visible');
+              var oldVisible = greenCylinder.getAttribute('visible');
               // See issue: https://github.com/aframevr/aframe/issues/579
               if (oldVisible === null) { oldVisible = true; }
               greenCylinder.setAttribute('visible', !oldVisible);
@@ -74,7 +74,7 @@
             }
             case pinkTorus: {
               // Yes, this is gross. See https://github.com/aframevr/aframe/issues/531
-              var oldMaterial = pinkTorus.getComputedAttribute('material');
+              var oldMaterial = pinkTorus.getAttribute('material');
               var oldOpacity = oldMaterial.opacity;
               var newOpacity = oldOpacity === 1 ? 0 : 1;
               var newMaterial = oldMaterial;


### PR DESCRIPTION
Just some cleanup of examples so they don't give off the deprecation error for `getComputedAttribute`