### PR TITLE
Fix has fileLoader test in a-assets.test.js

### DIFF
--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -32,7 +32,7 @@ suite('a-assets', function () {
   });
 
   test('has fileLoader', function () {
-    assert.ok(this.el.fileLoader.constructor, THREE.XHRLoader);
+    assert.equal(this.el.fileLoader.constructor, THREE.FileLoader);
   });
 
   test('waits for images to load', function (done) {


### PR DESCRIPTION
**Description:**

If I'm right, `has fileLoader` test in `a-assets.test.js` is wrong,
it checks if `el` has `fileLoader.constructor`.

This PR fixes that, lets it to check if `el.fileLoader.constructor` is `THREE.FileLoader`.

