### PR TITLE
ensure all components don't update if data has not changed (fixes #2322)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -198,10 +198,8 @@ Component.prototype = {
     }
     this.data = buildData(el, this.name, this.attrName, this.schema, this.attrValue);
 
-    // Don't update if properties haven't changed
-    if (!isSinglePropSchema && utils.deepEqual(oldData, this.data)) { return; }
-
     if (!this.initialized) {
+      // Initialize component.
       this.init();
       this.initialized = true;
       // Play the component if the entity is playing.
@@ -213,6 +211,10 @@ Component.prototype = {
         data: this.getData()
       }, false);
     } else {
+      // Don't update if properties haven't changed
+      if (utils.deepEqual(oldData, this.data)) { return; }
+
+      // Update component.
       this.update(oldData);
       el.emit('componentchanged', {
         id: this.id,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -110,25 +110,38 @@ module.exports.clone = function (obj) {
 };
 
 /**
- * Checks if two objects have the same attributes and values, including nested objects.
+ * Checks if two values are equal.
+ * Includes objects and arrays and nested objects and arrays.
+ * Try to keep this function performant as it will be called often to see if a component
+ * should be updated.
  *
  * @param {object} a - First object.
  * @param {object} b - Second object.
  * @returns {boolean} Whether two objects are deeply equal.
  */
 function deepEqual (a, b) {
-  var keysA = Object.keys(a);
-  var keysB = Object.keys(b);
+  var i;
+  var keysA;
+  var keysB;
   var valA;
   var valB;
-  var i;
+
+  // If not objects, compare as values.
+  if (typeof a !== 'object' || typeof b !== 'object' ||
+      a === null || b === null) { return a === b; }
+
+  // Different number of keys, not equal.
+  keysA = Object.keys(a);
+  keysB = Object.keys(b);
   if (keysA.length !== keysB.length) { return false; }
-  // If there are no keys, compare the objects.
-  if (keysA.length === 0) { return a === b; }
+
+  // Return `false` at the first sign of inequality.
   for (i = 0; i < keysA.length; ++i) {
     valA = a[keysA[i]];
     valB = b[keysA[i]];
-    if ((Array.isArray(valA) && Array.isArray(valB))) {
+    // Check nested array and object.
+    if ((typeof valA === 'object' || typeof valB === 'object') ||
+        (Array.isArray(valA) && Array.isArray(valB))) {
       if (!deepEqual(valA, valB)) { return false; }
     } else if (valA !== valB) {
       return false;

--- a/tests/utils/objects.test.js
+++ b/tests/utils/objects.test.js
@@ -61,6 +61,22 @@ suite('utils.objects', function () {
       assert.ok(deepEqual(objA, objB));
     });
 
+    test('can compare strings', function () {
+      var valA = 'abc';
+      var valB = 'abc';
+      var valC = 'def';
+      assert.ok(deepEqual(valA, valB));
+      assert.notOk(deepEqual(valA, valC));
+    });
+
+    test('can compare numbers', function () {
+      var valA = 1;
+      var valB = 1;
+      var valC = 2;
+      assert.ok(deepEqual(valA, valB));
+      assert.notOk(deepEqual(valA, valC));
+    });
+
     test('can compare for missing properties', function () {
       var objA = {id: 62, label: 'Foo', parent: null};
       var objB = {id: 62, label: 'Foo', parent: null, extraProp: true};
@@ -81,13 +97,30 @@ suite('utils.objects', function () {
       assert.notOk(deepEqual(objA, objC));
     });
 
-    /** SKIPPED: Comparison of nested objects is not yet implemented. */
-    test.skip('can compare nested objects', function () {
+    test('can compare nested objects', function () {
       var objA = {metadata: {source: 'Wikipedia, 2016'}};
       var objB = {metadata: {source: 'Wikipedia, 2016'}};
       var objC = {metadata: {source: 'Nature, 2015'}};
       assert.ok(deepEqual(objA, objB));
       assert.notOk(deepEqual(objA, objC));
+    });
+
+    test('can compare vec3s', function () {
+      var objA = {x: 0, y: 0, z: 0};
+      var objB = {x: 0, y: 0, z: 0};
+      var objC = {x: 1, y: 2, z: 3};
+      assert.ok(deepEqual(objA, objB));
+      assert.notOk(deepEqual(objA, objC));
+    });
+
+    test('can compare with null', function () {
+      assert.ok(deepEqual(null, null));
+      assert.notOk(deepEqual(null, {}));
+    });
+
+    test('can compare empty objects', function () {
+      assert.ok(deepEqual({}, {}));
+      assert.notOk(deepEqual({}, {a: 1}));
     });
   });
 });


### PR DESCRIPTION
**Description:**

**Changes proposed:**
- Do a equality check even if data is single-prop.
- Save an equality check on component initializations.
- Make utils.deepEqual handle simple values and nested objects.
- Unit tests for deepEquals and cases where componentChanged event should or should not fire.
