### PR TITLE
[docs] Fix material properties

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -87,8 +87,8 @@ These properties are available on top of the base material properties.
 | ambientOcclusionTextureOffset | How the ambient occlusion texture is offset in the x y direction.                                                                               | 0 0           |
 | color                         | Base diffuse color.                                                                                                                             | #fff          |
 | displacementMap               | Displacement map. Used to distort a mesh. Can either be a selector to an `<img>` an inline URL.                                                 | None          |
-| displacementMapScale          | The intensity of the displacement map effect                                                                                                    | 1             |
-| displacementMapBias           | The zero point of the displacement map.                                                                                                         | 0.5           |
+| displacementScale             | The intensity of the displacement map effect                                                                                                    | 1             |
+| displacementBias              | The zero point of the displacement map.                                                                                                         | 0.5           |
 | displacementTextureRepeat     | How many times the displacement texture repeats in the X and Y direction.                                                                       | 1 1           |
 | displacementTextureOffset     | How the displacement texture is offset in the x y direction.                                                                                    | 0 0           |
 | height                        | Height of video (in pixels), if defining a video texture.                                                                                       | 360           |
@@ -96,7 +96,7 @@ These properties are available on top of the base material properties.
 | fog                           | Whether or not material is affected by [fog][fog].                                                                                              | true          |
 | metalness                     | How metallic the material is from `0` to `1`.                                                                                                   | 0.5           |
 | normalMap                     | Normal map. Used to add the illusion of complex detail. Can either be a selector to an `<img>` an inline URL.                                   | None          |
-| normalMapScale                | Scale of the effect of the normal map in the X and Y directions.                                                                                | 1 1           |
+| normalScale                   | Scale of the effect of the normal map in the X and Y directions.                                                                                | 1 1           |
 | normalTextureRepeat           | How many times the normal texture repeats in the X and Y direction.                                                                             | 1 1           |
 | normalTextureOffset           | How the normal texture is offset in the x y direction.                                                                                          | 0 0           |
 | repeat                        | How many times a texture (defined by `src`) repeats in the X and Y direction.                                                                   | 1 1           |


### PR DESCRIPTION
For distortion map properties such as `displacementScale`, `displacementBias` and `normalScale`
