### PR TITLE
[docs] Removed dangling 'A-Frame' from Guide

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -486,7 +486,6 @@ to actual controllers.
 
 To have a visible cursor fixed to the [camera], we place the cursor as a child
 of the camera as explained above in [Parent and Child Transforms][parentchild].
-A-Frame
 
 [camera]: ../components/camera.md
 


### PR DESCRIPTION
**Description:**
In the [Building a Basic Scene](https://aframe.io/docs/master/guides/) guide, the [Adding Interaction](https://aframe.io/docs/master/guides/#adding-interaction) section has a random reference to 'A-Frame'.

**Changes proposed:**
- Remove dangling A-Frame :)

