### PR TITLE
fix typo: colon instead of comma in list of values

### DIFF
--- a/docs/guides/using-javascript-and-dom-apis.md
+++ b/docs/guides/using-javascript-and-dom-apis.md
@@ -259,7 +259,7 @@ slightly preferred to pass an object so A-Frame doesn't have to parse the
 string.
 
 ```js
-entityEl.setAttribute('position', {x: 1, y: 2: z: -3});
+entityEl.setAttribute('position', {x: 1, y: 2, z: -3});
 // Or entityEl.setAttribute('position', '1 2 -3');
 ```
 


### PR DESCRIPTION
**Description:**
Fixes typo in code example

**Changes proposed:**
- replace : with , in list of values
