### PR TITLE
fix video used in "360° Video Boilerplate video" to play back on mobile iOS

### DIFF
--- a/examples/boilerplate/360-video/index.html
+++ b/examples/boilerplate/360-video/index.html
@@ -9,8 +9,8 @@
   <body>
     <a-scene>
       <a-assets>
-        <video id="video" src="https://ucarecdn.com/bcece0a8-86ce-460e-856b-40dac4875f15/"
-               autoplay loop crossorigin></video>
+        <video id="video" src="https://ucarecdn.com/fadab25d-0b3a-45f7-8ef5-85318e92a261/"
+               autoplay loop crossorigin="anonymous"></video>
       </a-assets>
 
       <a-videosphere src="#video" rotation="0 180 0"></a-videosphere>


### PR DESCRIPTION
**Description:**

The "City" sample video used for the [360° Video Boilerplate](https://aframe.io/aframe/examples/boilerplate/360-video/) doesn't load on iOS.

After much diagnosis, I determined the culprit: the resolution.

**Changes proposed:**

- Changed resolution of video from `4096×2050` to `3168×1602`
