### PR TITLE
Support for vive-tracker

### DIFF
--- a/docs/components/vive-tracker.md
+++ b/docs/components/vive-tracker.md
@@ -1,0 +1,58 @@
+---
+title: vive-tracker
+type: components
+layout: docs
+parent_section: components
+---
+
+[trackedcontrols]: ./tracked-controls.md
+
+The vive-tracker component interfaces with the HTC Vive Tracker. It
+wraps the [tracked-controls component][trackedcontrols] while adding button
+mappings, events, and a model.
+
+## Example
+
+```html
+<a-box vive-tracker></a-box>
+
+<a-box vive-tracker="index: 0"></a-entity>
+<a-box vive-tracker="index: 1"></a-entity>
+<a-box vive-tracker="index: 2"></a-entity>
+```
+
+## Value
+
+| Property             | Description                                        | Default Value        |
+|----------------------|----------------------------------------------------|----------------------|
+| buttonColor          | Button colors when not pressed.                    | #FAFAFA (off-white)  |
+| buttonHighlightColor | Button colors when pressed and active.             | #22D1EE (light blue) |
+| index                | The index of the tracker that will be tracked.     | 0                    |
+| model                | Whether the model is loaded.                       | true                 |
+| rotationOffset       | Offset to apply to model rotation.                 | 0                    |
+
+## Events
+
+| Event Name      | Description              |
+| ----------      | -----------              |
+| gripdown        | Grip button pressed.     |
+| gripup          | Grip button released.    |
+| gripchanged     | Grip button changed.     |
+| menudown        | Menu button pressed.     |
+| menuup          | Menu button released.    |
+| menuchanged     | Menu button changed.     |
+| systemdown      | System button pressed.   |
+| systemup        | System button released.  |
+| systemchanged   | System button changed.   |
+| trackpaddown    | Trackpad pressed.        |
+| trackpadup      | Trackpad released.       |
+| trackpadchanged | Trackpad button changed. |
+| triggerdown     | Trigger pressed.         |
+| triggerup       | Trigger released.        |
+| triggerchanged  | Trigger changed.         |
+
+## Assets
+
+- [Controller OBJ](https://cdn.aframe.io/controllers/vive/vr_controller_vive.obj)
+- [Controller MTL](https://cdn.aframe.io/controllers/vive/vr_controller_vive.mtl)
+

--- a/examples/test/vive-tracker/index.html
+++ b/examples/test/vive-tracker/index.html
@@ -1,0 +1,87 @@
+<html>
+<head>
+<script src="../../../dist/aframe-master.js"></script>
+</head>
+<body>
+
+<script>
+  AFRAME.registerComponent('tracker-marker', {
+    schema: {type: 'string'},
+    init: function () {
+      // red ray forward (-Z)
+      var forwardRayEl = document.createElement('a-box');
+      forwardRayEl.setAttribute('width', '0.001');
+      forwardRayEl.setAttribute('height', '0.001');
+      forwardRayEl.setAttribute('depth', '1');
+      forwardRayEl.setAttribute('position', '0 0 -0.5');
+      forwardRayEl.setAttribute('color', 'red');
+      // blue ray up (+Y)
+      var upwardRayEl = document.createElement('a-box');
+      upwardRayEl.setAttribute('width', '0.001');
+      upwardRayEl.setAttribute('height', '1');
+      upwardRayEl.setAttribute('depth', '0.001');
+      upwardRayEl.setAttribute('position', '0 0.5 0');
+      upwardRayEl.setAttribute('color', 'blue');
+
+      // blue label with carets forward (-Z)
+      var labelEl = document.createElement('a-box');
+      labelEl.setAttribute('color', 'blue');
+      labelEl.setAttribute('text', 'zOffset:0.025; color:white; align:center; wrapCount:9; value:^' + this.data + '^');
+      labelEl.setAttribute('width', '0.1');
+      labelEl.setAttribute('height', '0.1');
+      labelEl.setAttribute('depth', '0.001');
+      labelEl.setAttribute('rotation', '-90 0 0');
+      
+      this.el.appendChild(forwardRayEl);
+      this.el.appendChild(upwardRayEl);
+      this.el.appendChild(labelEl);
+    }
+  })
+</script>
+
+<a-scene>
+  <a-sky color="#3CF"></a-sky>
+  <a-plane color="green" width="5" height="5" rotation="-90 0 0"></a-plane>
+  
+  <a-entity position="0 0 -2">
+   <a-entity tracker-marker="floor"></a-entity>
+  </a-entity>
+  
+  <!-- nothing wrong with the model, this looks right -->
+  <a-entity position="0 0 -1" obj-model="obj:https://cdn.aframe.io/controllers/vive/vr_tracker-vive.obj; mtl:https://cdn.aframe.io/controllers/vive/vr_tracker-vive.mtl">
+   <a-entity tracker-marker="model"></a-entity>
+  </a-entity>
+ 
+  <a-entity position="0 0 0">
+   <a-entity tracker-marker="center"></a-entity>
+  </a-entity>  
+  
+  <!-- first tracker -->
+  <a-entity vive-tracker="index:0">
+   <!-- show vive-tracker pose --> 
+   <a-entity tracker-marker="0"></a-entity>
+  </a-entity>
+  
+  <!-- second tracker -->
+  <a-entity vive-tracker="index:1; rotation:-90 0 0">
+   <!-- show vive-tracker pose --> 
+   <a-entity tracker-marker="1"></a-entity>
+  </a-entity>
+  
+  <!-- third tracker, to show what raw values look like -->
+  <a-entity vive-tracker="index:2;rotation:0 0 0">
+   <!-- show vive-tracker pose --> 
+   <a-entity tracker-marker="2(raw)"></a-entity>
+  </a-entity>
+  
+  <!-- controllers -->
+  <a-entity vive-controls="hand:left">
+    <a-entity tracker-marker="left"></a-entity>
+  </a-entity>
+  <a-entity vive-controls="hand:right">
+    <a-entity tracker-marker="right"></a-entity>
+  </a-entity>
+</a-scene>
+
+</body>
+</html>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -24,6 +24,7 @@ require('./text');
 require('./tracked-controls');
 require('./visible');
 require('./vive-controls');
+require('./vive-tracker');
 require('./wasd-controls');
 
 require('./scene/canvas');

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -65,16 +65,18 @@ function isControllerPresent (component, idPrefix, queryObject) {
     gamepad = gamepads[i];
     isPrefixMatch = (!idPrefix || idPrefix === '' || gamepad.id.indexOf(idPrefix) === 0);
     isPresent = isPrefixMatch;
-    if (isPresent && queryObject.hand) {
-      isPresent = (gamepad.hand || DEFAULT_HANDEDNESS) === queryObject.hand;
+    if (isPresent && (queryObject.hand !== undefined)) {
+      isPresent = (gamepad.hand === undefined ? DEFAULT_HANDEDNESS : gamepad.hand) === queryObject.hand;
     }
-    if (isPresent && queryObject.index) {
-      // Need to use count of gamepads with idPrefix.
+    if (isPresent && (queryObject.index !== undefined)) {
+      // Index filter provided, so
+      // check count of gamepads with idPrefix
+      // (and correct hand filter, if present).
       isPresent = index === queryObject.index;
+      // Update count of gamepads with idPrefix (and correct hand filter, if present).
+      index++;
     }
     if (isPresent) { break; }
-    // Update count of gamepads with idPrefix.
-    if (isPrefixMatch) { index++; }
   }
 
   return isPresent;

--- a/tests/components/vive-tracker.test.js
+++ b/tests/components/vive-tracker.test.js
@@ -1,0 +1,223 @@
+/* global assert, Event, process, setup, suite, test */
+var entityFactory = require('../helpers').entityFactory;
+
+suite('vive-tracker', function () {
+  var component;
+  var controlsSystem;
+  var el;
+
+  setup(function (done) {
+    el = entityFactory();
+    el.addEventListener('componentinitialized', function (evt) {
+      if (evt.detail.name !== 'vive-tracker') { return; }
+      component = el.components['vive-tracker'];
+      component.controllersWhenPresent = [
+        {id: 'OpenVR Tracker', index: 0, hand: '', pose: {}}
+      ];
+      controlsSystem = el.sceneEl.systems['tracked-controls'];
+      done();
+    });
+    el.setAttribute('vive-tracker', 'index: 0; model: false');
+  });
+
+  suite('checkIfControllerPresent', function () {
+    test('remember not present if no controllers on first call', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      controlsSystem.controllers = [];
+
+      // Mock not looked before.
+      component.controllerPresent = false;
+
+      component.checkIfControllerPresent();
+
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.strictEqual(component.controllerPresent, false);  // Not undefined.
+    });
+
+    test('does not remove event listeners if no controllers again', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      controlsSystem.controllers = [];
+
+      // Mock not looked before.
+      component.controllerPresent = false;
+
+      component.checkIfControllerPresent();
+
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.notOk(removeEventListenersSpy.called);
+      assert.strictEqual(component.controllerPresent, false);  // Not undefined.
+    });
+
+    test('attaches events if controller is newly present', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      controlsSystem.controllers = component.controllersWhenPresent;
+
+      // Mock not looked before.
+      component.controllerPresent = false;
+
+      component.checkIfControllerPresent();
+
+      assert.ok(injectTrackedControlsSpy.called);
+      assert.ok(addEventListenersSpy.called);
+      assert.notOk(removeEventListenersSpy.called);
+      assert.ok(component.controllerPresent);
+    });
+
+    test('does not inject/attach events again if controller is already present', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      controlsSystem.controllers = component.controllersWhenPresent;
+
+      // Mock looked before.
+      component.controllerEventsActive = true;
+      component.controllerPresent = true;
+
+      component.checkIfControllerPresent();
+
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.notOk(removeEventListenersSpy.called);
+      assert.ok(component.controllerPresent);
+    });
+
+    test('remove event listeners if controller disappears', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      controlsSystem.controllers = [];
+
+      // Mock looked before.
+      component.controllerEventsActive = true;
+      component.controllerPresent = true;
+
+      component.checkIfControllerPresent();
+
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.ok(removeEventListenersSpy.called);
+      assert.notOk(component.controllerPresent);
+    });
+  });
+
+  suite('axismove', function () {
+    test('emits trackpadmoved on axismove', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
+
+      component.checkIfControllerPresent();
+
+      // Install event handler listening for trackpad.
+      el.addEventListener('trackpadmoved', function (evt) {
+        assert.equal(evt.detail.x, 0.1);
+        assert.equal(evt.detail.y, 0.2);
+        assert.ok(evt.detail);
+        done();
+      });
+
+      // Emit axismove.
+      el.emit('axismove', {axis: [0.1, 0.2], changed: [true, false]});
+    });
+
+    test('does not emit trackpadmoved on axismove with no changes', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
+      component.checkIfControllerPresent();
+
+      // Install event handler listening for trackpadmoved.
+      el.addEventListener('trackpadmoved', function (evt) {
+        assert.notOk(evt.detail);
+      });
+
+      // Emit axismove.
+      el.emit('axismove', {axis: [0.1, 0.2], changed: [false, false]});
+
+      setTimeout(function () { done(); });
+    });
+  });
+
+  suite('buttonchanged', function () {
+    test('emits triggerchanged on buttonchanged', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
+      component.checkIfControllerPresent();
+
+      // Install event handler listening for triggerchanged.
+      el.addEventListener('triggerchanged', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+
+      // Emit buttonchanged.
+      el.emit('buttonchanged', {id: 1, state: {value: 0.5, pressed: true, touched: true}});
+    });
+
+    test('emits triggerdown on buttonchanged', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
+      component.checkIfControllerPresent();
+      el.addEventListener('triggerdown', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+      el.emit('buttondown', {id: 1});
+    });
+
+    test('emits triggerup on buttonchanged', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
+      component.checkIfControllerPresent();
+      el.addEventListener('triggerup', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+      el.emit('buttonup', {id: 1});
+    });
+  });
+
+  suite('gamepaddisconnected', function () {
+    /*
+      Apparent bug in FF Nightly where only one gamepadconnected/disconnected event is
+      fired which makes it difficult to handle in individual controller entities. We no
+      longer remove the controllersupdate listener as a result.
+    */
+    test('checks if controller present on gamepaddisconnected', function () {
+      var checkIfControllerPresentSpy = this.sinon.spy(component, 'checkIfControllerPresent');
+      // Because checkIfControllerPresent may be used in bound form, bind and reinstall.
+      component.checkIfControllerPresent = component.checkIfControllerPresent.bind(component);
+      component.pause();
+      component.play();
+
+      controlsSystem.controllers = [];
+      // Reset everGotGamepadEvent to mock not looked before.
+      delete component.everGotGamepadEvent;
+      // Fire emulated gamepaddisconnected event.
+      window.dispatchEvent(new Event('gamepaddisconnected'));
+      assert.ok(checkIfControllerPresentSpy.called);
+    });
+  });
+
+  suite('model', function () {
+    test('loads', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        assert.ok(el.getObject3D('mesh'));
+        done();
+      });
+      component.data.model = true;
+      component.injectTrackedControls();
+    });
+  });
+
+  suite('event listener', function () {
+    test('toggles controllerEventsActive', function () {
+      component.controllerEventsActive = false;
+      component.addEventListeners();
+      assert.ok(component.controllerEventsActive);
+      component.removeEventListeners();
+      assert.notOk(component.controllerEventsActive);
+    });
+  });
+});


### PR DESCRIPTION
Support for vive-tracker.

Handles quirk in Nightly where gamepad id strings are same for both controllers and trackers (either all `OpenVR Gamepad` or `OpenVR Tracker`), but hand properties are correct.

At the moment, applies a rotation correction to what gamepad API returns to make it behave more like Vive controller / natural expectations -- specifically, the rotation correction makes it so that the controller pose aligns with the corrected pose if you take the tracker, put it on top of the touchpad, and rotate so the LED-bearing protrusion points toward the strap / bottom of the handle -- but this may be removed pending discussions.

The rotation correction can be avoided by explicitly specifying zero rotation, e.g. `<a-entity vive-tracker="index:0; rotation:0 0 0">`

Uses tracker model from https://github.com/aframevr/assets/pull/22 with corrected pose orientation.