### PR TITLE
When updating component attrValue has to be used instead of component.data

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -686,10 +686,10 @@ var proto = Object.create(ANode.prototype, {
       function componentUpdate (el, componentName, propValue) {
         var component = el.components[componentName];
         if (component && typeof propValue === 'object') {
-          // Extend existing component data.
+          // Extend existing component attribute value.
           el.updateComponent(
             componentName,
-            utils.extendDeep(utils.extendDeep({}, component.data), propValue));
+            utils.extendDeep(utils.extendDeep({}, component.attrValue), propValue));
         } else {
           el.updateComponent(componentName, propValue);
         }

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -17,7 +17,12 @@ function parse (value, defaultVec) {
   var vec = {};
 
   if (value && typeof value === 'object') {
-    return vecParseFloat(value);
+    return vecParseFloat({
+      x: value.x || defaultVec && defaultVec.x,
+      y: value.y || defaultVec && defaultVec.y,
+      z: value.z || defaultVec && defaultVec.z,
+      w: value.w || defaultVec && defaultVec.w
+    });
   }
 
   if (typeof value !== 'string' || value === null) {

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -363,6 +363,29 @@ suite('a-entity', function () {
       el.setAttribute('test', 'asym', 1);
       el.setAttribute('test', 'other', 2);
     });
+
+    test('the attribute cache only stores the modified properties', function () {
+      var el = this.el;
+      el.setAttribute('geometry', {primitive: 'box'});
+      assert.deepEqual(el.components.geometry.attrValue, {primitive: 'box'});
+      el.setAttribute('geometry', {primitive: 'sphere', radius: 10});
+      assert.deepEqual(el.components.geometry.attrValue, {primitive: 'sphere', radius: 10});
+    });
+
+    test('when changing schema only the modified properties are cached', function () {
+      var el = this.el;
+      var geometry;
+      el.setAttribute('geometry', {primitive: 'box'});
+      assert.deepEqual(el.components.geometry.attrValue, {primitive: 'box'});
+      el.setAttribute('geometry', {primitive: 'sphere', radius: 10});
+      assert.deepEqual(el.components.geometry.attrValue, {primitive: 'sphere', radius: 10});
+      geometry = el.getAttribute('geometry');
+      assert.equal(geometry.primitive, 'sphere');
+      assert.equal(geometry.radius, 10);
+      assert.notOk(geometry.depth);
+      assert.notOk(geometry.height);
+      assert.notOk(geometry.width);
+    });
   });
 
   suite('flushToDOM', function () {

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -18,6 +18,11 @@ suite('utils.coordinates', function () {
         coordinates.parse('1 2.5 -3'), {x: 1, y: 2.5, z: -3});
     });
 
+    test('applies defaults to the missing values', function () {
+      assert.deepEqual(
+        coordinates.parse({x: 1}, {x: 0, y: 0, z: 0}), {x: 1, y: 0, z: 0});
+    });
+
     test('parses null', function () {
       assert.equal(coordinates.parse(null), null);
     });


### PR DESCRIPTION
The bug was discovered when doing:
````javascript
el.setAttribute('geometry', {primitive: 'box'});
el.setAttribute('geometry', {primitive: 'sphere'});
````
After the first line the value of el.components.geometry.attrValue was `{primitive: box}`
After the update `{"buffer":true,"primitive":"sphere","skipCache":false,"depth":1,"height":1,"width":1,"segmentsHeight":1,"segmentsWidth":1,"segmentsDepth":1}` causing the default values of the box primitive to be applied to the sphere primitive after update.
