### PR TITLE
Fix isCoordinate

### DIFF
--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -1,7 +1,7 @@
 /* global THREE */
 var extend = require('object-assign');
 // Coordinate string regex. Handles negative, positive, and decimals.
-var regex = /\s*(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s*/;
+var regex = /^\s*(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s+(-?\d*\.{0,1}\d+)\s*$/;
 module.exports.regex = regex;
 
 /**

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -8,7 +8,7 @@ suite('utils.coordinates', function () {
     });
 
     test('rejects invalid coordinate', function () {
-      assert.ok(coordinates.isCoordinate('1 1 2.5 -3'));
+      assert.ok(!coordinates.isCoordinate('1 1 2.5 -3'));
     });
   });
 


### PR DESCRIPTION
**Description:**

If I'm right, `isCoordinate` test is wrong because
'rejects invalid coordinate' doesn't reject.

This PR fixes this issue.
The root issue was `regex` is missing `^` and `$` and
it has matched four or more space separated numbers.
