### PR TITLE
[docs] daydream-control: fix typos

### DIFF
--- a/docs/components/daydream-controls.md
+++ b/docs/components/daydream-controls.md
@@ -21,8 +21,8 @@ and/or pressed buttons (trackpad).
 
 ```html
 <!-- Match Daydream controller if present and for specified hand. -->
- <a-entity gearvr-controls="hand: left"></a-entity>
- <a-entity gearvr-controls="hand: right"></a-entity>
+ <a-entity daydream-controls="hand: left"></a-entity>
+ <a-entity daydream-controls="hand: right"></a-entity>
 ```
 
 ## Value


### PR DESCRIPTION
well not really a typo tho

changes gearvr-controls in the example code to daydream-controls