### PR TITLE
[docs] Added doc for `materialvideoloadeddata`

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -60,7 +60,8 @@ depending on the material type applied.
 
 | Event Name              | Description                                                                                |
 |-------------------------|--------------------------------------------------------------------------------------------|
-| materialtextureloaded   | Texture loaded onto material. Or when the first frame is playing for video textures.       |
+| materialtextureloaded   | Texture loaded onto material.                                                              |
+| materialvideoloadeddata | Video data loaded and is going to play.                                                    |
 | materialvideoended      | For video textures, emitted when the video has reached its end (may not work with `loop`). |
 
 ## Built-in Materials


### PR DESCRIPTION
Added entry for previously undocumented `materialvideoloadeddata` event. Also removed misleading comment in `materialtextureloaded` about first video frame playing, because relying on it to retrieve eg. `texture.image.videoWidth` would be problematic. `materialvideoloadeddata` is a more reliable event for determining video start and ability to fetch video meta data.