### PR TITLE
update Examples > Primitives > Models for glTF (and document on Examples index)

### DIFF
--- a/examples/boilerplate/3d-model/index.html
+++ b/examples/boilerplate/3d-model/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>3D Model</title>
-    <meta name="description" content="3D Model — A-Frame">
+    <title>3D Model (COLLADA)</title>
+    <meta name="description" content="3D Model (COLLADA) — A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
   </head>
   <body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,7 +36,7 @@
       }
 
       .resources a {
-        color: rgba(0,0,0,0.5);
+        color: rgba(0,0,0,.5);
         display: inline-block;
         font-size: 1.2rem;
         margin: -0.25rem -0.5rem;
@@ -50,7 +50,8 @@
         color: #fff;
       }
 
-      h1, h2 {
+      h1,
+      h2 {
         line-height: 100%;
       }
 
@@ -90,6 +91,12 @@
         padding: 0.75rem 0;
         text-decoration: none;
         transition: opacity 0.075s ease-in-out;
+      }
+
+      .links a em {
+        font-size: .9rem;
+        font-style: normal;
+        opacity: .6;
       }
 
       .links a:hover {
@@ -192,7 +199,7 @@
       <li><a href="boilerplate/hello-world/">Hello World</a></li>
       <li><a href="boilerplate/360-video/">360&deg; Video</a></li>
       <li><a href="boilerplate/panorama/">Panorama</a></li>
-      <li><a href="boilerplate/3d-model/">3D Model</a></li>
+      <li><a href="boilerplate/3d-model/">3D Model (COLLADA)</a></li>
     </ul>
 
     <h2>Animations</h2>
@@ -221,7 +228,7 @@
       <li><a href="test/geometry-gallery/">Geometry Gallery</a></li>
       <li><a href="test/geometry-merging/">Geometry Merging</a></li>
       <li><a href="test/mixin/">Mixin</a></li>
-      <li><a href="test/model/">Model</a></li>
+      <li><a href="test/model/">Model <em>(glTF, OBJ, COLLADA)</em></a></li>
       <li><a href="test/opacity/">Opacity</a></li>
       <li><a href="test/physical/">Physically-Based Materials</a></li>
       <li><a href="test/pivot/">Pivot</a></li>
@@ -229,7 +236,7 @@
       <li><a href="test/shaders/">Shaders</a></li>
       <li><a href="test/text/">Text</a></li>
       <li><a href="test/text/anchors.html">Text Anchors</a></li>
-      <li><a href="test/text/msdf.html">Text Fonts (MSDF vs. SDF)</a></li>
+      <li><a href="test/text/msdf.html">Text Fonts <em>(MSDF vs. SDF)</em></a></li>
       <li><a href="test/text/scenarios.html">Text Scenarios</a></li>
       <li><a href="test/text/sizes.html">Text Sizes</a></li>
       <li><a href="test/towers/">Towers</a></li>
@@ -245,7 +252,7 @@
       <li><a href="primitives/cylinders/">Cylinders</a></li>
       <li><a href="primitives/defaults/">Defaults</a></li>
       <li><a href="primitives/images/">Images</a></li>
-      <li><a href="primitives/models/">Models</a></li>
+      <li><a href="primitives/models/">Models <em>(glTF, OBJ, COLLADA)</em></a></li>
       <li><a href="primitives/planes/">Planes</a></li>
       <li><a href="primitives/ring/">Ring</a></li>
       <li><a href="primitives/torus/">Torus</a></li>

--- a/examples/primitives/models/index.html
+++ b/examples/primitives/models/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Models</title>
-    <meta name="description" content="Models — A-Frame">
+    <title>Models (glTF, OBJ, COLLADA)</title>
+    <meta name="description" content="Models (glTF, OBJ, COLLADA) — A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
   </head>
   <body>
@@ -13,12 +13,15 @@
         <a-asset-item id="tree2" src="../../assets/models/tree2/tree2.dae"></a-asset-item>
         <a-asset-item id="crate-mtl" src="../../assets/models/crate/crate.mtl"></a-asset-item>
         <a-asset-item id="crate-obj" src="../../assets/models/crate/crate.obj"></a-asset-item>
+        <a-asset-item id="brainstem" src="https://cdn.aframe.io/test-models/models/brainstem/BrainStem.gltf"></a-asset-item>
         <img id="sky" src="peach-gradient.jpg">
       </a-assets>
 
       <a-entity position="0 0 4">
       	<a-camera></a-camera>
       </a-entity>
+
+      <a-gltf-model src="#brainstem" position="-2 0 -1" scale="1.6 1.6 1.6"></a-gltf-model>
 
       <a-obj-model src="#crate-obj" mtl="#crate-mtl"></a-obj-model>
 


### PR DESCRIPTION
**Description:**

glTF example updates (per https://twitter.com/superhoge/status/830993015577546752).

**Changes proposed:**
- Previously, only https://aframe.io/aframe/examples/test/model/ had an example of using a `glTF` model (using `<a-entity gltf-model>`)
- Updated https://aframe.io/aframe/examples/primitives/models/ to show `<a-gltf-model>`
- Updated https://aframe.io/aframe/examples/ to include text about model formats (so the examples are more easily searchable)
