### PR TITLE
Change script type to html in 360 gallery sample

### DIFF
--- a/docs/guides/building-a-360-image-gallery.md
+++ b/docs/guides/building-a-360-image-gallery.md
@@ -314,7 +314,7 @@ instances][multiple]:
 ```html
 <a-assets>
   <!-- ... -->
-  <script id="link" type="text/nunjucks">
+  <script id="link" type="text/html">
     <a-entity class="link"
       geometry="primitive: plane; height: 1; width: 1"
       material="shader: flat; src: ${thumb}"


### PR DESCRIPTION
When script type is nunjucks, a <SERVERNAME>/$%7Bthumb%7D not found is logged, and the thumbnail is not loaded.
Changing the text type to `html` solves this problem.

[Not working fiddle](https://jsfiddle.net/a0tuLa22/)
[Working fiddle](https://jsfiddle.net/okmnjako/1/)
