### PR TITLE
have removeAttribute reset property values if second arg passed (fixes #1614)

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -369,14 +369,23 @@ AFRAME.registerComponent('example-orthogonal-camera', {
 });
 ```
 
-### `removeAttribute (attr)`
+### `removeAttribute (attr, propertyName)`
 
 If `attr` is the name of a registered component, along with removing the
 attribute from the DOM, `removeAttribute` will also detach the component from
 the entity, invoking the component's `remove` lifecycle method.
 
 ```js
-entity.removeAttribute('sound');  // The entity will no longer play sound.
+entity.removeAttribute('goemetry');  // Detach the geometry component.
+entity.removeAttribute('sound');  // Detach the sound component.
+```
+
+If `propertyName` is given, `removeAttribute` will reset the property value of
+that property specified by `propertyName` to the property's default value:
+
+```js
+entity.setAttribute('material', 'color', 'blue');  // The color is blue.
+entity.removeAttribute('material', 'color');  // Reset the color to the default value, white.
 ```
 
 ### `removeObject3D (type)`

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -538,19 +538,30 @@ var proto = Object.create(ANode.prototype, {
   },
 
   /**
-   * If `attr` is a component name, removeAttribute detaches the component from the
-   * entity.
+   * If `attr` is a component name, detach the component from the entity.
+   *
+   * If `propertyName` is given, reset the component property value to its default.
    *
    * @param {string} attr - Attribute name, which could also be a component name.
+   * @param {string} propertyName - Component prop name, if resetting an individual prop.
    */
   removeAttribute: {
-    value: function (attr) {
+    value: function (attr, propertyName) {
       var component = this.components[attr];
-      if (component) {
+
+      // Remove component.
+      if (component && propertyName === undefined) {
         this.setEntityAttribute(attr, undefined, null);
-        // The component might not be removed if it's a default one
+        // Do not remove the component from the DOM if default component.
         if (this.components[attr]) { return; }
       }
+
+      // Reset component property value.
+      if (component && propertyName !== undefined) {
+        component.resetProperty(propertyName);
+        return;
+      }
+
       HTMLElement.prototype.removeAttribute.call(this, attr);
     }
   },

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -194,7 +194,8 @@ Component.prototype = {
     if (!el.hasLoaded) { return; }
 
     if (this.updateSchema) {
-      this.updateSchema(buildData(el, this.name, this.attrName, this.schema, this.attrValue, true));
+      this.updateSchema(buildData(el, this.name, this.attrName, this.schema, this.attrValue,
+                                  true));
     }
     this.data = buildData(el, this.name, this.attrName, this.schema, this.attrValue);
 
@@ -223,6 +224,22 @@ Component.prototype = {
         oldData: oldData
       }, false);
     }
+  },
+
+  /**
+   * Reset value of a property to the property's default value.
+   * If single-prop component, reset value to component's default value.
+   *
+   * @param {string} propertyName - Name of property to reset.
+   */
+  resetProperty: function (propertyName) {
+    if (isSingleProp(this.schema)) {
+      this.attrValue = undefined;
+    } else {
+      if (!(propertyName in this.attrValue)) { return; }
+      delete this.attrValue[propertyName];
+    }
+    this.updateProperties(this.attrValue);
   },
 
   /**

--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -1,4 +1,4 @@
-/* global sinon, setup, teardown */
+/* global AFRAME, sinon, setup, teardown */
 
 /**
  * __init.test.js is run before every test case.
@@ -34,4 +34,5 @@ teardown(function () {
     els[i].parentNode.removeChild(els[i]);
   }
   this.sinon.restore();
+  delete AFRAME.components.test;
 });

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -773,6 +773,14 @@ suite('a-entity', function () {
       // Geometry still exists since it is mixed in.
       assert.ok('geometry' in el.components);
     });
+
+    test('resets a component property', function () {
+      var el = this.el;
+      el.setAttribute('material', 'color: #F0F');
+      assert.equal(el.getAttribute('material').color, '#F0F');
+      el.removeAttribute('material', 'color');
+      assert.equal(el.getAttribute('material').color, '#FFF');
+    });
   });
 
   suite('initComponent', function () {

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, suite, test, setup, sinon, HTMLElement */
+/* global AFRAME, assert, process, suite, test, setup, sinon, HTMLElement */
 var buildData = require('core/component').buildData;
 var components = require('index').components;
 var helpers = require('../helpers');
@@ -290,6 +290,37 @@ suite('Component', function () {
         done();
       });
       el.setAttribute('material', '');
+    });
+  });
+
+  suite('resetProperty', function () {
+    var el;
+
+    setup(function (done) {
+      el = entityFactory();
+      el.addEventListener('loaded', () => { done(); });
+    });
+
+    test('resets property to default value', function () {
+      AFRAME.registerComponent('test', {
+        schema: {
+          bar: {default: 5},
+          foo: {default: 5}
+        }
+      });
+      el.setAttribute('test', {bar: 10, foo: 10});
+      el.components.test.resetProperty('bar');
+      assert.equal(el.getAttribute('test').bar, 5);
+      assert.equal(el.getAttribute('test').foo, 10);
+    });
+
+    test('resets property to default value for single-prop', function () {
+      AFRAME.registerComponent('test', {
+        schema: {default: 5}
+      });
+      el.setAttribute('test', 10);
+      el.components.test.resetProperty();
+      assert.equal(el.getAttribute('test'), 5);
     });
   });
 


### PR DESCRIPTION
**Description:**

## `removeAttribute (attr, propertyName)`

If `propertyName` is given, `removeAttribute` will reset the property value of
that property specified by `propertyName` to the property's default value:

```js
entity.setAttribute('material', 'color', 'blue');  // The color is blue.
entity.removeAttribute('material', 'color');  // Reset the color to the default value, white.
```

**Changes proposed:**
- `removeAttribute` second argument.
- Internal `Component.resetProperty`
- Have unit test global teardown do `delete AFRAME.components.test`
