### PR TITLE
Adds useable geometry to cursor #2259

### DIFF
--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -31,7 +31,7 @@ When the cursor clicks on the box, we can listen to the click event.
 <a-entity camera>
   <a-entity cursor="fuse: true; fuseTimeout: 500"
             position="0 0 -1"
-            geometry="primitive: ring"
+            geometry="primitive: ring; radiusInner: 0.02; radiusOuter: 0.03"
             material="color: black; shader: flat">
   </a-entity>
 </a-entity>


### PR DESCRIPTION
A possible alternative approach would be to update the cursor component to include a default or configurable style for the reticule ie:

`cursor="fuse: true; fuseTimeout: 500; style: ring"`

Thoughts?