### PR TITLE
Allow class selector

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -80,7 +80,7 @@ function assetParse (value) {
   if (parsedUrl) { return parsedUrl[1]; }
 
   // ID.
-  if (value.charAt(0) === '#') {
+  if ('#.'.indexOf(value.charAt(0)) >= 0) {
     el = selectorParse(value);
     if (el) {
       // Pass through media elements. If we have the elements, we don't have to call
@@ -91,7 +91,8 @@ function assetParse (value) {
       return el.getAttribute('src');
     }
     warn('"' + value + '" asset not found.');
-    return;
+    // if first character is period, it might be a relative URL, so fall through
+    if (value.charAt(0) !== '.') { return; }
   }
 
   // Non-wrapped url().

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -127,7 +127,7 @@ function deepEqual (a, b) {
   var valB;
 
   // If not objects or arrays, compare as values.
-  if (a === null || b === null ||
+  if (a === null || b === null || a === undefined || b === undefined ||
       !(a && b && (a.constructor === Object && b.constructor === Object) ||
                   (a.constructor === Array && b.constructor === Array))) {
     return a === b;


### PR DESCRIPTION
Using selectors for images / videos / canvas only works when the selector is by id (starts with `#`) although the selector syntax is more general.  This PR allows class selector (e.g. `.main-video`) to work as well.