### PR TITLE
Fix null parse test of coordinates

### DIFF
--- a/docs/core/utils.md
+++ b/docs/core/utils.md
@@ -25,7 +25,7 @@ AFRAME.utils.coordinates.isCoordinate('1 2 3')
 
 ### `.parse(value)`
 
-Parses an "x y z" string to an `{x, y, z}` vec3 object. Or parses an "x y z w" string to an {x, y, z w} vec3 object.
+Parses an "x y z" string to an `{x, y, z}` vec3 object. Or parses an "x y z w" string to an {x, y, z, w} vec4 object.
 
 ```js
 AFRAME.utils.coordinates.parse('1 2 -3')

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -1,7 +1,7 @@
 /* global THREE */
 var extend = require('object-assign');
 // Coordinate string regex. Handles negative, positive, and decimals.
-var regex = /\s*(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s*/;
+var regex = /^\s*(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s*$/;
 module.exports.regex = regex;
 
 /**

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -1,7 +1,7 @@
 /* global THREE */
 var extend = require('object-assign');
 // Coordinate string regex. Handles negative, positive, and decimals.
-var regex = /^\s*(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s*$/;
+var regex = /^\s*((-?\d*\.{0,1}\d+)\s+){2,3}(-?\d*\.{0,1}\d+)\s*$/;
 module.exports.regex = regex;
 
 /**

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -28,7 +28,7 @@ suite('utils.coordinates', function () {
     });
 
     test('parses null', function () {
-      assert.equal(coordinates.parse(null), undefined);
+      assert.equal(coordinates.parse(null), null);
     });
 
     test('can return fallback values', function () {

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -3,12 +3,16 @@ var coordinates = require('index').utils.coordinates;
 
 suite('utils.coordinates', function () {
   suite('isCoordinate', function () {
-    test('verifies valid coordinate', function () {
+    test('verifies valid vec3 coordinate', function () {
       assert.ok(coordinates.isCoordinate(' 1 2.5  -3'));
     });
 
+    test('verifies valid vec4 coordinate', function () {
+      assert.ok(coordinates.isCoordinate('1 1 2.5 -3'));
+    });
+
     test('rejects invalid coordinate', function () {
-      assert.ok(!coordinates.isCoordinate('1 1 2.5 -3'));
+      assert.notOk(coordinates.isCoordinate('1 1 2.5 -3 0.1'));
     });
   });
 

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -8,7 +8,7 @@ suite('utils.coordinates', function () {
     });
 
     test('rejects invalid coordinate', function () {
-      assert.ok(coordinates.isCoordinate('1 1 2.5 -3'));
+      assert.ok(!coordinates.isCoordinate('1 1 2.5 -3'));
     });
   });
 

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -24,7 +24,7 @@ suite('utils.coordinates', function () {
     });
 
     test('parses null', function () {
-      assert.equal(coordinates.parse(null), null);
+      assert.equal(coordinates.parse(null), undefined);
     });
 
     test('can return fallback values', function () {


### PR DESCRIPTION
**Description:**

This PR fixes the null parse test of coordinates.
`coordinate.parse(null)`  returns `undefined` if `defaultVec` isn't given.

LMK if not test but `coordinate.parse` impl is wrong, 
(I mean, if it should return `null` for null parse)
I'll close this PR end make another PR to fix the impl.
