### PR TITLE
[docs] Fix parseInt usage

### DIFF
--- a/docs/components/geometry.md
+++ b/docs/components/geometry.md
@@ -353,9 +353,9 @@ AFRAME.registerGeometry('example', {
     geometry.vertices.push.call(
       geometry.vertices,
       data.vertices.map(function (vertex) {
-        var points = vertex.split(' ').map(parseInt);
+        var points = vertex.split(' ').map(function(x){return parseInt(x);});
         return new THREE.Vector3(points[0], points[1], points[2]);
-      });
+      })
     );
     geometry.faces.push(new THREE.Face3(0, 1, 2));
     this.geometry = geometry;


### PR DESCRIPTION
If used in a naive way, ParseInt returns weird results like [3, NaN, NaN]. See for example http://stackoverflow.com/questions/262427/javascript-arraymap-and-parseint

Remove a ; which was a syntax error.