### PR TITLE
Prevent infinite recursion when an object with a self reference it's …

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -142,6 +142,7 @@ function deepEqual (a, b) {
     // Check nested array and object.
     if ((typeof valA === 'object' || typeof valB === 'object') ||
         (Array.isArray(valA) && Array.isArray(valB))) {
+      if (valA === valB) { continue; }
       if (!deepEqual(valA, valB)) { return false; }
     } else if (valA !== valB) {
       return false;

--- a/tests/utils/objects.test.js
+++ b/tests/utils/objects.test.js
@@ -122,5 +122,10 @@ suite('utils.objects', function () {
       assert.ok(deepEqual({}, {}));
       assert.notOk(deepEqual({}, {a: 1}));
     });
+
+    test('can compare the same object with self reference', function () {
+      var objA = {x: 0, y: 0, z: 0, self: objA};
+      assert.ok(deepEqual(objA, objA));
+    });
   });
 });


### PR DESCRIPTION
…compared with itself through deepEqual

This manifested during `a-saturday-night` development. If we have a schema of the following form:
````javascript
{
...
el: { type: 'selector' }
...
}
````
We end up on an infinite recursion on `deepEqual` when doing:
````javascript
el.setAttribute('myComponent', 'el', "#entityId");
el.setAttribute('myComponent', 'el', "#entityId");
````
the element `#entityId` will be passed to `deepEqual(entityIdEl, entityIdEl)`. Entity components hold references to the entity element creating a circular reference preventing `deepEqual` to find a stop condition.
