### PR TITLE
make accommodations necessary for iOS 10 HLS

### DIFF
--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -2,3 +2,4 @@ require('./flat');
 require('./standard');
 require('./sdf');
 require('./msdf');
+require('./ios10hls');

--- a/src/shaders/ios10hls.js
+++ b/src/shaders/ios10hls.js
@@ -1,7 +1,8 @@
 var registerShader = require('../core/shader').registerShader;
 
 /**
- * Custom shader for iOS 10 HLS.
+ * Custom shader for iOS 10 HTTP Live Streaming (HLS).
+ * For more information on HLS, see https://datatracker.ietf.org/doc/draft-pantos-http-live-streaming/
  */
 module.exports.Shader = registerShader('ios10hls', {
   schema: {

--- a/src/shaders/ios10hls.js
+++ b/src/shaders/ios10hls.js
@@ -1,0 +1,32 @@
+var registerShader = require('../core/shader').registerShader;
+
+/**
+ * Custom shader for iOS 10 HLS.
+ */
+module.exports.Shader = registerShader('ios10hls', {
+  schema: {
+    src: {type: 'map', is: 'uniform'},
+    opacity: {type: 'number', is: 'uniform', default: 1}
+  },
+
+  vertexShader: [
+    'varying vec2 vUV;',
+    'void main(void) {',
+    '  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);',
+    '  vUV = uv;',
+    '}'
+  ].join('\n'),
+
+  fragmentShader: [
+    'uniform sampler2D src;',
+    'uniform float opacity;',
+    'varying vec2 vUV;',
+    'void main() {',
+    '  vec2 offset = vec2(0, 0);',
+    '  vec2 repeat = vec2(1, 1);',
+    '  vec4 color = texture2D(src, vec2(vUV.x / repeat.x + offset.x, (1.0 - vUV.y) / repeat.y + offset.y)).bgra;',
+    '  gl_FragColor = vec4(color.rgb, opacity);',
+    '}'
+  ].join('\n')
+});
+

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -206,8 +206,8 @@ module.exports.System = registerSystem('material', {
 });
 
 function isHLS (videoEl) {
-  if (videoEl.type === 'application/x-mpegurl') return true;
-  if (videoEl.src && videoEl.src.indexOf('.m3u8') > 0) return true;
+  if (videoEl.type.toLowerCase() === 'application/x-mpegurl') { return true; }
+  if (videoEl.src && videoEl.src.toLowerCase().indexOf('.m3u8') > 0) { return true; }
   return false;
 }
 

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -1,6 +1,7 @@
 var registerSystem = require('../core/system').registerSystem;
 var THREE = require('../lib/three');
 var utils = require('../utils/');
+var isHLS = require('../utils/material').isHLS;
 
 var debug = utils.debug;
 var error = debug('components:texture:error');
@@ -204,12 +205,6 @@ module.exports.System = registerSystem('material', {
     });
   }
 });
-
-function isHLS (videoEl) {
-  if (videoEl.type.toLowerCase() === 'application/x-mpegurl') { return true; }
-  if (videoEl.src && videoEl.src.toLowerCase().indexOf('.m3u8') > 0) { return true; }
-  return false;
-}
 
 /**
  * Calculates consistent hash from a video element using its attributes.

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -133,8 +133,7 @@ function handleTextureEvents (el, texture) {
 module.exports.handleTextureEvents = handleTextureEvents;
 
 module.exports.isHLS = function (videoEl) {
-  if (videoEl.type.toLowerCase() === 'application/x-mpegurl') { return true; }
-  if (videoEl.type.toLowerCase() === 'application/vnd.apple.mpegurl') { return true; }
+  if (videoEl.type && videoEl.type.toLowerCase() in ['application/x-mpegurl', 'application/vnd.apple.mpegurl']) { return true; }
   if (videoEl.src && videoEl.src.toLowerCase().indexOf('.m3u8') > 0) { return true; }
   return false;
 };

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -119,6 +119,10 @@ function handleTextureEvents (el, texture) {
   // Video events.
   if (!texture.image || texture.image.tagName !== 'VIDEO') { return; }
   texture.image.addEventListener('loadeddata', function emitVideoTextureLoadedDataAll () {
+    // Check to see if we need to use iOS 10 HLS shader.
+    if (texture.needsCorrectionBGRA && texture.needsCorrectionFlipY) {
+      el.setAttribute('material', 'shader', 'ios10hls');
+    }
     el.emit('materialvideoloadeddata', {src: texture.image, texture: texture});
   });
   texture.image.addEventListener('ended', function emitVideoTextureEndedAll () {

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -131,3 +131,10 @@ function handleTextureEvents (el, texture) {
   });
 }
 module.exports.handleTextureEvents = handleTextureEvents;
+
+module.exports.isHLS = function (videoEl) {
+  if (videoEl.type.toLowerCase() === 'application/x-mpegurl') { return true; }
+  if (videoEl.type.toLowerCase() === 'application/vnd.apple.mpegurl') { return true; }
+  if (videoEl.src && videoEl.src.toLowerCase().indexOf('.m3u8') > 0) { return true; }
+  return false;
+};


### PR DESCRIPTION
Provides core support needed for iOS 10 HLS playback discussed in #1416.

Note that this leaves video flipped in Y dimension and also with B and R color channels reversed.
It is expected that corrections can be applied using custom shaders.
(Accommodating those corrections using the built-in shaders is outside the scope of this PR.)
