### PR TITLE
look-controls enable/disable lifecycle fix

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -18,7 +18,6 @@ module.exports.Component = registerComponent('look-controls', {
   },
 
   init: function () {
-    var self = this;
     var sceneEl = this.el.sceneEl;
 
     // Aux variables
@@ -30,16 +29,7 @@ module.exports.Component = registerComponent('look-controls', {
     this.setupHMDControls();
     this.bindMethods();
 
-    // Enable grab cursor class on canvas.
-    function enableGrabCursor () {
-      if (!self.data.enabled) { return; }
-      sceneEl.canvas.classList.add('a-grab-cursor');
-    }
-    if (!sceneEl.canvas) {
-      sceneEl.addEventListener('render-target-loaded', enableGrabCursor);
-    } else {
-      enableGrabCursor();
-    }
+    this.setEnabled(this.data.enabled);
 
     // Reset previous HMD position when we exit VR.
     sceneEl.addEventListener('exit-vr', this.onExitVR);
@@ -48,6 +38,9 @@ module.exports.Component = registerComponent('look-controls', {
   update: function (oldData) {
     var data = this.data;
     var hmdEnabled = data.hmdEnabled;
+    if (oldData && data.enabled !== oldData.enabled) {
+      this.setEnabled(data.enabled);
+    }
     if (!data.enabled) { return; }
     if (!hmdEnabled && oldData && hmdEnabled !== oldData.hmdEnabled) {
       this.pitchObject.rotation.set(0, 0, 0);
@@ -57,6 +50,31 @@ module.exports.Component = registerComponent('look-controls', {
     this.controls.update();
     this.updateOrientation();
     this.updatePosition();
+  },
+
+  setEnabled: function (enabled) {
+    var sceneEl = this.el.sceneEl;
+
+    function enableGrabCursor () {
+      sceneEl.canvas.classList.add('a-grab-cursor');
+    }
+    function disableGrabCursor () {
+      sceneEl.canvas.classList.remove('a-grab-cursor');
+    }
+
+    if (!sceneEl.canvas) {
+      if (enabled) {
+        sceneEl.addEventListener('render-target-loaded', enableGrabCursor);
+      } else {
+        sceneEl.addEventListener('render-target-loaded', disableGrabCursor);
+      }
+    } else {
+      if (enabled) {
+        enableGrabCursor();
+      } else {
+        disableGrabCursor();
+      }
+    }
   },
 
   play: function () {
@@ -259,6 +277,8 @@ module.exports.Component = registerComponent('look-controls', {
 
   onMouseDown: function (event) {
     if (!this.data.enabled) { return; }
+    // Handle only primary button.
+    if (event.button !== 0) { return; }
     this.mouseDown = true;
     this.previousMouseEvent = event;
     document.body.classList.add('a-grabbing');

--- a/tests/components/look-controls.test.js
+++ b/tests/components/look-controls.test.js
@@ -38,7 +38,9 @@ suite('look-controls', function () {
         document.body.classList.remove(GRABBING_CLASS);
         done();
       });
-      el.canvas.dispatchEvent(new Event('mousedown'));
+      var event = new Event('mousedown');
+      event.button = 0;
+      el.canvas.dispatchEvent(event);
     });
 
     test('removes grabbing class from document body on document body mouseup', function (done) {


### PR DESCRIPTION
**Description:**
As look-controls cursor setup only done in init would not work correctly if
changed during runtime.

**Changes proposed:**
-Modify to do on setup + change of enablement state.
-Also, fix for #2635
