### PR TITLE
add warning if component declared after the scene in HTML (fixes #2307)

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -2,6 +2,7 @@
 var initMetaTags = require('./metaTags').inject;
 var initWakelock = require('./wakelock');
 var re = require('../a-register-element');
+var scenes = require('./scenes');
 var systems = require('../system').systems;
 var THREE = require('../../lib/three');
 var TWEEN = require('tween.js');
@@ -56,7 +57,6 @@ module.exports = registerElement('a-scene', {
         this.render = bind(this.render, this);
         this.systems = {};
         this.time = 0;
-
         this.init();
       }
     },
@@ -105,6 +105,9 @@ module.exports = registerElement('a-scene', {
         window.addEventListener('load', resize);
         window.addEventListener('resize', resize);
         this.play();
+
+        // Add to scene index.
+        scenes.push(this);
       },
       writable: window.debug
     },
@@ -129,8 +132,12 @@ module.exports = registerElement('a-scene', {
      */
     detachedCallback: {
       value: function () {
+        var sceneIndex;
         window.cancelAnimationFrame(this.animationFrameID);
         this.animationFrameID = null;
+        // Remove from scene index.
+        sceneIndex = scenes.indexOf(this);
+        scenes.splice(sceneIndex, 1);
       }
     },
 

--- a/src/core/scene/scenes.js
+++ b/src/core/scene/scenes.js
@@ -1,0 +1,4 @@
+/*
+  Scene index for keeping track of created scenes.
+*/
+module.exports = [];

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
 var utils = require('./utils/');
 
 var debug = utils.debug;
-var error = debug('A-Frame:warn');
-var info = debug('A-Frame:info');
+var warn = debug('A-Frame:warn');
 
-if (document.currentScript && document.currentScript.parentNode !== document.head) {
-  error('Put the A-Frame <script> tag in the <head> of the HTML before <a-scene> to ensure everything for A-Frame is properly registered before they are used in the <body>.');
-  info('Also make sure that any component <script> tags are included after A-Frame, but still before <a-scene>.');
+if (document.currentScript && document.currentScript.parentNode !== document.head &&
+    !window.debug) {
+  warn('Put the A-Frame <script> tag in the <head> of the HTML *before* the scene to ' +
+       'ensure everything for A-Frame is properly registered before they are used from ' +
+       'HTML.');
 }
 
 // Polyfill `Promise`.
@@ -90,6 +91,7 @@ module.exports = window.AFRAME = {
     getMeshMixin: require('./extras/primitives/getMeshMixin'),
     primitives: require('./extras/primitives/primitives').primitives
   },
+  scenes: require('./core/scene/scenes'),
   schema: require('./core/schema'),
   shaders: shaders,
   systems: systems,

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -3,8 +3,10 @@ var AEntity = require('core/a-entity');
 var ANode = require('core/a-node');
 var AScene = require('core/scene/a-scene');
 var components = require('core/component').components;
-var helpers = require('../../helpers');
+var scenes = require('core/scene/scenes');
 var systems = require('core/system').systems;
+
+var helpers = require('../../helpers');
 
 /**
  * Tests in this suite should not involve WebGL contexts or renderer.
@@ -406,5 +408,35 @@ helpers.getSkipCISuite()('a-scene (with renderer)', function () {
     scene.render();
     sinon.assert.called(Component.tick);
     sinon.assert.calledWith(Component.tick, scene.time);
+  });
+});
+
+suite('scenes', function () {
+  var sceneEl;
+
+  setup(function () {
+    scenes.length = 0;
+    sceneEl = document.createElement('a-scene');
+  });
+
+  test('is appended with scene attach', function (done) {
+    assert.notOk(scenes.length);
+    sceneEl.addEventListener('loaded', () => {
+      assert.ok(scenes.length);
+      done();
+    });
+    document.body.appendChild(sceneEl);
+  });
+
+  test('is popped with scene detached', function (done) {
+    sceneEl.addEventListener('loaded', () => {
+      assert.ok(scenes.length);
+      document.body.removeChild(sceneEl);
+      setTimeout(() => {
+        assert.notOk(scenes.length);
+        done();
+      });
+    });
+    document.body.appendChild(sceneEl);
   });
 });


### PR DESCRIPTION
**Description:**

Store attached scene in an array.

When registering a component, compare document position of the script to the scene.

Also check if the scene hasn't loaded because we only care about static registration. If components are fetched and injected while the scene is already loaded, then that should be OK as further uses of the component will work.

**Changes proposed:**
- Cache that regex.
- Tweak case insensitive warning.

