### PR TITLE
removed height and width from a-enter-vr css class

### DIFF
--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -133,6 +133,7 @@ a-scene audio {
 .a-enter-vr {
   font-family: sans-serif, monospace;
   font-size: 13px;
+  width: 100%;
   font-weight: 200;
   line-height: 16px;
   position: absolute;

--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -133,10 +133,8 @@ a-scene audio {
 .a-enter-vr {
   font-family: sans-serif, monospace;
   font-size: 13px;
-  width: 100%;
   font-weight: 200;
   line-height: 16px;
-  height: 10%;
   position: absolute;
   right: 20px;
   bottom: 20px;


### PR DESCRIPTION
**Description:**
This PR fixes issue #2359. `div.a-enter-vr` extends across the window blocking cursor clicks / cursor grabbing events passing to the scene.

**Changes proposed:**
Changed css of `a-enter-vr`. Removed `height` and `width`. It seems like the `div` is only used for the button.
