### PR TITLE
Fix deepEqual for array props.

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -72,12 +72,20 @@ module.exports.clone = function (obj) {
 function deepEqual (a, b) {
   var keysA = Object.keys(a);
   var keysB = Object.keys(b);
+  var valA;
+  var valB;
   var i;
   if (keysA.length !== keysB.length) { return false; }
   // If there are no keys, compare the objects.
   if (keysA.length === 0) { return a === b; }
   for (i = 0; i < keysA.length; ++i) {
-    if (a[keysA[i]] !== b[keysA[i]]) { return false; }
+    valA = a[keysA[i]];
+    valB = b[keysA[i]];
+    if ((Array.isArray(valA) && Array.isArray(valB))) {
+      if (!deepEqual(valA, valB)) { return false; }
+    } else if (valA !== valB) {
+      return false;
+    }
   }
   return true;
 }

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -406,6 +406,19 @@ suite('Component', function () {
       component.updateProperties({color: 'blue'});
       assert.ok(updateStub.calledOnce);
     });
+
+    test('supports array properties', function () {
+      var updateStub = sinon.stub();
+      var TestComponent = registerComponent('dummy', {
+        schema: {list: {default: ['a']}},
+        update: updateStub
+      });
+      var el = document.createElement('a-entity');
+      var component = new TestComponent(el);
+      component.updateProperties({list: ['b']});
+      component.updateProperties({list: ['b']});
+      sinon.assert.calledOnce(updateStub);
+    });
   });
 
   suite('flushToDOM', function () {

--- a/tests/utils/objects.test.js
+++ b/tests/utils/objects.test.js
@@ -1,5 +1,8 @@
 /* global assert, suite, test */
-var diff = require('index').utils.diff;
+var utils = require('index').utils;
+
+var diff = utils.diff;
+var deepEqual = utils.deepEqual;
 
 suite('utils.objects', function () {
   suite('diff', function () {
@@ -48,6 +51,43 @@ suite('utils.objects', function () {
         metallic: undefined,
         roughness: 1
       });
+    });
+  });
+
+  suite('deepEqual', function () {
+    test('can compare identical objects', function () {
+      var objA = {id: 62, label: 'Foo', parent: null};
+      var objB = {id: 62, label: 'Foo', parent: null};
+      assert.ok(deepEqual(objA, objB));
+    });
+
+    test('can compare for missing properties', function () {
+      var objA = {id: 62, label: 'Foo', parent: null};
+      var objB = {id: 62, label: 'Foo', parent: null, extraProp: true};
+      assert.notOk(deepEqual(objA, objB));
+    });
+
+    test('can compare for differing property values', function () {
+      var objA = {id: 62, label: 'Foo', parent: null, extraProp: false};
+      var objB = {id: 62, label: 'Foo', parent: null, extraProp: true};
+      assert.notOk(deepEqual(objA, objB));
+    });
+
+    test('can compare nested arrays', function () {
+      var objA = {children: [1, 2, 3, 4]};
+      var objB = {children: [1, 2, 3, 4]};
+      var objC = {children: [1, 2, 3, 5]};
+      assert.ok(deepEqual(objA, objB));
+      assert.notOk(deepEqual(objA, objC));
+    });
+
+    /** SKIPPED: Comparison of nested objects is not yet implemented. */
+    test.skip('can compare nested objects', function () {
+      var objA = {metadata: {source: 'Wikipedia, 2016'}};
+      var objB = {metadata: {source: 'Wikipedia, 2016'}};
+      var objC = {metadata: {source: 'Nature, 2015'}};
+      assert.ok(deepEqual(objA, objB));
+      assert.notOk(deepEqual(objA, objC));
     });
   });
 });


### PR DESCRIPTION
Fixes #2227.

Also, the method mentions supporting nested objects but doesn't appear to. Just a we'll-add-support-when-it's-needed situation?