### PR TITLE
allow grabbing the canvas from screenshot component

### DIFF
--- a/docs/components/screenshot.md
+++ b/docs/components/screenshot.md
@@ -5,38 +5,44 @@ layout: docs
 parent_section: components
 ---
 
-The screenshot component lets us take different types of screenshots by using
+The screenshot component lets us take different types of screenshots with
 keyboard shortcuts. A-Frame attaches this component to the scene by default so
-it's automatically available.
+we don't have to do anything to use the component.
 
-To take a normal (perspective) screenshot, use the keyboard shortcut (`<ctrl> + <alt>
-+s`).
+## Shortcuts
 
-To take a 360&deg; (equirectangular) screenshot, use the keyboard shortcut
-(`<ctrl> + <alt> + <shift> +s`).
+### Equirectangular Screenshot
 
-To take a screenshot programmatically, call the component
+To take a 360&deg; (equirectangular) screenshot, press `<ctrl> + <alt> + <shift> + s`
+on the keyboard.
 
-```javascript
-// assuming your current scene is represented by sceneEl
-sceneEl.components.screenshot.capture('perspective')
-// projection property can be perspective or equirectangular
-```
+![Equirectangular Screenshot](https://cloud.githubusercontent.com/assets/674727/22461640/ea408ea4-e75e-11e6-9f8e-7566c4542587.png)
 
-## Example
+### Perspective Screenshot
 
-Unless we wish to customize the screenshot, explicitly setting the screenshot
-component is not needed since it's already attached to the scene by default.
-Otherwise, here's an example:
+To take a normal (perspective) screenshot, press `<ctrl> + <alt> + s` on the
+keyboard.
 
-```html
-<a-scene screenshot="projection: perspective"></a-scene>
-```
+![Perspective Screenshot](https://cloud.githubusercontent.com/assets/674727/22461641/ea43c218-e75e-11e6-8c5e-84c0bd2d691b.png)
 
 ## Properties
 
-| Property   | Description                                                    | Default Value   |
-|------------|----------------------------------------------------------------|-----------------|
-| width      | The width in pixels of the screenshot taken.                   | 4096            |
-| height     | The height in pixels of the screenshot taken.                  | 2048            |
-| projection | The screenshot type: `perspective` or `equirectangular`.       | equirectangular |
+| Property   | Description                                               | Default Value   |
+|------------|-----------------------------------------------------------|-----------------|
+| width      | The width in pixels of the screenshot taken.              | 4096            |
+| height     | The height in pixels of the screenshot taken.             | 2048            |
+
+## Methods
+
+To take a screenshot programatically and get a canvas, call `getCanvas()`:
+
+```js
+// `screenshot.projection` property can be `equirectangular` or `perspective`.
+document.querySelector('a-scene').components.screenshot.getCanvas('equirectangular');
+```
+
+To take a screenshot programmatically and automatically save the file, call `capture()`:
+
+```js
+document.querySelector('a-scene').components.screenshot.capture('perspective')
+```

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -121,13 +121,13 @@ module.exports.Component = registerComponent('screenshot', {
   /**
    * <ctrl> + <alt> + s = regular screenshot
    * <ctrl> + <alt> + <shift> + s = equirectangular screenshot
-   //  */
-  // onKeyDown: function (evt) {
-  //  var shortcutPressed = evt.keyCode === 83 && evt.ctrlKey && evt.altKey;
-  //  if (!this.data || !shortcutPressed) { return; }
-  //  var projection = evt.shiftKey ? 'equirectangular' : 'perspective';
-  //  this.capture(projection);
-  // },
+  */
+  onKeyDown: function (evt) {
+    var shortcutPressed = evt.keyCode === 83 && evt.ctrlKey && evt.altKey;
+    if (!this.data || !shortcutPressed) { return; }
+    var projection = evt.shiftKey ? 'equirectangular' : 'perspective';
+    this.capture(projection);
+  },
 
   /**
    * Captures a screenshot of the scene

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -135,8 +135,7 @@ module.exports.Component = registerComponent('screenshot', {
    * @param {string} projection - Screenshot projection (equirectangular | perspective)
    */
 
-  setCapture : function (projection) {
-
+  setCapture: function (projection) {
     var el = this.el;
     var renderer = el.renderer;
     var size;
@@ -168,10 +167,10 @@ module.exports.Component = registerComponent('screenshot', {
       this.quad.visible = true;
     }
     return {
-      camera : camera,
-      size : size,
-      projection : projection
-    }
+      camera: camera,
+      size: size,
+      projection: projection
+    };
   },
 
   // maintained for backwards compat
@@ -183,7 +182,7 @@ module.exports.Component = registerComponent('screenshot', {
   },
 
   // return canvas instead of triggering download
-  getCanvas : function (projection) {
+  getCanvas: function (projection) {
     var params = this.setCapture(projection);
     this.renderCapture(params.camera, params.size, params.projection);
     return this.canvas;

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -49,201 +49,201 @@ module.exports.Component = registerComponent('screenshot', {
     height: {default: 2048}
   },
 
-	init: function () {
-		var el = this.el;
-		var self = this;
-		if (el.renderer) {
-			setup();
-		} else {
-			el.addEventListener('render-target-loaded', setup);
-		}
-		function setup () {
-			var gl = el.renderer.getContext();
-			self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
-			self.material = new THREE.RawShaderMaterial({
-				uniforms: {map: {type: 't', value: null}},
-				vertexShader: VERTEX_SHADER,
-				fragmentShader: FRAGMENT_SHADER,
-				side: THREE.DoubleSide
-			});
-			self.quad = new THREE.Mesh(
-				new THREE.PlaneBufferGeometry(1, 1),
-				self.material
-			);
-			self.quad.visible = false;
-			self.camera = new THREE.OrthographicCamera(1 / -2, 1 / 2, 1 / 2, 1 / -2, -10000, 10000);
-			self.canvas = document.createElement('canvas');
-			self.ctx = self.canvas.getContext('2d');
-			if (el.camera) { el.camera.add(self.quad); }
-			self.onKeyDown = self.onKeyDown.bind(self);
-			self.onCameraActive = self.onCameraActive.bind(self);
-			el.addEventListener('camera-set-active', self.onCameraActive);
-		}
-	},
+  init: function () {
+    var el = this.el;
+    var self = this;
+    if (el.renderer) {
+      setup();
+    } else {
+      el.addEventListener('render-target-loaded', setup);
+    }
+    function setup () {
+      var gl = el.renderer.getContext();
+      self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+      self.material = new THREE.RawShaderMaterial({
+        uniforms: {map: {type: 't', value: null}},
+        vertexShader: VERTEX_SHADER,
+        fragmentShader: FRAGMENT_SHADER,
+        side: THREE.DoubleSide
+      });
+      self.quad = new THREE.Mesh(
+        new THREE.PlaneBufferGeometry(1, 1),
+        self.material
+      );
+      self.quad.visible = false;
+      self.camera = new THREE.OrthographicCamera(1 / -2, 1 / 2, 1 / 2, 1 / -2, -10000, 10000);
+      self.canvas = document.createElement('canvas');
+      self.ctx = self.canvas.getContext('2d');
+      if (el.camera) { el.camera.add(self.quad); }
+      self.onKeyDown = self.onKeyDown.bind(self);
+      self.onCameraActive = self.onCameraActive.bind(self);
+      el.addEventListener('camera-set-active', self.onCameraActive);
+    }
+  },
 
-	getRenderTarget: function (width, height) {
-		return new THREE.WebGLRenderTarget(width, height, {
-			minFilter: THREE.LinearFilter,
-			magFilter: THREE.LinearFilter,
-			wrapS: THREE.ClampToEdgeWrapping,
-			wrapT: THREE.ClampToEdgeWrapping,
-			format: THREE.RGBAFormat,
-			type: THREE.UnsignedByteType
-		});
-	},
+  getRenderTarget: function (width, height) {
+    return new THREE.WebGLRenderTarget(width, height, {
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      wrapS: THREE.ClampToEdgeWrapping,
+      wrapT: THREE.ClampToEdgeWrapping,
+      format: THREE.RGBAFormat,
+      type: THREE.UnsignedByteType
+    });
+  },
 
-	resize: function (width, height) {
-		// Resize quad
-		this.quad.scale.set(width, height, 1);
+  resize: function (width, height) {
+    // Resize quad
+    this.quad.scale.set(width, height, 1);
 
-		// Resize Camera
-		this.camera.left = width / -2;
-		this.camera.right = width / 2;
-		this.camera.top = height / 2;
-		this.camera.bottom = height / -2;
-		this.camera.updateProjectionMatrix();
+    // Resize Camera
+    this.camera.left = width / -2;
+    this.camera.right = width / 2;
+    this.camera.top = height / 2;
+    this.camera.bottom = height / -2;
+    this.camera.updateProjectionMatrix();
 
-		// Resize canvas
-		this.canvas.width = width;
-		this.canvas.height = height;
-	},
+    // Resize canvas
+    this.canvas.width = width;
+    this.canvas.height = height;
+  },
 
-	play: function () {
-		window.addEventListener('keydown', this.onKeyDown);
-	},
+  play: function () {
+    window.addEventListener('keydown', this.onKeyDown);
+  },
 
-	onCameraActive: function (evt) {
-		var cameraParent = this.quad.parent;
-		if (cameraParent) { cameraParent.remove(this.quad); }
-		evt.detail.cameraEl.getObject3D('camera').add(this.quad);
-	},
+  onCameraActive: function (evt) {
+    var cameraParent = this.quad.parent;
+    if (cameraParent) { cameraParent.remove(this.quad); }
+    evt.detail.cameraEl.getObject3D('camera').add(this.quad);
+  },
 
-	/**
-	 * <ctrl> + <alt> + s = regular screenshot
-	 * <ctrl> + <alt> + <shift> + s = equirectangular screenshot
-	 //  */
-	// onKeyDown: function (evt) {
-	// 	var shortcutPressed = evt.keyCode === 83 && evt.ctrlKey && evt.altKey;
-	// 	if (!this.data || !shortcutPressed) { return; }
-	// 	var projection = evt.shiftKey ? 'equirectangular' : 'perspective';
-	// 	this.capture(projection);
-	// },
+  /**
+   * <ctrl> + <alt> + s = regular screenshot
+   * <ctrl> + <alt> + <shift> + s = equirectangular screenshot
+   //  */
+  // onKeyDown: function (evt) {
+  //  var shortcutPressed = evt.keyCode === 83 && evt.ctrlKey && evt.altKey;
+  //  if (!this.data || !shortcutPressed) { return; }
+  //  var projection = evt.shiftKey ? 'equirectangular' : 'perspective';
+  //  this.capture(projection);
+  // },
 
-	/**
-	 * Captures a screenshot of the scene
-	 *
-	 * @param {string} projection - Screenshot projection (equirectangular | perspective)
-	 */
+  /**
+   * Captures a screenshot of the scene
+   *
+   * @param {string} projection - Screenshot projection (equirectangular | perspective)
+   */
 
-	setCapture : function (projection) {
+  setCapture : function (projection) {
 
-		var el = this.el;
-		var renderer = el.renderer;
-		var size;
-		var camera;
-		var cubeCamera;
-		// Configure camera
-		if (projection === 'perspective') {
-			// the quad is used for projection in the equirectangular mode
-			// we hide it in this case.
-			this.quad.visible = false;
-			// use scene camera
-			camera = el.camera;
-			size = renderer.getSize();
-		} else {
-			// use ortho camera
-			camera = this.camera;
-			// copy position and rotation of scene camera into the ortho one
-			camera.position.copy(el.camera.getWorldPosition());
-			camera.rotation.copy(el.camera.getWorldRotation());
-			// create cube camera and copy position from scene camera
-			cubeCamera = new THREE.CubeCamera(el.camera.near, el.camera.far, Math.min(this.cubeMapSize, 2048));
-			cubeCamera.position.copy(el.camera.getWorldPosition());
-			cubeCamera.rotation.copy(el.camera.getWorldRotation());
-			// render scene with cube camera
-			cubeCamera.updateCubeMap(el.renderer, el.object3D);
-			this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;
-			size = {width: this.data.width, height: this.data.height};
-			// use quad to project image taken by the cube camera
-			this.quad.visible = true;
-		}
-		return {
-			camera : camera,
-			size : size,
-			projection : projection
-		}
-	},
+    var el = this.el;
+    var renderer = el.renderer;
+    var size;
+    var camera;
+    var cubeCamera;
+    // Configure camera
+    if (projection === 'perspective') {
+      // the quad is used for projection in the equirectangular mode
+      // we hide it in this case.
+      this.quad.visible = false;
+      // use scene camera
+      camera = el.camera;
+      size = renderer.getSize();
+    } else {
+      // use ortho camera
+      camera = this.camera;
+      // copy position and rotation of scene camera into the ortho one
+      camera.position.copy(el.camera.getWorldPosition());
+      camera.rotation.copy(el.camera.getWorldRotation());
+      // create cube camera and copy position from scene camera
+      cubeCamera = new THREE.CubeCamera(el.camera.near, el.camera.far, Math.min(this.cubeMapSize, 2048));
+      cubeCamera.position.copy(el.camera.getWorldPosition());
+      cubeCamera.rotation.copy(el.camera.getWorldRotation());
+      // render scene with cube camera
+      cubeCamera.updateCubeMap(el.renderer, el.object3D);
+      this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;
+      size = {width: this.data.width, height: this.data.height};
+      // use quad to project image taken by the cube camera
+      this.quad.visible = true;
+    }
+    return {
+      camera : camera,
+      size : size,
+      projection : projection
+    }
+  },
 
-	// maintained for backwards compat
-	capture: function (projection) {
-		var params = this.setCapture(projection);
-		this.renderCapture(params.camera, params.size, params.projection);
-		// Trigger file download
-		this.saveCapture();
-	},
+  // maintained for backwards compat
+  capture: function (projection) {
+    var params = this.setCapture(projection);
+    this.renderCapture(params.camera, params.size, params.projection);
+    // Trigger file download
+    this.saveCapture();
+  },
 
-	// return canvas instead of triggering download
-	getCanvas : function (projection) {
-		var params = this.setCapture(projection);
-		this.renderCapture(params.camera, params.size, params.projection);
-		return this.canvas;
-	},
+  // return canvas instead of triggering download
+  getCanvas : function (projection) {
+    var params = this.setCapture(projection);
+    this.renderCapture(params.camera, params.size, params.projection);
+    return this.canvas;
+  },
 
-	renderCapture: function (camera, size, projection) {
-		var autoClear = this.el.renderer.autoClear;
-		var el = this.el;
-		var imageData;
-		var output;
-		var pixels;
-		var renderer = this.el.renderer;
-		// Create rendering target and buffer to store the read pixels
-		output = this.getRenderTarget(size.width, size.height);
-		pixels = new Uint8Array(4 * size.width * size.height);
-		// Resize quad, camera and canvas
-		this.resize(size.width, size.height);
-		// Render scene to render target
-		renderer.autoClear = true;
-		renderer.render(el.object3D, camera, output, true);
-		renderer.autoClear = autoClear;
-		// Read image pizels back
-		renderer.readRenderTargetPixels(output, 0, 0, size.width, size.height, pixels);
-		if (projection === 'perspective') {
-			pixels = this.flipPixelsVertically(pixels, size.width, size.height);
-		}
-		imageData = new ImageData(new Uint8ClampedArray(pixels), size.width, size.height);
-		// Hide quad after projecting the image
-		this.quad.visible = false;
-		// Copy pixels into canvas
-		this.ctx.putImageData(imageData, 0, 0);
-	},
+  renderCapture: function (camera, size, projection) {
+    var autoClear = this.el.renderer.autoClear;
+    var el = this.el;
+    var imageData;
+    var output;
+    var pixels;
+    var renderer = this.el.renderer;
+    // Create rendering target and buffer to store the read pixels
+    output = this.getRenderTarget(size.width, size.height);
+    pixels = new Uint8Array(4 * size.width * size.height);
+    // Resize quad, camera and canvas
+    this.resize(size.width, size.height);
+    // Render scene to render target
+    renderer.autoClear = true;
+    renderer.render(el.object3D, camera, output, true);
+    renderer.autoClear = autoClear;
+    // Read image pizels back
+    renderer.readRenderTargetPixels(output, 0, 0, size.width, size.height, pixels);
+    if (projection === 'perspective') {
+      pixels = this.flipPixelsVertically(pixels, size.width, size.height);
+    }
+    imageData = new ImageData(new Uint8ClampedArray(pixels), size.width, size.height);
+    // Hide quad after projecting the image
+    this.quad.visible = false;
+    // Copy pixels into canvas
+    this.ctx.putImageData(imageData, 0, 0);
+  },
 
-	flipPixelsVertically: function (pixels, width, height) {
-		var flippedPixels = pixels.slice(0);
-		for (var x = 0; x < width; ++x) {
-			for (var y = 0; y < height; ++y) {
-				flippedPixels[x * 4 + y * width * 4] = pixels[x * 4 + (height - y) * width * 4];
-				flippedPixels[x * 4 + 1 + y * width * 4] = pixels[x * 4 + 1 + (height - y) * width * 4];
-				flippedPixels[x * 4 + 2 + y * width * 4] = pixels[x * 4 + 2 + (height - y) * width * 4];
-				flippedPixels[x * 4 + 3 + y * width * 4] = pixels[x * 4 + 3 + (height - y) * width * 4];
-			}
-		}
-		return flippedPixels;
-	},
+  flipPixelsVertically: function (pixels, width, height) {
+    var flippedPixels = pixels.slice(0);
+    for (var x = 0; x < width; ++x) {
+      for (var y = 0; y < height; ++y) {
+        flippedPixels[x * 4 + y * width * 4] = pixels[x * 4 + (height - y) * width * 4];
+        flippedPixels[x * 4 + 1 + y * width * 4] = pixels[x * 4 + 1 + (height - y) * width * 4];
+        flippedPixels[x * 4 + 2 + y * width * 4] = pixels[x * 4 + 2 + (height - y) * width * 4];
+        flippedPixels[x * 4 + 3 + y * width * 4] = pixels[x * 4 + 3 + (height - y) * width * 4];
+      }
+    }
+    return flippedPixels;
+  },
 
-	saveCapture: function () {
-		this.canvas.toBlob(function (blob) {
-			var url = URL.createObjectURL(blob);
-			var fileName = 'screenshot-' + document.title + '-' + Date.now() + '.png';
-			var aEl = document.createElement('a');
-			aEl.href = url;
-			aEl.setAttribute('download', fileName);
-			aEl.innerHTML = 'downloading...';
-			aEl.style.display = 'none';
-			document.body.appendChild(aEl);
-			setTimeout(function () {
-				aEl.click();
-				document.body.removeChild(aEl);
-			}, 1);
-		}, 'image/png');
-	}
+  saveCapture: function () {
+    this.canvas.toBlob(function (blob) {
+      var url = URL.createObjectURL(blob);
+      var fileName = 'screenshot-' + document.title + '-' + Date.now() + '.png';
+      var aEl = document.createElement('a');
+      aEl.href = url;
+      aEl.setAttribute('download', fileName);
+      aEl.innerHTML = 'downloading...';
+      aEl.style.display = 'none';
+      document.body.appendChild(aEl);
+      setTimeout(function () {
+        aEl.click();
+        document.body.removeChild(aEl);
+      }, 1);
+    }, 'image/png');
+  }
 });

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -52,11 +52,13 @@ module.exports.Component = registerComponent('screenshot', {
   init: function () {
     var el = this.el;
     var self = this;
+
     if (el.renderer) {
       setup();
     } else {
       el.addEventListener('render-target-loaded', setup);
     }
+
     function setup () {
       var gl = el.renderer.getContext();
       self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
@@ -71,7 +73,7 @@ module.exports.Component = registerComponent('screenshot', {
         self.material
       );
       self.quad.visible = false;
-      self.camera = new THREE.OrthographicCamera(1 / -2, 1 / 2, 1 / 2, 1 / -2, -10000, 10000);
+      self.camera = new THREE.OrthographicCamera(-1 / 2, 1 / 2, 1 / 2, -1 / 2, -10000, 10000);
       self.canvas = document.createElement('canvas');
       self.ctx = self.canvas.getContext('2d');
       if (el.camera) { el.camera.add(self.quad); }
@@ -93,17 +95,17 @@ module.exports.Component = registerComponent('screenshot', {
   },
 
   resize: function (width, height) {
-    // Resize quad
+    // Resize quad.
     this.quad.scale.set(width, height, 1);
 
-    // Resize Camera
-    this.camera.left = width / -2;
+    // Resize camera.
+    this.camera.left = -1 * width / 2;
     this.camera.right = width / 2;
     this.camera.top = height / 2;
-    this.camera.bottom = height / -2;
+    this.camera.bottom = -1 * height / 2;
     this.camera.updateProjectionMatrix();
 
-    // Resize canvas
+    // Resize canvas.
     this.canvas.width = width;
     this.canvas.height = height;
   },
@@ -119,8 +121,8 @@ module.exports.Component = registerComponent('screenshot', {
   },
 
   /**
-   * <ctrl> + <alt> + s = regular screenshot
-   * <ctrl> + <alt> + <shift> + s = equirectangular screenshot
+   * <ctrl> + <alt> + s = Regular screenshot.
+   * <ctrl> + <alt> + <shift> + s = Equirectangular screenshot.
   */
   onKeyDown: function (evt) {
     var shortcutPressed = evt.keyCode === 83 && evt.ctrlKey && evt.altKey;
@@ -130,40 +132,39 @@ module.exports.Component = registerComponent('screenshot', {
   },
 
   /**
-   * Captures a screenshot of the scene
+   * Capture a screenshot of the scene.
    *
-   * @param {string} projection - Screenshot projection (equirectangular | perspective)
+   * @param {string} projection - Screenshot projection (equirectangular or perspective).
    */
-
   setCapture: function (projection) {
     var el = this.el;
     var renderer = el.renderer;
     var size;
     var camera;
     var cubeCamera;
-    // Configure camera
+    // Configure camera.
     if (projection === 'perspective') {
-      // the quad is used for projection in the equirectangular mode
-      // we hide it in this case.
+      // Quad is only used in equirectangular mode. Hide it in this case.
       this.quad.visible = false;
-      // use scene camera
+      // Use scene camera.
       camera = el.camera;
       size = renderer.getSize();
     } else {
-      // use ortho camera
+      // Use ortho camera.
       camera = this.camera;
-      // copy position and rotation of scene camera into the ortho one
+      // Copy position and rotation of scene camera into the ortho one.
       camera.position.copy(el.camera.getWorldPosition());
       camera.rotation.copy(el.camera.getWorldRotation());
-      // create cube camera and copy position from scene camera
-      cubeCamera = new THREE.CubeCamera(el.camera.near, el.camera.far, Math.min(this.cubeMapSize, 2048));
+      // Create cube camera and copy position from scene camera.
+      cubeCamera = new THREE.CubeCamera(el.camera.near, el.camera.far,
+                                        Math.min(this.cubeMapSize, 2048));
       cubeCamera.position.copy(el.camera.getWorldPosition());
       cubeCamera.rotation.copy(el.camera.getWorldRotation());
-      // render scene with cube camera
+      // Render scene with cube camera.
       cubeCamera.updateCubeMap(el.renderer, el.object3D);
       this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;
       size = {width: this.data.width, height: this.data.height};
-      // use quad to project image taken by the cube camera
+      // Use quad to project image taken by the cube camera.
       this.quad.visible = true;
     }
     return {
@@ -173,15 +174,19 @@ module.exports.Component = registerComponent('screenshot', {
     };
   },
 
-  // maintained for backwards compat
+  /**
+   * Maintained for backwards compatibility.
+   */
   capture: function (projection) {
     var params = this.setCapture(projection);
     this.renderCapture(params.camera, params.size, params.projection);
-    // Trigger file download
+    // Trigger file download.
     this.saveCapture();
   },
 
-  // return canvas instead of triggering download
+  /**
+   * Return canvas instead of triggering download (e.g., for uploading blob to server).
+   */
   getCanvas: function (projection) {
     var params = this.setCapture(projection);
     this.renderCapture(params.camera, params.size, params.projection);
@@ -195,24 +200,24 @@ module.exports.Component = registerComponent('screenshot', {
     var output;
     var pixels;
     var renderer = this.el.renderer;
-    // Create rendering target and buffer to store the read pixels
+    // Create rendering target and buffer to store the read pixels.
     output = this.getRenderTarget(size.width, size.height);
     pixels = new Uint8Array(4 * size.width * size.height);
-    // Resize quad, camera and canvas
+    // Resize quad, camera, and canvas.
     this.resize(size.width, size.height);
-    // Render scene to render target
+    // Render scene to render target.
     renderer.autoClear = true;
     renderer.render(el.object3D, camera, output, true);
     renderer.autoClear = autoClear;
-    // Read image pizels back
+    // Read image pizels back.
     renderer.readRenderTargetPixels(output, 0, 0, size.width, size.height, pixels);
     if (projection === 'perspective') {
       pixels = this.flipPixelsVertically(pixels, size.width, size.height);
     }
     imageData = new ImageData(new Uint8ClampedArray(pixels), size.width, size.height);
-    // Hide quad after projecting the image
+    // Hide quad after projecting the image.
     this.quad.visible = false;
-    // Copy pixels into canvas
+    // Copy pixels into canvas.
     this.ctx.putImageData(imageData, 0, 0);
   },
 
@@ -229,19 +234,22 @@ module.exports.Component = registerComponent('screenshot', {
     return flippedPixels;
   },
 
+  /**
+   * Download capture to file.
+   */
   saveCapture: function () {
     this.canvas.toBlob(function (blob) {
+      var fileName = 'screenshot-' + document.title.toLowerCase() + '-' + Date.now() + '.png';
+      var linkEl = document.createElement('a');
       var url = URL.createObjectURL(blob);
-      var fileName = 'screenshot-' + document.title + '-' + Date.now() + '.png';
-      var aEl = document.createElement('a');
-      aEl.href = url;
-      aEl.setAttribute('download', fileName);
-      aEl.innerHTML = 'downloading...';
-      aEl.style.display = 'none';
-      document.body.appendChild(aEl);
+      linkEl.href = url;
+      linkEl.setAttribute('download', fileName);
+      linkEl.innerHTML = 'downloading...';
+      linkEl.style.display = 'none';
+      document.body.appendChild(linkEl);
       setTimeout(function () {
-        aEl.click();
-        document.body.removeChild(aEl);
+        linkEl.click();
+        document.body.removeChild(linkEl);
       }, 1);
     }, 'image/png');
   }

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -49,182 +49,201 @@ module.exports.Component = registerComponent('screenshot', {
     height: {default: 2048}
   },
 
-  init: function () {
-    var el = this.el;
-    var self = this;
-    if (el.renderer) {
-      setup();
-    } else {
-      el.addEventListener('render-target-loaded', setup);
-    }
-    function setup () {
-      var gl = el.renderer.getContext();
-      self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
-      self.material = new THREE.RawShaderMaterial({
-        uniforms: {map: {type: 't', value: null}},
-        vertexShader: VERTEX_SHADER,
-        fragmentShader: FRAGMENT_SHADER,
-        side: THREE.DoubleSide
-      });
-      self.quad = new THREE.Mesh(
-        new THREE.PlaneBufferGeometry(1, 1),
-        self.material
-      );
-      self.quad.visible = false;
-      self.camera = new THREE.OrthographicCamera(1 / -2, 1 / 2, 1 / 2, 1 / -2, -10000, 10000);
-      self.canvas = document.createElement('canvas');
-      self.ctx = self.canvas.getContext('2d');
-      if (el.camera) { el.camera.add(self.quad); }
-      self.onKeyDown = self.onKeyDown.bind(self);
-      self.onCameraActive = self.onCameraActive.bind(self);
-      el.addEventListener('camera-set-active', self.onCameraActive);
-    }
-  },
+	init: function () {
+		var el = this.el;
+		var self = this;
+		if (el.renderer) {
+			setup();
+		} else {
+			el.addEventListener('render-target-loaded', setup);
+		}
+		function setup () {
+			var gl = el.renderer.getContext();
+			self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+			self.material = new THREE.RawShaderMaterial({
+				uniforms: {map: {type: 't', value: null}},
+				vertexShader: VERTEX_SHADER,
+				fragmentShader: FRAGMENT_SHADER,
+				side: THREE.DoubleSide
+			});
+			self.quad = new THREE.Mesh(
+				new THREE.PlaneBufferGeometry(1, 1),
+				self.material
+			);
+			self.quad.visible = false;
+			self.camera = new THREE.OrthographicCamera(1 / -2, 1 / 2, 1 / 2, 1 / -2, -10000, 10000);
+			self.canvas = document.createElement('canvas');
+			self.ctx = self.canvas.getContext('2d');
+			if (el.camera) { el.camera.add(self.quad); }
+			//self.onKeyDown = self.onKeyDown.bind(self);
+			self.onCameraActive = self.onCameraActive.bind(self);
+			el.addEventListener('camera-set-active', self.onCameraActive);
+		}
+	},
 
-  getRenderTarget: function (width, height) {
-    return new THREE.WebGLRenderTarget(width, height, {
-      minFilter: THREE.LinearFilter,
-      magFilter: THREE.LinearFilter,
-      wrapS: THREE.ClampToEdgeWrapping,
-      wrapT: THREE.ClampToEdgeWrapping,
-      format: THREE.RGBAFormat,
-      type: THREE.UnsignedByteType
-    });
-  },
+	getRenderTarget: function (width, height) {
+		return new THREE.WebGLRenderTarget(width, height, {
+			minFilter: THREE.LinearFilter,
+			magFilter: THREE.LinearFilter,
+			wrapS: THREE.ClampToEdgeWrapping,
+			wrapT: THREE.ClampToEdgeWrapping,
+			format: THREE.RGBAFormat,
+			type: THREE.UnsignedByteType
+		});
+	},
 
-  resize: function (width, height) {
-    // Resize quad
-    this.quad.scale.set(width, height, 1);
+	resize: function (width, height) {
+		// Resize quad
+		this.quad.scale.set(width, height, 1);
 
-    // Resize Camera
-    this.camera.left = width / -2;
-    this.camera.right = width / 2;
-    this.camera.top = height / 2;
-    this.camera.bottom = height / -2;
-    this.camera.updateProjectionMatrix();
+		// Resize Camera
+		this.camera.left = width / -2;
+		this.camera.right = width / 2;
+		this.camera.top = height / 2;
+		this.camera.bottom = height / -2;
+		this.camera.updateProjectionMatrix();
 
-    // Resize canvas
-    this.canvas.width = width;
-    this.canvas.height = height;
-  },
+		// Resize canvas
+		this.canvas.width = width;
+		this.canvas.height = height;
+	},
 
-  play: function () {
-    window.addEventListener('keydown', this.onKeyDown);
-  },
+	play: function () {
+		window.addEventListener('keydown', this.onKeyDown);
+	},
 
-  onCameraActive: function (evt) {
-    var cameraParent = this.quad.parent;
-    if (cameraParent) { cameraParent.remove(this.quad); }
-    evt.detail.cameraEl.getObject3D('camera').add(this.quad);
-  },
+	onCameraActive: function (evt) {
+		var cameraParent = this.quad.parent;
+		if (cameraParent) { cameraParent.remove(this.quad); }
+		evt.detail.cameraEl.getObject3D('camera').add(this.quad);
+	},
 
-  /**
-   * <ctrl> + <alt> + s = regular screenshot
-   * <ctrl> + <alt> + <shift> + s = equirectangular screenshot
-   */
-  onKeyDown: function (evt) {
-    var shortcutPressed = evt.keyCode === 83 && evt.ctrlKey && evt.altKey;
-    if (!this.data || !shortcutPressed) { return; }
-    var projection = evt.shiftKey ? 'equirectangular' : 'perspective';
-    this.capture(projection);
-  },
+	/**
+	 * <ctrl> + <alt> + s = regular screenshot
+	 * <ctrl> + <alt> + <shift> + s = equirectangular screenshot
+	 //  */
+	// onKeyDown: function (evt) {
+	// 	var shortcutPressed = evt.keyCode === 83 && evt.ctrlKey && evt.altKey;
+	// 	if (!this.data || !shortcutPressed) { return; }
+	// 	var projection = evt.shiftKey ? 'equirectangular' : 'perspective';
+	// 	this.capture(projection);
+	// },
 
-  /**
-   * Captures a screenshot of the scene
-   *
-   * @param {string} projection - Screenshot projection (equirectangular | perspective)
-   */
-  capture: function (projection) {
-    var el = this.el;
-    var renderer = el.renderer;
-    var size;
-    var camera;
-    var cubeCamera;
-    // Configure camera
-    if (projection === 'perspective') {
-      // the quad is used for projection in the equirectangular mode
-      // we hide it in this case.
-      this.quad.visible = false;
-      // use scene camera
-      camera = el.camera;
-      size = renderer.getSize();
-    } else {
-      // use ortho camera
-      camera = this.camera;
-      // copy position and rotation of scene camera into the ortho one
-      camera.position.copy(el.camera.getWorldPosition());
-      camera.rotation.copy(el.camera.getWorldRotation());
-      // create cube camera and copy position from scene camera
-      cubeCamera = new THREE.CubeCamera(el.camera.near, el.camera.far, Math.min(this.cubeMapSize, 2048));
-      cubeCamera.position.copy(el.camera.getWorldPosition());
-      cubeCamera.rotation.copy(el.camera.getWorldRotation());
-      // render scene with cube camera
-      cubeCamera.updateCubeMap(el.renderer, el.object3D);
-      this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;
-      size = {width: this.data.width, height: this.data.height};
-      // use quad to project image taken by the cube camera
-      this.quad.visible = true;
-    }
-    this.renderCapture(camera, size, projection);
-    // Trigger file download
-    this.saveCapture();
-  },
+	/**
+	 * Captures a screenshot of the scene
+	 *
+	 * @param {string} projection - Screenshot projection (equirectangular | perspective)
+	 */
 
-  renderCapture: function (camera, size, projection) {
-    var autoClear = this.el.renderer.autoClear;
-    var el = this.el;
-    var imageData;
-    var output;
-    var pixels;
-    var renderer = this.el.renderer;
-    // Create rendering target and buffer to store the read pixels
-    output = this.getRenderTarget(size.width, size.height);
-    pixels = new Uint8Array(4 * size.width * size.height);
-    // Resize quad, camera and canvas
-    this.resize(size.width, size.height);
-    // Render scene to render target
-    renderer.autoClear = true;
-    renderer.render(el.object3D, camera, output, true);
-    renderer.autoClear = autoClear;
-    // Read image pizels back
-    renderer.readRenderTargetPixels(output, 0, 0, size.width, size.height, pixels);
-    if (projection === 'perspective') {
-      pixels = this.flipPixelsVertically(pixels, size.width, size.height);
-    }
-    imageData = new ImageData(new Uint8ClampedArray(pixels), size.width, size.height);
-    // Hide quad after projecting the image
-    this.quad.visible = false;
-    // Copy pixels into canvas
-    this.ctx.putImageData(imageData, 0, 0);
-  },
+	setCapture : function (projection) {
 
-  flipPixelsVertically: function (pixels, width, height) {
-    var flippedPixels = pixels.slice(0);
-    for (var x = 0; x < width; ++x) {
-      for (var y = 0; y < height; ++y) {
-        flippedPixels[x * 4 + y * width * 4] = pixels[x * 4 + (height - y) * width * 4];
-        flippedPixels[x * 4 + 1 + y * width * 4] = pixels[x * 4 + 1 + (height - y) * width * 4];
-        flippedPixels[x * 4 + 2 + y * width * 4] = pixels[x * 4 + 2 + (height - y) * width * 4];
-        flippedPixels[x * 4 + 3 + y * width * 4] = pixels[x * 4 + 3 + (height - y) * width * 4];
-      }
-    }
-    return flippedPixels;
-  },
+		var el = this.el;
+		var renderer = el.renderer;
+		var size;
+		var camera;
+		var cubeCamera;
+		// Configure camera
+		if (projection === 'perspective') {
+			// the quad is used for projection in the equirectangular mode
+			// we hide it in this case.
+			this.quad.visible = false;
+			// use scene camera
+			camera = el.camera;
+			size = renderer.getSize();
+		} else {
+			// use ortho camera
+			camera = this.camera;
+			// copy position and rotation of scene camera into the ortho one
+			camera.position.copy(el.camera.getWorldPosition());
+			camera.rotation.copy(el.camera.getWorldRotation());
+			// create cube camera and copy position from scene camera
+			cubeCamera = new THREE.CubeCamera(el.camera.near, el.camera.far, Math.min(this.cubeMapSize, 2048));
+			cubeCamera.position.copy(el.camera.getWorldPosition());
+			cubeCamera.rotation.copy(el.camera.getWorldRotation());
+			// render scene with cube camera
+			cubeCamera.updateCubeMap(el.renderer, el.object3D);
+			this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;
+			size = {width: this.data.width, height: this.data.height};
+			// use quad to project image taken by the cube camera
+			this.quad.visible = true;
+		}
+		return {
+			camera : camera,
+			size : size,
+			projection : projection
+		}
+	},
 
-  saveCapture: function () {
-    this.canvas.toBlob(function (blob) {
-      var url = URL.createObjectURL(blob);
-      var fileName = 'screenshot-' + document.title + '-' + Date.now() + '.png';
-      var aEl = document.createElement('a');
-      aEl.href = url;
-      aEl.setAttribute('download', fileName);
-      aEl.innerHTML = 'downloading...';
-      aEl.style.display = 'none';
-      document.body.appendChild(aEl);
-      setTimeout(function () {
-        aEl.click();
-        document.body.removeChild(aEl);
-      }, 1);
-    }, 'image/png');
-  }
+	// maintained for backwards compat
+	capture: function (projection) {
+		var params = this.setCapture(projection);
+		this.renderCapture(params.camera, params.size, params.projection);
+		// Trigger file download
+		this.saveCapture();
+	},
+
+	// return canvas instead of triggering download
+	getCanvas : function (projection) {
+		var params = this.setCapture(projection);
+		this.renderCapture(params.camera, params.size, params.projection);
+		return this.canvas;
+	},
+
+	renderCapture: function (camera, size, projection) {
+		var autoClear = this.el.renderer.autoClear;
+		var el = this.el;
+		var imageData;
+		var output;
+		var pixels;
+		var renderer = this.el.renderer;
+		// Create rendering target and buffer to store the read pixels
+		output = this.getRenderTarget(size.width, size.height);
+		pixels = new Uint8Array(4 * size.width * size.height);
+		// Resize quad, camera and canvas
+		this.resize(size.width, size.height);
+		// Render scene to render target
+		renderer.autoClear = true;
+		renderer.render(el.object3D, camera, output, true);
+		renderer.autoClear = autoClear;
+		// Read image pizels back
+		renderer.readRenderTargetPixels(output, 0, 0, size.width, size.height, pixels);
+		if (projection === 'perspective') {
+			pixels = this.flipPixelsVertically(pixels, size.width, size.height);
+		}
+		imageData = new ImageData(new Uint8ClampedArray(pixels), size.width, size.height);
+		// Hide quad after projecting the image
+		this.quad.visible = false;
+		// Copy pixels into canvas
+		this.ctx.putImageData(imageData, 0, 0);
+	},
+
+	flipPixelsVertically: function (pixels, width, height) {
+		var flippedPixels = pixels.slice(0);
+		for (var x = 0; x < width; ++x) {
+			for (var y = 0; y < height; ++y) {
+				flippedPixels[x * 4 + y * width * 4] = pixels[x * 4 + (height - y) * width * 4];
+				flippedPixels[x * 4 + 1 + y * width * 4] = pixels[x * 4 + 1 + (height - y) * width * 4];
+				flippedPixels[x * 4 + 2 + y * width * 4] = pixels[x * 4 + 2 + (height - y) * width * 4];
+				flippedPixels[x * 4 + 3 + y * width * 4] = pixels[x * 4 + 3 + (height - y) * width * 4];
+			}
+		}
+		return flippedPixels;
+	},
+
+	saveCapture: function () {
+		this.canvas.toBlob(function (blob) {
+			var url = URL.createObjectURL(blob);
+			var fileName = 'screenshot-' + document.title + '-' + Date.now() + '.png';
+			var aEl = document.createElement('a');
+			aEl.href = url;
+			aEl.setAttribute('download', fileName);
+			aEl.innerHTML = 'downloading...';
+			aEl.style.display = 'none';
+			document.body.appendChild(aEl);
+			setTimeout(function () {
+				aEl.click();
+				document.body.removeChild(aEl);
+			}, 1);
+		}, 'image/png');
+	}
 });

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -75,7 +75,7 @@ module.exports.Component = registerComponent('screenshot', {
 			self.canvas = document.createElement('canvas');
 			self.ctx = self.canvas.getContext('2d');
 			if (el.camera) { el.camera.add(self.quad); }
-			//self.onKeyDown = self.onKeyDown.bind(self);
+			self.onKeyDown = self.onKeyDown.bind(self);
 			self.onCameraActive = self.onCameraActive.bind(self);
 			el.addEventListener('camera-set-active', self.onCameraActive);
 		}

--- a/tests/components/scene/screenshot.test.js
+++ b/tests/components/scene/screenshot.test.js
@@ -1,18 +1,22 @@
-/* global assert, setup, suite, test, sinon */
-suite('screenshot', function () {
+/* global assert, setup, suite, test */
+suite.only('screenshot', function () {
+  var component;
+  var sceneEl;
+
   setup(function (done) {
-    var el = this.sceneEl = document.createElement('a-scene');
-    this.sinon = sinon.sandbox.create();
-    el.addEventListener('loaded', function () { done(); });
-    document.body.appendChild(el);
+    sceneEl = document.createElement('a-scene');
+    sceneEl.addEventListener('loaded', () => {
+      component = sceneEl.components.screenshot;
+      done();
+    });
+    document.body.appendChild(sceneEl);
   });
 
   test('capture is called when key shortcut is pressed', function () {
-    var el = this.sceneEl;
-    var captureStub = this.sinon.stub(el.components.screenshot, 'capture');
+    var captureStub = this.sinon.stub(component, 'capture');
     // Must call onKeyDown method directly because Chrome doesn't provide a reliable method
     // for KeyboardEvent.
-    el.components.screenshot.onKeyDown({
+    component.onKeyDown({
       keyCode: 83,
       altKey: true,
       ctrlKey: true


### PR DESCRIPTION


**Description:**
Added ability to get the canvas of a screengrab of the scene by doing `sceneEl.components.screenshot.getCanvas()` - in order that screengrabs could be programmatically uploaded to server etc. using .toBlob()

It's based on the existing `.capture()` method, and you can specify a projection (`equirectangular`) - default - or regular screenshots (`perspective`)

Hinted at in conversation here - https://github.com/aframevr/aframe/issues/926#issuecomment-261511950

**Changes proposed:**
- add .getCanvas() method, which returns a canvas object with rendered projection
- keep existing .capture() method, for backward compatability.
