### PR TITLE
Fix isCoordinate by successfully matching numbers with e-notation

### DIFF
--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -1,7 +1,7 @@
 /* global THREE */
 var extend = require('object-assign');
 // Coordinate string regex. Handles negative, positive, and decimals.
-var regex = /^\s*((-?\d*\.{0,1}\d+)\s+){2,3}(-?\d*\.{0,1}\d+)\s*$/;
+var regex = /^\s*((-?\d*\.{0,1}\d+(e-?\d+)?)\s+){2,3}(-?\d*\.{0,1}\d+(e-?\d+)?)\s*$/;
 module.exports.regex = regex;
 
 /**

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -7,6 +7,10 @@ suite('utils.coordinates', function () {
       assert.ok(coordinates.isCoordinate(' 1 2.5  -3'));
     });
 
+    test('verifies valid vec3 coordinate with e-notation', function () {
+      assert.ok(coordinates.isCoordinate('1.2e3 2.5 3.4e-5'));
+    });
+
     test('verifies valid vec4 coordinate', function () {
       assert.ok(coordinates.isCoordinate('1 1 2.5 -3'));
     });


### PR DESCRIPTION
When I rotate an entity it sometimes comes back with an e-notation number. For example, the number coming back was:

`-71.99999999999999 62.074139506678954 -1.5056867448590336e-22`

This number isn't recognized by isCoordinate and my entity would disappear.

I've modified the regex pattern to successfully match a number with e-notation.
