### PR TITLE
accommodate both names for Vive controllers: old 'OpenVR Gamepad' and…

### DIFF
--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -28,11 +28,11 @@ so using idPrefix for Vive / OpenVR controllers is recommended.
 
 ## Value
 
-| Property    | Description                                                     | Default Value          |
-|-------------|-------------------------------------------------------------- --|------------------------|
-| controller  | Index of the controller in array returned by the Gamepad API.   | 0                      |
-| id          | Selects the controller from the Gamepad API using exact match.  | Match none by default! |
-| idPrefix    | Selects the controller from the Gamepad API using prefix match. | undefined              |
+| Property    | Description                                                     | Default Value |
+|-------------|-------------------------------------------------------------- --|---------------|
+| controller  | Index of the controller in array returned by the Gamepad API.   | 0             |
+| id          | Selects the controller from the Gamepad API using exact match.  |               |
+| idPrefix    | Selects the controller from the Gamepad API using prefix match. |               |
 
 ## Events
 

--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -18,16 +18,21 @@ the entity, observes buttons state and emits appropriate events.
 
 ## Example
 
+Note that due to recent browser-specific changes, Vive controllers may be returned
+by the Gamepad API with id values of either "OpenVR Gamepad" or "OpenVR Controller", 
+so using idPrefix for Vive / OpenVR controllers is recommended.
+
 ```html
-<a-entity tracked-controls="controller: 0; id: OpenVR Gamepad"></a-entity>
+<a-entity tracked-controls="controller: 0; idPrefix: OpenVR"></a-entity>
 ```
 
 ## Value
 
-| Property    | Description                                                    | Default Value    |
-|-------------|----------------------------------------------------------------|------------------|
-| controller  | Index of the controller in array returned by the Gamepad API.  | 0                |
-| id          | Selects the controller returned by the Gamepad API.            | OpenVR Gamepad   |
+| Property    | Description                                                     | Default Value          |
+|-------------|-------------------------------------------------------------- --|------------------------|
+| controller  | Index of the controller in array returned by the Gamepad API.   | 0                      |
+| id          | Selects the controller from the Gamepad API using exact match.  | Match none by default! |
+| idPrefix    | Selects the controller from the Gamepad API using prefix match. | undefined              |
 
 ## Events
 

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -13,8 +13,8 @@ var THREE = require('../lib/three');
 module.exports.Component = registerComponent('tracked-controls', {
   schema: {
     controller: {default: 0},
-    id: {default: 'Match none by default!'},
-    idPrefix: {default: undefined},
+    id: {type: 'string', default: ''},
+    idPrefix: {type: 'string', default: ''},
     rotationOffset: {default: 0}
   },
 

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -14,6 +14,7 @@ module.exports.Component = registerComponent('tracked-controls', {
   schema: {
     controller: {default: 0},
     id: {default: 'Match none by default!'},
+    idPrefix: {default: undefined},
     rotationOffset: {default: 0}
   },
 
@@ -26,10 +27,10 @@ module.exports.Component = registerComponent('tracked-controls', {
   update: function () {
     var controllers = this.system.controllers;
     var data = this.data;
-    controllers = controllers.filter(hasId);
+    controllers = controllers.filter(hasIdOrPrefix);
     // handId: 0 - right, 1 - left
     this.controller = controllers[data.controller];
-    function hasId (controller) { return controller.id === data.id; }
+    function hasIdOrPrefix (controller) { return data.idPrefix ? controller.id.indexOf(data.idPrefix) === 0 : controller.id === data.id; }
   },
 
   tick: function (time, delta) {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -5,7 +5,7 @@ var isControllerPresent = require('../utils/tracked-controls').isControllerPrese
 var VIVE_CONTROLLER_MODEL_OBJ_URL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.obj';
 var VIVE_CONTROLLER_MODEL_OBJ_MTL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.mtl';
 
-var GAMEPAD_ID_PREFIX = 'OpenVR Gamepad';
+var GAMEPAD_ID_PREFIX = 'OpenVR ';
 
 /**
  * Vive Controls Component
@@ -128,7 +128,7 @@ module.exports.Component = registerComponent('vive-controls', {
     // handId: 0 - right, 1 - left, 2 - anything else...
     var controller = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
     // if we have an OpenVR Gamepad, use the fixed mapping
-    el.setAttribute('tracked-controls', {id: GAMEPAD_ID_PREFIX, controller: controller, rotationOffset: data.rotationOffset});
+    el.setAttribute('tracked-controls', {idPrefix: GAMEPAD_ID_PREFIX, controller: controller, rotationOffset: data.rotationOffset});
     if (!this.data.model) { return; }
     this.el.setAttribute('obj-model', {
       obj: VIVE_CONTROLLER_MODEL_OBJ_URL,


### PR DESCRIPTION
… new 'OpenVR Controller'

```
Note that due to recent browser-specific changes, Vive controllers may be returned
by the Gamepad API with id values of either "OpenVR Gamepad" or "OpenVR Controller",
so using idPrefix for Vive / OpenVR controllers is recommended.
```
