### PR TITLE
[docs] Update link to aframe-text-geometry-component

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -21,7 +21,7 @@ basic thing because the browser's renderer and layout engine handles
 everything. In a 3D context, we don't have those luxuries. There are several
 other different ways to render text in A-Frame including:
 
-- [3D Text Geometry](https://www.npmjs.com/package/aframe-text-component)
+- [3D Text Geometry](https://www.npmjs.com/package/aframe-text-geometry-component)
 - [HTML Materials (DOM-to-Canvas-to-Texture)](https://github.com/mayognaise/aframe-html-shader)
 - Image Textures
 


### PR DESCRIPTION
**Description:**
Fix the link that goes to the old aframe-text-component package. It caused me to install the outdated one which doesn't work anymore.

**Changes proposed:**
- Change the link from "aframe-text-component" to the new version which is called "aframe-text-geometry-component"
