### PR TITLE
added missing close tag for <a-asset-item>

### DIFF
--- a/docs/primitives/a-collada-model.md
+++ b/docs/primitives/a-collada-model.md
@@ -13,7 +13,7 @@ modeling program or downloaded from the web.
 ```html
 <a-scene>
   <a-assets>
-    <a-asset-item id="tree" src="tree.dae">
+    <a-asset-item id="tree" src="tree.dae"></a-asset-item>
   </a-assets>
 
   <!-- Using the asset management system. -->


### PR DESCRIPTION
**Description:**

documentation update

**Changes proposed:**
- added missing closing tag in a-collada-model documentation
