### PR TITLE
Add shadow support.

### DIFF
--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -45,9 +45,10 @@ All light types support a few basic properties:
 | color     | Light color.                                                    | #fff          |
 | intensity | Light strength.                                                 | 1.0           |
 
-## Light types
+## Light Types
 
-Different types of lights include unique properties. We will go through each type, including its properties and when it may be the right choice.
+Different types of lights include unique properties. We will go through each
+type, including its properties and when it may be the right choice.
 
 ### Ambient
 
@@ -122,7 +123,10 @@ lit.
 
 ### Spot
 
-Spot lights are like point lights in the sense that they affect materials depending on its position and distance, but spot lights are not omni-directional. They mainly cast light in one direction, like the [Bat-Signal](https://en.wikipedia.org/wiki/Bat-Signal).
+Spot lights are like point lights in the sense that they affect materials
+depending on its position and distance, but spot lights are not
+omni-directional. They mainly cast light in one direction, like the
+[Bat-Signal](https://en.wikipedia.org/wiki/Bat-Signal).
 
 ```html
 <a-entity light="type: spot; angle: 45"></a-entity>
@@ -136,72 +140,97 @@ Spot lights are like point lights in the sense that they affect materials depend
 | penumbra    | Percent of the spotlight cone that is attenuated due to penumbra.                                              | 0.0           |
 | target      | element the spot should point to. set to null to transform spotlight by orientation, pointing to it's -Z axis. | null          |
 
-## Configuring shadows
+## Configuring Shadows
 
-A-Frame includes support for realtime shadow rendering. With proper configuration, objects — moving or stationary — will cast shadows adding depth and realism to a scene.
+[inspector]: ../guides/using-the-aframe-inspector.md
 
-Light types that support shadows (`point`, `spot`, and `directional`) include additional properties:
+A-Frame includes support for realtime shadow rendering. With proper
+configuration, objects (both moving or stationary) will cast shadows adding
+depth and realism to a scene. Since shadows come with many properties, it
+is very helpful to **[use the A-Frame Inspector to configure shadows][inspector]**
+
+Light types that support shadows (`point`, `spot`, and `directional`) include
+additional properties:
 
 | Property            | Light type      | Description                                                                                                                                | Default Value |
 |---------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | castShadow          |                 | Whether this light casts shadows on the scene.                                                                                             | false         |
 | shadowBias          |                 | Offset depth when deciding whether a surface is in shadow. Tiny adjustments here (in the order of 0.0001) may reduce artifacts in shadows. | 0             |
-| shadowCameraVisible |                 | Displays a visual aid showing the shadow camera's position and frustum. This is the light's view of the scene, used to project shadows.    | false         |
-| shadowCameraFar     |                 | Far plane of shadow camera frustum.                                                                                                        | 500           |
-| shadowCameraNear    |                 | Near plane of shadow camera frustum.                                                                                                       | 0.5           |
-| shadowCameraTop     | `directional`   | Top plane of shadow camera frustum.                                                                                                        | 5             |
-| shadowCameraRight   | `directional`   | Right plane of shadow camera frustum.                                                                                                      | 5             |
 | shadowCameraBottom  | `directional`   | Bottom plane of shadow camera frustum.                                                                                                     | -5            |
-| shadowCameraLeft    | `directional`   | Left plane of shadow camera frustum.                                                                                                       | -5            |
+| shadowCameraFar     |                 | Far plane of shadow camera frustum.                                                                                                        | 500           |
 | shadowCameraFov     | `point`, `spot` | Shadow camera's FOV.                                                                                                                       | 50            |
+| shadowCameraLeft    | `directional`   | Left plane of shadow camera frustum.                                                                                                       | -5            |
+| shadowCameraNear    |                 | Near plane of shadow camera frustum.                                                                                                       | 0.5           |
+| shadowCameraRight   | `directional`   | Right plane of shadow camera frustum.                                                                                                      | 5             |
+| shadowCameraTop     | `directional`   | Top plane of shadow camera frustum.                                                                                                        | 5             |
+| shadowCameraVisible |                 | Displays a visual aid showing the shadow camera's position and frustum. This is the light's view of the scene, used to project shadows.    | false         |
 | shadowMapHeight     |                 | Shadow map's vertical resolution. Larger shadow maps display more crisp shadows, at the cost of performance.                               | 512           |
 | shadowMapWidth      |                 | Shadow map's horizontal resolution.                                                                                                        | 512           |
 
-### Adding realtime shadows to a scene
+### Adding Real-Time Shadows
 
 [light-baking]: #todo
 
-> NOTE: Realtime shadows add performance overhead. When objects in a scene are stationary, or especially when optimizing for mobile devices, be aware of other techniques for realistic shadows, such as [baking light and shadow information into a texture][light-baking] before importing assets into A-Frame.
+> NOTE: Real-time shadows add performance overhead. When objects in a scene are
+> stationary, or especially when optimizing for mobile devices, be aware of
+> other techniques for realistic shadows, such as [baking light and shadow
+> information into a texture][light-baking] before importing assets into
+> A-Frame.
 
-* **1. Create at least one light** with `castShadows: true`. Three light types support shadows (`point`, `spot`, and `directional`). Of the three, `directional` lights will have the best performance. Combining an ambient light (without shadows) and a directional light (with shadows) is a good place to start.
+- **1. Create at least one light** with `castShadows: true`. Three light types
+  support shadows (`point`, `spot`, and `directional`). Of the three,
+  `directional` lights will have the best performance. Combining an ambient
+  light (without shadows) and a directional light (with shadows) is a good
+  place to start.
 
 ```html
 <a-scene>
-  <a-entity light="type:ambient; intensity: 0.5;"></a-entity>
-  <a-entity light="type:directional;
-                   castShadow:true;
+  <a-entity light="type: ambient; intensity: 0.5;"></a-entity>
+  <a-entity light="type: directional;
+                   castShadow: true;
                    intensity: 0.4;
                    shadowCameraVisible: true;"
             position="-5 3 1.5"></a-entity>
 </a-scene>
 ```
 
-In the example above, the directional light has lower intensity than the ambient light, for slightly softer shadows. Adding `shadowCameraVisible: true` creates a visual aid for debugging: objects outside the camera's view cannot cast or receive shadows.
+In the example above, the directional light has lower intensity than the
+ambient light, for slightly softer shadows. Adding `shadowCameraVisible: true`
+creates a visual aid for debugging: objects outside the camera's view cannot
+cast or receive shadows.
 
-* **2. Add the shadow component** to objects in the scene that should cast or receive shadows.
+- **2. Add the shadow component** to objects in the scene that should cast or
+  receive shadows.
 
 ```html
 <a-gltf-model src="tree.gltf" shadow="receive: false"></a-gltf-model>
 ```
 
-* **3. Adjust the shadow camera** position and frustum (`shadowCameraTop`, `shadowCameraRight`, ...) of the directional light, until it envelops the scene tightly. If the frustum is too small, shadows will be missing or partially clipped. If the frustum is too large, shadows will appear coarse or pixelated. The size of the shadow map (`shadowMapHeight: 512`, `shadowMapWidth: 512`) determines the resolution at which shadows are computed, so tightly sizing the shadow camera around your scene will make the best use of this resolution and device performance.
+- **3. Adjust the shadow camera** position and frustum (`shadowCameraTop`,
+  `shadowCameraRight`, ...) of the directional light, until it envelops the
+  scene tightly. If the frustum is too small, shadows will be missing or
+  partially clipped. If the frustum is too large, shadows will appear coarse or
+  pixelated. The size of the shadow map (`shadowMapHeight: 512`, `shadowMapWidth:
+  512`) determines the resolution at which shadows are computed, so tightly
+  sizing the shadow camera around your scene will make the best use of this
+  resolution and device performance.
 
-* **4. Refine** shadow appearance. Scene-wide options, affecting all lights, may be configured on the scene's shadow system.
+- **4. Refine** shadow appearance. Scene-wide options, affecting all lights,
+  may be configured on the scene's shadow system.
 
-## Shadow system properties
+## Shadow System Properties
 
-These global options affect the entire scene, and are set using the `shadow` system on the `<a-scene>` root element.
+These global options affect the entire scene, and are set using the `shadow`
+system on the `<a-scene>` root element.
 
 ```html
 <a-scene shadow="type: pcfsoft">
-
   <!-- ... -->
-
 </a-scene>
 ```
 
 | Property           | Description                                                                                                                                                                                                                                                                                      | Default Value |
 |--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| type               | Defines shadow map type (`basic`, `pcf`, `pcfsoft`), with varying appearance and perforance characteristics.                                                                                                                                                                                     | `pcf`         |
+| type               | Defines shadow map type (`basic`, `pcf`, `pcfsoft`) with varying appearance and perforance characteristics.                                                                                                                                                                                     | `pcf`         |
 | renderReverseSided | Whether to render the opposite side as specified by the material into the shadow map. When disabled, an appropriate shadow.bias must be set on the light source for surfaces that can both cast and receive shadows at the same time to render correctly.                                        | true          |
 | renderSingleSided  | Whether to treat materials specified as double-sided as if they were specified as front-sided when rendering the shadow map. When disabled, an appropriate shadow.bias must be set on the light source for surfaces that can both cast and receive shadows at the same time to render correctly. | true          |

--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -33,15 +33,21 @@ To manually disable the defaults, without adding other lights:
 </a-scene>
 ```
 
+<!--toc-->
+
 ## Properties
 
-We will go through the different types of lights and their respective properties one by one.
+All light types support a few basic properties:
 
 | Property  | Description                                                     | Default Value |
 |-----------|-----------------------------------------------------------------|---------------|
 | type      | One of `ambient`, `directional`, `hemisphere`, `point`, `spot`. | directional   |
 | color     | Light color.                                                    | #fff          |
 | intensity | Light strength.                                                 | 1.0           |
+
+## Light types
+
+Different types of lights include unique properties. We will go through each type, including its properties and when it may be the right choice.
 
 ### Ambient
 
@@ -79,6 +85,8 @@ creating a child entity it targets. For example, pointing down its -Z axis:
 	<a-entity id="directionaltarget" position="0 0 -1"></a-entity>
 </a-light>
 ```
+
+Directional lights are the most efficient type for adding realtime shadows to a scene.
 
 ### Hemisphere
 
@@ -127,3 +135,73 @@ Spot lights are like point lights in the sense that they affect materials depend
 | distance    | Distance where intensity becomes 0. If `distance` is `0`, then the point light does not decay with distance.   | 0.0           |
 | penumbra    | Percent of the spotlight cone that is attenuated due to penumbra.                                              | 0.0           |
 | target      | element the spot should point to. set to null to transform spotlight by orientation, pointing to it's -Z axis. | null          |
+
+## Configuring shadows
+
+A-Frame includes support for realtime shadow rendering. With proper configuration, objects — moving or stationary — will cast shadows adding depth and realism to a scene.
+
+Light types that support shadows (`point`, `spot`, and `directional`) include additional properties:
+
+| Property            | Light type      | Description                                                                                                                                | Default Value |
+|---------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| castShadow          |                 | Whether this light casts shadows on the scene.                                                                                             | false         |
+| shadowBias          |                 | Offset depth when deciding whether a surface is in shadow. Tiny adjustments here (in the order of 0.0001) may reduce artifacts in shadows. | 0             |
+| shadowCameraVisible |                 | Displays a visual aid showing the shadow camera's position and frustum. This is the light's view of the scene, used to project shadows.    | false         |
+| shadowCameraFar     |                 | Far plane of shadow camera frustum.                                                                                                        | 500           |
+| shadowCameraNear    |                 | Near plane of shadow camera frustum.                                                                                                       | 0.5           |
+| shadowCameraTop     | `directional`   | Top plane of shadow camera frustum.                                                                                                        | 5             |
+| shadowCameraRight   | `directional`   | Right plane of shadow camera frustum.                                                                                                      | 5             |
+| shadowCameraBottom  | `directional`   | Bottom plane of shadow camera frustum.                                                                                                     | -5            |
+| shadowCameraLeft    | `directional`   | Left plane of shadow camera frustum.                                                                                                       | -5            |
+| shadowCameraFov     | `point`, `spot` | Shadow camera's FOV.                                                                                                                       | 50            |
+| shadowMapHeight     |                 | Shadow map's vertical resolution. Larger shadow maps display more crisp shadows, at the cost of performance.                               | 512           |
+| shadowMapWidth      |                 | Shadow map's horizontal resolution.                                                                                                        | 512           |
+
+### Adding realtime shadows to a scene
+
+[light-baking]: #todo
+
+> NOTE: Realtime shadows add performance overhead. When objects in a scene are stationary, or especially when optimizing for mobile devices, be aware of other techniques for realistic shadows, such as [baking light and shadow information into a texture][light-baking] before importing assets into A-Frame.
+
+* **1. Create at least one light** with `castShadows: true`. Three light types support shadows (`point`, `spot`, and `directional`). Of the three, `directional` lights will have the best performance. Combining an ambient light (without shadows) and a directional light (with shadows) is a good place to start.
+
+```html
+<a-scene>
+  <a-entity light="type:ambient; intensity: 0.5;"></a-entity>
+  <a-entity light="type:directional;
+                   castShadow:true;
+                   intensity: 0.4;
+                   shadowCameraVisible: true;"
+            position="-5 3 1.5"></a-entity>
+</a-scene>
+```
+
+In the example above, the directional light has lower intensity than the ambient light, for slightly softer shadows. Adding `shadowCameraVisible: true` creates a visual aid for debugging: objects outside the camera's view cannot cast or receive shadows.
+
+* **2. Add the shadow component** to objects in the scene that should cast or receive shadows.
+
+```html
+<a-gltf-model src="tree.gltf" shadow="receive: false"></a-gltf-model>
+```
+
+* **3. Adjust the shadow camera** position and frustum (`shadowCameraTop`, `shadowCameraRight`, ...) of the directional light, until it envelops the scene tightly. If the frustum is too small, shadows will be missing or partially clipped. If the frustum is too large, shadows will appear coarse or pixelated. The size of the shadow map (`shadowMapHeight: 512`, `shadowMapWidth: 512`) determines the resolution at which shadows are computed, so tightly sizing the shadow camera around your scene will make the best use of this resolution and device performance.
+
+* **4. Refine** shadow appearance. Scene-wide options, affecting all lights, may be configured on the scene's shadow system.
+
+## Shadow system properties
+
+These global options affect the entire scene, and are set using the `shadow` system on the `<a-scene>` root element.
+
+```html
+<a-scene shadow="type: pcfsoft">
+
+  <!-- ... -->
+
+</a-scene>
+```
+
+| Property           | Description                                                                                                                                                                                                                                                                                      | Default Value |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| type               | Defines shadow map type (`basic`, `pcf`, `pcfsoft`), with varying appearance and perforance characteristics.                                                                                                                                                                                     | `pcf`         |
+| renderReverseSided | Whether to render the opposite side as specified by the material into the shadow map. When disabled, an appropriate shadow.bias must be set on the light source for surfaces that can both cast and receive shadows at the same time to render correctly.                                        | true          |
+| renderSingleSided  | Whether to treat materials specified as double-sided as if they were specified as front-sided when rendering the shadow map. When disabled, an appropriate shadow.bias must be set on the light source for surfaces that can both cast and receive shadows at the same time to render correctly. | true          |

--- a/docs/components/shadow.md
+++ b/docs/components/shadow.md
@@ -1,0 +1,30 @@
+---
+title: shadow
+type: components
+layout: docs
+parent_section: components
+---
+
+The shadow component enables shadows for an entity and its children. Receiving shadows from surrounding objects and casting shadows onto other objects may (and often should) be enabled independently.
+
+Without this component, entities do not cast or receive shadows.
+
+## Example
+
+The example below configures a tree model to cast shadows onto the surrounding scene, but not to receive shadows itself.
+
+```html
+<a-entity light="type:directional; castShadow:true;" position="1 1 1"></a-entity>
+<a-gltf-model src="tree.gltf" shadow="receive: false"></a-gltf-model>
+```
+
+[light]: ./light.md#configuring-shadows
+
+**IMPORTANT:** Adding the `shadow` component alone is not enough to display shadows in your scene. At least one light must have `castShadow: true` enabled. Additionally, the light's shadow camera (used for depth projection) must be configured correctly. Refer to the [light][light] component for more information.
+
+## Properties
+
+| Property | Description                                                     | Default Value |
+|----------|-----------------------------------------------------------------|---------------|
+| cast     | Whether the entity casts shadows onto the surrounding scene.    | true          |
+| receive  | Whether the entity receives shadows from the surrounding scene. | true          |

--- a/docs/components/shadow.md
+++ b/docs/components/shadow.md
@@ -5,13 +5,16 @@ layout: docs
 parent_section: components
 ---
 
-The shadow component enables shadows for an entity and its children. Receiving shadows from surrounding objects and casting shadows onto other objects may (and often should) be enabled independently.
+The shadow component enables shadows for an entity and its children. Receiving
+shadows from surrounding objects and casting shadows onto other objects may
+(and often should) be enabled independently.
 
-Without this component, entities do not cast or receive shadows.
+Without this component, an entity will not cast nor receive shadows.
 
 ## Example
 
-The example below configures a tree model to cast shadows onto the surrounding scene, but not to receive shadows itself.
+The example below configures a tree model to cast shadows onto the surrounding
+scene but not receive shadows itself.
 
 ```html
 <a-entity light="type:directional; castShadow:true;" position="1 1 1"></a-entity>
@@ -20,7 +23,11 @@ The example below configures a tree model to cast shadows onto the surrounding s
 
 [light]: ./light.md#configuring-shadows
 
-**IMPORTANT:** Adding the `shadow` component alone is not enough to display shadows in your scene. At least one light must have `castShadow: true` enabled. Additionally, the light's shadow camera (used for depth projection) must be configured correctly. Refer to the [light][light] component for more information.
+**IMPORTANT:** Adding the `shadow` component alone is not enough to display
+shadows in your scene. We must have at least one light with `castShadow:
+true` enabled.  Additionally, the light's shadow camera (used for depth
+projection) usually must be configured correctly. Refer to the [light][light]
+component for more information.
 
 ## Properties
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -234,6 +234,7 @@
       <li><a href="test/pivot/">Pivot</a></li>
       <li><a href="test/raycaster/">Raycaster</a></li>
       <li><a href="test/shaders/">Shaders</a></li>
+      <li><a href="test/shadows/">Shadows</a></li>
       <li><a href="test/text/">Text</a></li>
       <li><a href="test/text/anchors.html">Text Anchors</a></li>
       <li><a href="test/text/msdf.html">Text Fonts <em>(MSDF vs. SDF)</em></a></li>

--- a/examples/test/shadows/index.html
+++ b/examples/test/shadows/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Shadows</title>
+    <meta name="description" content="Shadows - A-Frame">
+    <script src="../../../dist/aframe-master.js"></script>
+  </head>
+  <body>
+    <a-scene light="shadowMapType: basic" stats>
+      <a-assets>
+        <a-mixin id="wall"
+                 geometry="primitive: box; height: 30; width: 30; depth: 2"
+                 material="color: #333; metalness: 0; roughness: 1"
+                 shadow="cast: false; receive: true"></a-mixin>
+      </a-assets>
+
+      <a-entity position="0 8.4 -8">
+        <a-entity light="color: #AAA; type: ambient"></a-entity>
+
+        <!-- Center point light. -->
+        <a-entity geometry="primitive: sphere; radius: 0.15"
+                  material="color: #FAFAFA; shader: flat"
+                  light="castShadow: true; color: #FAFAFA; intensity: 0.5; shadowBias: 0.01
+                         shadowCameraNear: 1; shadowCameraBias: 0.01;
+                         type: point; shadowMapWidth: 1024; shadowMapHeight: 1024"
+                  position="0 -1 1">
+          <a-animation attribute="scale" to="2 2 2" dur="3000" direction="alternate"
+                       repeat="indefinite"></a-animation>
+          <a-animation attribute="intensity" to="1" dur="3000" direction="alternate"
+                       repeat="indefinite"></a-animation>
+        </a-entity>
+
+        <!-- Animating point light. -->
+        <a-entity>
+          <a-entity geometry="primitive: sphere; radius: 0.25"
+                    material="color: #FAFAFA; shader: flat"
+                    light="castShadow: true; color: #FAFAFA; intensity: 1; shadowBias: 0.01
+                           shadowCameraNear: 1; shadowCameraBias: 0.01;
+                           type: point; shadowMapWidth: 1024; shadowMapHeight: 1024"
+                    position="0 5 5"></a-entity>
+          <a-animation attribute="rotation" to="0 360 360" dur="5000" easing="linear"
+                       repeat="indefinite"></a-animation>
+        </a-entity>
+
+        <!-- Torus. -->
+        <a-entity geometry="primitive: torusKnot; radius: 4; radiusTubular: 0.1;
+                            segmentsRadial: 150; segmentsTubular: 20; p: 17; q: 4; side: back"
+                  material="color: #EF2D5E; metalness: 0.75"
+                  shadow="cast: true; receive: true"
+                  position="0 -1 2">
+          <a-animation attribute="rotation" dur="36000" to="0 360 0" repeat="indefinite"
+                       easing="linear"></a-animation>
+        </a-entity>
+
+        <!-- Walls. -->
+        <a-entity mixin="wall" position="0 0 -10"></a-entity>
+        <a-entity mixin="wall" position="-10 0 0" rotation="0 90 0"></a-entity>
+        <a-entity mixin="wall" position="10 0 0" rotation="0 90 0"></a-entity>
+        <a-entity mixin="wall" position="0 10 0" rotation="90 0 0"></a-entity>
+        <a-entity mixin="wall" position="0 -10 0" rotation="90 0 0"></a-entity>
+      </a-entity>
+
+      <!-- Meshes -->
+      <a-entity geometry="primitive: box" material="color: #EF2D5E; metalness: 0" shadow
+                position="0 0 -4"></a-entity>
+      <a-entity geometry="primitive: sphere" material="color: #EF2D5E; metalness: 0" shadow
+                position="-2 0 -4"></a-entity>
+      <a-entity geometry="primitive: cylinder" material="color: #EF2D5E; metalness: 0" shadow
+                position="2 0 -4"></a-entity>
+
+      <a-sky color="#111"></a-sky>
+    </a-scene>
+  </body>
+</html>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,6 +14,7 @@ require('./position');
 require('./raycaster');
 require('./rotation');
 require('./scale');
+require('./shadow');
 require('./sound');
 require('./text');
 require('./tracked-controls');

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -20,7 +20,21 @@ module.exports.Component = registerComponent('light', {
     intensity: {default: 1.0, min: 0, if: {type: ['ambient', 'directional', 'hemisphere', 'point', 'spot']}},
     penumbra: {default: 0, min: 0, max: 1, if: {type: ['spot']}},
     type: {default: 'directional', oneOf: ['ambient', 'directional', 'hemisphere', 'point', 'spot']},
-    target: {type: 'selector', if: {type: ['spot', 'directional']}}
+    target: {type: 'selector', if: {type: ['spot', 'directional']}},
+
+    // Shadows.
+    castShadow: {default: false, if: {type: ['point', 'spot', 'directional']}},
+    shadowBias: {default: 0, if: {castShadow: true}},
+    shadowCameraFar: {default: 500, if: {castShadow: true}},
+    shadowCameraFov: {default: 50, if: {castShadow: true}},
+    shadowCameraNear: {default: 0.5, if: {castShadow: true}},
+    shadowCameraTop: {default: 5, if: {castShadow: true}},
+    shadowCameraRight: {default: 5, if: {castShadow: true}},
+    shadowCameraBottom: {default: -5, if: {castShadow: true}},
+    shadowCameraLeft: {default: -5, if: {castShadow: true}},
+    shadowCameraVisible: {default: false, if: {castShadow: true}},
+    shadowMapHeight: {default: 512, if: {castShadow: true}},
+    shadowMapWidth: {default: 512, if: {castShadow: true}}
   },
 
   /**
@@ -44,6 +58,7 @@ module.exports.Component = registerComponent('light', {
 
     // Existing light.
     if (light && !('type' in diffData)) {
+      var shadowsLoaded = false;
       // Light type has not changed. Update light.
       Object.keys(diffData).forEach(function (key) {
         var value = data[key];
@@ -81,6 +96,24 @@ module.exports.Component = registerComponent('light', {
             break;
           }
 
+          case 'castShadow':
+          case 'shadowBias':
+          case 'shadowCameraFar':
+          case 'shadowCameraFov':
+          case 'shadowCameraNear':
+          case 'shadowCameraTop':
+          case 'shadowCameraRight':
+          case 'shadowCameraBottom':
+          case 'shadowCameraLeft':
+          case 'shadowCameraVisible':
+          case 'shadowMapHeight':
+          case 'shadowMapWidth':
+            if (!shadowsLoaded) {
+              self.updateShadow();
+              shadowsLoaded = true;
+            }
+            break;
+
           default: {
             light[key] = value;
           }
@@ -91,6 +124,7 @@ module.exports.Component = registerComponent('light', {
 
     // No light yet or light type has changed. Create and add light.
     this.setLight(this.data);
+    this.updateShadow();
   },
 
   setLight: function (data) {
@@ -116,6 +150,47 @@ module.exports.Component = registerComponent('light', {
         el.getObject3D('light-target').position.set(0, 0, -1);
       }
     }
+  },
+
+  /**
+   * Updates shadow-related properties on the current light.
+   */
+  updateShadow: function () {
+    var el = this.el;
+    var data = this.data;
+    var light = this.light;
+
+    light.castShadow = data.castShadow;
+
+    // Shadow camera helper.
+    var cameraHelper = el.getObject3D('cameraHelper');
+    if (data.shadowCameraVisible && !cameraHelper) {
+      el.setObject3D('cameraHelper', new THREE.CameraHelper(light.shadow.camera));
+    } else if (!data.shadowCameraVisible && cameraHelper) {
+      el.removeObject3D('cameraHelper');
+    }
+
+    if (!data.castShadow) { return light; }
+
+    // Shadow appearance.
+    light.shadow.bias = data.shadowBias;
+    light.shadow.mapSize.height = data.shadowMapHeight;
+    light.shadow.mapSize.width = data.shadowMapWidth;
+
+    // Shadow camera.
+    light.shadow.camera.near = data.shadowCameraNear;
+    light.shadow.camera.far = data.shadowCameraFar;
+    if (light.shadow.camera instanceof THREE.OrthographicCamera) {
+      light.shadow.camera.top = data.shadowCameraTop;
+      light.shadow.camera.right = data.shadowCameraRight;
+      light.shadow.camera.bottom = data.shadowCameraBottom;
+      light.shadow.camera.left = data.shadowCameraLeft;
+    } else {
+      light.shadow.camera.fov = data.shadowCameraFov;
+    }
+    light.shadow.camera.updateProjectionMatrix();
+
+    if (cameraHelper) { cameraHelper.update(); }
   },
 
   /**
@@ -188,6 +263,10 @@ module.exports.Component = registerComponent('light', {
    * Remove light on remove (callback).
    */
   remove: function () {
-    this.el.removeObject3D('light');
+    var el = this.el;
+    el.removeObject3D('light');
+    if (el.getObject3D('cameraHelper')) {
+      el.removeObject3D('cameraHelper');
+    }
   }
 });

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -26,7 +26,7 @@ module.exports.Component = registerComponent('light', {
     castShadow: {default: false, if: {type: ['point', 'spot', 'directional']}},
     shadowBias: {default: 0, if: {castShadow: true}},
     shadowCameraFar: {default: 500, if: {castShadow: true}},
-    shadowCameraFov: {default: 50, if: {castShadow: true}},
+    shadowCameraFov: {default: 90, if: {castShadow: true}},
     shadowCameraNear: {default: 0.5, if: {castShadow: true}},
     shadowCameraTop: {default: 5, if: {castShadow: true}},
     shadowCameraRight: {default: 5, if: {castShadow: true}},

--- a/src/components/shadow.js
+++ b/src/components/shadow.js
@@ -1,0 +1,52 @@
+var component = require('../core/component');
+var THREE = require('../lib/three');
+var bind = require('../utils/bind');
+var registerComponent = component.registerComponent;
+
+/**
+ * Shadow component.
+ *
+ * When applied to an entity, that entity's geometry and any descendants will cast or receive
+ * shadows as specified by the `cast` and `receive` properties.
+ */
+module.exports.Component = registerComponent('shadow', {
+  schema: {
+    cast: {default: true},
+    receive: {default: true}
+  },
+
+  init: function () {
+    this.onMeshChanged = bind(this.update, this);
+    this.el.addEventListener('object3dset', this.onMeshChanged);
+    this.system.setShadowMapEnabled(true);
+  },
+
+  update: function () {
+    var data = this.data;
+    this.updateDescendants(data.cast, data.receive);
+  },
+
+  remove: function () {
+    var el = this.el;
+    el.removeEventListener('object3dset', this.onMeshChanged);
+    this.updateDescendants(false, false);
+  },
+
+  updateDescendants: function (cast, receive) {
+    var sceneEl = this.el.sceneEl;
+    this.el.object3D.traverse(function (node) {
+      if (!(node instanceof THREE.Mesh)) { return; }
+
+      node.castShadow = cast;
+      node.receiveShadow = receive;
+
+      // If scene has already rendered, materials must be updated.
+      if (sceneEl.hasLoaded && node.material) {
+        var materials = node.material.materials || [node.material];
+        for (var i = 0; i < materials.length; i++) {
+          materials[i].needsUpdate = true;
+        }
+      }
+    });
+  }
+});

--- a/src/systems/index.js
+++ b/src/systems/index.js
@@ -3,5 +3,6 @@ require('./geometry');
 require('./gltf-model');
 require('./light');
 require('./material');
+require('./shadow');
 require('./tracked-controls');
 

--- a/src/systems/shadow.js
+++ b/src/systems/shadow.js
@@ -1,0 +1,51 @@
+var registerSystem = require('../core/system').registerSystem;
+var bind = require('../utils/bind');
+var THREE = require('../lib/three');
+
+var SHADOW_MAP_TYPE_MAP = {
+  basic: THREE.BasicShadowMap,
+  pcf: THREE.PCFShadowMap,
+  pcfsoft: THREE.PCFSoftShadowMap
+};
+
+/**
+ * Shadow system.
+ *
+ * Enabled automatically when one or more shadow components are added to the scene, the system sets
+ * options on the WebGLRenderer for configuring shadow appearance.
+ */
+module.exports.System = registerSystem('shadow', {
+  schema: {
+    type: {default: 'pcf', oneOf: ['basic', 'pcf', 'pcfsoft']},
+    renderReverseSided: {default: true},
+    renderSingleSided: {default: true}
+  },
+
+  init: function () {
+    var sceneEl = this.sceneEl;
+    var data = this.data;
+
+    this.shadowMapEnabled = false;
+
+    sceneEl.addEventListener('render-target-loaded', bind(function () {
+      // Renderer is not initialized in most tests.
+      if (!sceneEl.renderer) { return; }
+      sceneEl.renderer.shadowMap.type = SHADOW_MAP_TYPE_MAP[data.type];
+      sceneEl.renderer.shadowMap.renderReverseSided = data.renderReverseSided;
+      sceneEl.renderer.shadowMap.renderSingleSided = data.renderSingleSided;
+      this.setShadowMapEnabled(this.shadowMapEnabled);
+    }, this));
+  },
+
+  /**
+   * Enables/disables the renderer shadow map.
+   * @param {boolean} enabled
+   */
+  setShadowMapEnabled: function (enabled) {
+    var renderer = this.sceneEl.renderer;
+    this.shadowMapEnabled = enabled;
+    if (renderer) {
+      renderer.shadowMap.enabled = enabled;
+    }
+  }
+});

--- a/tests/components/light.test.js
+++ b/tests/components/light.test.js
@@ -48,6 +48,16 @@ suite('light', function () {
       el.setAttribute('light', 'angle', 180);
       assert.equal(el.getObject3D('light').angle, Math.PI);
     });
+
+    test('can update light shadow', function () {
+      var el = this.el;
+      el.setAttribute('light', {
+        castShadow: true,
+        shadowBias: 0.25
+      });
+      assert.ok(el.getObject3D('light').castShadow);
+      assert.equal(el.getObject3D('light').shadow.bias, 0.25);
+    });
   });
 
   suite('getLight', function () {
@@ -95,6 +105,17 @@ suite('light', function () {
   suite('remove', function () {
     test('removes light', function () {
       var el = this.el;
+      el.removeAttribute('light');
+      assert.equal(el.object3D.children.length, 0);
+    });
+
+    test('removes shadow camera helper', function () {
+      var el = this.el;
+      el.setAttribute('light', {
+        castShadow: true,
+        shadowCameraVisible: true
+      });
+      assert.ok(el.getObject3D('cameraHelper'));
       el.removeAttribute('light');
       assert.equal(el.object3D.children.length, 0);
     });

--- a/tests/components/shadow.test.js
+++ b/tests/components/shadow.test.js
@@ -1,0 +1,63 @@
+/* global assert, setup, suite, test */
+var entityFactory = require('../helpers').entityFactory;
+var THREE = require('index').THREE;
+
+suite('shadow component', function () {
+  var component;
+  var el;
+  var mesh;
+
+  setup(function (done) {
+    el = entityFactory();
+    el.addEventListener('componentinitialized', function (evt) {
+      if (evt.detail.name !== 'shadow') { return; }
+      component = el.components.shadow;
+      done();
+    });
+    el.setAttribute('shadow', {});
+    mesh = new THREE.Mesh(
+      new THREE.Sphere(2),
+      new THREE.MeshBasicMaterial({color: 0xffff00})
+    );
+  });
+
+  suite('update', function () {
+    test('sets cast and receive properties on meshes', function () {
+      el.object3D.add(mesh);
+      component.update();
+      assert.ok(mesh.castShadow);
+      assert.ok(mesh.receiveShadow);
+      el.setAttribute('shadow', {cast: true, receive: false});
+      assert.ok(mesh.castShadow);
+      assert.notOk(mesh.receiveShadow);
+      el.setAttribute('shadow', {cast: false, receive: false});
+      assert.notOk(mesh.castShadow);
+      assert.notOk(mesh.receiveShadow);
+    });
+
+    test('sets needsUpdate on materials', function () {
+      el.object3D.add(mesh);
+      component.update();
+      assert.ok(mesh.material.needsUpdate);
+    });
+
+    test('refreshes after setObject3D', function () {
+      el.setObject3D('foo', mesh);
+      component.update();
+      assert.ok(mesh.castShadow);
+      assert.ok(mesh.receiveShadow);
+    });
+  });
+
+  suite('remove', function () {
+    test('cleans up shadow references', function () {
+      el.object3D.add(mesh);
+      component.update();
+      assert.ok(mesh.castShadow);
+      assert.ok(mesh.receiveShadow);
+      el.removeAttribute('shadow');
+      assert.notOk(mesh.castShadow);
+      assert.notOk(mesh.receiveShadow);
+    });
+  });
+});

--- a/tests/systems/shadow.test.js
+++ b/tests/systems/shadow.test.js
@@ -1,0 +1,46 @@
+/* global process, setup, suite, test, assert, THREE */
+var entityFactory = require('../helpers').entityFactory;
+
+suite('shadow system', function () {
+  var renderer;
+  var system;
+
+  setup(function (done) {
+    var el = this.el = entityFactory();
+    el.addEventListener('loaded', function () {
+      renderer = el.sceneEl.renderer = {shadowMap: {}};
+      system = el.sceneEl.systems.shadow;
+      done();
+    });
+  });
+
+  suite('init', function () {
+    test('disabled by default', function () {
+      assert.notOk(renderer.shadowMap.enabled);
+    });
+
+    test('configures renderer properties', function (done) {
+      var sceneEl = this.el.sceneEl;
+
+      // Systems cannot yet be directly updated.
+      system.data.type = 'basic';
+      system.data.renderReverseSided = false;
+      system.data.renderSingleSided = false;
+      sceneEl.emit('render-target-loaded');
+
+      process.nextTick(function () {
+        assert.equal(renderer.shadowMap.type, THREE.BasicShadowMap);
+        assert.notOk(renderer.shadowMap.renderReverseSided);
+        assert.notOk(renderer.shadowMap.renderSingleSided);
+        done();
+      });
+    });
+  });
+
+  suite('setShadowMapEnabled', function () {
+    test('updates the renderer', function () {
+      system.setShadowMapEnabled(true);
+      assert.ok(renderer.shadowMap.enabled);
+    });
+  });
+});


### PR DESCRIPTION
**Description:**

Fixes #651.

Migrates [shadows from aframe-extras](https://github.com/donmccurdy/aframe-extras/tree/master/src/shadows), with a few changes to the API. Example includes shadows on the "Hello World" example, but we should probably come up with something more interesting.

Some of the shadow properties are non-default; this has worked better so far (from various bugs filed against extras) but perhaps we want to be consistent with THREE defaults instead? In any case, tweaks to the shadow camera properties are going to be par for the course on any serious scene.

**Changes proposed:**
- Add `shadow` component, which recursively enables cast/receive on child geometry. Note that it is recursive and on by default.
- Add shadow properties to the `light` component, for supported types.
- Add shadow setup to the `light` system. The shadowMap is enabled automatically, and not exposed in schema, but the shadow type can be set with `<a-scene light="shadowMapType: pcfsoft">`.

/cc @fernandojsg @takahirox
