### PR TITLE
don't load css in node environment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,9 +34,12 @@ if (utils.device.isIOSOlderThan10(navigator.userAgent)) {
 require('webvr-polyfill');
 
 require('present'); // Polyfill `performance.now()`.
+
 // CSS.
-require('./style/aframe.css');
-require('./style/rStats.css');
+if (utils.device.isBrowserLikeEnvironment) {
+  require('./style/aframe.css');
+  require('./style/rStats.css');
+}
 
 // Required before `AEntity` so that all components are registered.
 var AScene = require('./core/scene/a-scene');

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -96,3 +96,17 @@ module.exports.isLandscape = function () {
 module.exports.isIOSOlderThan10 = function (userAgent) {
   return /(iphone|ipod|ipad).*os.(7|8|9)/i.test(userAgent);
 };
+
+/**
+ * Check if running in a browser or spoofed browser (bundler).
+ * We need to check a node api that isn't mocked on either side.
+ * `require` and `module.exports` are mocked in browser by bundlers.
+ * `window` is mocked in node.
+ * `process` is also mocked by browserify, but has custom properties.
+ */
+module.exports.isBrowserEnvironment = !!(!process || process.browser);
+
+/**
+ * Check if running in node on the server.
+ */
+module.exports.isNodeEnvironment = !module.exports.isBrowserEnvironment;

--- a/tests/node/test.js
+++ b/tests/node/test.js
@@ -4,23 +4,8 @@
 const path = require('path');
 const assert = require('chai').assert;
 const jsdom = require('jsdom');
-const Module = require('module');
-const sinon = require('sinon');
-
-const _require = Module.prototype.require;
 
 suite('node acceptance tests', function () {
-  let sandbox;
-
-  suiteSetup(function () {
-    sandbox = sinon.sandbox.create();
-    sandbox.stub(Module.prototype, 'require', function () {
-      if (arguments[0].indexOf('.css') === -1) {
-        return _require.apply(this, arguments);
-      }
-    });
-  });
-
   setup(function () {
     let _window = global.window = jsdom.jsdom().defaultView;
     global.navigator = _window.navigator;
@@ -43,13 +28,25 @@ suite('node acceptance tests', function () {
     delete global.WebVRConfig;
   });
 
-  suiteTeardown(function () {
-    sandbox.restore();
-  });
-
   test('can run in node', function () {
     let aframe = require(path.join(process.cwd(), 'src'));
 
     assert.ok(aframe.version);
+  });
+
+  suite('environment', function () {
+    let aframe;
+
+    setup(function () {
+      aframe = require(path.join(process.cwd(), 'src'));
+    });
+
+    test('isNodeEnvironment is true for node', function () {
+      assert.strictEqual(aframe.utils.device.isNodeEnvironment, true);
+    });
+
+    test('isBrowserEnvironment is false for node', function () {
+      assert.strictEqual(aframe.utils.device.isBrowserEnvironment, false);
+    });
   });
 });

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -36,3 +36,13 @@ suite('isIOSOlderThan10', function () {
     assert.notOk(device.isIOSOlderThan10(v12));
   });
 });
+
+suite('environment', function () {
+  test('isNodeEnvironment is false for browser tests', function () {
+    assert.strictEqual(device.isNodeEnvironment, false);
+  });
+
+  test('isBrowserEnvironment is true for browser tests', function () {
+    assert.strictEqual(device.isBrowserEnvironment, true);
+  });
+});


### PR DESCRIPTION
Now that #2484 has landed, we can begin to iterate on the node experience and make it better. This removes the need to mock `require` to ignore css requiring in node (which is a bundler-only feature).