### PR TITLE
use debug fork with no timestamp/diffing

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "browserify-css": "^0.8.2",
-    "debug": "^2.2.0",
+    "debug": "ngokevin/debug#noTimestamp",
     "deep-assign": "^2.0.0",
     "document-register-element": "dmarcos/document-register-element#8ccc532b7",
     "envify": "^3.4.1",


### PR DESCRIPTION
**Description:**

We use the console library `debug`. On each log, it appends a millisecond diff from the previous log. If an error/warning/log repeats, then the browser won't be able to collapse all the logs into one line in the console, spamming it. 

I've removed the diff logic on my fork, shaving some bytes in the process. If you do `var warn = AFRAME.utils.debug('hey:warn'); while (1) { warn('hey'); }` in the console, the browser will now know it's repeated.

**Changes proposed:**
- Use `ngokevin/debug#noTimestamp` (https://github.com/ngokevin/debug/tree/noTimestamp) (https://github.com/ngokevin/debug/commit/ef5f8e66d49ce8bc64c6f282c15f8b7164409e3a)

