### PR TITLE
Enhance efficiency of github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,10 @@
+<!--
+Please if you have a question rather than reporting the issue, please post it on Stackoverflow
+or ask it on A-Frame Slack #questions channel
+https://stackoverflow.com/questions/ask/?tags=aframe
+https://aframe.io/community/#slack
+-->
+
 **Description:**
 
 - A-Frame Version:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,7 @@
-<!--
-Please if you have a question rather than reporting the issue, please post it on Stackoverflow
-or ask it on A-Frame Slack #questions channel
-https://stackoverflow.com/questions/ask/?tags=aframe
-https://aframe.io/community/#slack
--->
+<!-- If you have a support question, please ask at https://stackoverflow.com/questions/ask/?tags=aframe rather than filing an issue. -->
 
 **Description:**
 
 - A-Frame Version:
-- Platform/Device:
-- Reproducible Code Snippet or Demo URL [highly encouraged]:
+- Platform / Device:
+- Reproducible Code Snippet or URL:


### PR DESCRIPTION
**Description:**
As community grows it happens more often where users create issues which really belong to slack or stackoverflow.

**Changes proposed:**
- Perhaps change in github issue template proposed in this PR will increases the likelihood subjects to be posted to places where these belong and therefore ensure quality of issues posted in github.
