### PR TITLE
Document and test unique array component property type behavior

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -311,16 +311,16 @@ entity.play();
 
 For example, the [sound component][sound] on play will begin playing the sound.
 
-### `setAttribute (attr, value, componentAttrValue)`
+### `setAttribute (componentName, value, [propertyValue | clobber])`
 
-If `attr` is not the name of a registered component or the component is a
+If `componentName` is not the name of a registered component or the component is a
 single-property component, `setAttribute` behaves as it normally would:
 
 ```js
 entity.setAttribute('visible', false);
 ```
 
-Though if `attr` is the name of a registered component, it may handle special
+Though if `componentName` is the name of a registered component, it may handle special
 parsing for the value. For example, the [position component][position] is a
 single-property component, but its property type parser allows it to take an
 object:
@@ -329,11 +329,12 @@ object:
 entity.setAttribute('position', { x: 1, y: 2, z: 3 });
 ```
 
-#### Putting Multi-Property Component Data
+#### Updating Multi-Property Component Data
 
-To set or replace component data for a multi-property component, we can pass
-the name of a registered component as the `attr`, and pass an object of
-properties as the `value`:
+To update component data for a multi-property component, we can pass the name
+of a registered component as the `componentName`, and pass an object of
+properties as the `value`. A string is also acceptable (e.g., `type: spot;
+distance: 30`), but objects will save A-Frame some work in parsing:
 
 ```js
 // Only the properties passed in the object will be overwritten.
@@ -344,25 +345,34 @@ entity.setAttribute('light', {
 });
 ```
 
-Alternatively, including `true` as a third argument will reset all other
-properties for the component to their defaults. 
-Array-type properties behave uniquely when set this way. First, the component 
-data will be assigned by reference to the new array, so later changes to an
-array variable that was passed to `setAttribute` will also be  reflected in the 
-component data. Second, unlike other property types, updates to an array 
-property with this method do not automatically trigger the component's 
-`update` method. 
-
-
-#### Updating Multi-Property Component Data
-
-To update individual properties for a multi-property component, we can pass the
-name of registered component as the `attr`, a property name as the second
+Or to update individual properties for a multi-property component, we can pass
+the name of registered component as the `componentName`, a property name as the second
 argument, and the property value to set as the third argument:
 
 ```js
 // All previous properties for the material component (besides the color)  will be unaffected.
 entity.setAttribute('material', 'color', 'crimson');
+```
+
+Note that array property types behave uniquely:
+
+- Arrays are mutable. They are assigned by reference so changes to arrays will
+  be visible by the component.
+- Updates to array type properties will not trigger the component's `update` method
+  nor emit events.
+
+#### Putting Multi-Property Component Data
+
+If `true` is passed as the third argument to `.setAttribute`, then
+non-specified properties will be reset and clobbered:
+
+```js
+// All previous properties for the light component will be removed and overwritten.
+entity.setAttribute('light', {
+  type: 'spot',
+  distance: 30,
+  intensity: 2.0
+}, true);
 ```
 
 ### `setObject3D (type, obj)`
@@ -379,9 +389,9 @@ AFRAME.registerComponent('example-orthogonal-camera', {
 });
 ```
 
-### `removeAttribute (attr, propertyName)`
+### `removeAttribute (componentName, propertyName)`
 
-If `attr` is the name of a registered component, along with removing the
+If `componentName` is the name of a registered component, along with removing the
 attribute from the DOM, `removeAttribute` will also detach the component from
 the entity, invoking the component's `remove` lifecycle method.
 

--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -336,13 +336,23 @@ the name of a registered component as the `attr`, and pass an object of
 properties as the `value`:
 
 ```js
-// All previous properties for the light component will be removed and overwritten.
+// Only the properties passed in the object will be overwritten.
 entity.setAttribute('light', {
   type: 'spot',
   distance: 30,
   intensity: 2.0
 });
 ```
