### PR TITLE
scene detach should call component pause/remove handlers

### DIFF
--- a/src/components/scene/stats.js
+++ b/src/components/scene/stats.js
@@ -38,6 +38,7 @@ module.exports.Component = registerComponent('stats', {
   remove: function () {
     this.el.removeEventListener('enter-vr', this.hideBound);
     this.el.removeEventListener('exit-vr', this.showBound);
+    if (!this.statsEl) { return; }  // Scene detached.
     this.statsEl.parentNode.removeChild(this.statsEl);
   },
 

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -100,9 +100,13 @@ var proto = Object.create(ANode.prototype, {
    */
   detachedCallback: {
     value: function () {
-      if (!this.parentEl || this.isScene) { return; }
+      if (!this.parentEl) { return; }
+
       // Remove components.
       Object.keys(this.components).forEach(bind(this.removeComponent, this));
+
+      if (this.isScene) { return; }
+
       this.removeFromParent();
       ANode.prototype.detachedCallback.call(this);
     }

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -327,6 +327,30 @@ helpers.getSkipCISuite()('a-scene (with renderer)', function () {
       });
     });
 
+    test('calls component pause handlers', function (done) {
+      var el = this.el;
+      AFRAME.registerComponent('foo', {
+        pause: function () {
+          delete AFRAME.components.foo;
+          done();
+        }
+      });
+      el.setAttribute('foo', '');
+      document.body.removeChild(el);
+    });
+
+    test('calls component remove handlers', function (done) {
+      var el = this.el;
+      AFRAME.registerComponent('foo', {
+        remove: function () {
+          delete AFRAME.components.foo;
+          done();
+        }
+      });
+      el.setAttribute('foo', '');
+      document.body.removeChild(el);
+    });
+
     test('does not destroy document.body', function (done) {
       var el = this.el;
       document.body.removeChild(el);


### PR DESCRIPTION
**Description:**

Scene component handlers were not being removed when detached. Reproduced in unit tests that involved event listeners on a scene component.

**Changes proposed:**
- Have sceneEl call `removeComponent`s on detach.
