### PR TITLE
[docs] call the right method in example

### DIFF
--- a/docs/core/component.md
+++ b/docs/core/component.md
@@ -606,5 +606,5 @@ Let's access the `bar` member and `qux` method:
 ```js
 var fooComponent = document.querySelector('[foo]').components.foo;
 console.log(fooComponent.bar);
-fooComponent.baz();
+fooComponent.qux();
 ```


### PR DESCRIPTION
It says "Let's access the `bar` member and `qux` method"... so let's don't call `baz`, which doesn't exist.