### PR TITLE
Bump Three.js to r83

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "present": "0.0.6",
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
-    "three": "^0.82.1",
+    "three": "^0.83.0",
     "tween.js": "^15.0.0",
     "webvr-polyfill": "^0.9.23"
   },

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -134,8 +134,8 @@ module.exports.Component = registerComponent('sound', {
     el.setObject3D(this.attrName, this.pool);
 
     this.pool.children.forEach(function (sound) {
-      sound.source.onended = function () {
-        sound.onEnded();
+      sound.onEnded = function () {
+        sound.isPlaying = false;
         el.emit('sound-ended', {index: i});
       };
     });
@@ -146,7 +146,7 @@ module.exports.Component = registerComponent('sound', {
    */
   pauseSound: function () {
     this.pool.children.forEach(function (sound) {
-      if (!sound.source.buffer || !sound.isPlaying || !sound.pause) { return; }
+      if (!sound.source || !sound.source.buffer || !sound.isPlaying || !sound.pause) { return; }
       sound.pause();
     });
   },
@@ -157,7 +157,7 @@ module.exports.Component = registerComponent('sound', {
   playSound: function () {
     var found = false;
     this.pool.children.forEach(function (sound) {
-      if (!sound.isPlaying && sound.source.buffer && !found) {
+      if (!sound.isPlaying && sound.buffer && !found) {
         sound.play();
         found = true;
         return;
@@ -175,7 +175,7 @@ module.exports.Component = registerComponent('sound', {
    */
   stopSound: function () {
     this.pool.children.forEach(function (sound) {
-      if (!sound.source.buffer) { return; }
+      if (!sound.source || !sound.source.buffer) { return; }
       sound.stop();
     });
   }

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -4,7 +4,7 @@ var debug = require('../utils/debug');
 var registerElement = require('./a-register-element').registerElement;
 var THREE = require('../lib/three');
 
-var fileLoader = new THREE.XHRLoader();
+var fileLoader = new THREE.FileLoader();
 var warn = debug('core:a-assets:warn');
 
 /**

--- a/tests/components/sound.test.js
+++ b/tests/components/sound.test.js
@@ -66,6 +66,7 @@ suite('sound', function () {
         disconnect: sinon.stub(),
         pause: sinon.stub(),
         isPlaying: false,
+        buffer: true,
         source: {buffer: true}
       };
       el.pause();
@@ -78,6 +79,7 @@ suite('sound', function () {
         disconnect: sinon.stub(),
         pause: sinon.stub(),
         isPlaying: true,
+        buffer: true,
         source: {buffer: true}
       };
       el.components.sound.isPlaying = true;
@@ -93,6 +95,7 @@ suite('sound', function () {
         disconnect: sinon.stub(),
         play: sinon.stub(),
         isPlaying: false,
+        buffer: true,
         source: {buffer: true}
       };
       el.components.sound.autoplay = true;
@@ -108,6 +111,7 @@ suite('sound', function () {
         disconnect: sinon.stub(),
         isPlaying: true,
         pause: sinon.stub(),
+        buffer: true,
         source: {buffer: true}
       };
       el.components.sound.pauseSound();
@@ -122,6 +126,7 @@ suite('sound', function () {
         disconnect: sinon.stub(),
         play: sinon.stub(),
         isPlaying: false,
+        buffer: true,
         source: {buffer: true}
       };
       el.components.sound.playSound();
@@ -136,6 +141,7 @@ suite('sound', function () {
         disconnect: sinon.stub(),
         isPlaying: true,
         stop: sinon.stub(),
+        buffer: true,
         source: {buffer: true}
       };
       el.components.sound.stopSound();


### PR DESCRIPTION
**Description:**

This PR updates Three.js to r83.
It passed `npm test` and I confirmed examples keep working.
LMK if there's any other tests I need to check.

#2212

**Changes:**
- Rename `THREE.XHRLoader` with `THREE.FileLoader` in `a-assets`
- Update sound component for `THREE.Audio` which generates `source` when it  starts to play in r83.
