### PR TITLE
Accept glTF file which does not include default scene

### DIFF
--- a/src/components/gltf-model.js
+++ b/src/components/gltf-model.js
@@ -22,7 +22,7 @@ module.exports.Component = registerComponent('gltf-model', {
     this.remove();
 
     this.loader.load(src, function gltfLoaded (gltfModel) {
-      self.model = gltfModel.scene;
+      self.model = gltfModel.scene || gltfModel.scenes[0];
       self.model.animations = gltfModel.animations;
       self.system.registerModel(self.model);
       el.setObject3D('mesh', self.model);

--- a/tests/assets/box/Box_no_default_scene.gltf
+++ b/tests/assets/box/Box_no_default_scene.gltf
@@ -1,0 +1,249 @@
+{
+    "accessors": {
+        "accessor_21": {
+            "bufferView": "bufferView_29",
+            "byteOffset": 0,
+            "byteStride": 0,
+            "componentType": 5123,
+            "count": 36,
+            "type": "SCALAR"
+        },
+        "accessor_23": {
+            "bufferView": "bufferView_30",
+            "byteOffset": 0,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 24,
+            "max": [
+                0.5,
+                0.5,
+                0.5
+            ],
+            "min": [
+                -0.5,
+                -0.5,
+                -0.5
+            ],
+            "type": "VEC3"
+        },
+        "accessor_25": {
+            "bufferView": "bufferView_30",
+            "byteOffset": 288,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 24,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                -1,
+                -1,
+                -1
+            ],
+            "type": "VEC3"
+        }
+    },
+    "animations": {},
+    "asset": {
+        "generator": "collada2gltf@027f74366341d569dea42e9a68b7104cc3892054",
+        "premultipliedAlpha": true,
+        "profile": {
+            "api": "WebGL",
+            "version": "1.0.2"
+        },
+        "version": "1.0"
+    },
+    "bufferViews": {
+        "bufferView_29": {
+            "buffer": "Box",
+            "byteLength": 72,
+            "byteOffset": 0,
+            "target": 34963
+        },
+        "bufferView_30": {
+            "buffer": "Box",
+            "byteLength": 576,
+            "byteOffset": 72,
+            "target": 34962
+        }
+    },
+    "buffers": {
+        "Box": {
+            "byteLength": 648,
+            "type": "arraybuffer",
+            "uri": "Box.bin"
+        }
+    },
+    "materials": {
+        "Effect-Red": {
+            "name": "Red",
+            "technique": "technique0",
+            "values": {
+                "diffuse": [
+                    0.8,
+                    0,
+                    0,
+                    1
+                ],
+                "shininess": 256,
+                "specular": [
+                    0.2,
+                    0.2,
+                    0.2,
+                    1
+                ]
+            }
+        }
+    },
+    "meshes": {
+        "Geometry-mesh002": {
+            "name": "Mesh",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_25",
+                        "POSITION": "accessor_23"
+                    },
+                    "indices": "accessor_21",
+                    "material": "Effect-Red",
+                    "mode": 4
+                }
+            ]
+        }
+    },
+    "nodes": {
+        "Geometry-mesh002Node": {
+            "children": [],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1
+            ],
+            "meshes": [
+                "Geometry-mesh002"
+            ],
+            "name": "Mesh"
+        },
+        "node_1": {
+            "children": [
+                "Geometry-mesh002Node"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                -1,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1
+            ],
+            "name": "Y_UP_Transform"
+        }
+    },
+    "programs": {
+        "program_0": {
+            "attributes": [
+                "a_normal",
+                "a_position"
+            ],
+            "fragmentShader": "Box0FS",
+            "vertexShader": "Box0VS"
+        }
+    },
+    "scenes": {
+        "scene1": {
+            "nodes": [
+                "node_1"
+            ]
+        }
+    },
+    "shaders": {
+        "Box0FS": {
+            "type": 35632,
+            "uri": "Box0FS.glsl"
+        },
+        "Box0VS": {
+            "type": 35633,
+            "uri": "Box0VS.glsl"
+        }
+    },
+    "skins": {},
+    "techniques": {
+        "technique0": {
+            "attributes": {
+                "a_normal": "normal",
+                "a_position": "position"
+            },
+            "parameters": {
+                "diffuse": {
+                    "type": 35666
+                },
+                "modelViewMatrix": {
+                    "semantic": "MODELVIEW",
+                    "type": 35676
+                },
+                "normal": {
+                    "semantic": "NORMAL",
+                    "type": 35665
+                },
+                "normalMatrix": {
+                    "semantic": "MODELVIEWINVERSETRANSPOSE",
+                    "type": 35675
+                },
+                "position": {
+                    "semantic": "POSITION",
+                    "type": 35665
+                },
+                "projectionMatrix": {
+                    "semantic": "PROJECTION",
+                    "type": 35676
+                },
+                "shininess": {
+                    "type": 5126
+                },
+                "specular": {
+                    "type": 35666
+                }
+            },
+            "program": "program_0",
+            "states": {
+                "enable": [
+                    2929,
+                    2884
+                ]
+            },
+            "uniforms": {
+                "u_diffuse": "diffuse",
+                "u_modelViewMatrix": "modelViewMatrix",
+                "u_normalMatrix": "normalMatrix",
+                "u_projectionMatrix": "projectionMatrix",
+                "u_shininess": "shininess",
+                "u_specular": "specular"
+            }
+        }
+    }
+}

--- a/tests/components/gltf-model.test.js
+++ b/tests/components/gltf-model.test.js
@@ -3,6 +3,7 @@ var entityFactory = require('../helpers').entityFactory;
 var THREE = require('index').THREE;
 
 var SRC = '/base/tests/assets/box/Box.gltf';
+var SRC_NO_DEFAULT_SCENE = '/base/tests/assets/box/Box_no_default_scene.gltf';
 
 suite('gltf-model', function () {
   setup(function (done) {
@@ -84,5 +85,14 @@ suite('gltf-model', function () {
     });
 
     el.setAttribute('gltf-model', '#gltf');
+  });
+
+  test('can load data not including default scene', function (done) {
+    var el = this.el;
+    el.addEventListener('model-loaded', function () {
+      assert.ok(el.components['gltf-model'].model);
+      done();
+    });
+    el.setAttribute('gltf-model', `url(${SRC_NO_DEFAULT_SCENE})`);
   });
 });


### PR DESCRIPTION
**Description:**

This PR lets `gltf-model` accept glTF file which doesn't include default scene parameter.

    this.loader.load(src, function gltfLoaded (gltfModel) {
      self.model = gltfModel.scene;

`gltfModel.scene` (default scene) is optional in glTF specification.
If it isn't specified in the data file, let's use `gltfModel.scenes[0]` instead.
This follows Three.js glTF loader example.

https://github.com/mrdoob/three.js/blob/75384cfe6341b823e96cbec673c4ad92389b20cf/examples/webgl_loader_gltf.html#L231

**Changes proposed:**
- if default scene isn't specified in the glTF file, use scenes[0] instead.
