### PR TITLE
#2268 adding disclaimer about allow-vr attribute

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -23,6 +23,8 @@ download or install anything. Check out the [official MozVR
 CodePens](http://codepen.io/mozvr/) and the [A-Frame Hello World
 CodePen][codepen]:
 
+**Note:** VR mode currently won't work until the `allowvr` attribute is added to CodePen's I-Frames.
+
 <p data-height="300" data-theme-id="0" data-slug-hash="BjygdO" data-default-tab="html" data-user="mozvr" class="codepen">See the Pen <a href="http://codepen.io/team/mozvr/pen/BjygdO/">Hello World â A-Frame</a> by Mozilla VR (<a href="http://codepen.io/mozvr">@mozvr</a>) on <a href="http://codepen.io">CodePen</a>.</p>
 
 ## Grab the Boilerplate


### PR DESCRIPTION
**Description:**
Adding a disclaimer to the Getting Started guide that the Codepen link won't work unless the developers themselves add the allow-vr attribute to the a-frames. 

**Changes proposed:**

```
## Play with CodePen

[CodePen][codepen] is a playground for front-end web development. We can edit
HTML and JavaScript directly in the browser with its text editor, see changes
live, and share code snippets. This is a fast way to dive in without having to
download or install anything. Check out the [official MozVR
CodePens](http://codepen.io/mozvr/) and the [A-Frame Hello World
CodePen][codepen]:

**Note:** VR mode currently won't work until the `allowvr` attribute is added to CodePen's I-Frames.
```

