### PR TITLE
Emulated oculus and vive controls

### DIFF
--- a/docs/components/oculus-touch-controls.md
+++ b/docs/components/oculus-touch-controls.md
@@ -22,6 +22,7 @@ mappings, events, and a Touch controller model.
 
 | Property             | Description                                        | Default Value        |
 |----------------------|----------------------------------------------------|----------------------|
+| emulated             | Whether to emulate (treat as present regardless).  | false                |
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Touch controller model is loaded.      | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |

--- a/docs/components/oculus-touch-controls.md
+++ b/docs/components/oculus-touch-controls.md
@@ -27,6 +27,9 @@ mappings, events, and a Touch controller model.
 | model                | Whether the Touch controller model is loaded.      | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |
 
+The emulated property is rarely needed, but is provided for use cases that must force controller
+event listeners to be added despite no controllers actually being present, e.g. motion / event capture replays.
+
 ## Events
 
 | Event Name           | Description                    |

--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -25,6 +25,7 @@ buttons (trigger, grip, menu, system) and trackpad.
 |----------------------|----------------------------------------------------|----------------------|
 | buttonColor          | Button colors when not pressed.                    | #FAFAFA (off-white)  |
 | buttonHighlightColor | Button colors when pressed and active.             | #22D1EE (light blue) |
+| emulated             | Whether to emulate (treat as present regardless).  | false                |
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Vive controller model is loaded.       | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |

--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -30,6 +30,9 @@ buttons (trigger, grip, menu, system) and trackpad.
 | model                | Whether the Vive controller model is loaded.       | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |
 
