### PR TITLE
warn about camelCase mappings in registerPrimitive

### DIFF
--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -45,6 +45,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
           var self = this;
           Object.keys(mappings).forEach(function resolveCollision (key) {
             var newAttribute;
+            if (key != key.toLowerCase()) console.warn('Mapping keys should be specified in lower case. This mapping may not be recognized');
             if (components[key]) {
               newAttribute = mappings[key].replace('.', '-');
               mappings[newAttribute] = mappings[key];

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -45,7 +45,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
           var self = this;
           Object.keys(mappings).forEach(function resolveCollision (key) {
             var newAttribute;
-            if (key != key.toLowerCase()) console.warn('Mapping keys should be specified in lower case. This mapping may not be recognized');
+            if (key != key.toLowerCase()) { warn('Mapping keys should be specified in lower case. The mapping key ' + key + ' may not be recognized'); }
             if (components[key]) {
               newAttribute = mappings[key].replace('.', '-');
               mappings[newAttribute] = mappings[key];

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -45,7 +45,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
           var self = this;
           Object.keys(mappings).forEach(function resolveCollision (key) {
             var newAttribute;
-            if (key != key.toLowerCase()) { warn('Mapping keys should be specified in lower case. The mapping key ' + key + ' may not be recognized'); }
+            if (key !== key.toLowerCase()) { warn('Mapping keys should be specified in lower case. The mapping key ' + key + ' may not be recognized'); }
             if (components[key]) {
               newAttribute = mappings[key].replace('.', '-');
               mappings[newAttribute] = mappings[key];


### PR DESCRIPTION
Added a warning in registerPrimitive when the user has provided mappings keys that are not all lower case. Since the DOM reports all element attributes in lower case (regardless of how the user typed them in the HTML source), the mappings keys must also be lower case.

This issue was discussed here
  https://github.com/aframevr/aframe/issues/2629
A separate PR was previously accepted to update the documentation to mention that mappings are case-sensitive.

**Description:**

**Changes proposed:**
-
-
-
