### PR TITLE
FAQ: suggest the prefix-free playinline attribute

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -111,7 +111,7 @@ Because of an [iOS platform restriction][iosvideo] in order to get inline video
 (with or without autoplay), we must:
 
 - Set the `<meta name="apple-mobile-web-app-capable" content="yes">` meta tag (will be injected if missing).
-- Set the `webkit-playsinline` attribute to the video element (is automatically added to all videos).
+- Set the `playsinline` attribute to the video element (is automatically added to all videos).
 - Pin the webpage to the iOS homescreen.
 
 Inline video support on iOS 10 may change this. On certain Android devices or


### PR DESCRIPTION
**Description:**

Removes the prefix from the `playsinline` attribute. iOS 10 does not support the prefixed version at all.