### PR TITLE
 Allow "perspective" screenshots to have width/height properties apply

### DIFF
--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -148,7 +148,7 @@ module.exports.Component = registerComponent('screenshot', {
       this.quad.visible = false;
       // Use scene camera.
       camera = el.camera;
-      size = renderer.getSize();
+      size = {width: this.data.width, height: this.data.height};
     } else {
       // Use ortho camera.
       camera = this.camera;

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -138,7 +138,7 @@ module.exports.Component = registerComponent('screenshot', {
    */
   setCapture: function (projection) {
     var el = this.el;
-    var renderer = el.renderer;
+    //var renderer = el.renderer;
     var size;
     var camera;
     var cubeCamera;

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -138,7 +138,6 @@ module.exports.Component = registerComponent('screenshot', {
    */
   setCapture: function (projection) {
     var el = this.el;
-    // var renderer = el.renderer;
     var size;
     var camera;
     var cubeCamera;

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -138,7 +138,7 @@ module.exports.Component = registerComponent('screenshot', {
    */
   setCapture: function (projection) {
     var el = this.el;
-    //var renderer = el.renderer;
+    // var renderer = el.renderer;
     var size;
     var camera;
     var cubeCamera;


### PR DESCRIPTION
**Description:**
This allows customizing the size of the "perspective" screenshots taken by specifying the width and height e.g. <a-scene screenshot="width: 1024; height: 1024">. Before this only applied to "equirectangular" screenshots, and "perspective" just took the current dimensions of the scene canvas. 

**Changes proposed:**
copy line 166 to line 151

