### PR TITLE
Accept el.setAttribute('mixin', '')

### DIFF
--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -129,7 +129,7 @@ module.exports = registerElement('a-node', {
 
     updateMixins: {
       value: function (newMixins, oldMixins) {
-        var newMixinsIds = newMixins.split(' ');
+        var newMixinsIds = newMixins ? newMixins.split(' ') : [];
         var oldMixinsIds = oldMixins ? oldMixins.split(' ') : [];
         // To determine what listeners will be removed
         var diff = oldMixinsIds.filter(function (i) { return newMixinsIds.indexOf(i) < 0; });

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1045,6 +1045,19 @@ suite('a-entity', function () {
       assert.equal(el.getAttribute('sound__2').src, soundUrl);
       assert.equal(el.getAttribute('sound__2').autoplay, true);
     });
+
+    test('clear mixin', function () {
+      var el = this.el;
+      mixinFactory('material', {material: 'shader: flat'});
+      mixinFactory('position', {position: '1 2 3'});
+      el.setAttribute('mixin', 'material position');
+      el.setAttribute('material', 'color: red');
+      assert.shallowDeepEqual(el.getAttribute('material'), {shader: 'flat', color: 'red'});
+      assert.shallowDeepEqual(el.getAttribute('position'), {x: 1, y: 2, z: 3});
+      el.setAttribute('mixin', '');
+      assert.shallowDeepEqual(el.getAttribute('material'), {color: 'red'});
+      assert.shallowDeepEqual(el.getAttribute('position'), {x: 0, y: 0, z: 0});
+    });
   });
 });
 


### PR DESCRIPTION
**Description:**

This PR enables `el.setAttribute('mixin', '')` (#2280).
It clears all mixins of el.

This PR doesn't touch `removeAttribute('mixin')` because
another guy is working on here #2282
