### PR TITLE
Remove modifier key conditions from util.shouldCaptureKeyEvent(e)

### DIFF
--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -197,7 +197,6 @@ module.exports.Component = registerComponent('wasd-controls', {
 
   onKeyUp: function (event) {
     var code;
-    if (!shouldCaptureKeyEvent(event)) { return; }
     code = event.code || KEYCODE_TO_CODE[event.keyCode];
     this.keys[code] = false;
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -119,9 +119,7 @@ module.exports.diff = function (a, b) {
  * @returns {Boolean} Whether the key event should be captured.
  */
 module.exports.shouldCaptureKeyEvent = function (event) {
-  if (event.metaKey) {
-    return false;
-  }
+  if (event.metaKey) { return false; }
   return document.activeElement === document.body;
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -119,9 +119,6 @@ module.exports.diff = function (a, b) {
  * @returns {Boolean} Whether the key event should be captured.
  */
 module.exports.shouldCaptureKeyEvent = function (event) {
-  if (event.shiftKey || event.metaKey || event.altKey || event.ctrlKey) {
-    return false;
-  }
   return document.activeElement === document.body;
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -119,6 +119,9 @@ module.exports.diff = function (a, b) {
  * @returns {Boolean} Whether the key event should be captured.
  */
 module.exports.shouldCaptureKeyEvent = function (event) {
+  if (event.metaKey) {
+    return false;
+  }
   return document.activeElement === document.body;
 };
 


### PR DESCRIPTION
Fixes #1479.

The condition for modifier keys was introduced by 8697452f, with the goal of fixing the issue that it now seems to be causing.

I'm testing in three browsers:

* Chrome (KeyboardEvent.**code**)
* Firefox (KeyboardEvent.**code**)
* Safari (KeyboardEvent.**keyCode**)

Currently, all three exhibit #1479 for all modifier keys. With this change, <kbd>shift</kbd>, <kbd>alt</kbd>, and <kbd>ctrl</kbd> are fixed, and do not interfere with WASD controls.. <kbd>meta</kbd> is unfortunately not fixed, but that's a browser implementation "feature" and pretty much unavoidable with userland code.