### PR TITLE
Fix coordinates override bug

### DIFF
--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -18,10 +18,10 @@ function parse (value, defaultVec) {
 
   if (value && typeof value === 'object') {
     return vecParseFloat({
-      x: value.x || defaultVec && defaultVec.x,
-      y: value.y || defaultVec && defaultVec.y,
-      z: value.z || defaultVec && defaultVec.z,
-      w: value.w || defaultVec && defaultVec.w
+      x: value.x !== undefined ? value.x : (defaultVec && defaultVec.x),
+      y: value.y !== undefined ? value.y : (defaultVec && defaultVec.y),
+      z: value.z !== undefined ? value.z : (defaultVec && defaultVec.z),
+      w: value.w !== undefined ? value.w : (defaultVec && defaultVec.w)
     });
   }
 

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -38,6 +38,12 @@ suite('utils.coordinates', function () {
                               {x: 1, y: 2, z: -3});
     });
 
+    test('zero value of object won\'t be overriden by defaults', function () {
+      assert.shallowDeepEqual(
+        coordinates.parse({x: 0, y: 1}, {x: 4, y: 5, z: 6}),
+        {x: 0, y: 1, z: 6});
+    });
+
     test('parses object with strings', function () {
       assert.shallowDeepEqual(coordinates.parse({x: '1', y: '2', z: -3}),
                               {x: 1, y: 2, z: -3});


### PR DESCRIPTION
**Description:**

This PR fixes the coordinates override bug in `coordinates.parse()` that
property value 0 is overridden by defaultVec's when object is given to the method.
Animation pivots/warps examples went wrong because of this bug and this PR fixes them.
