### PR TITLE
Expose animations on root gltf object.

### DIFF
--- a/src/components/gltf-model.js
+++ b/src/components/gltf-model.js
@@ -23,6 +23,7 @@ module.exports.Component = registerComponent('gltf-model', {
 
     this.loader.load(src, function gltfLoaded (gltfModel) {
       self.model = gltfModel.scene;
+      self.model.animations = gltfModel.animations;
       self.system.registerModel(self.model);
       el.setObject3D('mesh', self.model);
       el.emit('model-loaded', {format: 'gltf', model: self.model});

--- a/tests/components/gltf-model.test.js
+++ b/tests/components/gltf-model.test.js
@@ -1,5 +1,6 @@
 /* global assert, process, setup, suite, test */
 var entityFactory = require('../helpers').entityFactory;
+var THREE = require('index').THREE;
 
 var SRC = '/base/tests/assets/box/Box.gltf';
 
@@ -54,5 +55,34 @@ suite('gltf-model', function () {
       el2.setAttribute('gltf-model', '#gltf');
     });
     el.sceneEl.appendChild(el2);
+  });
+
+  test('attaches animation clips to model', function (done) {
+    var el = this.el;
+    var sceneMock = new THREE.Object3D();
+    var animations = [
+      new THREE.AnimationClip('run', 1.0, []),
+      new THREE.AnimationClip('jump', 1.0, [])
+    ];
+    var gltfMock = {
+      scene: sceneMock,
+      scenes: [sceneMock],
+      animations: animations
+    };
+
+    this.sinon.stub(THREE, 'GLTFLoader', function MockGLTFLoader () {
+      this.load = function (url, onLoad) {
+        process.nextTick(onLoad.bind(null, gltfMock));
+      };
+    });
+
+    el.addEventListener('model-loaded', function () {
+      var model = el.components['gltf-model'].model;
+      assert.ok(model);
+      assert.equal(model.animations, animations);
+      done();
+    });
+
+    el.setAttribute('gltf-model', '#gltf');
   });
 });


### PR DESCRIPTION
The GLTFLoader response is formatted as:

```
{
  animations: {Array<THREE.AnimationClip>},
  cameras: {Array<THREE.Camera>},
  scene: {Scene},
  scenes: {Array<THREE.Scene>}
}
```

I'm not confident enough about the API choice to propose an animation component yet, but we should at least expose the underlying animation objects so that users can write their own playback. This PR takes the approach of THREE.ObjectLoader, attaching animations to the root object. By contrast, THREE.JSONLoader attaches the animations to Geometry objects (which doesn't make sense in this case). Another option would be emitting the animations with the `model-loaded` event details, but not attaching them anywhere.

An absolute-minimum animation component, compatible with this, would be:

```js
AFRAME.registerComponent('play-all-animations', {
  init: function () {
    this.el.addEventListener('model-loaded', function (e) {
      var model = e.detail.model;
      var clips = model.animations;

      if (!clips) { return; }

      this.remove();

      var mixer = this.mixer = new THREE.AnimationMixer(model);
      clips.forEach(function (clip) {
        mixer.clipAction(clip).play();
      });
    }.bind(this));
  },
  remove: function () {
    if (this.mixer) { this.mixer.stopAllAction(); }
  },
  tick: function (t, dt) {
    if (this.mixer && dt) { this.mixer.update(dt / 1000); }
  }
});
```

/cc @caseyyee 