### PR TITLE
fix iOS version test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ window.WebVRConfig = window.WebVRConfig || {
 
 // Workaround for iOS Safari canvas sizing issues in stereo (webvr-polyfill/issues/102).
 // Should be fixed in iOS 10.
-if (/(iphone|ipod|ipad).*os.*(7|8|9)/i.test(navigator.userAgent)) {
+if (/(iphone|ipod|ipad).*os.(7|8|9)/i.test(navigator.userAgent)) {
   window.WebVRConfig.BUFFER_SCALE = 1 / window.devicePixelRatio;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
-var debug = require('./utils/debug');
+var utils = require('./utils/');
+
+var debug = utils.debug;
 var error = debug('A-Frame:warn');
 var info = debug('A-Frame:info');
 
@@ -22,8 +24,8 @@ window.WebVRConfig = window.WebVRConfig || {
 };
 
 // Workaround for iOS Safari canvas sizing issues in stereo (webvr-polyfill/issues/102).
-// Should be fixed in iOS 10.
-if (/(iphone|ipod|ipad).*os.(7|8|9)/i.test(navigator.userAgent)) {
+// Only for iOS on versions older than 10.
+if (utils.device.isIOSOlderThan10(navigator.userAgent)) {
   window.WebVRConfig.BUFFER_SCALE = 1 / window.devicePixelRatio;
 }
 
@@ -50,7 +52,6 @@ var THREE = window.THREE = require('./lib/three');
 var TWEEN = window.TWEEN = require('tween.js');
 
 var pkg = require('../package');
-var utils = require('./utils/');
 
 require('./components/index'); // Register standard components.
 require('./geometries/index'); // Register standard geometries.

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -75,3 +75,10 @@ module.exports.isGearVR = isGearVR;
 module.exports.isLandscape = function () {
   return window.orientation === 90 || window.orientation === -90;
 };
+
+/**
+ * Check if device is iOS and older than version 10.
+ */
+module.exports.isIOSOlderThan10 = function (userAgent) {
+  return /(iphone|ipod|ipad).*os.(7|8|9)/i.test(userAgent);
+};

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -1,0 +1,29 @@
+/* global assert, suite, test */
+var device = require('utils').device;
+
+suite('isIOSOlderThan10', function () {
+  test('is true for versions 7, 8, 9', function () {
+    var v7 = `Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1
+             (KHTML, like Gecko) CriOS/30.0.1599.12 Mobile/11A465 Safari/8536.25
+             (3B92C18B-D9DE-4CB7-A02A-22FD2AF17C8F)`;
+    var v8 = `Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4
+              (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4`;
+    var v9 = `Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17
+              (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4`;
+    assert.ok(device.isIOSOlderThan10(v7));
+    assert.ok(device.isIOSOlderThan10(v8));
+    assert.ok(device.isIOSOlderThan10(v9));
+  });
+
+  test('is false for version 10, 11, 12', function () {
+    var v10 = `Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.38
+              (KHTML, like Gecko) Version/10.0 Mobile/14A5297c Safari/602.1`;
+    var v11 = `Mozilla/5.0 (iPhone; CPU iPhone OS 11_1 like Mac OS X) AppleWebKit/602.1.38
+              (KHTML, like Gecko) Version/11.0 Mobile/14A5297c Safari/602.1`;
+    var v12 = `Mozilla/5.0 (iPhone; CPU iPhone OS 12_7 like Mac OS X) AppleWebKit/602.1.38
+              (KHTML, like Gecko) Version/12.0 Mobile/14A5297c Safari/602.1`;
+    assert.notOk(device.isIOSOlderThan10(v10));
+    assert.notOk(device.isIOSOlderThan10(v11));
+    assert.notOk(device.isIOSOlderThan10(v12));
+  });
+});


### PR DESCRIPTION
**Description:**
Fixes #2008 

The blurry effect from #2008 was actually caused by incorrectly setting BUFFER_SCALE to 0.5 even on iOS 10.

**Changes proposed:**
- The workaround was created to fix webvr-polyfill/issues/102, however they PRed a different solution for it since, so this workaround in aframe might not be needed at all (haven't tested).