### PR TITLE
Correctly remove the loading message while injecting inspector

### DIFF
--- a/src/components/scene/inspector.js
+++ b/src/components/scene/inspector.js
@@ -57,7 +57,7 @@ module.exports.Component = registerComponent('inspector', {
   },
 
   hideLoader: function () {
-    this.el.removeChild(this.loadingMessageEl);
+    document.body.removeChild(this.loadingMessageEl);
   },
 
   /**

--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -70,7 +70,7 @@ a-scene.fullscreen .a-canvas {
   font-family: Roboto,sans-serif;
   text-align: center;
   z-index: 99999;
-  width: 174px;
+  width: 204px;
 }
 
 /* Inspector loader animation */


### PR DESCRIPTION
Currently aframe throws an error when injecting the inspector:
```
Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at i.hideLoader (https://aframe.io/aframe/dist/aframe-master.min.js:198:1434)
    at HTMLScriptElement.AFRAME.INSPECTOR.AFRAME.inspectorInjected.e.onload (https://aframe.io/aframe/dist/aframe-master.min.js:198:1838)
```
As the inspector component adds the loading message as a child of `body` but tries to delete it as a child of `el`.

I believe it should fix https://github.com/aframevr/aframe-inspector/issues/446