### PR TITLE
processPropertyDefinition now parses default string values

### DIFF
--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -1,6 +1,7 @@
 var debug = require('../utils/debug');
 var propertyTypes = require('./propertyTypes').propertyTypes;
 var warn = debug('core:schema:warn');
+var parseCoordinates = require('../utils/coordinates').parse;
 
 /**
  * A schema is classified as a schema for a single property if:
@@ -75,6 +76,18 @@ function processPropertyDefinition (propDefinition) {
   // Fill in default value.
   if (!('default' in propDefinition)) {
     propDefinition.default = propType.default;
+  } else if (typeName === 'vec2' && typeof defaultVal === 'string') {
+    // Parse default string val into object
+    if (defaultVal.split(' ').length !== 2) {
+      warn('Default value for type vec2 can only be 2 coordinates');
+    }
+    propDefinition.default = parseCoordinates(defaultVal);
+  } else if (typeName === 'vec3' && typeof defaultVal === 'string') {
+    // Parse default string val into object
+    if (defaultVal.split(' ').length !== 3) {
+      warn('Default value for type vec3 can only be 3 coordinates');
+    }
+    propDefinition.default = parseCoordinates(defaultVal);
   }
 
   return propDefinition;

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -166,7 +166,7 @@ suite('Component', function () {
       });
     });
 
-    test.only('vec2 and vec3 default string values are converted to coordinate objects', function (done) {
+    test('vec2 and vec3 default string values are converted to coordinate objects', function (done) {
       var schemaVec2 = processSchema({
         v: {type: 'vec2', default: '1 1'}
       });

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -165,6 +165,25 @@ suite('Component', function () {
         done();
       });
     });
+
+    test.only('vec2 and vec3 default string values are converted to coordinate objects', function (done) {
+      var schemaVec2 = processSchema({
+        v: {type: 'vec2', default: '1 1'}
+      });
+
+      var schemaVec3 = processSchema({
+        v: {type: 'vec3', default: '2 2 2'}
+      });
+      var el = document.createElement('a-entity');
+      var dataVec2 = buildData(el, 'dummy', 'dummy', schemaVec2, {}, null);
+      var dataVec3 = buildData(el, 'dummy', 'dummy', schemaVec3, {}, null);
+      assert.equal(dataVec2.v.x, 1);
+      assert.equal(dataVec2.v.y, 1);
+      assert.equal(dataVec3.v.x, 2);
+      assert.equal(dataVec3.v.y, 2);
+      assert.equal(dataVec3.v.z, 2);
+      done();
+    });
   });
 
   suite('updateProperties', function () {


### PR DESCRIPTION
**Description:**
This fixes issue #2412. The code(shown below) from the issue now returns true. If a type `vec2` or `vec3` is given, the normalization procedure should run `parse` and change it into an object with the correct coordinates.

```
<script>
  AFRAME.registerComponent('test', {
    schema: { v: {type: 'vec2', default: '1 1'} }
  });
</script>
<a-scene>
  <a-entity test></a-entity>
</a-scene>
<script>
  document.addEventListener('DOMContentLoaded', () => {
    var e = document.querySelector('a-entity');
    var def = e.components.test.schema.v.default;
    var shouldBeTrue =
      JSON.stringify(def) === JSON.stringify(e.getAttribute('test').v);
    console.log('Are equal?', shouldBeTrue);
  });
</script>
``` 

**Changes proposed:**

`processPropertyDefinition` now runs `parse` on the default string values such as `'1 1'` into `{x: 1, y: 1}` and `'2 2 2'` into `{x: 2, y: 2, z: 2 }`. The function `parse` was labeled `parseCoordinates` to be more clear and avoid conflicting names in the file. Not sure if that was necessary though.

An error is given if the string does not have 2 or 3 values separated by an empty space. For example, `type: 'vec2` and `default: 1 1 1` would run `warn('Default value for type vec2 can only be 2 coordinates')`. 