### PR TITLE
hand-controls support for Nightly with Oculus Touch

### DIFF
--- a/docs/components/oculus-touch-controls.md
+++ b/docs/components/oculus-touch-controls.md
@@ -45,26 +45,26 @@ mappings, events, and a Touch controller model.
 | griptouchstart       | Grip button touched.           |
 | griptouchend         | Grip button no longer touched. |
 | gripchanged          | Grip button changed.           |
-| Adown                | A button pressed.              |
-| Aup                  | A button released.             |
-| Atouchstart          | A button touched.              |
-| Atouchend            | A button no longer touched.    |
-| Achanged             | A button changed.              |
-| Bdown                | B button pressed.              |
-| Bup                  | B button released.             |
-| Btouchstart          | B button touched.              |
-| Btouchend            | B button no longer touched.    |
-| Bchanged             | B button changed.              |
-| Xdown                | X button pressed.              |
-| Xup                  | X button released.             |
-| Xtouchstart          | X button touched.              |
-| Xtouchend            | X button no longer touched.    |
-| Xchanged             | X button changed.              |
-| Ydown                | Y button pressed.              |
-| Yup                  | Y button released.             |
-| Ytouchstart          | Y button touched.              |
-| Ytouchend            | Y button no longer touched.    |
-| Ychanged             | Y button changed.              |
+| abuttondown          | A button pressed.              |
+| abuttonup            | A button released.             |
+| abuttontouchstart    | A button touched.              |
+| abuttontouchend      | A button no longer touched.    |
+| abuttonchanged       | A button changed.              |
+| bbuttondown          | B button pressed.              |
+| bbuttonup            | B button released.             |
+| bbuttontouchstart    | B button touched.              |
+| bbuttontouchend      | B button no longer touched.    |
+| bbuttonchanged       | B button changed.              |
+| xbuttondown          | X button pressed.              |
+| xbuttonup            | X button released.             |
+| xbuttontouchstart    | X button touched.              |
+| xbuttontouchend      | X button no longer touched.    |
+| xbuttonchanged       | X button changed.              |
+| ybuttondown          | Y button pressed.              |
+| ybuttonup            | Y button released.             |
+| ybuttontouchstart    | Y button touched.              |
+| ybuttontouchend      | Y button no longer touched.    |
+| ybuttonchanged       | Y button changed.              |
 | menudown             | Menu button pressed.           |
 | menuup               | Menu button released.          |
 | menuchanged          | Menu button changed.           |

--- a/docs/components/oculus-touch-controls.md
+++ b/docs/components/oculus-touch-controls.md
@@ -22,6 +22,7 @@ mappings, events, and a Touch controller model.
 
 | Property             | Description                                        | Default Value        |
 |----------------------|----------------------------------------------------|----------------------|
+| emulated             | Whether to emulate (treat as present regardless).  | false                |
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Touch controller model is loaded.      | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |

--- a/docs/components/oculus-touch-controls.md
+++ b/docs/components/oculus-touch-controls.md
@@ -22,7 +22,6 @@ mappings, events, and a Touch controller model.
 
 | Property             | Description                                        | Default Value        |
 |----------------------|----------------------------------------------------|----------------------|
-| emulated             | Whether to emulate (treat as present regardless).  | false                |
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Touch controller model is loaded.      | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |

--- a/docs/components/oculus-touch-controls.md
+++ b/docs/components/oculus-touch-controls.md
@@ -35,34 +35,43 @@ mappings, events, and a Touch controller model.
 | triggerup            | Trigger released.              |
 | triggertouchstart    | Trigger touched.               |
 | triggertouchend      | Trigger no longer touched.     |
+| triggerchanged       | Trigger changed.               |
 | thumbstickdown       | Thumbstick pressed.            |
 | thumbstickup         | Thumbstick released.           |
 | thumbsticktouchstart | Thumbstick touched.            |
 | thumbsticktouchend   | Thumbstick no longer touched.  |
+| thumbstickchanged    | Thumbstick changed.            |
 | gripdown             | Grip button pressed.           |
 | gripup               | Grip button released.          |
 | griptouchstart       | Grip button touched.           |
 | griptouchend         | Grip button no longer touched. |
+| gripchanged          | Grip button changed.           |
 | Adown                | A button pressed.              |
 | Aup                  | A button released.             |
 | Atouchstart          | A button touched.              |
 | Atouchend            | A button no longer touched.    |
+| Achanged             | A button changed.              |
 | Bdown                | B button pressed.              |
 | Bup                  | B button released.             |
 | Btouchstart          | B button touched.              |
 | Btouchend            | B button no longer touched.    |
+| Bchanged             | B button changed.              |
 | Xdown                | X button pressed.              |
 | Xup                  | X button released.             |
 | Xtouchstart          | X button touched.              |
 | Xtouchend            | X button no longer touched.    |
+| Xchanged             | X button changed.              |
 | Ydown                | Y button pressed.              |
 | Yup                  | Y button released.             |
 | Ytouchstart          | Y button touched.              |
 | Ytouchend            | Y button no longer touched.    |
+| Ychanged             | Y button changed.              |
 | menudown             | Menu button pressed.           |
 | menuup               | Menu button released.          |
+| menuchanged          | Menu button changed.           |
 | systemdown           | System button pressed.         |
 | systemup             | System button released.        |
+| systemchanged        | System button changed.         |
 
 ## Assets
 

--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -25,7 +25,6 @@ buttons (trigger, grip, menu, system) and trackpad.
 |----------------------|----------------------------------------------------|----------------------|
 | buttonColor          | Button colors when not pressed.                    | #FAFAFA (off-white)  |
 | buttonHighlightColor | Button colors when pressed and active.             | #22D1EE (light blue) |
-| emulated             | Whether to emulate (treat as present regardless).  | false                |
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Vive controller model is loaded.       | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |

--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -25,6 +25,7 @@ buttons (trigger, grip, menu, system) and trackpad.
 |----------------------|----------------------------------------------------|----------------------|
 | buttonColor          | Button colors when not pressed.                    | #FAFAFA (off-white)  |
 | buttonHighlightColor | Button colors when pressed and active.             | #22D1EE (light blue) |
+| emulated             | Whether to emulate (treat as present regardless).  | false                |
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Vive controller model is loaded.       | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |

--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -32,18 +32,23 @@ buttons (trigger, grip, menu, system) and trackpad.
 
 ## Events
 
-| Event Name   | Description             |
-| ----------   | -----------             |
-| gripdown     | Grip button pressed.    |
-| gripup       | Grip button released.   |
-| menudown     | Menu button pressed.    |
-| menuup       | Menu button released.   |
-| systemdown   | System button pressed.  |
-| systemup     | System button released. |
-| trackpaddown | Trackpad pressed.       |
-| trackpadup   | Trackpad released.      |
-| triggerdown  | Trigger pressed.        |
-| triggerup    | Trigger released.       |
+| Event Name      | Description              |
+| ----------      | -----------              |
+| gripdown        | Grip button pressed.     |
+| gripup          | Grip button released.    |
+| gripchanged     | Grip button changed.     |
+| menudown        | Menu button pressed.     |
+| menuup          | Menu button released.    |
+| menuchanged     | Menu button changed.     |
+| systemdown      | System button pressed.   |
+| systemup        | System button released.  |
+| systemchanged   | System button changed.   |
+| trackpaddown    | Trackpad pressed.        |
+| trackpadup      | Trackpad released.       |
+| trackpadchanged | Trackpad button changed. |
+| triggerdown     | Trigger pressed.         |
+| triggerup       | Trigger released.        |
+| triggerchanged  | Trigger changed.         |
 
 ## Assets
 

