### PR TITLE
Add warnings if cursor and raycaster don't have scenes.

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -39,6 +39,10 @@ module.exports.Component = registerComponent('cursor', {
 
   init: function () {
     var cursorEl = this.el;
+    if (cursorEl.sceneEl === null) {
+      console.warn('There is no scene element for the cursor.');
+      return;
+    }
     var canvas = cursorEl.sceneEl.canvas;
     this.fuseTimeout = undefined;
     this.mouseDownEl = null;

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -77,6 +77,11 @@ module.exports.Component = registerComponent('raycaster', {
       return;
     }
 
+    if (this.el.sceneEl === null) {
+      console.warn('There is no scene element for the raycaster.');
+      return;
+    }
+
     // If objects not defined, intersect with everything.
     this.objects = this.el.sceneEl.object3D.children;
   },


### PR DESCRIPTION
**Description:**

If you try to do something like the below, you'll get knock on errors in raycaster and cursor due to there being no scene element.   I'm still getting used to the codebase so I just added these patches, but perhaps the right way to handle it would be to actually stop the element from appending if there is no nearby scene, instead of just warning.  testing for a scene in many different places seems redundant, but please advise :) 

https://github.com/aframevr/aframe/issues/2225

```
var el = document.createElement('a-entity');
el.setAttribute('cursor','')
document.body.appendChild(el);

```

**Changes proposed:**
- warn if no scene element in raycaster and cursor
- return early so we dont throw an error.
-
