### PR TITLE
Preserve type of default property values.

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -332,7 +332,9 @@ function buildData (el, name, attrName, schema, elData, silent) {
     data = {};
     Object.keys(schema).forEach(function applyDefault (key) {
       var defaultValue = schema[key].default;
-      data[key] = typeof defaultValue === 'object' ? utils.extend({}, defaultValue) : defaultValue;
+      data[key] = defaultValue && defaultValue.constructor === Object
+        ? utils.extend({}, defaultValue)
+        : defaultValue;
     });
   }
 

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -52,6 +52,19 @@ suite('Component', function () {
       assert.equal(data, 'blue');
     });
 
+    test('preserves type of default values', function () {
+      var schema = processSchema({
+        list: {default: [1, 2, 3, 4]},
+        none: {default: null},
+        string: {default: ''}
+      });
+      var el = document.createElement('a-entity');
+      var data = buildData(el, 'dummy', 'dummy', schema, undefined, null);
+      assert.shallowDeepEqual(data.list, [1, 2, 3, 4]);
+      assert.equal(data.none, null);
+      assert.equal(data.string, '');
+    });
+
     test('uses mixin values', function () {
       var data;
       var TestComponent = registerComponent('dummy', {


### PR DESCRIPTION
Fixes #2140.
Fixes #2143.

Not sure we have consensus on this as a method of detecting POJOs (maybe it should be a util?), but this fixes the cases I'm aware of.
