### PR TITLE
Show an error message when the inspector URL could not be loaded

### DIFF
--- a/src/components/scene/inspector.js
+++ b/src/components/scene/inspector.js
@@ -18,6 +18,7 @@ var INSPECTOR_DEV_URL = 'https://aframe.io/aframe-inspector/dist/aframe-inspecto
 var INSPECTOR_RELEASE_URL = 'https://unpkg.com/aframe-inspector@' + getFuzzyPatchVersion(pkg.version) + '/dist/aframe-inspector.min.js';
 var INSPECTOR_URL = process.env.INSPECTOR_VERSION === 'dev' ? INSPECTOR_DEV_URL : INSPECTOR_RELEASE_URL;
 var LOADING_MESSAGE = 'Loading Inspector';
+var LOADING_ERROR_MESSAGE = 'Could not load Inspector';
 
 module.exports.Component = registerComponent('inspector', {
   schema: {
@@ -84,6 +85,9 @@ module.exports.Component = registerComponent('inspector', {
       AFRAME.INSPECTOR.open();
       self.hideLoader();
       self.removeEventListeners();
+    };
+    script.onerror = function () {
+      self.loadingMessageEl.innerHTML = LOADING_ERROR_MESSAGE;
     };
     document.head.appendChild(script);
     AFRAME.inspectorInjected = true;


### PR DESCRIPTION
**Description:**

I was giving an A-Frame talk and wanted to show the Inspector… Could not make it because I didn't have a working network connection. At that time, I didn't know that the Inspector was being pulled on the fly, and the "Loading…" message was being shown indefinitely, no errors on the console, and I found it confusing.

This shows an error message in the "loading" magenta button when the injected `<script>` tag fires an `error` event.

**Changes proposed:**

- Add an `onerror` event handler that shows an error message in place of "Loading…"

