### PR TITLE
Exit fullscreen when on ExitVR()

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -216,6 +216,8 @@ module.exports = registerElement('a-scene', {
         // Don't exit VR if not in VR.
         if (!this.is('vr-mode')) { return Promise.resolve('Not in VR.'); }
 
+        exitFullscreen();
+
         if (this.checkHeadsetConnected() || this.isMobile) {
           return this.effect.exitPresent().then(exitVRSuccess, exitVRFailure);
         }
@@ -488,4 +490,14 @@ function requestFullscreen (canvas) {
     canvas.mozRequestFullScreen ||  // The capitalized `S` is not a typo.
     canvas.msRequestFullscreen;
   requestFullscreen.apply(canvas);
+}
+
+function exitFullscreen () {
+  if (document.exitFullscreen) {
+    document.exitFullscreen();
+  } else if (document.mozCancelFullScreen) {
+    document.mozCancelFullScreen();
+  } else if (document.webkitExitFullscreen) {
+    document.webkitExitFullscreen();
+  }
 }


### PR DESCRIPTION
Right now if we call `scene.exitVR()` it will just go back to the standard state if we are on VR but not if we're just in fullscreen mode. This PR introduces a call to `exitFullScreen` on the `exitVR` function.