### PR TITLE
Fix deepEqual when comparing non Object instantiated objects

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -125,10 +125,13 @@ function deepEqual (a, b) {
   var keysB;
   var valA;
   var valB;
+  var areBothObjects = a && b && a.constructor === Object && b.constructor === Object;
+  var areBothArrays = a && b && a.constructor === Array && b.constructor === Array;
 
-  // If not objects, compare as values.
-  if (typeof a !== 'object' || typeof b !== 'object' ||
-      a === null || b === null) { return a === b; }
+  // If not objects or arrays, compare as values.
+  if (!(areBothObjects || areBothArrays) || a === null || b === null) {
+    return a === b;
+  }
 
   // Different number of keys, not equal.
   keysA = Object.keys(a);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -125,11 +125,11 @@ function deepEqual (a, b) {
   var keysB;
   var valA;
   var valB;
-  var areBothObjects = a && b && a.constructor === Object && b.constructor === Object;
-  var areBothArrays = a && b && a.constructor === Array && b.constructor === Array;
 
   // If not objects or arrays, compare as values.
-  if (!(areBothObjects || areBothArrays) || a === null || b === null) {
+  if (a === null || b === null ||
+      !(a && b && (a.constructor === Object && b.constructor === Object) ||
+                  (a.constructor === Array && b.constructor === Array))) {
     return a === b;
   }
 

--- a/tests/utils/objects.test.js
+++ b/tests/utils/objects.test.js
@@ -1,5 +1,7 @@
 /* global assert, suite, test */
+// var entityFactory = require('../helpers').entityFactory;
 var utils = require('index').utils;
+var entityFactory = require('../helpers').entityFactory;
 
 var diff = utils.diff;
 var deepEqual = utils.deepEqual;
@@ -126,6 +128,16 @@ suite('utils.objects', function () {
     test('can compare the same object with self reference', function () {
       var objA = {x: 0, y: 0, z: 0, self: objA};
       assert.ok(deepEqual(objA, objA));
+    });
+
+    test('avoid deep equal of object that are not instantiated' +
+         'with the Object constructor in order to avoid infinite loops', function (done) {
+      var el1 = entityFactory();
+      var el2 = entityFactory();
+      el2.addEventListener('loaded', function () {
+        assert.notOk(deepEqual(el1, el2));
+        done();
+      });
     });
   });
 });

--- a/tests/utils/objects.test.js
+++ b/tests/utils/objects.test.js
@@ -1,7 +1,5 @@
 /* global assert, suite, test */
-// var entityFactory = require('../helpers').entityFactory;
 var utils = require('index').utils;
-var entityFactory = require('../helpers').entityFactory;
 
 var diff = utils.diff;
 var deepEqual = utils.deepEqual;
@@ -131,13 +129,9 @@ suite('utils.objects', function () {
     });
 
     test('avoid deep equal of object that are not instantiated' +
-         'with the Object constructor in order to avoid infinite loops', function (done) {
-      var el1 = entityFactory();
-      var el2 = entityFactory();
-      el2.addEventListener('loaded', function () {
-        assert.notOk(deepEqual(el1, el2));
-        done();
-      });
+         'with the Object constructor in order to avoid infinite loops', function () {
+      assert.notOk(deepEqual(document.createElement('a-entity'),
+                             document.createElement('a-entity')));
     });
   });
 });


### PR DESCRIPTION
**Description:**

We end up in an infinite loop when a property of the type `selector` changes value. Two HTML elements are passed through the `deepEqual` function that runs ad infinitum since each entity references the components that reference the entity itself, that reference the components, that reference the entity...

**Changes proposed:**
Deep equal only compares deeply if the passed objects are plain JS objects.
