### PR TITLE
fix video used in "360° Video Boilerplate video" to play back on mobile iOS

### DIFF
--- a/examples/boilerplate/360-video/index.html
+++ b/examples/boilerplate/360-video/index.html
@@ -9,8 +9,8 @@
   <body>
     <a-scene>
       <a-assets>
-        <video id="video" src="https://ucarecdn.com/bcece0a8-86ce-460e-856b-40dac4875f15/"
-               autoplay loop crossorigin></video>
+        <video id="video" src="https://ucarecdn.com/fadab25d-0b3a-45f7-8ef5-85318e92a261/"
+               autoplay loop crossorigin="anonymous"></video>
       </a-assets>
 
       <a-videosphere src="#video" rotation="0 180 0"></a-videosphere>

--- a/examples/test/videosphere/index.html
+++ b/examples/test/videosphere/index.html
@@ -9,13 +9,21 @@
   <body>
     <a-scene stats>
       <a-assets>
-        <video id="lego" preload="true"
-               src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/t-197/walking_the_dog_360_video_short.webm"
+        <!--
+        Notes about using `preload` with `<video>` elements (via https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Attributes):
+        - The `autoplay` attribute has precedence over `preload`. If `autoplay` is specified, the browser would obviously need to start downloading the video for playback.
+        - The specification does not force the browser to follow the value of this attribute; it is a mere hint.
+        -->
+        <!--
+        Source: https://www.youtube.com/watch?v=zUzLvybAGKM
+        -->
+        <video id="dolphins" preload="true"
+               src="https://ucarecdn.com/16cbcc72-ef7a-44f5-be04-3988d0ce9c6c/nice_dive_with_wild_dolphins.mp4"
                width="360" height="360" autoplay loop="true"
-               crossOrigin="anonymous"></video>
+               crossorigin="anonymous"></video>
       </a-assets>
 
-      <a-entity material="shader: flat; src: #lego" geometry="primitive: sphere; radius: 100"
+      <a-entity material="shader: flat; src: #dolphins" geometry="primitive: sphere; radius: 100"
                 scale="-1 1 1">
       </a-entity>
     </a-scene>

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -308,7 +308,7 @@ function createVideoEl (src, width, height) {
   var videoEl = document.createElement('video');
   videoEl.width = width;
   videoEl.height = height;
-  // Support inline videos for iOS webviews.
+  // Support inline videos on iOS mobile.
   videoEl.setAttribute('playsinline', '');
   videoEl.setAttribute('webkit-playsinline', '');
   videoEl.autoplay = true;
@@ -318,6 +318,7 @@ function createVideoEl (src, width, height) {
     warn('`$s` is not a valid video', src);
   }, true);
   videoEl.src = src;
+  // TODO: Fix up for playback on iOS mobile (à la `a-assets`).
   return videoEl;
 }
 
@@ -344,7 +345,7 @@ function fixVideoAttributes (videoEl) {
     videoEl.preload = 'none';
   }
   videoEl.crossOrigin = videoEl.crossOrigin || 'anonymous';
-  // To support inline videos in iOS webviews.
+  // To support inline videos on iOS mobile.
   videoEl.setAttribute('playsinline', '');
   videoEl.setAttribute('webkit-playsinline', '');
   return videoEl;


### PR DESCRIPTION
**Description:**

The "City" sample video used for the [360° Video Boilerplate](https://aframe.io/aframe/examples/boilerplate/360-video/) doesn't load on iOS.

After much diagnosis, I determined the culprit: the resolution.

**Changes proposed:**

- Changed resolution of video from `4096×2050` to `3168×1602`
