### PR TITLE
object property type (fixes #2555)

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -13,6 +13,7 @@ registerPropertyType('asset', '', assetParse);
 registerPropertyType('boolean', false, boolParse);
 registerPropertyType('color', '#FFF', defaultParse, defaultStringify);
 registerPropertyType('int', 0, intParse);
+registerPropertyType('object', '', objectParse, JSON.stringify);
 registerPropertyType('number', 0, numberParse);
 registerPropertyType('map', '', assetParse);
 registerPropertyType('model', '', assetParse);
@@ -117,6 +118,17 @@ function intParse (value) {
 
 function numberParse (value) {
   return parseFloat(value, 10);
+}
+
+/**
+ * `{\"bar\": 10}` to {bar: 10}
+ */
+function objectParse (value) {
+  if (!value) { return null; }
+  if (typeof value !== 'string') { return value; }
+  // Add double quotes if not true JSON.
+  value = value.replace(/(['"])?([a-zA-Z0-9_]+)(['"])?:/g, '"$2": ');
+  return JSON.parse(value);
 }
 
 function selectorParse (value) {

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -94,6 +94,38 @@ suite('propertyTypes', function () {
     });
   });
 
+  suite('object', function () {
+    var parse = propertyTypes.object.parse;
+    var stringify = propertyTypes.object.stringify;
+
+    test('parses object', function () {
+      assert.shallowDeepEqual(parse({foo: 1}), {foo: 1});
+    });
+
+    test('parses object from string with no quotes', function () {
+      assert.shallowDeepEqual(parse('{foo: 1, bar: 2}'), {foo: 1, bar: 2});
+      assert.shallowDeepEqual(parse('{foo: "a", bar: "b"}'), {foo: 'a', bar: 'b'});
+    });
+
+    test('parses object from string with quotes', function () {
+      assert.shallowDeepEqual(parse('{"foo": 1, "bar": 2}'), {foo: 1, bar: 2});
+      assert.shallowDeepEqual(parse('{"foo": "a", "bar": "b"}'), {foo: 'a', bar: 'b'});
+    });
+
+    test('parses nested object', function () {
+      assert.shallowDeepEqual(parse('{foo: {bar: {qux: 1.5}}}'), {foo: {bar: {qux: 1.5}}});
+    });
+
+    test('parses back', function () {
+      assert.shallowDeepEqual(parse(stringify({foo: 1})), {foo: 1});
+    });
+
+    test('stringifies object', function () {
+      var obj = {foo: 'bar', bar: {qaz: -5}, qux: 1.5};
+      assert.equal(stringify(obj), JSON.stringify(obj));
+    });
+  });
+
   suite('selector', function () {
     var parse = propertyTypes.selector.parse;
     var stringify = propertyTypes.selector.stringify;


### PR DESCRIPTION
**Description:**

Useful for like initial game state that have properties that are objects. Or allow accepting general JSON.

More useful when used with setAttribute to let the component accept and pass through objects:

```js
el.setAttribute('comp', 'objProp', {some: 'object', foo: {bar: 10}});
el.setAttribute('comp', 'objProp', jsonString);
```

Can do with HTML, but not something I'd use often.

```html
<a-entity comp="objProp: {foo: \"bar\", qaz: 10}">
```
