### PR TITLE
Robustness tweaks for tracked controls

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -109,7 +109,7 @@ module.exports.Component = registerComponent('tracked-controls', {
     // Scale offset by user height.
     deltaControllerPosition.multiplyScalar(userHeight);
     // Apply controller X and Y rotation (tilting up/down/left/right is usually moving the arm)
-    if (pose.orientation) {
+    if (pose && pose.orientation) {
       controllerQuaternion.fromArray(pose.orientation);
     } else {
       controllerQuaternion.copy(headObject3D.quaternion);
@@ -145,12 +145,12 @@ module.exports.Component = registerComponent('tracked-controls', {
     // Compose pose from Gamepad.
     pose = controller.pose;
     // If no orientation, use camera.
-    if (pose.orientation) {
+    if (pose && pose.orientation) {
       dolly.quaternion.fromArray(pose.orientation);
     } else {
       dolly.quaternion.copy(headObject3D.quaternion);
     }
-    if (pose.position) {
+    if (pose && pose.position) {
       dolly.position.fromArray(pose.position);
     } else {
       // The controller is not 6DOF, so apply arm model.
@@ -160,7 +160,7 @@ module.exports.Component = registerComponent('tracked-controls', {
     dolly.updateMatrix();
 
     // Apply transforms, if 6DOF and in VR.
-    if (pose.position && vrDisplay) {
+    if (pose && pose.position && vrDisplay) {
       if (vrDisplay.stageParameters) {
         standingMatrix.fromArray(vrDisplay.stageParameters.sittingToStandingTransform);
         dolly.applyMatrix(standingMatrix);

--- a/src/systems/tracked-controls.js
+++ b/src/systems/tracked-controls.js
@@ -7,6 +7,7 @@ var utils = require('../utils');
  * It maintains a list with the available tracked controllers
  */
 module.exports.System = registerSystem('tracked-controls', {
+  schema: {alwaysAllowIdPrefixes: {type: 'array'}},
   init: function () {
     var self = this;
     this.controllers = [];
@@ -26,7 +27,12 @@ module.exports.System = registerSystem('tracked-controls', {
     var gamepads = trackedControlsUtils.getGamepadsByPrefix('');
     for (var i = 0; i < gamepads.length; i++) {
       var gamepad = gamepads[i];
-      if (gamepad && gamepad.pose) { controllers.push(gamepad); }
+      if (gamepad && gamepad.pose) { controllers.push(gamepad); } else
+      if (gamepad && this.data.alwaysAllowIdPrefixes) {
+        this.data.alwaysAllowIdPrefixes.forEach(function (idPrefix) {
+          if (gamepad.id.indexOf(idPrefix) === 0) { controllers.push(gamepad); }
+        });
+      }
     }
   },
 

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -1,3 +1,4 @@
+var DEFAULT_HANDEDNESS = require('../constants').DEFAULT_HANDEDNESS;
 /**
  * Return enumerated gamepads matching id prefix.
  *
@@ -48,7 +49,7 @@ module.exports.isControllerPresent = function (sceneEl, idPrefix, queryObject) {
     isPrefixMatch = (!idPrefix || idPrefix === '' || gamepad.id.indexOf(idPrefix) === 0);
     isPresent = isPrefixMatch;
     if (isPresent && queryObject.hand) {
-      isPresent = gamepad.hand === queryObject.hand;
+      isPresent = (gamepad.hand || DEFAULT_HANDEDNESS) === queryObject.hand;
     }
     if (isPresent && queryObject.index) {
       isPresent = index === queryObject.index; // need to use count of gamepads with idPrefix


### PR DESCRIPTION
Robustness tweaks for tracked-controls
- if matching hand filter supplied to isControllerPresent, and gamepad provides no hand, use DEFAULT_HANDEDNESS for matching purposes
- defend against missing pose
- allow system-level specification of id prefixes that should always be included when present in controller list, e.g. if pose is sometimes missing