### PR TITLE
Point polyfill to private fork to fix low res issue on phones + problem with webview in android (fixes #1940, #2117)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "three": "^0.83.0",
     "three-bmfont-text": "^2.1.0",
     "tween.js": "^15.0.0",
-    "webvr-polyfill": "^0.9.23"
+    "webvr-polyfill": "dmarcos/webvr-polyfill#a02a8089b"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
…em with webview in android

The private fork cherry-picks a commit from a rejected PR (https://github.com/googlevr/webvr-polyfill/pull/175/commits/afd03b53c1830fb1073783b79112494deb9c0a0d) and makes `dpdb,json` local to the repo so we can easily add devices. 

@andymartinwork (from a-frame slack channel) confirmed that the webview issue is gone. We need more testing on the low res issue on more devices. We have to engage people to tell us if they're still having problems.
