### PR TITLE
exclude dist/aframe-v* from npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 examples
 tests
+dist/aframe-v*
+dist/*min*


### PR DESCRIPTION
**Description:**

Shrink the npm install size by a few MB.