### PR TITLE
Warn on component names that contain uppercase characters

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -254,6 +254,12 @@ module.exports.registerComponent = function (name, definition) {
   var NewComponent;
   var proto = {};
 
+  var testForUpperCase = new RegExp("(?=\S*[A-Z])")
+
+  if(testForUpperCase.test(name)===true){
+      console.warn( 'The component name `' + name + '` contains uppercase characters, but HTML ignores the capitalization of attributes.  Consider changing it.  Your component can be accessed as '+ name.toLowerCase());
+  }
+  
   if (name.indexOf('__') !== -1) {
     throw new Error('The component name `' + name + '` is not allowed. ' +
                     'The sequence __ (double underscore) is reserved to specify an id' +

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -254,15 +254,15 @@ module.exports.registerComponent = function (name, definition) {
   var NewComponent;
   var proto = {};
 
-  var testForUpperCase = new RegExp("(?=\S*[A-Z])");
+  var testForUpperCase = new RegExp('[A-Z]+');
 
-  if(testForUpperCase.test(name)===true){
-      console.warn( 'The component name `' + name + '` contains uppercase characters,'+ 
-        'but HTML ignores the capitalization of attributes. '+
-        'Consider changing it. '+
-        'Your component can be accessed as '+ name.toLowerCase());
+  if (testForUpperCase.test(name) === true) {
+    console.warn('The component name `' + name + '`contains uppercase characters,' +
+                  'but HTML ignores the capitalization of attributes. ' +
+                  'Consider changing it. ' +
+                  'Your component can be accessed as ' + name.toLowerCase());
   }
-  
+
   if (name.indexOf('__') !== -1) {
     throw new Error('The component name `' + name + '` is not allowed. ' +
                     'The sequence __ (double underscore) is reserved to specify an id' +

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -254,10 +254,13 @@ module.exports.registerComponent = function (name, definition) {
   var NewComponent;
   var proto = {};
 
-  var testForUpperCase = new RegExp("(?=\S*[A-Z])")
+  var testForUpperCase = new RegExp("(?=\S*[A-Z])");
 
   if(testForUpperCase.test(name)===true){
-      console.warn( 'The component name `' + name + '` contains uppercase characters, but HTML ignores the capitalization of attributes.  Consider changing it.  Your component can be accessed as '+ name.toLowerCase());
+      console.warn( 'The component name `' + name + '` contains uppercase characters,'+ 
+        'but HTML ignores the capitalization of attributes. '+
+        'Consider changing it. '+
+        'Your component can be accessed as '+ name.toLowerCase());
   }
   
   if (name.indexOf('__') !== -1) {


### PR DESCRIPTION
**Description:**

This PR checks for uppercase characters in component names.  Since HTML changes these to lowercase, it's important that users have a warning about how to correctly access their components.

https://github.com/aframevr/aframe/issues/2139

**Changes proposed:**
- Use a regex to test the name for uppercase, warn if this is the case.
