### PR TITLE
isValidDefaultValue warning with component name

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -352,7 +352,7 @@ module.exports.registerComponent = function (name, definition) {
     multiple: NewComponent.prototype.multiple,
     parse: NewComponent.prototype.parse,
     parseAttrValueForCache: NewComponent.prototype.parseAttrValueForCache,
-    schema: utils.extend(processSchema(NewComponent.prototype.schema)),
+    schema: utils.extend(processSchema(NewComponent.prototype.schema, NewComponent.prototype.name)),
     stringify: NewComponent.prototype.stringify,
     type: NewComponent.prototype.type
   };

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -25,25 +25,29 @@ module.exports.isSingleProperty = isSingleProperty;
  * Build step to schema to use `type` to inject default value, parser, and stringifier.
  *
  * @param {object} schema
+ * @param {string} componentName
  * @returns {object} Schema.
  */
-module.exports.process = function (schema) {
+module.exports.process = function (schema, componentName) {
   // For single property schema, run processPropDefinition over the whole schema.
   if (isSingleProperty(schema)) {
-    return processPropertyDefinition(schema);
+    return processPropertyDefinition(schema, componentName);
   }
 
   // For multi-property schema, run processPropDefinition over each property definition.
   Object.keys(schema).forEach(function (propName) {
-    schema[propName] = processPropertyDefinition(schema[propName]);
+    schema[propName] = processPropertyDefinition(schema[propName], componentName);
   });
   return schema;
 };
 
 /**
  * Inject default value, parser, stringifier for single property.
+ *
+ * @param {object} propDefinition
+ * @param {string} componentName
  */
-function processPropertyDefinition (propDefinition) {
+function processPropertyDefinition (propDefinition, componentName) {
   var defaultVal = propDefinition.default;
   var propType;
   var typeName = propDefinition.type;
@@ -81,7 +85,7 @@ function processPropertyDefinition (propDefinition) {
   if ('default' in propDefinition) {
     // Check that default values are valid.
     if (!isValidDefaultValue(typeName, defaultVal)) {
-      warn('Default value `', defaultVal, '`, does not match type `', typeName, '`');
+      warn('Default value `', defaultVal, '`, does not match type `', typeName, '`', 'in Component `', componentName, '`');
     }
   } else {
     // Fill in default value.

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -85,7 +85,8 @@ function processPropertyDefinition (propDefinition, componentName) {
   if ('default' in propDefinition) {
     // Check that default values are valid.
     if (!isValidDefaultValue(typeName, defaultVal)) {
-      warn('Default value `', defaultVal, '`, does not match type `', typeName, '`', 'in Component `', componentName, '`');
+      warn('Default value `' + defaultVal + '` does not match type `' + typeName +
+           '` in Component `' + componentName + '`');
     }
   } else {
     // Fill in default value.


### PR DESCRIPTION
**Description:**
When `isValidDefaultValue` returns `false` the warning should include the component's name.

**Changes proposed:**
Passed down the component's name so that it warns with the name. Also adjusted it so the runtime is at the end. 
For an invalid default value passed in like this:
```js
AFRAME.registerComponent('test', {
        schema: {
          type: 'string',
          default: 0,
        },
      })
```
Now the warning output in the console is: 
```
core:schema:warn Default value `0` does not match type `string` in Component `test` +0ms
```