### PR TITLE
Fixes #2088

### DIFF
--- a/src/components/light.js
+++ b/src/components/light.js
@@ -55,7 +55,7 @@ module.exports.Component = registerComponent('light', {
             break;
           }
 
-          case 'groundcolor': {
+          case 'groundColor': {
             light.groundColor.set(value);
             break;
           }


### PR DESCRIPTION
**Description:**
The docs refer to the ground color prop in hemisphere light as groundColor. But the code refers to it as groundcolor. Should this be case insensitive?

**Changes proposed:**
- Update groundcolor to groundColor in light.js.