### PR TITLE
[docs] Update using-the-aframe-inspector.md

### DIFF
--- a/docs/guides/using-the-aframe-inspector.md
+++ b/docs/guides/using-the-aframe-inspector.md
@@ -61,7 +61,7 @@ rotate, pan, or zoom the viewport to change the view of the scene:
 
 From the viewport, we can also select entities and transform them:
 
-- **Select**: left-click on an entity
+- **Select**: left-click on an entity, double-click to focus the camera on it
 - **Transform**: select a helper tool on the upper-right corner of the
   viewport, drag the red/blue/green helpers surrounding an entity to transform
   it


### PR DESCRIPTION
**Description:**
Could not find an explanation of how to refocus the viewport camera on an object for easier rotation before,
but happened to stumble upon it. Would also like to suggest adding some info about it to the 'h' hotkeys menu in-inspector.

**Changes proposed:**
- Add information about double-clicking to focus the camera on an entity