### PR TITLE
add Gyro

### DIFF
--- a/src/extras/primitives/primitives/a-camera.js
+++ b/src/extras/primitives/primitives/a-camera.js
@@ -18,6 +18,7 @@ registerPrimitive('a-camera', {
     near: 'camera.near',
     'wasd-controls-enabled': 'wasd-controls.enabled',
     'reverse-mouse-drag': 'look-controls.reverseMouseDrag',
+    'gyro-enabled': 'look-controls.gyroEnabled',
     'user-height': 'camera.userHeight',
     zoom: 'camera.zoom'
   },


### PR DESCRIPTION
if gyro is disabled(default is enabled), user is only drag to rotate camera, user can't use mobile auto move, like this video demo
it is used for mobile device
https://youtu.be/Yysc7OlDbzw

you can use it and test it on mobile
```
<a-camera gyro-enabled="false"></a-camera>
```