### PR TITLE
Expose material.alphaTest and material.depthWrite properties

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -19,6 +19,8 @@ var shaderNames = shader.shaderNames;
 module.exports.Component = registerComponent('material', {
   schema: {
     depthTest: {default: true},
+    depthWrite: {default: true},
+    alphaTest: {default: 0.0, min: 0.0, max: 1.0},
     flatShading: {default: false},
     opacity: {default: 1.0, min: 0.0, max: 1.0},
     shader: {default: 'standard', oneOf: shaderNames},
@@ -108,8 +110,12 @@ module.exports.Component = registerComponent('material', {
     material.opacity = data.opacity;
     material.transparent = data.transparent !== false || data.opacity < 1.0;
     material.depthTest = data.depthTest !== false;
+    material.depthWrite = data.depthWrite !== false;
     material.shading = data.flatShading ? THREE.FlatShading : THREE.SmoothShading;
     material.visible = data.visible;
+
+    if (data.alphaTest !== material.alphaTest) { material.needsUpdate = true; }
+    material.alphaTest = data.alphaTest;
   },
 
   /**

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -113,7 +113,6 @@ module.exports.Component = registerComponent('material', {
     material.depthWrite = data.depthWrite !== false;
     material.shading = data.flatShading ? THREE.FlatShading : THREE.SmoothShading;
     material.visible = data.visible;
-
     if (data.alphaTest !== material.alphaTest) { material.needsUpdate = true; }
     material.alphaTest = data.alphaTest;
   },

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -231,6 +231,33 @@ suite('material', function () {
     });
   });
 
+  suite('depthWrite', function () {
+    test('can be set to false', function () {
+      var el = this.el;
+      assert.ok(el.getObject3D('mesh').material.depthWrite);
+      el.setAttribute('material', 'depthWrite: false');
+      assert.equal(el.getObject3D('mesh').material.depthWrite, 0);
+    });
+  });
+
+  suite('alphaTest', function () {
+    test('can be updated', function () {
+      var el = this.el;
+      assert.equal(el.getObject3D('mesh').material.alphaTest, 0);
+      el.setAttribute('material', 'alphaTest: 1.0');
+      assert.equal(el.getObject3D('mesh').material.alphaTest, 1);
+    });
+
+    test('sets material.needsUpdate true if alphaTest is updated', function () {
+      var el = this.el;
+      el.setAttribute('material', 'alphaTest: 0.0');
+      el.getObject3D('mesh').material.needsUpdate = false;
+      assert.equal(el.getObject3D('mesh').material.needsUpdate, 0);
+      el.setAttribute('material', 'alphaTest: 1.0');
+      assert.equal(el.getObject3D('mesh').material.needsUpdate, 1);
+    });
+  });
+
   test('can set visible to false', function () {
     var el = this.el;
     assert.ok(el.getObject3D('mesh').material.visible);


### PR DESCRIPTION
**Description:**

#2497

**Changes proposed:**
- Expose `material.alphaTest` and `material.depthWrite` properties
- Sets `material.needsUpdate` `true` if `material.alphaTest` is updated (Three.js manner)
