### PR TITLE
[docs] Switch event names for vive-controls

### DIFF
--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -38,7 +38,7 @@ buttons (trigger, grip, menu, system) and trackpad.
 | menuup       | Menu button released.   |
 | systemdown   | System button pressed.  |
 | systemup     | System button released. |
-| trackpadup   | Trackpad pressed.       |
-| trackpaddown | Trackpad released.      |
-| triggerup    | Trigger pressed.        |
-| triggerdown  | Trigger released.       |
+| trackpaddown | Trackpad pressed.       |
+| trackpadup   | Trackpad released.      |
+| triggerdown  | Trigger pressed.        |
+| triggerup    | Trigger released.       |


### PR DESCRIPTION
**Description:**
Event names for vive-controls had wrong description

**Changes proposed:**
- Switch trackpad and trigger event names to match correct description