### PR TITLE
document the 'textfontset' text component event

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -96,6 +96,12 @@ Inspector, and play with all the possible values to see the effects instantly!
 The implementation is based on [mattdesl's three-bmfont-text][three-bmfont-text].
 [Read more about the text properties][threetextusage].
 
+## Events
+
+| Event Name  | Description                                  |
+|--- --- --- -|--- --- --- --- --- --- --- --- --- --- --- --|
+| textfontset | Emitted when the font source has been loaded |
+
 ## Fonts
 
 We can specify different fonts, although the process is not as simple as Web


### PR DESCRIPTION
**Description:**

Document the `textfontset` event that is emitted by the `text` component.

Found this missing from the docs when looking into http://stackoverflow.com/questions/43546821/how-to-change-dynamically-the-text-value-of-an-a-text/43551574

_also, do you think there's a better solution to that issue?_

**Changes proposed:**
- update `text` component doc with event
