### PR TITLE
Avoid touchstart collision

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -227,7 +227,8 @@ module.exports.Component = registerComponent('tracked-controls', {
     if (buttonState.touched === previousButtonState.touched) { return false; }
 
     evtName = buttonState.touched ? 'start' : 'end';
-    this.el.emit('touch' + evtName, {id: id, state: buttonState});
+    // Due to unfortunate name collision, add empty touches array to avoid Daydream error.
+    this.el.emit('touch' + evtName, {id: id, state: buttonState, touches: []});
     previousButtonState.touched = buttonState.touched;
     return true;
   },

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -1,5 +1,3 @@
-/* global CustomEvent */
-
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
 
@@ -230,9 +228,7 @@ module.exports.Component = registerComponent('tracked-controls', {
 
     evtName = buttonState.touched ? 'start' : 'end';
     // Due to unfortunate name collision, add empty touches array to avoid Daydream error.
-    // this.el.emit doesn't allow changes to event outside detail...
-    // this.el.emit('touch' + evtName, {id: id, state: buttonState, touches: []});
-    this.el.dispatchEvent(new CustomEvent('touch' + evtName, {touches: [], detail: {id: id, state: buttonState}}));
+    this.el.emit('touch' + evtName, {id: id, state: buttonState}, true, {touches: []});
     previousButtonState.touched = buttonState.touched;
     return true;
   },

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -1,3 +1,5 @@
+/* global CustomEvent */
+
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
 
@@ -228,7 +230,9 @@ module.exports.Component = registerComponent('tracked-controls', {
 
     evtName = buttonState.touched ? 'start' : 'end';
     // Due to unfortunate name collision, add empty touches array to avoid Daydream error.
-    this.el.emit('touch' + evtName, {id: id, state: buttonState, touches: []});
+    // this.el.emit doesn't allow changes to event outside detail...
+    // this.el.emit('touch' + evtName, {id: id, state: buttonState, touches: []});
+    this.el.dispatchEvent(new CustomEvent('touch' + evtName, {touches: [], detail: {id: id, state: buttonState}}));
     previousButtonState.touched = buttonState.touched;
     return true;
   },

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -219,13 +219,16 @@ module.exports = registerElement('a-node', {
      *   Custom data to pass as `detail` to the event.
      * @param {Boolean=} [bubbles=true]
      *   Whether the event should bubble.
+     * @param {Object=} [extraData]
+     *   Extra data to pass to the event, if any.
      */
     emit: {
-      value: function (name, detail, bubbles) {
+      value: function (name, detail, bubbles, extraData) {
         var self = this;
         detail = detail || {};
         if (bubbles === undefined) { bubbles = true; }
         var data = { bubbles: !!bubbles, detail: detail };
+        if (extraData) { utils.extend(data, extraData); }
         return name.split(' ').map(function (eventName) {
           return utils.fireEvent(self, eventName, data);
         });

--- a/tests/core/a-node.test.js
+++ b/tests/core/a-node.test.js
@@ -24,6 +24,17 @@ suite('a-node', function () {
       el.emit('hadouken', {power: 10});
     });
 
+    test('can emit event with extraData', function (done) {
+      var el = this.el;
+      el.addEventListener('hadouken', function (event) {
+        assert.equal(event.cancelable, true);
+        assert.equal(event.detail.power, 10);
+        assert.equal(event.detail.target, el);
+        done();
+      });
+      el.emit('hadouken', {power: 10}, true, {cancelable: true});
+    });
+
     test('bubbles', function (done) {
       var el = this.el;
       var child = document.createElement('a-node');


### PR DESCRIPTION
Due to unfortunate name collision, add empty touches array to avoid Daydream error in TouchPanner.