### PR TITLE
Check that parent element exists

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -295,7 +295,7 @@ var proto = Object.create(ANode.prototype, {
 
       ANode.prototype.load.call(this, function entityLoadCallback () {
         self.updateComponents();
-        if (self.isScene || self.parentEl.isPlaying) { self.play(); }
+        if (self.isScene || (self.parentEl && self.parentEl.isPlaying)) { self.play(); }
       });
     },
     writable: window.debug


### PR DESCRIPTION
**Description:**

In some cases a component can be created and unmounted before it has fully finished loading. This leads to errors when the entityLoadCallback tries to access the isPlaying property of the parent element (as it no longer exists).

![screen shot 2017-03-24 at 11 23 43](https://cloud.githubusercontent.com/assets/6763606/24294404/346ea4a4-108e-11e7-94ed-797c44f52177.png)

![screen shot 2017-03-24 at 11 24 04](https://cloud.githubusercontent.com/assets/6763606/24294405/346edd3e-108e-11e7-9abe-4f82f6582861.png)

**Changes proposed:**
- Check for existence of entity parent
