### PR TITLE
extend / extendDeep typo in the registerPrimitive example

### DIFF
--- a/docs/primitives/index.md
+++ b/docs/primitives/index.md
@@ -107,7 +107,7 @@ var extendDeep = AFRAME.utils.extendDeep;
 // This makes the material component a default component and maps all the base material properties.
 var meshMixin = AFRAME.primitives.getMeshMixin();
 
-AFRAME.registerPrimitive('a-box', extend({}, meshMixin, {
+AFRAME.registerPrimitive('a-box', extendDeep({}, meshMixin, {
   // Preset default components. These components and component properties will be attached to the entity out-of-the-box.
   defaultComponents: {
     geometry: {primitive: 'box'}


### PR DESCRIPTION
**Description:** extend not found

**Changes proposed:**
- replaced extend by extendDeep in the registerPrimitive example

