### PR TITLE
Add defaultCompoenents to a-obj-model.js

### DIFF
--- a/src/extras/primitives/primitives/a-obj-model.js
+++ b/src/extras/primitives/primitives/a-obj-model.js
@@ -3,6 +3,10 @@ var registerPrimitive = require('../primitives').registerPrimitive;
 var utils = require('../../../utils/');
 
 registerPrimitive('a-obj-model', utils.extendDeep({}, meshMixin, {
+  defaultComponents: {
+    'obj-model': {}
+  },
+
   mappings: {
     src: 'obj-model.obj',
     mtl: 'obj-model.mtl'


### PR DESCRIPTION
I think `a-obj-model` should have `defaultComponents` like other primitives have.
This update fixes #2163 