--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -68,14 +68,14 @@ module.exports.Component = registerComponent('hand-controls', {
     el.addEventListener('griptouchend', this.onGripTouchEnd);
     el.addEventListener('thumbstickdown', this.onThumbstickDown);
     el.addEventListener('thumbstickup', this.onThumbstickUp);
-    el.addEventListener('Atouchstart', this.onAorXTouchStart);
-    el.addEventListener('Atouchend', this.onAorXTouchEnd);
-    el.addEventListener('Btouchstart', this.onBorYTouchStart);
-    el.addEventListener('Btouchend', this.onBorYTouchEnd);
-    el.addEventListener('Xtouchstart', this.onAorXTouchStart);
-    el.addEventListener('Xtouchend', this.onAorXTouchEnd);
-    el.addEventListener('Ytouchstart', this.onBorYTouchStart);
-    el.addEventListener('Ytouchend', this.onBorYTouchEnd);
+    el.addEventListener('abuttontouchstart', this.onAorXTouchStart);
+    el.addEventListener('abuttontouchend', this.onAorXTouchEnd);
+    el.addEventListener('bbuttontouchstart', this.onBorYTouchStart);
+    el.addEventListener('bbuttontouchend', this.onBorYTouchEnd);
+    el.addEventListener('xbuttontouchstart', this.onAorXTouchStart);
+    el.addEventListener('xbuttontouchend', this.onAorXTouchEnd);
+    el.addEventListener('ybuttontouchstart', this.onBorYTouchStart);
+    el.addEventListener('ybuttontouchend', this.onBorYTouchEnd);
     el.addEventListener('surfacetouchstart', this.onSurfaceTouchStart);
     el.addEventListener('surfacetouchend', this.onSurfaceTouchEnd);
   },
@@ -96,14 +96,14 @@ module.exports.Component = registerComponent('hand-controls', {
     el.removeEventListener('griptouchend', this.onGripTouchEnd);
     el.removeEventListener('thumbstickdown', this.onThumbstickDown);
     el.removeEventListener('thumbstickup', this.onThumbstickUp);
-    el.removeEventListener('Atouchstart', this.onAorXTouchStart);
-    el.removeEventListener('Atouchend', this.onAorXTouchEnd);
-    el.removeEventListener('Btouchstart', this.onBorYTouchStart);
-    el.removeEventListener('Btouchend', this.onBorYTouchEnd);
-    el.removeEventListener('Xtouchstart', this.onAorXTouchStart);
-    el.removeEventListener('Xtouchend', this.onAorXTouchEnd);
-    el.removeEventListener('Ytouchstart', this.onBorYTouchStart);
-    el.removeEventListener('Ytouchend', this.onBorYTouchEnd);
+    el.removeEventListener('abuttontouchstart', this.onAorXTouchStart);
+    el.removeEventListener('abuttontouchend', this.onAorXTouchEnd);
+    el.removeEventListener('bbuttontouchstart', this.onBorYTouchStart);
+    el.removeEventListener('bbuttontouchend', this.onBorYTouchEnd);
+    el.removeEventListener('xbuttontouchstart', this.onAorXTouchStart);
+    el.removeEventListener('xbuttontouchend', this.onAorXTouchEnd);
+    el.removeEventListener('ybuttontouchstart', this.onBorYTouchStart);
+    el.removeEventListener('ybuttontouchend', this.onBorYTouchEnd);
     el.removeEventListener('surfacetouchstart', this.onSurfaceTouchStart);
     el.removeEventListener('surfacetouchend', this.onSurfaceTouchEnd);
   },

--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -36,8 +36,14 @@ module.exports.Component = registerComponent('hand-controls', {
     this.onGripTouchEnd = function () { self.handleButton('grip', 'touchend'); };
     this.onThumbstickDown = function () { self.handleButton('thumbstick', 'down'); };
     this.onThumbstickUp = function () { self.handleButton('thumbstick', 'up'); };
+    this.onThumbstickTouchStart = function () { self.handleButton('thumbstick', 'touchstart'); };
+    this.onThumbstickTouchEnd = function () { self.handleButton('thumbstick', 'touchend'); };
+    this.onAorXDown = function () { self.handleButton('AorX', 'down'); };
+    this.onAorXUp = function () { self.handleButton('AorX', 'up'); };
     this.onAorXTouchStart = function () { self.handleButton('AorX', 'touchstart'); };
     this.onAorXTouchEnd = function () { self.handleButton('AorX', 'touchend'); };
+    this.onBorYDown = function () { self.handleButton('BorY', 'down'); };
+    this.onBorYUp = function () { self.handleButton('BorY', 'up'); };
     this.onBorYTouchStart = function () { self.handleButton('BorY', 'touchstart'); };
     this.onBorYTouchEnd = function () { self.handleButton('BorY', 'touchend'); };
     this.onSurfaceTouchStart = function () { self.handleButton('surface', 'touchstart'); };
@@ -68,12 +74,22 @@ module.exports.Component = registerComponent('hand-controls', {
     el.addEventListener('griptouchend', this.onGripTouchEnd);
     el.addEventListener('thumbstickdown', this.onThumbstickDown);
     el.addEventListener('thumbstickup', this.onThumbstickUp);
+    el.addEventListener('thumbsticktouchstart', this.onThumbstickTouchStart);
+    el.addEventListener('thumbstickthouchend', this.onThumbstickTouchEnd);
+    el.addEventListener('abuttondown', this.onAorXDown);
+    el.addEventListener('abuttonup', this.onAorXUp);
     el.addEventListener('abuttontouchstart', this.onAorXTouchStart);
     el.addEventListener('abuttontouchend', this.onAorXTouchEnd);
+    el.addEventListener('bbuttondown', this.onBorYDown);
+    el.addEventListener('bbuttonup', this.onBorYUp);
     el.addEventListener('bbuttontouchstart', this.onBorYTouchStart);
     el.addEventListener('bbuttontouchend', this.onBorYTouchEnd);
+    el.addEventListener('xbuttondown', this.onAorXDown);
+    el.addEventListener('xbuttonup', this.onAorXUp);
     el.addEventListener('xbuttontouchstart', this.onAorXTouchStart);
     el.addEventListener('xbuttontouchend', this.onAorXTouchEnd);
+    el.addEventListener('ybuttondown', this.onBorYDown);
+    el.addEventListener('ybuttonup', this.onBorYUp);
     el.addEventListener('ybuttontouchstart', this.onBorYTouchStart);
     el.addEventListener('ybuttontouchend', this.onBorYTouchEnd);
     el.addEventListener('surfacetouchstart', this.onSurfaceTouchStart);
@@ -96,12 +112,22 @@ module.exports.Component = registerComponent('hand-controls', {
     el.removeEventListener('griptouchend', this.onGripTouchEnd);
     el.removeEventListener('thumbstickdown', this.onThumbstickDown);
     el.removeEventListener('thumbstickup', this.onThumbstickUp);
+    el.removeEventListener('thumbsticktouchstart', this.onThumbstickTouchStart);
+    el.removeEventListener('thumbstickthouchend', this.onThumbstickTouchEnd);
+    el.removeEventListener('abuttondown', this.onAorXDown);
+    el.removeEventListener('abuttonup', this.onAorXUp);
     el.removeEventListener('abuttontouchstart', this.onAorXTouchStart);
     el.removeEventListener('abuttontouchend', this.onAorXTouchEnd);
     el.removeEventListener('bbuttontouchstart', this.onBorYTouchStart);
+    el.removeEventListener('bbuttondown', this.onBorYDown);
+    el.removeEventListener('bbuttonup', this.onBorYUp);
     el.removeEventListener('bbuttontouchend', this.onBorYTouchEnd);
+    el.removeEventListener('xbuttondown', this.onAorXDown);
+    el.removeEventListener('xbuttonup', this.onAorXUp);
     el.removeEventListener('xbuttontouchstart', this.onAorXTouchStart);
     el.removeEventListener('xbuttontouchend', this.onAorXTouchEnd);
+    el.removeEventListener('ybuttondown', this.onBorYDown);
+    el.removeEventListener('ybuttonup', this.onBorYUp);
     el.removeEventListener('ybuttontouchstart', this.onBorYTouchStart);
     el.removeEventListener('ybuttontouchend', this.onBorYTouchEnd);
     el.removeEventListener('surfacetouchstart', this.onSurfaceTouchStart);
@@ -161,15 +187,16 @@ module.exports.Component = registerComponent('hand-controls', {
     var isGripActive = this.pressedButtons['grip'];
     var isSurfaceActive = this.pressedButtons['surface'] || this.touchedButtons['surface'];
     var isTrackpadActive = this.pressedButtons['trackpad'] || this.touchedButtons['trackpad'];
+    var isThumbstickActive = this.pressedButtons['thumbstick'] || this.touchedButtons['thumbstick'];
     var isTriggerActive = this.pressedButtons['trigger'] || this.touchedButtons['trigger'];
-    var isABXYActive = this.touchedButtons['AorX'] || this.touchedButtons['BorY'];
+    var isABXYActive = this.pressedButtons['AorX'] || this.pressedButtons['BorY'] || this.touchedButtons['AorX'] || this.touchedButtons['BorY'];
     var isOculusTouch = this.isOculusTouchController();
     // this works well with Oculus Touch, but Vive needs tweaks
     if (isGripActive) {
       if (!isOculusTouch) {
         gesture = 'fist';
       } else
-      if (isSurfaceActive || isABXYActive || isTrackpadActive) {
+      if (isSurfaceActive || isABXYActive || isTrackpadActive || isThumbstickActive) {
         gesture = isTriggerActive ? 'fist' : 'pointing';
       } else {
         gesture = isTriggerActive ? 'thumb' : 'pistol';

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -105,9 +105,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   checkIfControllerPresent: function () {
     var data = this.data;
     var isPresent = false;
-    var whichControllers;
     // Find which controller matches both prefix and hand.
-    whichControllers = (this.getGamepadsByPrefix(GAMEPAD_ID_PREFIX) || [])
+    var whichControllers = (this.getGamepadsByPrefix(GAMEPAD_ID_PREFIX) || [])
       .filter(function (gamepad) { return gamepad.hand === data.hand; });
     if (whichControllers && whichControllers.length) { isPresent = true; }
     if (isPresent === this.controllerPresent) { return; }

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -26,7 +26,6 @@ var EMULATED_TOUCH_THRESHOLD = 0.001;
 module.exports.Component = registerComponent('oculus-touch-controls', {
   schema: {
     hand: {default: 'left'},
-    emulated: {default: false},
     buttonColor: {type: 'color', default: '#999'},          // Off-white.
     buttonTouchColor: {type: 'color', default: '#8AB'},
     buttonHighlightColor: {type: 'color', default: '#2DF'}, // Light blue.
@@ -91,13 +90,6 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     this.getGamepadsByPrefix = getGamepadsByPrefix; // to allow mock
   },
 
-  update: function (oldData) {
-    // Check for emulated flag setting, not just change, to avoid spurious check after init(),
-    if (('emulated' in oldData) && (this.data.emulated !== oldData.emulated)) {
-      this.checkIfControllerPresent();
-    }
-  },
-
   addEventListeners: function () {
     var el = this.el;
     el.addEventListener('buttonchanged', this.onButtonChanged);
@@ -128,14 +120,14 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     whichControllers = (this.getGamepadsByPrefix(GAMEPAD_ID_PREFIX) || [])
       .filter(function (gamepad) { return gamepad.hand === data.hand; });
     if (whichControllers && whichControllers.length) { isPresent = true; }
-    if ((isPresent || data.emulated) === this.controllerPresent) { return; }
+    if (isPresent === this.controllerPresent) { return; }
     this.controllerPresent = isPresent;
     if (isPresent) {
       // Inject with specific gamepad id, if provided. This works around a temporary issue
       // where Chromium uses `Oculus Touch (Right)` but Firefox uses `Oculus Touch (right)`.
       this.injectTrackedControls(whichControllers[0]);
-    }
-    if (isPresent || data.emulated) { this.addEventListeners(); } else { this.removeEventListeners(); }
+      this.addEventListeners();
+    } else { this.removeEventListeners(); }
   },
 
   onGamepadConnectionEvent: function (evt) {

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -94,7 +94,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   update: function (oldData) {
     // Check for emulated flag setting, not just change, to avoid spurious check after init(),
     if (('emulated' in oldData) && (this.data.emulated !== oldData.emulated)) {
-      this.checkIfControllersPresent();
+      this.checkIfControllerPresent();
     }
   },
 

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -288,8 +288,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     Object.keys(axesMapping).map(function (key) {
       var value = axesMapping[key];
       var detail = {};
-      var changed = false;
-      value.map(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; });
+      var changed = !evt.detail.changed;
+      if (!changed) { value.map(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; }); }
       if (changed) {
         value.map(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
         self.el.emit(key + 'moved', detail);

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -92,7 +92,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   update: function (oldData) {
-    if ((oldData.emulated !== undefined) && (this.data.emulated !== oldData.emulated)) {
+    // Check for emulated flag setting, not just change, to avoid spurious check after init(),
+    if (('emulated' in oldData) && (this.data.emulated !== oldData.emulated)) {
       this.checkIfControllersPresent();
     }
   },

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -47,7 +47,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     },
     'right': {
       axes: {'thumbstick': [0, 1]},
-      buttons: ['thumbstick', 'trigger', 'grip', 'abutton', 'abutton', 'surface']
+      buttons: ['thumbstick', 'trigger', 'grip', 'abutton', 'bbutton', 'surface']
     }
   },
 

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -287,10 +287,14 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     Object.keys(axesMapping).map(function (key) {
       var value = axesMapping[key];
       var detail = {};
-      value.map(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
-      self.el.emit(key + 'moved', detail);
+      var changed = false;
+      value.map(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; });
+      if (changed) {
+        value.map(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
+        self.el.emit(key + 'moved', detail);
+        // If we updated the model based on axis values, that call would go here.
+      }
     });
-    // If we updated the model based on axis values, that call would go here.
   },
 
   updateModel: function (buttonName, evtName) {

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -285,13 +285,13 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     // In theory, it might be better to use mapping from axis to control.
     // In practice, it is not clear whether the additional overhead is worthwhile,
     // and if we did grouping of axes, we really need de-duplication there.
-    Object.keys(axesMapping).map(function (key) {
+    Object.keys(axesMapping).forEach(function (key) {
       var value = axesMapping[key];
       var detail = {};
       var changed = !evt.detail.changed;
-      if (!changed) { value.map(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; }); }
+      if (!changed) { value.forEach(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; }); }
       if (changed) {
-        value.map(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
+        value.forEach(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
         self.el.emit(key + 'moved', detail);
         // If we updated the model based on axis values, that call would go here.
       }

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -43,21 +43,11 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   mapping: {
     'left': {
       axes: {'thumbstick': [0, 1]},
-      button0: 'thumbstick',
-      button1: 'trigger',
-      button2: 'grip',
-      button3: 'xbutton',
-      button4: 'ybutton',
-      button5: 'surface'
+      buttons: ['thumbstick', 'trigger', 'grip', 'xbutton', 'ybutton', 'surface']
     },
     'right': {
       axes: {'thumbstick': [0, 1]},
-      button0: 'thumbstick',
-      button1: 'trigger',
-      button2: 'grip',
-      button3: 'abutton',
-      button4: 'bbutton',
-      button5: 'surface'
+      buttons: ['thumbstick', 'trigger', 'grip', 'abutton', 'abutton', 'surface']
     }
   },
 
@@ -203,7 +193,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onButtonChanged: function (evt) {
-    var button = this.mapping[this.data.hand]['button' + evt.detail.id];
+    var button = this.mapping[this.data.hand].buttons[evt.detail.id];
     var buttonMeshes = this.buttonMeshes;
     var isPreviousValueEmulatedTouch;
     var analogValue;
@@ -259,7 +249,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onButtonEvent: function (id, evtName) {
-    var buttonName = this.mapping[this.data.hand]['button' + id];
+    var buttonName = this.mapping[this.data.hand].buttons[id];
     var i;
     if (Array.isArray(buttonName)) {
       for (i = 0; i < buttonName.length; i++) {

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -46,8 +46,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       button0: 'thumbstick',
       button1: 'trigger',
       button2: 'grip',
-      button3: 'X',
-      button4: 'Y',
+      button3: 'xbutton',
+      button4: 'ybutton',
       button5: 'surface'
     },
     'right': {
@@ -55,8 +55,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       button0: 'thumbstick',
       button1: 'trigger',
       button2: 'grip',
-      button3: 'A',
-      button4: 'B',
+      button3: 'abutton',
+      button4: 'bbutton',
       button5: 'surface'
     }
   },
@@ -249,10 +249,10 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     buttonMeshes.grip = controllerObject3D.getObjectByName(leftHand ? 'buttonHand_oculus-touch-controller-left.004' : 'buttonHand_oculus-touch-controller-right.005');
     buttonMeshes.thumbstick = controllerObject3D.getObjectByName(leftHand ? 'stick_oculus-touch-controller-left.007' : 'stick_oculus-touch-controller-right.004');
     buttonMeshes.trigger = controllerObject3D.getObjectByName(leftHand ? 'buttonTrigger_oculus-touch-controller-left.005' : 'buttonTrigger_oculus-touch-controller-right.006');
-    buttonMeshes.X = controllerObject3D.getObjectByName('buttonX_oculus-touch-controller-left.002');
-    buttonMeshes.A = controllerObject3D.getObjectByName('buttonA_oculus-touch-controller-right.002');
-    buttonMeshes.Y = controllerObject3D.getObjectByName('buttonY_oculus-touch-controller-left.001');
-    buttonMeshes.B = controllerObject3D.getObjectByName('buttonB_oculus-touch-controller-right.003');
+    buttonMeshes.xbutton = controllerObject3D.getObjectByName('buttonX_oculus-touch-controller-left.002');
+    buttonMeshes.abutton = controllerObject3D.getObjectByName('buttonA_oculus-touch-controller-right.002');
+    buttonMeshes.ybutton = controllerObject3D.getObjectByName('buttonY_oculus-touch-controller-left.001');
+    buttonMeshes.bbutton = controllerObject3D.getObjectByName('buttonB_oculus-touch-controller-right.003');
 
     // Offset pivot point
     controllerObject3D.position = PIVOT_OFFSET;

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -169,18 +169,17 @@ module.exports.Component = registerComponent('tracked-controls', {
     var controllerAxes = this.controller.axes;
     var i;
     var previousAxis = this.axis;
+    var changedAxes = [];
 
     // Check if axis changed.
     for (i = 0; i < controllerAxes.length; ++i) {
-      if (previousAxis[i] !== controllerAxes[i]) {
-        changed = true;
-        break;
-      }
+      changedAxes.push(previousAxis[i] !== controllerAxes[i]);
+      if (changedAxes[i]) { changed = true; }
     }
     if (!changed) { return false; }
 
     this.axis = controllerAxes.slice();
-    this.el.emit('axismove', {axis: this.axis});
+    this.el.emit('axismove', {axis: this.axis, changed: changedAxes});
     return true;
   },
 

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -30,11 +30,7 @@ module.exports.Component = registerComponent('vive-controls', {
   // 4 - system ( never dispatched on this layer )
   mapping: {
     axes: {'trackpad': [0, 1]},
-    button0: 'trackpad',
-    button1: 'trigger',
-    button2: 'grip',
-    button3: 'menu',
-    button4: 'system'
+    buttons: ['trackpad', 'trigger', 'grip', 'menu', 'system']
   },
 
   // Use these labels for detail on axis events such as thumbstickmoved.
@@ -155,7 +151,7 @@ module.exports.Component = registerComponent('vive-controls', {
   },
 
   onButtonChanged: function (evt) {
-    var button = this.mapping['button' + evt.detail.id];
+    var button = this.mapping.buttons[evt.detail.id];
     var buttonMeshes = this.buttonMeshes;
     var value;
     if (!button) { return; }
@@ -207,7 +203,7 @@ module.exports.Component = registerComponent('vive-controls', {
   },
 
   onButtonEvent: function (id, evtName) {
-    var buttonName = this.mapping['button' + id];
+    var buttonName = this.mapping.buttons[id];
     var i;
     if (Array.isArray(buttonName)) {
       for (i = 0; i < buttonName.length; i++) {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -202,8 +202,8 @@ module.exports.Component = registerComponent('vive-controls', {
     Object.keys(axesMapping).map(function (key) {
       var value = axesMapping[key];
       var detail = {};
-      var changed = false;
-      value.map(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; });
+      var changed = !evt.detail.changed;
+      if (!changed) { value.map(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; }); }
       if (changed) {
         value.map(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
         self.el.emit(key + 'moved', detail);

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -72,7 +72,7 @@ module.exports.Component = registerComponent('vive-controls', {
   update: function (oldData) {
     // Check for emulated flag setting, not just change, to avoid spurious check after init(),
     if (('emulated' in oldData) && (this.data.emulated !== oldData.emulated)) {
-      this.checkIfControllersPresent();
+      this.checkIfControllerPresent();
     }
   },
 

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -195,10 +195,14 @@ module.exports.Component = registerComponent('vive-controls', {
     Object.keys(axesMapping).map(function (key) {
       var value = axesMapping[key];
       var detail = {};
-      value.map(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
-      self.el.emit(key + 'moved', detail);
+      var changed = false;
+      value.map(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; });
+      if (changed) {
+        value.map(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
+        self.el.emit(key + 'moved', detail);
+        // If we updated the model based on axis values, that call would go here.
+      }
     });
-    // If we updated the model based on axis values, that call would go here.
   },
 
   onButtonEvent: function (id, evtName) {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -199,13 +199,13 @@ module.exports.Component = registerComponent('vive-controls', {
     // In theory, it might be better to use mapping from axis to control.
     // In practice, it is not clear whether the additional overhead is worthwhile,
     // and if we did grouping of axes, we really need de-duplication there.
-    Object.keys(axesMapping).map(function (key) {
+    Object.keys(axesMapping).forEach(function (key) {
       var value = axesMapping[key];
       var detail = {};
       var changed = !evt.detail.changed;
-      if (!changed) { value.map(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; }); }
+      if (!changed) { value.forEach(function (axisNumber) { changed |= evt.detail.changed[axisNumber]; }); }
       if (changed) {
-        value.map(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
+        value.forEach(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
         self.el.emit(key + 'moved', detail);
         // If we updated the model based on axis values, that call would go here.
       }

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -16,7 +16,6 @@ var GAMEPAD_ID_PREFIX = 'OpenVR ';
 module.exports.Component = registerComponent('vive-controls', {
   schema: {
     hand: {default: 'left'},
-    emulated: {default: false},
     buttonColor: {type: 'color', default: '#FAFAFA'},  // Off-white.
     buttonHighlightColor: {type: 'color', default: '#22D1EE'},  // Light blue.
     model: {default: true},
@@ -69,13 +68,6 @@ module.exports.Component = registerComponent('vive-controls', {
     this.isControllerPresent = isControllerPresent; // to allow mock
   },
 
-  update: function (oldData) {
-    // Check for emulated flag setting, not just change, to avoid spurious check after init(),
-    if (('emulated' in oldData) && (this.data.emulated !== oldData.emulated)) {
-      this.checkIfControllerPresent();
-    }
-  },
-
   addEventListeners: function () {
     var el = this.el;
     el.addEventListener('buttonchanged', this.onButtonChanged);
@@ -105,10 +97,12 @@ module.exports.Component = registerComponent('vive-controls', {
     // Until then, use hardcoded index.
     var controllerIndex = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
     var isPresent = this.isControllerPresent(this.el.sceneEl, GAMEPAD_ID_PREFIX, { index: controllerIndex });
-    if ((isPresent || data.emulated) === this.controllerPresent) { return; }
+    if (isPresent === this.controllerPresent) { return; }
     this.controllerPresent = isPresent;
-    if (isPresent) { this.injectTrackedControls(); } // inject track-controls
-    if (isPresent || data.emulated) { this.addEventListeners(); } else { this.removeEventListeners(); }
+    if (isPresent) {
+      this.injectTrackedControls();
+      this.addEventListeners();
+    } else { this.removeEventListeners(); }
   },
 
   onGamepadConnectionEvent: function (evt) {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -16,6 +16,7 @@ var GAMEPAD_ID_PREFIX = 'OpenVR ';
 module.exports.Component = registerComponent('vive-controls', {
   schema: {
     hand: {default: 'left'},
+    emulated: {default: false},
     buttonColor: {type: 'color', default: '#FAFAFA'},  // Off-white.
     buttonHighlightColor: {type: 'color', default: '#22D1EE'},  // Light blue.
     model: {default: true},
@@ -29,14 +30,17 @@ module.exports.Component = registerComponent('vive-controls', {
   // 3 - menu ( dispatch but better for menu options )
   // 4 - system ( never dispatched on this layer )
   mapping: {
-    axis0: 'trackpad',
-    axis1: 'trackpad',
+    axes: {'trackpad': [0, 1]},
     button0: 'trackpad',
     button1: 'trigger',
     button2: 'grip',
     button3: 'menu',
     button4: 'system'
   },
+
+  // Use these labels for detail on axis events such as thumbstickmoved.
+  // e.g. for thumbstickmoved detail, the first axis returned is labeled x, and the second is labeled y.
+  axisLabels: ['x', 'y', 'z', 'w'],
 
   bindMethods: function () {
     this.onModelLoaded = bind(this.onModelLoaded, this);
@@ -45,6 +49,8 @@ module.exports.Component = registerComponent('vive-controls', {
     this.removeControllersUpdateListener = bind(this.removeControllersUpdateListener, this);
     this.onGamepadConnected = bind(this.onGamepadConnected, this);
     this.onGamepadDisconnected = bind(this.onGamepadDisconnected, this);
+    this.onAxisMoved = bind(this.onAxisMoved, this);
+    this.onGamepadConnectionEvent = bind(this.onGamepadConnectionEvent, this);
   },
 
   init: function () {
@@ -87,42 +93,38 @@ module.exports.Component = registerComponent('vive-controls', {
 
   checkIfControllerPresent: function () {
     var data = this.data;
-    var controller = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
-    var isPresent = this.isControllerPresent(this.el.sceneEl, GAMEPAD_ID_PREFIX, { index: controller });
-    if (isPresent === this.controllerPresent) { return; }
+    // Once OpenVR / SteamVR return correct hand data in the supporting browsers, we can use hand property.
+    // var isPresent = this.isControllerPresent(this.el.sceneEl, GAMEPAD_ID_PREFIX, { hand: data.hand });
+    // Until then, use hardcoded index.
+    var controllerIndex = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
+    var isPresent = this.isControllerPresent(this.el.sceneEl, GAMEPAD_ID_PREFIX, { index: controllerIndex });
+    if ((isPresent || data.emulated) === this.controllerPresent) { return; }
     this.controllerPresent = isPresent;
     if (isPresent) { this.injectTrackedControls(); } // inject track-controls
+    if (isPresent || data.emulated) { this.addEventListeners(); } else { this.removeEventListeners(); }
   },
 
-  onGamepadConnected: function (evt) {
-    // for now, don't disable controller update listening, due to
-    // apparent issue with FF Nightly only sending one event and seeing one controller;
-    // this.everGotGamepadEvent = true;
-    // this.removeControllersUpdateListener();
-    this.checkIfControllerPresent();
-  },
-
-  onGamepadDisconnected: function (evt) {
-    // for now, don't disable controller update listening, due to
-    // apparent issue with FF Nightly only sending one event and seeing one controller;
-    // this.everGotGamepadEvent = true;
-    // this.removeControllersUpdateListener();
+  onGamepadConnectionEvent: function (evt) {
+    this.everGotGamepadEvent = true;
+    // Due to an apparent bug in FF Nightly
+    // where only one gamepadconnected / disconnected event is fired,
+    // which makes it difficult to handle in individual controller entities,
+    // we no longer remove the controllersupdate listener as a result.
     this.checkIfControllerPresent();
   },
 
   play: function () {
     this.checkIfControllerPresent();
-    window.addEventListener('gamepadconnected', this.onGamepadConnected, false);
-    window.addEventListener('gamepaddisconnected', this.onGamepadDisconnected, false);
     this.addControllersUpdateListener();
-    this.addEventListeners();
+    window.addEventListener('gamepadconnected', this.onGamepadConnectionEvent, false);
+    window.addEventListener('gamepaddisconnected', this.onGamepadConnectionEvent, false);
   },
 
   pause: function () {
-    window.removeEventListener('gamepadconnected', this.onGamepadConnected, false);
-    window.removeEventListener('gamepaddisconnected', this.onGamepadDisconnected, false);
-    this.removeControllersUpdateListener();
     this.removeEventListeners();
+    this.removeControllersUpdateListener();
+    window.removeEventListener('gamepadconnected', this.onGamepadConnectionEvent, false);
+    window.removeEventListener('gamepaddisconnected', this.onGamepadConnectionEvent, false);
   },
 
   injectTrackedControls: function () {
@@ -178,8 +180,18 @@ module.exports.Component = registerComponent('vive-controls', {
   },
 
   onAxisMoved: function (evt) {
-    if (evt.detail.axis[0] === 0 && evt.detail.axis[1] === 0) { return; }
-    this.el.emit('trackpadmoved', { x: evt.detail.axis[0], y: evt.detail.axis[1] });
+    var self = this;
+    var axesMapping = this.mapping.axes;
+    // In theory, it might be better to use mapping from axis to control.
+    // In practice, it is not clear whether the additional overhead is worthwhile,
+    // and if we did grouping of axes, we really need de-duplication there.
+    Object.keys(axesMapping).map(function (key) {
+      var value = axesMapping[key];
+      var detail = {};
+      value.map(function (axisNumber) { detail[self.axisLabels[axisNumber]] = evt.detail.axis[axisNumber]; });
+      self.el.emit(key + 'moved', detail);
+    });
+    // If we updated the model based on axis values, that call would go here.
   },
 
   onButtonEvent: function (id, evtName) {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -157,9 +157,16 @@ module.exports.Component = registerComponent('vive-controls', {
     var button = this.mapping['button' + evt.detail.id];
     var buttonMeshes = this.buttonMeshes;
     var value;
-    if (!button || !buttonMeshes || button !== 'trigger') { return; }
-    value = evt.detail.state.value;
-    buttonMeshes.trigger.rotation.x = -value * (Math.PI / 12);
+    if (!button) { return; }
+
+    // Update button mesh, if any.
+    if (buttonMeshes && button === 'trigger') {
+      value = evt.detail.state.value;
+      buttonMeshes.trigger.rotation.x = -value * (Math.PI / 12);
+    }
+
+    // Pass along changed event with button state, using button mapping for convenience.
+    this.el.emit(button + 'changed', evt.detail.state);
   },
 
   onModelLoaded: function (evt) {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -69,6 +69,13 @@ module.exports.Component = registerComponent('vive-controls', {
     this.isControllerPresent = isControllerPresent; // to allow mock
   },
 
+  update: function (oldData) {
+    // Check for emulated flag setting, not just change, to avoid spurious check after init(),
+    if (('emulated' in oldData) && (this.data.emulated !== oldData.emulated)) {
+      this.checkIfControllersPresent();
+    }
+  },
+
   addEventListeners: function () {
     var el = this.el;
     el.addEventListener('buttonchanged', this.onButtonChanged);

--- a/tests/components/oculus-touch-controls.test.js
+++ b/tests/components/oculus-touch-controls.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test */
+/* global assert, process, setup, suite, test, CustomEvent, Event */
 var entityFactory = require('../helpers').entityFactory;
 var controllerComponentName = 'oculus-touch-controls';
 
@@ -10,6 +10,46 @@ suite(controllerComponentName, function () {
       var controllerComponent = el.components[controllerComponentName];
       controllerComponent.isControllerPresent = function () { return controllerComponent.isControllerPresentMockValue; };
       done();
+    });
+  });
+
+  suite('emulated', function () {
+    test('when emulated, if no controllers, add event listeners but do not inject tracked-controls', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      // mock isControllerPresent to return false
+      controllerComponent.isControllerPresentMockValue = false;
+      // pretend we haven't looked before
+      delete controllerComponent.controllerPresent;
+      // set the emulated flag directly, to avoid having to wait for DOM update
+      controllerComponent.data.emulated = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.ok(controllerComponent.data.emulated);
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+      assert.ok(addEventListenersSpy.called);
+    });
+
+    test('when not emulated by default, if no controllers, do not add event listeners or inject tracked-controls', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      // mock isControllerPresent to return false
+      controllerComponent.isControllerPresentMockValue = false;
+      // pretend we haven't looked before
+      delete controllerComponent.controllerPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(controllerComponent.data.emulated);
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+      assert.notOk(addEventListenersSpy.called);
     });
   });
 
@@ -80,7 +120,7 @@ suite(controllerComponentName, function () {
       var el = this.el;
       var controllerComponent = el.components[controllerComponentName];
       var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      // mock isControllerPresent to return true
+      // mock isControllerPresent to return false
       controllerComponent.isControllerPresentMockValue = false;
       // pretend we've looked before
       controllerComponent.controllerPresent = true;
@@ -92,26 +132,62 @@ suite(controllerComponentName, function () {
     });
   });
 
-  suite.skip('onGamepadConnected / Disconnected', function () {
-    test('if we get onGamepadConnected or onGamepadDisconnected, remove periodic change listener and check if present', function () {
+  suite('axismove', function () {
+    var name = 'thumbstick';
+    // Due to an apparent bug in FF Nightly
+    // where only one gamepadconnected / disconnected event is fired,
+    // which makes it difficult to handle in individual controller entities,
+    // we no longer remove the controllersupdate listener as a result.
+    test('if we get axismove, emit ' + name + 'moved', function (done) {
       var el = this.el;
       var controllerComponent = el.components[controllerComponentName];
-      var removeControllersUpdateListenerSpy = this.sinon.spy(controllerComponent, 'removeControllersUpdateListener');
+      var evt;
+      // mock isControllerPresent to return true
+      controllerComponent.isControllerPresentMockValue = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for thumbstickmoved
+      this.el.addEventListener(name + 'moved', function (evt) {
+        assert.equal(evt.detail.x, 0.1);
+        assert.equal(evt.detail.y, 0.2);
+        assert.ok(evt.detail);
+        done();
+      });
+      // emit axismove
+      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2]}});
+      this.el.dispatchEvent(evt);
+    });
+  });
+
+  suite('gamepadconnected / disconnected', function () {
+    // Due to an apparent bug in FF Nightly
+    // where only one gamepadconnected / disconnected event is fired,
+    // which makes it difficult to handle in individual controller entities,
+    // we no longer remove the controllersupdate listener as a result.
+    test('if we get gamepadconnected or gamepaddisconnected, check if present', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
       var checkIfControllerPresentSpy = this.sinon.spy(controllerComponent, 'checkIfControllerPresent');
+      // Because checkIfControllerPresent may be used in bound form, bind and reinstall.
+      controllerComponent.checkIfControllerPresent = controllerComponent.checkIfControllerPresent.bind(controllerComponent);
+      controllerComponent.pause();
+      controllerComponent.play();
+      // mock isControllerPresent to return true
+      controllerComponent.isControllerPresentMockValue = true;
       // reset everGotGamepadEvent so we don't think we've looked before
       delete controllerComponent.everGotGamepadEvent;
-      // do the call
-      controllerComponent.onGamepadConnected();
+      // fire emulated gamepadconnected event
+      window.dispatchEvent(new Event('gamepadconnected'));
       // check assertions
-      assert.ok(removeControllersUpdateListenerSpy.called);
       assert.ok(checkIfControllerPresentSpy.called);
       assert.ok(controllerComponent.everGotGamepadEvent);
+      // mock isControllerPresent to return false
+      controllerComponent.isControllerPresentMockValue = false;
       // reset everGotGamepadEvent so we don't think we've looked before
       delete controllerComponent.everGotGamepadEvent;
-      // do the call
-      controllerComponent.onGamepadDisconnected();
+      // fire emulated gamepaddisconnected event
+      window.dispatchEvent(new Event('gamepaddisconnected'));
       // check assertions
-      assert.ok(removeControllersUpdateListenerSpy.called);
       assert.ok(checkIfControllerPresentSpy.called);
       assert.ok(controllerComponent.everGotGamepadEvent);
     });

--- a/tests/components/oculus-touch-controls.test.js
+++ b/tests/components/oculus-touch-controls.test.js
@@ -2,6 +2,8 @@
 var entityFactory = require('../helpers').entityFactory;
 var controllerComponentName = 'oculus-touch-controls';
 
+var emulatedControllers = [{id: 'Oculus Touch (Left)', hand: 'left'}, {id: 'Oculus Touch (right)', hand: 'right'}];
+
 suite(controllerComponentName, function () {
   setup(function (done) {
     var el = this.el = entityFactory();
@@ -9,6 +11,9 @@ suite(controllerComponentName, function () {
     el.addEventListener('loaded', function () {
       var controllerComponent = el.components[controllerComponentName];
       controllerComponent.isControllerPresent = function () { return controllerComponent.isControllerPresentMockValue; };
+      controllerComponent.getGamepadsByPrefix = function () {
+        return controllerComponent.isControllerPresentMockValue ? emulatedControllers : null;
+      };
       done();
     });
   });
@@ -30,8 +35,8 @@ suite(controllerComponentName, function () {
       // check assertions
       assert.ok(controllerComponent.data.emulated);
       assert.notOk(injectTrackedControlsSpy.called);
-      assert.ok(controllerComponent.controllerPresent === false); // not undefined
       assert.ok(addEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
     });
 
     test('when not emulated by default, if no controllers, do not add event listeners or inject tracked-controls', function () {
@@ -48,8 +53,8 @@ suite(controllerComponentName, function () {
       // check assertions
       assert.notOk(controllerComponent.data.emulated);
       assert.notOk(injectTrackedControlsSpy.called);
-      assert.ok(controllerComponent.controllerPresent === false); // not undefined
       assert.notOk(addEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
     });
   });
 

--- a/tests/components/oculus-touch-controls.test.js
+++ b/tests/components/oculus-touch-controls.test.js
@@ -155,8 +155,27 @@ suite(controllerComponentName, function () {
         done();
       });
       // emit axismove
-      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2]}});
+      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [true, false]}});
       this.el.dispatchEvent(evt);
+    });
+
+    test('if we get axismove with no changes, do not emit ' + name + 'moved', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+      // mock isControllerPresent to return true
+      controllerComponent.isControllerPresentMockValue = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for thumbstickmoved
+      this.el.addEventListener(name + 'moved', function (evt) {
+        assert.notOk(evt.detail);
+      });
+      // emit axismove with no changes
+      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [false, false]}});
+      this.el.dispatchEvent(evt);
+      // finish next tick
+      setTimeout(function () { done(); }, 0);
     });
   });
 
@@ -171,12 +190,12 @@ suite(controllerComponentName, function () {
       controllerComponent.isControllerPresentMockValue = true;
       // do the check
       controllerComponent.checkIfControllerPresent();
-      // install event handler listening for thumbstickmoved
+      // install event handler listening for triggerchanged
       this.el.addEventListener(name + 'changed', function (evt) {
         assert.ok(evt.detail);
         done();
       });
-      // emit axismove
+      // emit buttonchanged
       evt = new CustomEvent('buttonchanged', {'detail': {id: id, state: {value: 0.5, pressed: true, touched: true}}});
       this.el.dispatchEvent(evt);
     });

--- a/tests/components/oculus-touch-controls.test.js
+++ b/tests/components/oculus-touch-controls.test.js
@@ -18,46 +18,6 @@ suite(controllerComponentName, function () {
     });
   });
 
-  suite('emulated', function () {
-    test('when emulated, if no controllers, add event listeners but do not inject tracked-controls', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      // mock isControllerPresent to return false
-      controllerComponent.isControllerPresentMockValue = false;
-      // pretend we haven't looked before
-      delete controllerComponent.controllerPresent;
-      // set the emulated flag directly, to avoid having to wait for DOM update
-      controllerComponent.data.emulated = true;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // check assertions
-      assert.ok(controllerComponent.data.emulated);
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.ok(addEventListenersSpy.called);
-      assert.ok(controllerComponent.controllerPresent === false); // not undefined
-    });
-
-    test('when not emulated by default, if no controllers, do not add event listeners or inject tracked-controls', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      // mock isControllerPresent to return false
-      controllerComponent.isControllerPresentMockValue = false;
-      // pretend we haven't looked before
-      delete controllerComponent.controllerPresent;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // check assertions
-      assert.notOk(controllerComponent.data.emulated);
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.notOk(addEventListenersSpy.called);
-      assert.ok(controllerComponent.controllerPresent === false); // not undefined
-    });
-  });
-
   suite('checkIfControllerPresent', function () {
     test('first-time, if no controllers, remove event listeners and remember not present', function () {
       var el = this.el;

--- a/tests/components/oculus-touch-controls.test.js
+++ b/tests/components/oculus-touch-controls.test.js
@@ -139,10 +139,6 @@ suite(controllerComponentName, function () {
 
   suite('axismove', function () {
     var name = 'thumbstick';
-    // Due to an apparent bug in FF Nightly
-    // where only one gamepadconnected / disconnected event is fired,
-    // which makes it difficult to handle in individual controller entities,
-    // we no longer remove the controllersupdate listener as a result.
     test('if we get axismove, emit ' + name + 'moved', function (done) {
       var el = this.el;
       var controllerComponent = el.components[controllerComponentName];
@@ -160,6 +156,28 @@ suite(controllerComponentName, function () {
       });
       // emit axismove
       evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2]}});
+      this.el.dispatchEvent(evt);
+    });
+  });
+
+  suite('buttonchanged', function () {
+    var name = 'trigger';
+    var id = 1;
+    test('if we get buttonchanged, emit ' + name + 'changed', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+      // mock isControllerPresent to return true
+      controllerComponent.isControllerPresentMockValue = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for thumbstickmoved
+      this.el.addEventListener(name + 'changed', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+      // emit axismove
+      evt = new CustomEvent('buttonchanged', {'detail': {id: id, state: {value: 0.5, pressed: true, touched: true}}});
       this.el.dispatchEvent(evt);
     });
   });

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -204,6 +204,7 @@ suite('tracked-controls', function () {
       assert.deepEqual(component.axis, [0.5, 0.5, 0.5]);
       assert.equal(emitSpy.getCalls()[0].args[0], 'axismove');
       assert.deepEqual(emitSpy.getCalls()[0].args[1].axis, [0.5, 0.5, 0.5]);
+      assert.deepEqual(emitSpy.getCalls()[0].args[1].changed, [true, true, true]);
     });
 
     test('emits axismove if axis changed', function () {
@@ -217,6 +218,21 @@ suite('tracked-controls', function () {
       const emitCall = emitSpy.getCalls()[0];
       assert.equal(emitCall.args[0], 'axismove');
       assert.deepEqual(emitCall.args[1].axis, [1, 1, 1]);
+      assert.deepEqual(emitCall.args[1].changed, [true, true, true]);
+    });
+
+    test('emits axismove with correct axis changed flags', function () {
+      controller.axes = [0.5, 0.5, 0.5];
+      component.tick();
+      assert.deepEqual(component.axis, [0.5, 0.5, 0.5]);
+
+      const emitSpy = this.sinon.spy(el, 'emit');
+      controller.axes = [1, 0.5, 0.5];
+      component.tick();
+      const emitCall = emitSpy.getCalls()[0];
+      assert.equal(emitCall.args[0], 'axismove');
+      assert.deepEqual(emitCall.args[1].axis, [1, 0.5, 0.5]);
+      assert.deepEqual(emitCall.args[1].changed, [true, false, false]);
     });
   });
 

--- a/tests/components/vive-controls.test.js
+++ b/tests/components/vive-controls.test.js
@@ -154,8 +154,27 @@ suite(controllerComponentName, function () {
         done();
       });
       // emit axismove
-      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2]}});
+      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [true, false]}});
       this.el.dispatchEvent(evt);
+    });
+
+    test('if we get axismove with no changes, do not emit ' + name + 'moved', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+      // mock isControllerPresent to return true
+      controllerComponent.isControllerPresentMockValue = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for thumbstickmoved
+      this.el.addEventListener(name + 'moved', function (evt) {
+        assert.notOk(evt.detail);
+      });
+      // emit axismove
+      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [false, false]}});
+      this.el.dispatchEvent(evt);
+      // finish next tick
+      setTimeout(function () { done(); }, 0);
     });
   });
 
@@ -170,12 +189,12 @@ suite(controllerComponentName, function () {
       controllerComponent.isControllerPresentMockValue = true;
       // do the check
       controllerComponent.checkIfControllerPresent();
-      // install event handler listening for thumbstickmoved
+      // install event handler listening for triggerchanged
       this.el.addEventListener(name + 'changed', function (evt) {
         assert.ok(evt.detail);
         done();
       });
-      // emit axismove
+      // emit buttonchanged
       evt = new CustomEvent('buttonchanged', {'detail': {id: id, state: {value: 0.5, pressed: true, touched: true}}});
       this.el.dispatchEvent(evt);
     });

--- a/tests/components/vive-controls.test.js
+++ b/tests/components/vive-controls.test.js
@@ -138,10 +138,6 @@ suite(controllerComponentName, function () {
 
   suite('axismove', function () {
     var name = 'trackpad';
-    // Due to an apparent bug in FF Nightly
-    // where only one gamepadconnected / disconnected event is fired,
-    // which makes it difficult to handle in individual controller entities,
-    // we no longer remove the controllersupdate listener as a result.
     test('if we get axismove, emit ' + name + 'moved', function (done) {
       var el = this.el;
       var controllerComponent = el.components[controllerComponentName];
@@ -159,6 +155,28 @@ suite(controllerComponentName, function () {
       });
       // emit axismove
       evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2]}});
+      this.el.dispatchEvent(evt);
+    });
+  });
+
+  suite('buttonchanged', function () {
+    var name = 'trigger';
+    var id = 1;
+    test('if we get buttonchanged, emit ' + name + 'changed', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+      // mock isControllerPresent to return true
+      controllerComponent.isControllerPresentMockValue = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for thumbstickmoved
+      this.el.addEventListener(name + 'changed', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+      // emit axismove
+      evt = new CustomEvent('buttonchanged', {'detail': {id: id, state: {value: 0.5, pressed: true, touched: true}}});
       this.el.dispatchEvent(evt);
     });
   });

--- a/tests/components/vive-controls.test.js
+++ b/tests/components/vive-controls.test.js
@@ -13,46 +13,6 @@ suite(controllerComponentName, function () {
     });
   });
 
-  suite('emulated', function () {
-    test('when emulated, if no controllers, add event listeners but do not inject tracked-controls', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      // mock isControllerPresent to return false
-      controllerComponent.isControllerPresentMockValue = false;
-      // pretend we haven't looked before
-      delete controllerComponent.controllerPresent;
-      // set the emulated flag directly, to avoid having to wait for DOM update
-      controllerComponent.data.emulated = true;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // check assertions
-      assert.ok(controllerComponent.data.emulated);
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.ok(controllerComponent.controllerPresent === false); // not undefined
-      assert.ok(addEventListenersSpy.called);
-    });
-
-    test('when not emulated by default, if no controllers, do not add event listeners or inject tracked-controls', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      // mock isControllerPresent to return false
-      controllerComponent.isControllerPresentMockValue = false;
-      // pretend we haven't looked before
-      delete controllerComponent.controllerPresent;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // check assertions
-      assert.notOk(controllerComponent.data.emulated);
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.ok(controllerComponent.controllerPresent === false); // not undefined
-      assert.notOk(addEventListenersSpy.called);
-    });
-  });
-
   suite('checkIfControllerPresent', function () {
     test('first-time, if no controllers, remove event listeners and remember not present', function () {
       var el = this.el;


### PR DESCRIPTION
This PR includes #2513 in its entirety (is intended to be committed after #2513 is merged) and modifies `hand-controls` to accommodate Nightly support for Oculus Touch by using button press as well as touch for all gesture determinations.

As of 2017-03-22, Nightly has adopted button and axis mapping that is compatible with Chromium, so #2446 is no longer necessary; however, it does not provide the capacitive touch events that Chromium does, so this cherry-pick is needed for full `hand-controls` gesture support.

Per discussion, #2513 modifies the event names generated by Oculus Touch, which is why that PR is required.