### PR TITLE
Array buffer asset item

### DIFF
--- a/docs/core/asset-management-system.md
+++ b/docs/core/asset-management-system.md
@@ -169,6 +169,16 @@ particular events on these elements; noted here for convenience:
 A-Frame uses these progress events, comparing how much time the browser
 buffered with the duration of the asset, to detect when the asset becomes loaded.
 
+## Specifying Response Type
+
+Content fetched by `<a-asset-item>` will be returned as plain text. If we want
+to use a different response type such as `arraybuffer`, use `<a-asset-item>`'s
+`response-type` attribute:
+
+```html
+<a-asset-item response-type="arraybuffer" src="model.gltf"></a-asset-item>
+```
+
 ## How It Works Internally
 
 Every element in A-Frame inherits from `<a-node>`, the `AFRAME.ANode`

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -98,9 +98,7 @@ registerElement('a-asset-item', {
       value: function () {
         var self = this;
         var src = this.getAttribute('src');
-        var responseType = this.getAttribute('responseType');
-        if (responseType === null) responseType = 'text';
-        fileLoader.setResponseType(responseType);
+        fileLoader.setResponseType(this.getAttribute('response-type' || 'text'));
         fileLoader.load(src, function handleOnLoad (textResponse) {
           self.data = textResponse;
           /*

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -98,6 +98,9 @@ registerElement('a-asset-item', {
       value: function () {
         var self = this;
         var src = this.getAttribute('src');
+        var responseType = this.getAttribute('responseType');
+        if (responseType === null) responseType = 'text';
+        fileLoader.setResponseType(responseType);
         fileLoader.load(src, function handleOnLoad (textResponse) {
           self.data = textResponse;
           /*

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -233,9 +233,9 @@ suite('a-asset-item', function () {
   });
 
   test('loads as text without responseType attribute', function (done) {
-    // remove cache data not to load from it
-    THREE.Cache.remove(XHR_SRC);
     var assetItem = document.createElement('a-asset-item');
+    // Remove cache data to not load from it.
+    THREE.Cache.remove(XHR_SRC);
     assetItem.setAttribute('src', XHR_SRC);
     assetItem.addEventListener('loaded', function (evt) {
       assert.ok(assetItem.data !== null);
@@ -247,10 +247,10 @@ suite('a-asset-item', function () {
   });
 
   test('loads as arraybuffer', function (done) {
-    THREE.Cache.remove(XHR_SRC);
     var assetItem = document.createElement('a-asset-item');
+    THREE.Cache.remove(XHR_SRC);
     assetItem.setAttribute('src', XHR_SRC);
-    assetItem.setAttribute('responseType', 'arraybuffer');
+    assetItem.setAttribute('response-type', 'arraybuffer');
     assetItem.addEventListener('loaded', function (evt) {
       assert.ok(assetItem.data !== null);
       assert.ok(assetItem.data instanceof ArrayBuffer);
@@ -260,7 +260,7 @@ suite('a-asset-item', function () {
     document.body.appendChild(this.sceneEl);
   });
 
-  test('loads from cache as arraybuffer without responseType attribute', function (done) {
+  test('loads from cache as arraybuffer without response-type attribute', function (done) {
     var assetItem = document.createElement('a-asset-item');
     assetItem.setAttribute('src', XHR_SRC);
     assetItem.addEventListener('loaded', function (evt) {

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -231,4 +231,57 @@ suite('a-asset-item', function () {
     this.assetsEl.appendChild(assetItem);
     document.body.appendChild(this.sceneEl);
   });
+
+  test('loads as text without responseType attribute', function (done) {
+    // remove cache data not to load from it
+    THREE.Cache.remove(XHR_SRC);
+    var assetItem = document.createElement('a-asset-item');
+    assetItem.setAttribute('src', XHR_SRC);
+    assetItem.addEventListener('loaded', function (evt) {
+      assert.ok(assetItem.data !== null);
+      assert.ok(typeof assetItem.data === 'string');
+      done();
+    });
+    this.assetsEl.appendChild(assetItem);
+    document.body.appendChild(this.sceneEl);
+  });
+
+  test('loads as arraybuffer', function (done) {
+    THREE.Cache.remove(XHR_SRC);
+    var assetItem = document.createElement('a-asset-item');
+    assetItem.setAttribute('src', XHR_SRC);
+    assetItem.setAttribute('responseType', 'arraybuffer');
+    assetItem.addEventListener('loaded', function (evt) {
+      assert.ok(assetItem.data !== null);
+      assert.ok(assetItem.data instanceof ArrayBuffer);
+      done();
+    });
+    this.assetsEl.appendChild(assetItem);
+    document.body.appendChild(this.sceneEl);
+  });
+
+  test('loads from cache as arraybuffer without responseType attribute', function (done) {
+    var assetItem = document.createElement('a-asset-item');
+    assetItem.setAttribute('src', XHR_SRC);
+    assetItem.addEventListener('loaded', function (evt) {
+      assert.ok(assetItem.data !== null);
+      assert.ok(assetItem.data instanceof ArrayBuffer);
+      done();
+    });
+    this.assetsEl.appendChild(assetItem);
+    document.body.appendChild(this.sceneEl);
+  });
+
+  test('reloads as text', function (done) {
+    THREE.Cache.remove(XHR_SRC);
+    var assetItem = document.createElement('a-asset-item');
+    assetItem.setAttribute('src', XHR_SRC);
+    assetItem.addEventListener('loaded', function (evt) {
+      assert.ok(assetItem.data !== null);
+      assert.ok(typeof assetItem.data === 'string');
+      done();
+    });
+    this.assetsEl.appendChild(assetItem);
+    document.body.appendChild(this.sceneEl);
+  });
 });


### PR DESCRIPTION
**Description:**

This PR adds `responseType` attribute to `a-asset-item`.
It's necessary for `THREE.GLTFLoader` in r84. #2378
And it'll be helpful for user components which need `arraybuffer` data.

It has a limitation.
If we attempt to load the same data as different `responseType`s,
only the `responseType` of the first attempt is applied
because it loads from cache  if exists.

I think it won't cause any problems because
there's no situation that we wanna load the same data with different `responseType`s.
(If exists, let me know.)

**Changes proposed:**
- Add `responseType` attribute to `a-asset-item`. 
- Add `responseType` tests
