### PR TITLE
Add NPOT texture support, and fix texture offset/repeat behavior

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -55,6 +55,9 @@ depending on the material type applied.
 | shader      | Which material to use. Defaults to the [standard material][standard]. Can be set to the [flat material][flat] or to a registered custom material. | standard      |
 | side        | Which sides of the mesh to render. Can be one of `front`, `back`, or `double`.                                                                    | front         |
 | visible | Whether material is visible. Raycasters will ignore invisible materials. | true |
+| offset | Texture offset to be used. | {x: 0, y: 0} |
+| repeat | Texture repeat to be used. | {x: 1, y: 1} |
+| npot | Use settings for non-power-of-two (NPOT) texture. | false |
 
 ## Events
 

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -24,7 +24,10 @@ module.exports.Component = registerComponent('material', {
     shader: {default: 'standard', oneOf: shaderNames},
     side: {default: 'front', oneOf: ['front', 'back', 'double']},
     transparent: {default: false},
-    visible: {default: true}
+    visible: {default: true},
+    offset: {default: {x: 0, y: 0}},
+    repeat: {default: {x: 1, y: 1}},
+    npot: {default: false}
   },
 
   init: function () {

--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -10,7 +10,7 @@ module.exports.Shader = registerShader('flat', {
     color: {type: 'color'},
     fog: {default: true},
     height: {default: 256},
-    offset: {type: 'vec2', default: {x: 1, y: 1}},
+    offset: {type: 'vec2', default: {x: 0, y: 0}},
     repeat: {type: 'vec2', default: {x: 1, y: 1}},
     src: {type: 'map'},
     width: {default: 512},

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -33,7 +33,7 @@ module.exports.Shader = registerShader('standard', {
     normalTextureOffset: {type: 'vec2'},
     normalTextureRepeat: {type: 'vec2', default: {x: 1, y: 1}},
 
-    offset: {type: 'vec2', default: {x: 1, y: 1}},
+    offset: {type: 'vec2', default: {x: 0, y: 0}},
     repeat: {type: 'vec2', default: {x: 1, y: 1}},
     roughness: {default: 0.5, min: 0.0, max: 1.0},
     sphericalEnvMap: {type: 'map'},

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -266,6 +266,8 @@ function setTextureProperties (texture, data) {
   var repeat = data.repeat || {x: 1, y: 1};
   var npot = data.npot || false;
 
+  // To support NPOT textures, wrap must be ClampToEdge (not Repeat),
+  // and filters must not use mipmaps (i.e. Nearest or Linear).
   if (npot) {
     texture.wrapS = THREE.ClampToEdgeWrapping;
     texture.wrapT = THREE.ClampToEdgeWrapping;
@@ -274,13 +276,13 @@ function setTextureProperties (texture, data) {
   }
 
   // Don't bother setting repeat if it is 1/1. Power-of-two is required to repeat.
-  if (!(repeat.x === 1 && repeat.y === 1)) {
+  if (repeat.x !== 1 || repeat.y !== 1) {
     texture.wrapS = THREE.RepeatWrapping;
     texture.wrapT = THREE.RepeatWrapping;
     texture.repeat.set(repeat.x, repeat.y);
   }
   // Don't bother setting offset if it is 0/0.
-  if (!(offset.x === 0 && offset.y === 0)) {
+  if (offset.x !== 0 || offset.y !== 0) {
     texture.offset.set(offset.x, offset.y);
   }
 }

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -264,17 +264,25 @@ function loadImageTexture (src, data) {
 function setTextureProperties (texture, data) {
   var offset = data.offset || {x: 0, y: 0};
   var repeat = data.repeat || {x: 1, y: 1};
+  var npot = data.npot || false;
+
+  if (npot) {
+    texture.wrapS = THREE.ClampToEdgeWrapping;
+    texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearFilter;
+  }
 
   // Don't bother setting repeat if it is 1/1. Power-of-two is required to repeat.
-  if (repeat.x === 1 && repeat.y === 1) { return; }
-
-  texture.wrapS = THREE.RepeatWrapping;
-  texture.wrapT = THREE.RepeatWrapping;
-  texture.repeat.set(repeat.x, repeat.y);
-
+  if (!(repeat.x === 1 && repeat.y === 1)) {
+    texture.wrapS = THREE.RepeatWrapping;
+    texture.wrapT = THREE.RepeatWrapping;
+    texture.repeat.set(repeat.x, repeat.y);
+  }
   // Don't bother setting offset if it is 0/0.
-  if (offset.x === 0 && offset.y === 0) { return; }
-  texture.offset.set(offset.x, offset.y);
+  if (!(offset.x === 0 && offset.y === 0)) {
+    texture.offset.set(offset.x, offset.y);
+  }
 }
 
 /**

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -13,7 +13,7 @@ module.exports.updateMap = function (shader, data) {
     if (src === shader.textureSrc) { return; }
     // Texture added or changed.
     shader.textureSrc = src;
-    el.sceneEl.systems.material.loadTexture(src, {src: src, repeat: data.repeat, offset: data.offset}, setMap);
+    el.sceneEl.systems.material.loadTexture(src, {src: src, repeat: data.repeat, offset: data.offset, npot: data.npot}, setMap);
     return;
   }
 


### PR DESCRIPTION
Add support for NPOT texture settings e.g. material="src:#imgElement; npot:true"
Fix support for texture offset / repeat (broken defaults and broken apply logic)