### PR TITLE
Throw an error if HTML file is opened with `file://` protocol

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,12 @@ if (document.currentScript && document.currentScript.parentNode !== document.hea
        'HTML.');
 }
 
+if (window.location.protocol === 'file:') {
+  warn('This HTML file is currently served via the file:// protocol. This does not ' +
+       'work well with assets or files fetched in the A-Frame scene. Consider serving ' +
+       'this file from a hosted or local server with a http:// or https:// protocol.');
+}
+
 // Polyfill `Promise`.
 window.Promise = window.Promise || require('promise-polyfill');
 


### PR DESCRIPTION
**Description:**

Since assets do not load well when the html page is not served from a server, let the user know in the form of a warning.

- Fixes #2533