### PR TITLE
Fix a-asset-item

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -99,8 +99,8 @@ registerElement('a-asset-item', {
         var self = this;
         var src = this.getAttribute('src');
         fileLoader.setResponseType(this.getAttribute('response-type' || 'text'));
-        fileLoader.load(src, function handleOnLoad (textResponse) {
-          self.data = textResponse;
+        fileLoader.load(src, function handleOnLoad (response) {
+          self.data = response;
           /*
             Workaround for a Chrome bug. If another XHR is sent to the same url before the
             previous one closes, the second request never finishes.

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -98,7 +98,7 @@ registerElement('a-asset-item', {
       value: function () {
         var self = this;
         var src = this.getAttribute('src');
-        fileLoader.setResponseType(this.getAttribute('response-type' || 'text'));
+        fileLoader.setResponseType(this.getAttribute('response-type') || 'text');
         fileLoader.load(src, function handleOnLoad (response) {
           self.data = response;
           /*


### PR DESCRIPTION
**Description:**

This PR fixes a `a-asset-item` bug and renames a variable to an appropriate one.

**Changes proposed:**
- Rename `textResponse` to `response` because its data type depends on `response-type`
- Fix `fileLoader.setResponseType()` argument. It should be `response-type` attribute or `text`
