### PR TITLE
Fix a-asset-item

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -99,7 +99,6 @@ registerElement('a-asset-item', {
         var self = this;
         var src = this.getAttribute('src');
         fileLoader.load(src, function handleOnLoad (textResponse) {
-          THREE.Cache.files[src] = textResponse;
           self.data = textResponse;
           /*
             Workaround for a Chrome bug. If another XHR is sent to the same url before the

--- a/tests/assets/dummy.txt
+++ b/tests/assets/dummy.txt
@@ -1,0 +1,1 @@
+dummy file for a-assets.test.js

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -5,7 +5,7 @@ var THREE = require('lib/three');
 // Use data URI where a load event is needed.
 var IMG_SRC = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-var XHR_SRC = 'base/src/README.md';
+var XHR_SRC = '/base/tests/assets/dummy.txt';
 
 suite('a-assets', function () {
   setup(function () {


### PR DESCRIPTION
**Description:**

This PR fixes `a-asset-item` and its test. #2378

**Changes proposed:**
- Remove `THREE.Cache.files[src] = responseText;` from `a-asset-item` because data is cached in `THREE.FileLoader`. `a-asset-item` doesn't need to explicitly call it.
- Fix `XHR_SRC` file path in `a-assets.test.js`. The path was to non-existing file. I added a new dummy file and set path to it. `a-asset-item` has side effect to `THREE.Cache` so I think it'd better we have an `a-assets-test.js` specific dummy file.
