### PR TITLE
warn if trying to append to an element without a nearby scene

### DIFF
--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -98,7 +98,6 @@ module.exports = registerElement('a-node', {
                         'outside of the A-Frame scene. ' +
                         'Try appending to the "a-scene" element. '
                       );
-          return;
         }
 
         // Default to waiting for all nodes.

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -93,6 +93,14 @@ module.exports = registerElement('a-node', {
 
         if (this.hasLoaded) { return; }
 
+        if (self.closestScene() === null) {
+          console.warn('You are attempting to attach an entity ' +
+                        'outside of the A-Frame scene. ' +
+                        'Try appending to the "a-scene" element. '
+                      );
+          return;
+        }
+
         // Default to waiting for all nodes.
         childFilter = childFilter || function (el) { return el.isNode; };
 


### PR DESCRIPTION
**Description:**

This PR adds a console warning if you try to append an element without a scene nearby.

Previously, this code 'failed silently' -- your entities need to be children of a scene.
```
var el = document.createElement('a-entity');
document.body.appendChild(el);
```

Now it displays a warning 
```You are attempting to attach an entity outside of the A-Frame scene. Try appending to the "a-scene" element. ```

https://github.com/aframevr/aframe/issues/2225

**Changes proposed:**
- Check is there is a closest scene before loading.


P.S.  Please let me know if there's an earlier place we should be doing this check -- it does end up actually appending the element to the document body, which seems undesirable, but harmless i guess since it doesn't do anything.  If someone missing the warning and sees the element in the DOM, it could be confusing.  Also not sure if there's a performance impact from checking this for all elements (doesn't seem like it.)
