### PR TITLE
add node compatibility and regression test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
   matrix:
     - CI_ACTION="npm run test:firefox -- --single-run"
     - CI_ACTION="npm run test:chrome -- --single-run"
+    - CI_ACTION="npm run test:node"
     - CI_ACTION="npm run lint"
     - CI_ACTION="npm run build"
     - CI_ACTION="npm run test:docs"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "karma start ./tests/karma.conf.js",
     "test:docs": "node scripts/docsLint.js",
     "test:firefox": "npm test -- --browsers Firefox",
-    "test:chrome": "npm test -- --browsers Chrome"
+    "test:chrome": "npm test -- --browsers Chrome",
+    "test:node": "mocha tests/node"
   },
   "repository": "aframevr/aframe",
   "license": "MIT",
@@ -59,6 +60,7 @@
     "glob": "^7.1.1",
     "husky": "^0.11.7",
     "istanbul": "^0.4.5",
+    "jsdom": "^9.11.0",
     "karma": "^1.3.0",
     "karma-browserify": "^5.1.0",
     "karma-chai-shallow-deep-equal": "0.0.4",

--- a/tests/node/test.js
+++ b/tests/node/test.js
@@ -1,0 +1,55 @@
+/* eslint-env mocha */
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const jsdom = require('jsdom');
+const Module = require('module');
+const sinon = require('sinon');
+
+const _require = Module.prototype.require;
+
+describe('node acceptance tests', function () {
+  let sandbox;
+
+  before(function () {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(Module.prototype, 'require', function () {
+      if (arguments[0].indexOf('.css') === -1) {
+        return _require.apply(this, arguments);
+      }
+    });
+  });
+
+  beforeEach(function () {
+    let _window = global.window = jsdom.jsdom().defaultView;
+    global.navigator = _window.navigator;
+    global.document = _window.document;
+    global.HTMLElement = _window.HTMLElement;
+    Object.defineProperty(_window, 'WebVRConfig', {
+      get () {
+        return global.WebVRConfig;
+      },
+      set (WebVRConfig) {
+        global.WebVRConfig = WebVRConfig;
+      }
+    });
+  });
+
+  afterEach(function () {
+    delete global.window;
+    delete global.document;
+    delete global.HTMLElement;
+    delete global.WebVRConfig;
+  });
+
+  after(function () {
+    sandbox.restore();
+  });
+
+  it('can run in node', function () {
+    let aframe = require(path.join(process.cwd(), 'src'));
+
+    expect(aframe.version).to.be.ok;
+  });
+});


### PR DESCRIPTION
After #2476 and #2477 were merged, it is now possible to run aframe in node. This is a regression test to preserve this functionality as aframe grows, and to iterate upon to make it run better in node. This is a partial solution to #2031, but there will most likely need to be more work.

I tried to put the test in `tests/` first, but it made the globbing [here](https://github.com/aframevr/aframe/blob/3b9d8f419d45f3167d0053208cab6fb557dd8b22/tests/karma.conf.js#L24) difficult because `tests/!(node)/**/*.test.js` kept ignoring the `tests/__init.test.js`.