### PR TITLE
Fix shared array reference

### DIFF
--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -138,6 +138,7 @@ function parseProperty (value, propDefinition) {
   // Use default value if value is falsy.
   if (value === undefined || value === null || value === '') {
     value = propDefinition.default;
+    if (Array.isArray(value)) { value = value.slice(); }
   }
   // Invoke property type parser.
   return propDefinition.parse(value, propDefinition.default);

--- a/tests/core/schema.test.js
+++ b/tests/core/schema.test.js
@@ -119,6 +119,16 @@ suite('schema', function () {
         scale: {x: 0, y: 0, z: 0}
       });
     });
+
+    test('does not share the reference to an array without default values specification', function () {
+      var schema = processSchema({
+        foo: {type: 'array'},
+        bar: {type: 'array'}
+      });
+      var parsed = parseProperties({}, schema);
+
+      assert.ok(parsed.foo !== parsed.bar);
+    });
   });
 
   suite('processPropertyDefinition', function () {


### PR DESCRIPTION
**Description:**

This PR fixes the issue "Array property type default share the same reference" #2554


**Changes proposed:**
- clone default value with `.slice()` if it's an array in `parseProperty()` of `schema.js`
