### PR TITLE
Change setBaseUrl to setTexturePath to avoid three.js deprecation warning

### DIFF
--- a/src/components/obj-model.js
+++ b/src/components/obj-model.js
@@ -43,7 +43,7 @@ module.exports.Component = registerComponent('obj-model', {
       if (el.hasAttribute('material')) {
         warn('Material component properties are ignored when a .MTL is provided');
       }
-      mtlLoader.setBaseUrl(mtlUrl.substr(0, mtlUrl.lastIndexOf('/') + 1));
+      mtlLoader.setTexturePath(mtlUrl.substr(0, mtlUrl.lastIndexOf('/') + 1));
       mtlLoader.load(mtlUrl, function (materials) {
         materials.preload();
         objLoader.setMaterials(materials);


### PR DESCRIPTION
I *believe* this accomplishes the same task but don't have enough samples to be 100% sure.