+The emulated property is rarely needed, but is provided for use cases that must force controller
+event listeners to be added despite no controllers actually being present, e.g. motion / event capture replays.
+
 ## Events
 
 | Event Name   | Description             |

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -16,6 +16,7 @@ var GAMEPAD_ID_PREFIX = 'OpenVR ';
 module.exports.Component = registerComponent('vive-controls', {
   schema: {
     hand: {default: 'left'},
+    emulated: {default: false},
     buttonColor: {type: 'color', default: '#FAFAFA'},  // Off-white.
     buttonHighlightColor: {type: 'color', default: '#22D1EE'},  // Light blue.
     model: {default: true},
@@ -45,6 +46,7 @@ module.exports.Component = registerComponent('vive-controls', {
     this.removeControllersUpdateListener = bind(this.removeControllersUpdateListener, this);
     this.onGamepadConnected = bind(this.onGamepadConnected, this);
     this.onGamepadDisconnected = bind(this.onGamepadDisconnected, this);
+    this.onGamepadConnectionEvent = bind(this.onGamepadConnectionEvent, this);
   },
 
   init: function () {
@@ -87,42 +89,38 @@ module.exports.Component = registerComponent('vive-controls', {
 
   checkIfControllerPresent: function () {
     var data = this.data;
-    var controller = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
-    var isPresent = this.isControllerPresent(this.el.sceneEl, GAMEPAD_ID_PREFIX, { index: controller });
-    if (isPresent === this.controllerPresent) { return; }
+    // Once OpenVR / SteamVR return correct hand data in the supporting browsers, we can use hand property.
+    // var isPresent = this.isControllerPresent(this.el.sceneEl, GAMEPAD_ID_PREFIX, { hand: data.hand });
+    // Until then, use hardcoded index.
+    var controllerIndex = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
+    var isPresent = this.isControllerPresent(this.el.sceneEl, GAMEPAD_ID_PREFIX, { index: controllerIndex });
+    if ((isPresent || data.emulated) === this.controllerPresent) { return; }
     this.controllerPresent = isPresent;
     if (isPresent) { this.injectTrackedControls(); } // inject track-controls
+    if (isPresent || data.emulated) { this.addEventListeners(); } else { this.removeEventListeners(); }
   },
 
-  onGamepadConnected: function (evt) {
-    // for now, don't disable controller update listening, due to
-    // apparent issue with FF Nightly only sending one event and seeing one controller;
-    // this.everGotGamepadEvent = true;
-    // this.removeControllersUpdateListener();
-    this.checkIfControllerPresent();
-  },
-
-  onGamepadDisconnected: function (evt) {
-    // for now, don't disable controller update listening, due to
-    // apparent issue with FF Nightly only sending one event and seeing one controller;
-    // this.everGotGamepadEvent = true;
-    // this.removeControllersUpdateListener();
+  onGamepadConnectionEvent: function (evt) {
+    this.everGotGamepadEvent = true;
+    // Due to an apparent bug in FF Nightly
+    // where only one gamepadconnected / disconnected event is fired,
+    // which makes it difficult to handle in individual controller entities,
+    // we no longer remove the controllersupdate listener as a result.
     this.checkIfControllerPresent();
   },
 
   play: function () {
     this.checkIfControllerPresent();
-    window.addEventListener('gamepadconnected', this.onGamepadConnected, false);
-    window.addEventListener('gamepaddisconnected', this.onGamepadDisconnected, false);
     this.addControllersUpdateListener();
-    this.addEventListeners();
+    window.addEventListener('gamepadconnected', this.onGamepadConnectionEvent, false);
+    window.addEventListener('gamepaddisconnected', this.onGamepadConnectionEvent, false);
   },
 
   pause: function () {
-    window.removeEventListener('gamepadconnected', this.onGamepadConnected, false);
-    window.removeEventListener('gamepaddisconnected', this.onGamepadDisconnected, false);
-    this.removeControllersUpdateListener();
     this.removeEventListeners();
+    this.removeControllersUpdateListener();
+    window.removeEventListener('gamepadconnected', this.onGamepadConnectionEvent, false);
+    window.removeEventListener('gamepaddisconnected', this.onGamepadConnectionEvent, false);
   },
 
   injectTrackedControls: function () {

--- a/tests/components/oculus-touch-controls.test.js
+++ b/tests/components/oculus-touch-controls.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test */
+/* global assert, process, setup, suite, test, Event */
 var entityFactory = require('../helpers').entityFactory;
 var controllerComponentName = 'oculus-touch-controls';
 
@@ -10,6 +10,46 @@ suite(controllerComponentName, function () {
       var controllerComponent = el.components[controllerComponentName];
       controllerComponent.isControllerPresent = function () { return controllerComponent.isControllerPresentMockValue; };
       done();
+    });
+  });
+
+  suite('emulated', function () {
+    test('when emulated, if no controllers, add event listeners but do not inject tracked-controls', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      // mock isControllerPresent to return false
+      controllerComponent.isControllerPresentMockValue = false;
+      // pretend we haven't looked before
+      delete controllerComponent.controllerPresent;
+      // set the emulated flag directly, to avoid having to wait for DOM update
+      controllerComponent.data.emulated = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.ok(controllerComponent.data.emulated);
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+      assert.ok(addEventListenersSpy.called);
+    });
+
+    test('when not emulated by default, if no controllers, do not add event listeners or inject tracked-controls', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      // mock isControllerPresent to return false
+      controllerComponent.isControllerPresentMockValue = false;
+      // pretend we haven't looked before
+      delete controllerComponent.controllerPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(controllerComponent.data.emulated);
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+      assert.notOk(addEventListenersSpy.called);
     });
   });
 
@@ -80,7 +120,7 @@ suite(controllerComponentName, function () {
       var el = this.el;
       var controllerComponent = el.components[controllerComponentName];
       var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      // mock isControllerPresent to return true
+      // mock isControllerPresent to return false
       controllerComponent.isControllerPresentMockValue = false;
       // pretend we've looked before
       controllerComponent.controllerPresent = true;
@@ -92,26 +132,35 @@ suite(controllerComponentName, function () {
     });
   });
 
-  suite.skip('onGamepadConnected / Disconnected', function () {
-    test('if we get onGamepadConnected or onGamepadDisconnected, remove periodic change listener and check if present', function () {
+  suite('gamepadconnected / disconnected', function () {
+    // Due to an apparent bug in FF Nightly
+    // where only one gamepadconnected / disconnected event is fired,
+    // which makes it difficult to handle in individual controller entities,
+    // we no longer remove the controllersupdate listener as a result.
+    test('if we get gamepadconnected or gamepaddisconnected, check if present', function () {
       var el = this.el;
       var controllerComponent = el.components[controllerComponentName];
-      var removeControllersUpdateListenerSpy = this.sinon.spy(controllerComponent, 'removeControllersUpdateListener');
       var checkIfControllerPresentSpy = this.sinon.spy(controllerComponent, 'checkIfControllerPresent');
+      // Because checkIfControllerPresent may be used in bound form, bind and reinstall.
+      controllerComponent.checkIfControllerPresent = controllerComponent.checkIfControllerPresent.bind(controllerComponent);
+      controllerComponent.pause();
+      controllerComponent.play();
+      // mock isControllerPresent to return true
+      controllerComponent.isControllerPresentMockValue = true;
       // reset everGotGamepadEvent so we don't think we've looked before
       delete controllerComponent.everGotGamepadEvent;
-      // do the call
-      controllerComponent.onGamepadConnected();
+      // fire emulated gamepadconnected event
+      window.dispatchEvent(new Event('gamepadconnected'));
       // check assertions
-      assert.ok(removeControllersUpdateListenerSpy.called);
       assert.ok(checkIfControllerPresentSpy.called);
       assert.ok(controllerComponent.everGotGamepadEvent);
+      // mock isControllerPresent to return false
+      controllerComponent.isControllerPresentMockValue = false;
       // reset everGotGamepadEvent so we don't think we've looked before
       delete controllerComponent.everGotGamepadEvent;
-      // do the call
-      controllerComponent.onGamepadDisconnected();
+      // fire emulated gamepaddisconnected event
+      window.dispatchEvent(new Event('gamepaddisconnected'));
       // check assertions
-      assert.ok(removeControllersUpdateListenerSpy.called);
       assert.ok(checkIfControllerPresentSpy.called);
       assert.ok(controllerComponent.everGotGamepadEvent);
     });

--- a/tests/components/vive-controls.test.js
+++ b/tests/components/vive-controls.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test */
+/* global assert, process, setup, suite, test, Event */
 var entityFactory = require('../helpers').entityFactory;
 var controllerComponentName = 'vive-controls';
 
@@ -10,6 +10,46 @@ suite(controllerComponentName, function () {
       var controllerComponent = el.components[controllerComponentName];
       controllerComponent.isControllerPresent = function () { return controllerComponent.isControllerPresentMockValue; };
       done();
+    });
+  });
+
+  suite('emulated', function () {
+    test('when emulated, if no controllers, add event listeners but do not inject tracked-controls', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      // mock isControllerPresent to return false
+      controllerComponent.isControllerPresentMockValue = false;
+      // pretend we haven't looked before
+      delete controllerComponent.controllerPresent;
+      // set the emulated flag directly, to avoid having to wait for DOM update
+      controllerComponent.data.emulated = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.ok(controllerComponent.data.emulated);
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+      assert.ok(addEventListenersSpy.called);
+    });
+
+    test('when not emulated by default, if no controllers, do not add event listeners or inject tracked-controls', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      // mock isControllerPresent to return false
+      controllerComponent.isControllerPresentMockValue = false;
+      // pretend we haven't looked before
+      delete controllerComponent.controllerPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(controllerComponent.data.emulated);
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+      assert.notOk(addEventListenersSpy.called);
     });
   });
 
@@ -96,26 +136,35 @@ suite(controllerComponentName, function () {
     });
   });
 
-  suite.skip('onGamepadConnected / Disconnected', function () {
-    test('if we get onGamepadConnected or onGamepadDisconnected, remove periodic change listener and check if present', function () {
+  suite('gamepadconnected / disconnected', function () {
+    // Due to an apparent bug in FF Nightly
+    // where only one gamepadconnected / disconnected event is fired,
+    // which makes it difficult to handle in individual controller entities,
+    // we no longer remove the controllersupdate listener as a result.
+    test('if we get gamepadconnected or gamepaddisconnected, check if present', function () {
       var el = this.el;
       var controllerComponent = el.components[controllerComponentName];
-      var removeControllersUpdateListenerSpy = this.sinon.spy(controllerComponent, 'removeControllersUpdateListener');
       var checkIfControllerPresentSpy = this.sinon.spy(controllerComponent, 'checkIfControllerPresent');
+      // Because checkIfControllerPresent may be used in bound form, bind and reinstall.
+      controllerComponent.checkIfControllerPresent = controllerComponent.checkIfControllerPresent.bind(controllerComponent);
+      controllerComponent.pause();
+      controllerComponent.play();
+      // mock isControllerPresent to return true
+      controllerComponent.isControllerPresentMockValue = true;
       // reset everGotGamepadEvent so we don't think we've looked before
       delete controllerComponent.everGotGamepadEvent;
-      // do the call
-      controllerComponent.onGamepadConnected();
+      // fire emulated gamepadconnected event
+      window.dispatchEvent(new Event('gamepadconnected'));
       // check assertions
-      assert.ok(removeControllersUpdateListenerSpy.called);
       assert.ok(checkIfControllerPresentSpy.called);
       assert.ok(controllerComponent.everGotGamepadEvent);
+      // mock isControllerPresent to return false
+      controllerComponent.isControllerPresentMockValue = false;
       // reset everGotGamepadEvent so we don't think we've looked before
       delete controllerComponent.everGotGamepadEvent;
-      // do the call
-      controllerComponent.onGamepadDisconnected();
+      // fire emulated gamepaddisconnected event
+      window.dispatchEvent(new Event('gamepaddisconnected'));
       // check assertions
-      assert.ok(removeControllersUpdateListenerSpy.called);
       assert.ok(checkIfControllerPresentSpy.called);
       assert.ok(controllerComponent.everGotGamepadEvent);
     });


### PR DESCRIPTION
(Per request, this PR no longer extends #2413 / #2415 to `oculus-touch-controls` as `thumbstickmoved`)

Should fix #2379.
