### PR TITLE
expose axismove vive controls issue 2413

### DIFF
--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -55,6 +55,7 @@ module.exports.Component = registerComponent('vive-controls', {
     this.onButtonUp = function (evt) { self.onButtonEvent(evt.detail.id, 'up'); };
     this.onButtonTouchStart = function (evt) { self.onButtonEvent(evt.detail.id, 'touchstart'); };
     this.onButtonTouchEnd = function (evt) { self.onButtonEvent(evt.detail.id, 'touchend'); };
+    this.onAxisMoved = bind(this.onAxisMoved, this);
     this.controllerPresent = false;
     this.everGotGamepadEvent = false;
     this.lastControllerCheck = 0;
@@ -180,7 +181,7 @@ module.exports.Component = registerComponent('vive-controls', {
     if (evt.detail.axis[0] === 0 && evt.detail.axis[1] === 0) {
       return;
     }
-    this.el.emit('trackpadmoved', evt);
+    this.el.emit('trackpadmoved', evt.detail);
   },
 
   onButtonEvent: function (id, evtName) {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -178,10 +178,8 @@ module.exports.Component = registerComponent('vive-controls', {
   },
 
   onAxisMoved: function (evt) {
-    if (evt.detail.axis[0] === 0 && evt.detail.axis[1] === 0) {
-      return;
-    }
-    this.el.emit('trackpadmoved', evt.detail);
+    if (evt.detail.axis[0] === 0 && evt.detail.axis[1] === 0) { return; }
+    this.el.emit('trackpadmoved', { x: evt.detail.axis[0], y: evt.detail.axis[1] });
   },
 
   onButtonEvent: function (id, evtName) {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -70,6 +70,7 @@ module.exports.Component = registerComponent('vive-controls', {
     el.addEventListener('touchstart', this.onButtonTouchStart);
     el.addEventListener('touchend', this.onButtonTouchEnd);
     el.addEventListener('model-loaded', this.onModelLoaded);
+    el.addEventListener('axismove', this.onAxisMoved);
   },
 
   removeEventListeners: function () {
@@ -80,6 +81,7 @@ module.exports.Component = registerComponent('vive-controls', {
     el.removeEventListener('touchstart', this.onButtonTouchStart);
     el.removeEventListener('touchend', this.onButtonTouchEnd);
     el.removeEventListener('model-loaded', this.onModelLoaded);
+    el.removeEventListener('axismove', this.onAxisMoved);
   },
 
   checkIfControllerPresent: function () {
@@ -172,6 +174,13 @@ module.exports.Component = registerComponent('vive-controls', {
     buttonMeshes.trigger = controllerObject3D.getObjectByName('trigger');
     // Offset pivot point
     controllerObject3D.position.set(0, -0.015, 0.04);
+  },
+
+  onAxisMoved: function (evt) {
+    if (evt.detail.axis[0] === 0 && evt.detail.axis[1] === 0) {
+      return;
+    }
+    this.el.emit('trackpadmoved', evt);
   },
 
   onButtonEvent: function (id, evtName) {


### PR DESCRIPTION
**Description:**
Exposes 'axismove' events from tracked-controls component in vive-controls as 'trackpadmoved'.

https://github.com/aframevr/aframe/issues/2413

**Changes proposed:**
- add onAxisMoved event listener function, which exposes the underlying event
