### PR TITLE
Update webvr-polyfill dependency. the fork is now hosted on the aframevr org (fix #2495)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "three": "^0.84.0",
     "three-bmfont-text": "^2.1.0",
     "tween.js": "^15.0.0",
-    "webvr-polyfill": "dmarcos/webvr-polyfill#a02a8089b"
+    "webvr-polyfill": "aframevr/webvr-polyfill#9faf790a"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
I moved the webvr-polyfill fork to the aframevr org and rebase on top of the later master
