### PR TITLE
Fixed 404'ing image links

### DIFF
--- a/docs/guides/building-with-components.md
+++ b/docs/guides/building-with-components.md
@@ -39,11 +39,11 @@ This is the starting point for our scene:
 
     <!-- Images. -->
     <img id="city" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/city.jpg">
-    <img id="city-thumb" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/thumb-city.png">
+    <img id="city-thumb" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/thumb-city.jpg">
     <img id="cubes" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/cubes.jpg">
-    <img id="cubes-thumb" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/thumb-cubes.png">
+    <img id="cubes-thumb" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/thumb-cubes.jpg">
     <img id="sechelt" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/sechelt.jpg">
-    <img id="sechelt-thumb" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/thumb-sechelt.png">
+    <img id="sechelt-thumb" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/thumb-sechelt.jpg">
   </a-assets>
 
   <!-- 360-degree image. -->


### PR DESCRIPTION
Thumbnail images we're not available as PNGs, only as JPGs.

**Description:**
Fixing broken images for users running documentation.

**Changes proposed:**
- Changing thumbnail image links to .jpg
![2017-03-17_22-21-54](https://cloud.githubusercontent.com/assets/5576685/24069231/3bc7b160-0b60-11e7-9e07-9fed6078b37f.png)
