### PR TITLE
expose constants on default export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,7 @@ module.exports = window.AFRAME = {
   ANode: ANode,
   AScene: AScene,
   components: components,
+  constants: require('./constants'),
   geometries: require('./core/geometry').geometries,
   registerComponent: registerComponent,
   registerElement: require('./core/a-register-element').registerElement,


### PR DESCRIPTION
For example, make it less error prone for your app to stay in sync with upstream changes to `DEFAULT_CAMERA_HEIGHT`.