### PR TITLE
Check for presence of parent element

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -295,7 +295,7 @@ var proto = Object.create(ANode.prototype, {
 
       ANode.prototype.load.call(this, function entityLoadCallback () {
         self.updateComponents();
-        if (self.isScene || self.parentEl.isPlaying) { self.play(); }
+        if (self.isScene || (self.parentEl && self.parentEl.isPlaying)) { self.play(); }
       });
     },
     writable: window.debug

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -291,7 +291,7 @@ var proto = Object.create(ANode.prototype, {
     value: function () {
       var self = this;
 
-      if (this.hasLoaded) { return; }
+      if (this.hasLoaded || !this.parentEl) { return; }
 
       ANode.prototype.load.call(this, function entityLoadCallback () {
         self.updateComponents();

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -294,8 +294,11 @@ var proto = Object.create(ANode.prototype, {
       if (this.hasLoaded || !this.parentEl) { return; }
 
       ANode.prototype.load.call(this, function entityLoadCallback () {
+        // Check if entity was detached while it was waiting to load.
+        if (!self.parentEl) { return; }
+
         self.updateComponents();
-        if (self.isScene || (self.parentEl && self.parentEl.isPlaying)) { self.play(); }
+        if (self.isScene || self.parentEl.isPlaying) { self.play(); }
       });
     },
     writable: window.debug
@@ -490,7 +493,8 @@ var proto = Object.create(ANode.prototype, {
         delete componentsToUpdate[name];
         self.updateComponent(name, data);
       }
-    }
+    },
+    writable: window.debug
   },
 
   /**

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -543,6 +543,15 @@ suite('a-entity', function () {
     });
   });
 
+  suite.only('load', function () {
+    test('does not try to load if not attached', function () {
+      var el = document.createElement('a-entity');
+      var nodeLoadSpy = this.sinon.spy(ANode.prototype, 'load');
+      el.load();
+      assert.notOk(nodeLoadSpy.called);
+    });
+  });
+
   suite('getDOMAttribute', function () {
     test('returns parsed component data', function () {
       var componentData;

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -543,12 +543,30 @@ suite('a-entity', function () {
     });
   });
 
-  suite.only('load', function () {
+  suite('load', function () {
     test('does not try to load if not attached', function () {
       var el = document.createElement('a-entity');
       var nodeLoadSpy = this.sinon.spy(ANode.prototype, 'load');
       el.load();
       assert.notOk(nodeLoadSpy.called);
+    });
+
+    test('does not try to initialized during load callback if not attached', function (done) {
+      var childEl = document.createElement('a-entity');
+      var el = document.createElement('a-entity');
+      var nodeLoadSpy;
+
+      el.parentEl = true;
+      el.appendChild(childEl);
+      el.load();
+      el.parentEl = null;
+      childEl.emit('loaded');
+
+      nodeLoadSpy = this.sinon.spy(AEntity.prototype, 'updateComponents');
+      setTimeout(function () {
+        assert.notOk(nodeLoadSpy.called);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
**Description:**

In some cases a component can be created and unmounted before it has fully finished loading. This leads to errors when the entityLoadCallback tries to access the isPlaying property of the parent element (as it no longer exists).

![screen shot 2017-03-24 at 11 23 43](https://cloud.githubusercontent.com/assets/6763606/24294923/7186f9f2-1090-11e7-8ba5-8f8e42c480cb.png)
![screen shot 2017-03-24 at 11 24 04](https://cloud.githubusercontent.com/assets/6763606/24294924/71880022-1090-11e7-9a0c-39604c5ce7c9.png)


**Changes proposed:**
- Check for existence of entity parent