+
+Alternatively, including `true` as a third argument will reset all other
+properties for the component to their defaults. 
+Array-type properties behave uniquely when set this way. First, the component 
+data will be assigned by reference to the new array, so later changes to an
+array variable that was passed to `setAttribute` will also be  reflected in the 
+component data. Second, unlike other property types, updates to an array 
+property with this method do not automatically trigger the component's 
+`update` method. 
+
 
 #### Updating Multi-Property Component Data
 

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -338,25 +338,28 @@ suite('a-entity', function () {
     });
 
     test('partial updates of array properties assign by reference', function () {
+      // Arrays are assigned by reference and mutable.
       var sourceArray = [1, 2, 3];
-      registerComponent('array-comp', {
-        schema: { arr: { type: 'array' } }
+      registerComponent('test', {
+        schema: {array: {type: 'array'}}
       });
-      this.el.setAttribute('array-comp', { arr: sourceArray });
-      assert.strictEqual(this.el.getAttribute('array-comp').arr, sourceArray);
+      this.el.setAttribute('test', {array: sourceArray});
+      assert.strictEqual(this.el.getAttribute('test').array, sourceArray);
     });
+
     test('partial updates of array-type properties do not trigger update', function () {
+      // Updates to array do not trigger update handler.
       var updateSpy;
-      registerComponent('array-comp2', {
-        schema: { arr: { type: 'array' } },
-        update: function (oldData) { }
+      registerComponent('test', {
+        schema: {array: {type: 'array'}},
+        update: function () { /* no-op */ }
       });
-      this.el.setAttribute('array-comp2', { arr: [1, 2, 3] });
-      updateSpy = this.sinon.spy(this.el.components['array-comp2'], 'update');
+      this.el.setAttribute('test', {arr: [1, 2, 3]});
+      updateSpy = this.sinon.spy(this.el.components.test, 'update');
       // setAttribute does not trigger update because utils.extendDeep
       // called by componentUpdate assigns the new value directly into the
       // component data
-      this.el.setAttribute('array-comp2', { arr: [4, 5, 6] });
+      this.el.setAttribute('test', {arr: [4, 5, 6]});
       assert.isFalse(updateSpy.called);
     });
 

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -337,6 +337,29 @@ suite('a-entity', function () {
       assert.equal(geometry.width, 3);
     });
 
+    test('partial updates of array properties assign by reference', function () {
+      var sourceArray = [1, 2, 3];
+      registerComponent('array-comp', {
+        schema: { arr: { type: 'array' } }
+      });
+      this.el.setAttribute('array-comp', { arr: sourceArray });
+      assert.strictEqual(this.el.getAttribute('array-comp').arr, sourceArray);
+    });
+    test('partial updates of array-type properties do not trigger update', function () {
+      var updateSpy;
+      registerComponent('array-comp2', {
+        schema: { arr: { type: 'array' } },
+        update: function (oldData) { }
+      });
+      this.el.setAttribute('array-comp2', { arr: [1, 2, 3] });
+      updateSpy = this.sinon.spy(this.el.components['array-comp2'], 'update');
+      // setAttribute does not trigger update because utils.extendDeep
+      // called by componentUpdate assigns the new value directly into the
+      // component data
+      this.el.setAttribute('array-comp2', { arr: [4, 5, 6] });
+      assert.isFalse(updateSpy.called);
+    });
+
     test('can partially update vec3', function () {
       var el = this.el;
       el.setAttribute('position', {y: 20});


### PR DESCRIPTION
**Description:**

The behavior of `setAttribute('component', {...}) changed starting with v0.4.0 such that array property types behave uniquely. 

1. Arrays are assigned by reference, so later changes to the variable that was passed in `setAttribute` will also be reflected in the component data
2. Updating an array property by passing it in an object to `setAttribute` will never trigger the component's `update` method (because it is assigned by reference [here](https://github.com/aframevr/aframe/blob/master/src/core/a-entity.js#L707) before the check for changes to call update [here](https://github.com/aframevr/aframe/blob/dec48d73bbe0d0189ae203eb12431ffc5521e0a2/src/core/component.js#L221))

See full discussion in #2227. 

**Changes proposed:**

- Document current behavior
- Add test cases to detect future changes in behavior

I also added documentation of the clobber update flag, but I can remove this if its not something you want in the docs. 
