### PR TITLE
fix system init triggering component updates (fixes #2365)

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -416,6 +416,17 @@ module.exports = registerElement('a-scene', {
     },
 
     /**
+     * Wrap `updateComponent` to not initialize the component if the component has a system
+     * (aframevr/aframe#2365).
+     */
+    updateComponent: {
+      value: function (componentName) {
+        if (componentName in systems) { return; }
+        AEntity.prototype.updateComponent.apply(this, arguments);
+      }
+    },
+
+    /**
      * Behavior-updater meant to be called from scene render.
      * Abstracted to a different function to facilitate unit testing (`scene.tick()`) without
      * needing to render.


### PR DESCRIPTION
**Description:**

Wrap `updateComponent` from scene to check if a system exists for the component. If there is a system of the same name, don't trigger component update.
