### PR TITLE
Set material.needsUpdate=true if side switches from/to double

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -106,15 +106,22 @@ module.exports.Component = registerComponent('material', {
   updateMaterial: function () {
     var data = this.data;
     var material = this.material;
-    material.side = parseSide(data.side);
+    var needsUpdate = false;
+    var side = parseSide(data.side);
+    if (material.side === THREE.DoubleSide && side !== THREE.DoubleSide ||
+      material.side !== THREE.DoubleSide && side === THREE.DoubleSide) {
+      needsUpdate = true;
+    }
+    material.side = side;
     material.opacity = data.opacity;
     material.transparent = data.transparent !== false || data.opacity < 1.0;
     material.depthTest = data.depthTest !== false;
     material.depthWrite = data.depthWrite !== false;
     material.shading = data.flatShading ? THREE.FlatShading : THREE.SmoothShading;
     material.visible = data.visible;
-    if (data.alphaTest !== material.alphaTest) { material.needsUpdate = true; }
+    if (data.alphaTest !== material.alphaTest) { needsUpdate = true; }
     material.alphaTest = data.alphaTest;
+    if (needsUpdate) { material.needsUpdate = true; }
   },
 
   /**

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -195,6 +195,17 @@ suite('material', function () {
       el.setAttribute('material', 'side: double');
       assert.equal(el.getObject3D('mesh').material.side, THREE.DoubleSide);
     });
+
+    test('sets material.needsUpdate true if side switchs from/to double', function () {
+      var el = this.el;
+      el.setAttribute('material', 'side: front');
+      el.getObject3D('mesh').material.needsUpdate = false;
+      el.setAttribute('material', 'side: double');
+      assert.equal(el.getObject3D('mesh').material.needsUpdate, 1);
+      el.getObject3D('mesh').material.needsUpdate = false;
+      el.setAttribute('material', 'side: front');
+      assert.equal(el.getObject3D('mesh').material.needsUpdate, 1);
+    });
   });
 
   suite('transparent', function () {


### PR DESCRIPTION
**Description:**

This PR sets `material.needsUpdate=true` to update shader
if `material.side` switches from/to `THREE.Double`.

Three.js code
- https://github.com/mrdoob/three.js/blob/fc1159a6415dd7c833b2bf7ee41374c2b2a6cc6a/src/renderers/shaders/ShaderChunk/normal_flip.glsl#L1
- https://github.com/mrdoob/three.js/blob/4a77f64f1479042e9b76734d14acc1ea4f9bfd17/src/renderers/webgl/WebGLPrograms.js#L197
- https://github.com/mrdoob/three.js/blob/adb7979ddf7c0fa678084add5c076172de68e217/src/renderers/webgl/WebGLProgram.js#L351


**Changes proposed:**
- set material.needsUpdate=true if side switches from/to double
- add a test for that
