### PR TITLE
Accept mixin ids separated with spaces, tabs, and new lines

### DIFF
--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -129,8 +129,8 @@ module.exports = registerElement('a-node', {
 
     updateMixins: {
       value: function (newMixins, oldMixins) {
-        var newMixinsIds = newMixins ? newMixins.split(' ') : [];
-        var oldMixinsIds = oldMixins ? oldMixins.split(' ') : [];
+        var newMixinsIds = newMixins ? newMixins.trim().split(/\s+/) : [];
+        var oldMixinsIds = oldMixins ? oldMixins.trim().split(/\s+/) : [];
         // To determine what listeners will be removed
         var diff = oldMixinsIds.filter(function (i) { return newMixinsIds.indexOf(i) < 0; });
         this.mixinEls = [];

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1046,6 +1046,19 @@ suite('a-entity', function () {
       assert.equal(el.getAttribute('sound__2').autoplay, true);
     });
 
+    test('applies mixin ids separated with spaces, tabs, and new lines', function () {
+      var el = this.el;
+      mixinFactory('material', {material: 'shader: flat'});
+      mixinFactory('position', {position: '1 2 3'});
+      mixinFactory('rotation', {rotation: '10 20 30'});
+      el.setAttribute('mixin', '  material\t\nposition \t  rotation\n  ');
+      el.setAttribute('material', 'color: red');
+      assert.shallowDeepEqual(el.getAttribute('material'), {shader: 'flat', color: 'red'});
+      assert.shallowDeepEqual(el.getAttribute('position'), {x: 1, y: 2, z: 3});
+      assert.shallowDeepEqual(el.getAttribute('rotation'), {x: 10, y: 20, z: 30});
+      assert.equal(el.mixinEls.length, 3);
+    });
+
     test('clear mixin', function () {
       var el = this.el;
       mixinFactory('material', {material: 'shader: flat'});


### PR DESCRIPTION
**Description:**

This PR enables mixin ids following/followed by/separated with spaces, tabs, and new lines like this
`el.setAttribute('mixin', '  id1\tid2\n\nid3  ');`
It'd be useful for users.

Refer to #2291

