### PR TITLE
Remove time from TWEEN.update()

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -443,7 +443,8 @@ module.exports = registerElement('a-scene', {
       value: function (time, timeDelta) {
         var systems = this.systems;
         // Animations.
-        TWEEN.update(time);
+        TWEEN.update();
+
         // Components.
         this.behaviors.forEach(function (component) {
           if (!component.el.isPlaying) { return; }


### PR DESCRIPTION
Currently we're using `AFRAME.TWEEN` in most of our demos by just creating the object, setting up the parameters and finally calling `start()` without any parameter.

eg: 
https://github.com/aframevr/a-blast/blob/af93008a6613fd9dd9758234fffe609de6c8f249/src/components/gamestate-visuals.js#L45

https://github.com/aframevr/a-painter/blob/2f32632756cb308c6fcf382e399adeabd0ead715/src/components/ui.js#L514

The problem is that if we don't pass a time `TWEEN` will use `performance.now()` that, as discussed in the previous PR, it will start counting since the page was almost loaded, and it will differ from the actual `time` that we're using to update globally TWEEN (https://github.com/aframevr/aframe/blob/master/src/core/scene/a-scene.js#L446) adding a delay that could be around 1 or 2 seconds or even more depending on the page/a-scene loading times.

One solution could be to force the user to call `mytween.start(SceneEL.clock.elapsedTime)` but I find it quite ugly, so, as `TWEEN` really cares about the time to calculate its deltas, we could just remove the `time` parameter while calling `update` and it will take `performance.now()` https://github.com/tweenjs/tween.js/blob/master/src/Tween.js#L52 and it will be coherent with the `start()` call by the user.