### PR TITLE
Fix runtime error in `embedded` component when `vr-mode-ui` component is disabled

### DIFF
--- a/src/components/scene/embedded.js
+++ b/src/components/scene/embedded.js
@@ -12,10 +12,10 @@ module.exports.Component = registerComponent('embedded', {
     var sceneEl = this.el;
     var enterVREl = sceneEl.querySelector('.a-enter-vr');
     if (this.data === true) {
-      enterVREl.classList.add('embedded');
+      if (enterVREl) { enterVREl.classList.add('embedded'); }
       sceneEl.removeFullScreenStyles();
     } else {
-      enterVREl.classList.remove('embedded');
+      if (enterVREl) { enterVREl.classList.remove('embedded'); }
       sceneEl.addFullScreenStyles();
     }
   }

--- a/tests/components/scene/embedded.test.js
+++ b/tests/components/scene/embedded.test.js
@@ -1,0 +1,57 @@
+/* global assert, process, setup, suite, test */
+var entityFactory = require('../../helpers').entityFactory;
+
+var ENTER_VR_CLASS = '.a-enter-vr.embedded';
+var SCENE_FULL_SCREEN_CLASS = 'fullscreen';
+
+suite('embedded', function () {
+  setup(function (done) {
+    this.entityEl = entityFactory();
+    var el = this.el = this.entityEl.parentNode;
+    var resolvePromise = function () { return Promise.resolve(); };
+    el.setAttribute('embedded', '');
+    el.effect = {
+      requestPresent: resolvePromise,
+      exitPresent: resolvePromise
+    };
+    el.addEventListener('loaded', function () { done(); });
+  });
+
+  test('adds embedded class to Enter VR element', function () {
+    var scene = this.el;
+    assert.equal(scene.querySelectorAll(ENTER_VR_CLASS).length, 1);
+  });
+
+  test('removes fullscreen class from scene element', function () {
+    var scene = this.el;
+    assert.notOk(scene.classList.contains(SCENE_FULL_SCREEN_CLASS));
+  });
+
+  test('can remove embedded class from Enter VR element', function () {
+    var scene = this.el;
+    scene.setAttribute('embedded', false);
+    assert.notOk(scene.querySelector(ENTER_VR_CLASS));
+  });
+
+  test('can add fullscreen class to scene element', function () {
+    var scene = this.el;
+    scene.setAttribute('embedded', false);
+    assert.ok(scene.classList.contains(SCENE_FULL_SCREEN_CLASS));
+  });
+
+  suite('with vr-mode-ui disabled', function () {
+    test('removes fullscreen class from scene element', function () {
+      var scene = this.el;
+      scene.setAttribute('vr-mode-ui', 'enabled', false);
+      scene.setAttribute('embedded', true);
+      assert.notOk(scene.classList.contains(SCENE_FULL_SCREEN_CLASS));
+    });
+
+    test('can add fullscreen class to scene element', function () {
+      var scene = this.el;
+      scene.setAttribute('vr-mode-ui', 'enabled', false);
+      scene.setAttribute('embedded', false);
+      assert.ok(scene.classList.contains(SCENE_FULL_SCREEN_CLASS));
+    });
+  });
+});


### PR DESCRIPTION
**Description:**

It should be possible to use A-Frame embedded without the VR mode UI enabled. After all, embedding often means a heavily customized solution including custom UI to enter and leave VR.

**Changes proposed:**

- Only add and remove `embedded` class from Enter VR element if it exists in the DOM
- Added test for `embedded` component, which tests the component's ability to work both when the `vr-mode-ui` component is enabled and disabled.