### PR TITLE
also apply userHeight to controller when no stage parameters (fixes #2448)

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -90,8 +90,7 @@ module.exports.Component = registerComponent('tracked-controls', {
           dolly.applyMatrix(standingMatrix);
         } else {
           // Apply default camera height
-          var userHeight = this.el.sceneEl.camera.el.components.camera.data.userHeight;
-          dolly.position.y += userHeight;
+          dolly.position.y += el.sceneEl.camera.el.getAttribute('camera').userHeight;
           dolly.updateMatrix();
         }
       }

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -84,9 +84,16 @@ module.exports.Component = registerComponent('tracked-controls', {
       dolly.updateMatrix();
 
       // Apply transforms.
-      if (vrDisplay && vrDisplay.stageParameters) {
-        standingMatrix.fromArray(vrDisplay.stageParameters.sittingToStandingTransform);
-        dolly.applyMatrix(standingMatrix);
+      if (vrDisplay) {
+        if (vrDisplay.stageParameters) {
+          standingMatrix.fromArray(vrDisplay.stageParameters.sittingToStandingTransform);
+          dolly.applyMatrix(standingMatrix);
+        } else {
+          // Apply default camera height
+          var userHeight = this.el.sceneEl.camera.el.components.camera.data.userHeight;
+          dolly.position.y += userHeight;
+          dolly.updateMatrix();
+        }
       }
 
       // Decompose.

--- a/src/systems/tracked-controls.js
+++ b/src/systems/tracked-controls.js
@@ -13,13 +13,12 @@ module.exports.System = registerSystem('tracked-controls', {
     this.lastControllersUpdate = 0;
     // Throttle the (renamed) tick handler to minimum 10ms interval.
     this.tick = utils.throttle(this.throttledTick, 10, this);
-    if (navigator.getVRDisplays) {
-      this.sceneEl.addEventListener('enter-vr', function () {
-        navigator.getVRDisplays().then(function (displays) {
-          if (displays.length) { self.vrDisplay = displays[0]; }
-        });
+    if (!navigator.getVRDisplays) { return; }
+    this.sceneEl.addEventListener('enter-vr', function () {
+      navigator.getVRDisplays().then(function (displays) {
+        if (displays.length) { self.vrDisplay = displays[0]; }
       });
-    }
+    });
   },
 
   updateControllerList: function () {

--- a/src/systems/tracked-controls.js
+++ b/src/systems/tracked-controls.js
@@ -13,12 +13,13 @@ module.exports.System = registerSystem('tracked-controls', {
     this.lastControllersUpdate = 0;
     // Throttle the (renamed) tick handler to minimum 10ms interval.
     this.tick = utils.throttle(this.throttledTick, 10, this);
-    if (!navigator.getVRDisplays) { return; }
-    navigator.getVRDisplays().then(function (displays) {
-      if (displays.length > 0) {
-        self.vrDisplay = displays[0];
-      }
-    });
+    if (navigator.getVRDisplays) {
+      this.sceneEl.addEventListener('enter-vr', function () {
+        navigator.getVRDisplays().then(function (displays) {
+          if (displays.length) { self.vrDisplay = displays[0]; }
+        });
+      });
+    }
   },
 
   updateControllerList: function () {


### PR DESCRIPTION
to fix Nightly issue with null stageParameters,
add camera userHeight if null stageParameters;
to keep tests working, only getVRDisplays when VR entered.

(NOTE: tried to move getVRDisplays from system into component where dolly is,
but got weird effect where right hand was applying offset but right hand wasn't,
so there may still be some strange race condition somewhere)
