### PR TITLE
[docs] Fix event type in event listener component

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -555,7 +555,7 @@ running on the page:
 
     init: function () {
       var data = this.data;
-      this.el.addEventListener('click', function () {
+      this.el.addEventListener('mouseenter', function () {
         this.setAttribute('scale', data.to);
       });
     }


### PR DESCRIPTION
**Description:**
In the scale-on-mouseenter component code, switch event listener from 'click' to 'mouseenter'.

