### PR TITLE
Alphatest addition

### DIFF
--- a/src/components/collada-model.js
+++ b/src/components/collada-model.js
@@ -21,6 +21,11 @@ module.exports.Component = registerComponent('collada-model', {
 
     this.loader.load(src, function (colladaModel) {
       self.model = colladaModel.scene;
+      self.model.traverse(function(child){
+        if(typeof child.material !== "undefined"){
+          child.material.alphaTest = 0.5;
+        }
+      });
       el.setObject3D('mesh', self.model);
       el.emit('model-loaded', {format: 'collada', model: self.model});
     });


### PR DESCRIPTION
By allowing an alphatest, transparencies in models loaded will now work better.

I personally believe this should be an option able to be set in the schema... Perhaps this should only be added in once schema has been updated and changed to allow for multiple variables without breaking backwards compatibility? I do think single variable schemas should be removed as they limit functionality WAY too much for the future, unless there is a way to set one of the multiple variables as the default for single variables.


As far as I can tell this pull request of tested code should not be added to the repo yet as alphatest might cause undesired consequences like hiding a material that has no texture set to it because the file wasn't found etc.... I do think its a good example of possibilities for model loading and the necessity to fine tune things, as models are beastly complicated to get right.

