### PR TITLE
fix videoPlayback html attributes

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -175,7 +175,7 @@ function fixUpMediaElement (mediaEl) {
   var newMediaEl = setCrossOrigin(mediaEl);
 
   // Plays inline for mobile.
-  if (newMediaEl.tagName === 'VIDEO') {
+  if (newMediaEl.tagName && newMediaEl.tagName.toLowerCase() === 'video') {
     newMediaEl.setAttribute('playsinline', '');
     newMediaEl.setAttribute('webkit-playsinline', '');
   }

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -308,7 +308,9 @@ function createVideoEl (src, width, height) {
   var videoEl = document.createElement('video');
   videoEl.width = width;
   videoEl.height = height;
-  videoEl.setAttribute('webkit-playsinline', '');  // Support inline videos for iOS webviews.
+  // Support inline videos for iOS webviews.
+  videoEl.setAttribute('playsinline', '');
+  videoEl.setAttribute('webkit-playsinline', '');
   videoEl.autoplay = true;
   videoEl.loop = true;
   videoEl.crossOrigin = 'anonymous';
@@ -333,8 +335,8 @@ function createVideoEl (src, width, height) {
  * @returns {Element} Video element with the correct properties updated.
  */
 function fixVideoAttributes (videoEl) {
-  videoEl.autoplay = videoEl.getAttribute('autoplay') !== 'false';
-  videoEl.controls = videoEl.getAttribute('controls') !== 'false';
+  videoEl.autoplay = videoEl.hasAttribute('autoplay') && videoEl.getAttribute('autoplay') !== 'false';
+  videoEl.controls = videoEl.hasAttribute('controls') && videoEl.getAttribute('controls') !== 'false';
   if (videoEl.getAttribute('loop') === 'false') {
     videoEl.removeAttribute('loop');
   }
@@ -343,6 +345,7 @@ function fixVideoAttributes (videoEl) {
   }
   videoEl.crossOrigin = videoEl.crossOrigin || 'anonymous';
   // To support inline videos in iOS webviews.
+  videoEl.setAttribute('playsinline', '');
   videoEl.setAttribute('webkit-playsinline', '');
   return videoEl;
 }


### PR DESCRIPTION
**Description:**

Video tags assume that autoplay/controls should be set if absent from video elements.
This seems to deviate from the expected standard as described here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Attributes

`webkit-playsinline` is superseded by `playsinline` and should be set as well

**Changes proposed:**
- adhere autoplay and controls attributes if not set (do not automatically assume autoplay / controls is intended)
- check video tag correctly and set playinline where webkit-playsinline is set
