### PR TITLE
[docs] add more notes to guides about using a local server

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -266,8 +266,8 @@ image, or a 360&deg; video. For example, a dark gray background would be:
 
 ## Applying an Image Texture
 
-> From this point on, you must be serving your HTML over a Web server (such as a local
-> [Mongoose](https://www.cesanta.com/products/binary)) for image textures to load.
+> Make sure you're [serving your HTML using a local server](../introduction/getting-started.md#using-a-local-server)
+> for textures to load properly.
 
 We can apply an image texture to the box with an image, video, or `<canvas>`
 using the `src` attribute, just like we would with a normal `<img>` element.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -266,6 +266,9 @@ image, or a 360&deg; video. For example, a dark gray background would be:
 
 ## Applying an Image Texture
 
+> From this point on, you must be serving your HTML over a Web server (such as a local
+> [Mongoose](https://www.cesanta.com/products/binary)) for image textures to load.
+
 We can apply an image texture to the box with an image, video, or `<canvas>`
 using the `src` attribute, just like we would with a normal `<img>` element.
 We also should remove the `color="red"` that we set so that the color doesn't

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -41,20 +41,7 @@ We can grab the boilerplate in one of two ways:
 
 <a class="btn btn-download" href="https://github.com/aframevr/aframe-boilerplate/archive/master.zip" download="aframe-boilerplate.zip">Download .ZIP<span></span></a>
 
-We should develop with a local server so that files are properly served. We can either:
-
-- Download the [Mongoose](https://www.cesanta.com/products/binary) application
-  and open it from the same directory as your HTML file.
-- Or use Node and npm to start the local server with `npm install && npm run start`.
-
-[angle]: https://www.npmjs.com/package/angle
-
-If you have npm, you can get started with scene template right from the command
-line with [`angle`][angle], a command line interface for A-Frame:
-
-```sh
-npm install -g angle && angle initscene
-```
+In either case, it is important to [deploy the boilerplate from a local server](#deploy-local) so that assets load correctly.
 
 ## Include the JS Build
 
@@ -73,6 +60,8 @@ If we want to serve it locally, we can download the JS build:
 <a id="builds-prod" class="btn btn-download" href="https://aframe.io/releases/0.4.0/aframe.min.js" download>Production Version <span>0.4.0</span></a> <em class="install-note">Minified</em>
 <a id="builds-dev" class="btn btn-download" href="https://aframe.io/releases/0.4.0/aframe.js" download>Development Version <span>0.4.0</span></a> <em class="install-note">Uncompressed with Source Maps</em>
 
+It is important to [deploy the HTML from a local server](#deploy-local) so that assets load correctly.
+
 ## Install from npm
 
 For more advanced users who want to use their own build steps, we can install through npm:
@@ -89,6 +78,25 @@ Then we can just require A-Frame from our app, perhaps built with Browserify or 
 
 ```js
 require('aframe');
+```
+
+<a id="deploy-local"></a>
+
+## Deploy from Local Server
+
+We should develop with a local server so that files are properly served. We can either:
+
+- Download the [Mongoose](https://www.cesanta.com/products/binary) application
+  and open it from the same directory as your HTML file.
+- Or use Node and npm to start the local server with `npm install && npm run start`.
+
+[angle]: https://www.npmjs.com/package/angle
+
+If you have npm, you can get started with scene template right from the command
+line with [`angle`][angle], a command line interface for A-Frame:
+
+```sh
+npm install -g angle && angle initscene
 ```
 
 [codepen]: http://codepen.io/team/mozvr/pen/BjygdO

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -41,7 +41,7 @@ We can grab the boilerplate in one of two ways:
 
 <a class="btn btn-download" href="https://github.com/aframevr/aframe-boilerplate/archive/master.zip" download="aframe-boilerplate.zip">Download .ZIP<span></span></a>
 
-In either case, it is important to [deploy the boilerplate from a local server](#deploy-local) so that assets load correctly.
+In either case, it is important to [serve the boilerplate from a local server](#using-a-local-server) so that assets load correctly.
 
 ## Include the JS Build
 
@@ -60,7 +60,7 @@ If we want to serve it locally, we can download the JS build:
 <a id="builds-prod" class="btn btn-download" href="https://aframe.io/releases/0.4.0/aframe.min.js" download>Production Version <span>0.4.0</span></a> <em class="install-note">Minified</em>
 <a id="builds-dev" class="btn btn-download" href="https://aframe.io/releases/0.4.0/aframe.js" download>Development Version <span>0.4.0</span></a> <em class="install-note">Uncompressed with Source Maps</em>
 
-It is important to [deploy the HTML from a local server](#deploy-local) so that assets load correctly.
+It is important to [serve the HTML from a local server](#using-a-local-server) so that assets load correctly.
 
 ## Install from npm
 
@@ -80,15 +80,13 @@ Then we can just require A-Frame from our app, perhaps built with Browserify or 
 require('aframe');
 ```
 
-<a id="deploy-local"></a>
-
-## Deploy from Local Server
+## Using a Local Server
 
 We should develop with a local server so that files are properly served. We can either:
 
 - Download the [Mongoose](https://www.cesanta.com/products/binary) application
   and open it from the same directory as your HTML file.
-- Or use Node and npm to start the local server with `npm install && npm run start`.
+- Use Node and npm to start the local server with `npm install && npm run start`.
 
 [angle]: https://www.npmjs.com/package/angle
 


### PR DESCRIPTION
I understand this is mentioned briefly in `getting-started.md`, but it's done as kind of an option? It implies you can either 'Grab the Boilerplate' _or_ 'Include the JS Build' (from CDN). And indeed the latter will work up to a point, but it breaks at this step.
