### PR TITLE
Skip type checking if an object is passed through setAttribute twice

### DIFF
--- a/docs/introduction/best-practices.md
+++ b/docs/introduction/best-practices.md
@@ -55,6 +55,19 @@ ways to help improve performance of an A-Frame scene:
   handlers to hook into the global render loop. Use utilities such as
   `AFRAME.utils.throttleTick` to limit the number of times the `tick` handler
   is run if appropriate.
+- Avoid instantiating variables in the `tick` handler to minimize garbage collection cycles. If you are going to continously modify a component in the tick, make sure to pass the same object with updated properties. A-Frame will keep track of the latest passed object and disable type checking on subsequent calls for an extra speed boost. This is an example of a recommended tick function that modifies the rotation on every tick:
+```js
+AFRAME.registerComponent('foo', {
+  tick: function () {
+    var rotationTmp = this.rotationTmp = this.rotationTmp || {x: 0, y: 0, z: 0};
+    var rotation = el.getAttribute('rotation');
+    rotationTmp.x = rotation.x + 0.1;
+    rotationTmp.y = rotation.y + 0.1;
+    rotationTmp.z = rotation.z + 0.1;
+    el.setAttribute('rotation', rotationTmp);
+  }
+});
+```
 
 ## VR Design
 

--- a/examples/performance/cubes/components.js
+++ b/examples/performance/cubes/components.js
@@ -1,0 +1,72 @@
+/* global AFRAME, THREE */
+function randomIncRad (multiplier) {
+  return multiplier * Math.random();
+}
+
+function randomIncDeg (multiplier) {
+  return randomIncRad(multiplier) * THREE.Math.RAD2DEG;
+}
+
+// COMPONENTS
+// ------------------
+AFRAME.registerComponent('rotate-obj3d', {
+  tick: function () {
+    var el = this.el;
+    el.object3D.rotation.x += randomIncRad(0.1);
+    el.object3D.rotation.y += randomIncRad(0.2);
+    el.object3D.rotation.z += randomIncRad(0.3);
+  }
+});
+
+AFRAME.registerComponent('rotate-get-obj3d', {
+  tick: function () {
+    var el = this.el;
+    var rotation = el.getAttribute('rotation');
+
+    rotation.x += randomIncRad(0.1);
+    rotation.y += randomIncRad(0.2);
+    rotation.z += randomIncRad(0.3);
+
+    el.object3D.rotation.x = rotation.x;
+    el.object3D.rotation.y = rotation.y;
+    el.object3D.rotation.z = rotation.z;
+  }
+});
+
+AFRAME.registerComponent('rotate-obj3d-set', {
+  tick: function () {
+    var el = this.el;
+    var rotation = el.getAttribute('rotation');
+
+    rotation.x += randomIncDeg(0.1);
+    rotation.y += randomIncDeg(0.2);
+    rotation.z += randomIncDeg(0.3);
+
+    el.setAttribute('rotation', rotation);
+  }
+});
+
+AFRAME.registerComponent('rotate-get-set', {
+  tick: function () {
+    var el = this.el;
+    var rotationAux = this.rotationAux = this.rotationAux || {x: 0, y: 0, z: 0};
+    var rotation = el.getAttribute('rotation');
+    rotationAux.x = rotation.x + randomIncDeg(0.1);
+    rotationAux.y = rotation.y + randomIncDeg(0.2);
+    rotationAux.z = rotation.z + randomIncDeg(0.3);
+    el.setAttribute('rotation', rotationAux);
+  }
+});
+
+AFRAME.registerComponent('rotate-get-settext', {
+  tick: function () {
+    var el = this.el;
+    var rotation = el.getAttribute('rotation');
+
+    rotation.x += randomIncDeg(0.1);
+    rotation.y += randomIncDeg(0.2);
+    rotation.z += randomIncDeg(0.3);
+
+    el.setAttribute('rotation', rotation.x + ' ' + rotation.y + ' ' + rotation.z);
+  }
+});

--- a/examples/performance/cubes/index.html
+++ b/examples/performance/cubes/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Rotating Cubes Performance Test - A-Frame</title>
+    <meta name="description" content="">
+    <script src="../../../dist/aframe-master.js"></script>
+    <script src="utils.js"></script>
+    <script src="components.js"></script>
+    <script src="main.js"></script>
+  </head>
+  <style>
+    body {
+      color: #cccccc;
+      font-family: Monospace;
+      font-size: 13px;
+      text-align: center;
+      margin: 0px;
+      overflow: hidden;
+    }
+
+    #info {
+      background-color: #000;
+      position: absolute;
+      top: 0px;
+      width: 100%;
+      padding: 5px;
+      z-index: 9999;
+    }
+    #info a {
+      color: #fff;
+    }
+  </style>
+  <body>
+    <div id="info">
+      <a href="?numobjects=5000">none</a>
+      <a href="?component=rotate-obj3d&numobjects=5000">rotate-obj3d</a>
+      <a href="?component=rotate-get-obj3d&numobjects=5000">rotate-get-obj3d</a>
+      <a href="?component=rotate-obj3d-set&numobjects=5000">rotate-obj3d-set</a>
+      <a href="?component=rotate-get-set&numobjects=5000">rotate-get-set</a>
+      <a href="?component=rotate-get-settext&numobjects=5000">rotate-get-settext</a>
+    </div>
+    <a-scene stats main></a-scene>
+  </body>
+</html>
+

--- a/examples/performance/cubes/main.js
+++ b/examples/performance/cubes/main.js
@@ -1,0 +1,49 @@
+/* global AFRAME */
+AFRAME.registerComponent('main', {
+  init: function () {
+    var urlParams = this.getUrlParams();
+    var defaultNumObjects = 5000;
+    var numObjects = urlParams.numobjects || defaultNumObjects;
+    this.cubeDistributionWidth = 100;
+    for (var i = 0; i < numObjects; i++) {
+      var cubeEl = document.createElement('a-entity');
+
+      if (urlParams.component) {
+        cubeEl.setAttribute(urlParams.component, '');
+      }
+      cubeEl.setAttribute('position', this.getRandomPosition());
+      cubeEl.setAttribute('geometry', {primitive: 'box'});
+      cubeEl.setAttribute('material', {color: this.getRandomColor(), shader: 'flat'});
+      this.el.sceneEl.appendChild(cubeEl);
+    }
+  },
+
+  getUrlParams: function () {
+    var match;
+    var pl = /\+/g;  // Regex for replacing addition symbol with a space
+    var search = /([^&=]+)=?([^&]*)/g;
+    var decode = function (s) { return decodeURIComponent(s.replace(pl, ' ')); };
+    var query = window.location.search.substring(1);
+    var urlParams = {};
+
+    match = search.exec(query);
+    while (match) {
+      urlParams[decode(match[1])] = decode(match[2]);
+      match = search.exec(query);
+    }
+    return urlParams;
+  },
+
+  getRandomPosition: function () {
+    var cubeDistributionWidth = this.cubeDistributionWidth;
+    return {
+      x: Math.random() * cubeDistributionWidth - cubeDistributionWidth / 2,
+      y: Math.random() * cubeDistributionWidth - cubeDistributionWidth / 2,
+      z: Math.random() * cubeDistributionWidth - cubeDistributionWidth
+    };
+  },
+
+  getRandomColor: function () {
+    return '#' + ('000000' + Math.random().toString(16).slice(2, 8).toUpperCase()).slice(-6);
+  }
+});

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -511,9 +511,10 @@ var proto = Object.create(ANode.prototype, {
    *
    * @param {string} attr - Component name.
    * @param {object} attrValue - The value of the DOM attribute.
+   * @param {bollean} clobber - if the new attrValue will ccompletely replace the previous properties
    */
   updateComponent: {
-    value: function (attr, attrValue) {
+    value: function (attr, attrValue, clobber) {
       var component = this.components[attr];
       var isDefault = attr in this.defaultComponents;
       if (component) {
@@ -522,7 +523,7 @@ var proto = Object.create(ANode.prototype, {
           return;
         }
         // Component already initialized. Update component.
-        component.updateProperties(attrValue);
+        component.updateProperties(attrValue, clobber);
         return;
       }
       // Component not yet initialized. Initialize component.
@@ -682,6 +683,8 @@ var proto = Object.create(ANode.prototype, {
    */
   setAttribute: {
     value: function (attrName, arg1, arg2) {
+      var arg1Type = typeof arg1;
+      var clobber;
       var componentName;
       var isDebugMode;
 
@@ -690,12 +693,11 @@ var proto = Object.create(ANode.prototype, {
 
       // Determine which type of setAttribute to call based on the types of the arguments.
       if (COMPONENTS[componentName]) {
-        if (typeof arg1 === 'string' && typeof arg2 !== 'undefined') {
+        if (arg1Type === 'string' && typeof arg2 !== 'undefined') {
           singlePropertyUpdate(this, attrName, arg1, arg2);
-        } else if (typeof arg1 === 'object' && arg2 === true) {
-          multiPropertyClobber(this, attrName, arg1);
         } else {
-          componentUpdate(this, attrName, arg1);
+          clobber = arg1Type !== 'object' || (arg1Type === 'object' && arg2 === true);
+          this.updateComponent(attrName, arg1, clobber);
         }
 
         // In debug mode, write component data up to the DOM.
@@ -712,30 +714,6 @@ var proto = Object.create(ANode.prototype, {
        */
       function singlePropertyUpdate (el, componentName, propName, propertyValue) {
         el.updateComponentProperty(componentName, propName, propertyValue);
-      }
-
-      /**
-       * Just update multiple component properties at once for a multi-property component.
-       * >> setAttribute('foo', {bar: 'baz'})
-       */
-      function componentUpdate (el, componentName, propValue) {
-        var component = el.components[componentName];
-        if (component && typeof propValue === 'object') {
-          // Extend existing component attribute value.
-          el.updateComponent(
-            componentName,
-            utils.extendDeep(utils.extendDeep({}, component.attrValue), propValue));
-        } else {
-          el.updateComponent(componentName, propValue);
-        }
-      }
-
-      /**
-       * Pass in complete data set for a multi-property component.
-       * >> setAttribute('foo', {bar: 'baz'}, true)
-       */
-      function multiPropertyClobber (el, componentName, propObject) {
-        el.updateComponent(componentName, propObject);
       }
 
       /**

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -35,6 +35,8 @@ var Component = module.exports.Component = function (el, attrValue, id) {
   this.id = id;
   this.attrName = this.name + (id ? '__' + id : '');
   this.el.components[this.attrName] = this;
+  // Last value passed to updateProperties
+  this.previousAttrValue = undefined;
   this.updateProperties(attrValue);
 };
 
@@ -150,6 +152,7 @@ Component.prototype = {
   updateCachedAttrValue: function (value) {
     var isSinglePropSchema = isSingleProp(this.schema);
     var attrValue = this.parseAttrValueForCache(value);
+    if (value === undefined) { return; }
     this.attrValue = extendProperties({}, attrValue, isSinglePropSchema);
   },
 
@@ -199,21 +202,35 @@ Component.prototype = {
    *
    * @param {string} attrValue - HTML attribute value.
    *        If undefined, use the cached attribute value and continue updating properties.
+   * @param {bolloean} clobber - The previous component data is overwritten by the atrrValue
    */
-  updateProperties: function (attrValue) {
+  updateProperties: function (attrValue, clobber) {
     var el = this.el;
-    var isSinglePropSchema = isSingleProp(this.schema);
-    var oldData = extendProperties({}, this.data, isSinglePropSchema);
+    var isSinglePropSchema;
+    var oldData;
+    var skipTypeChecking;
 
-    if (attrValue !== undefined) { this.updateCachedAttrValue(attrValue); }
-
-    if (!el.hasLoaded) { return; }
-
-    if (this.updateSchema) {
-      this.updateSchema(buildData(el, this.name, this.attrName, this.schema, this.attrValue,
-                                  true));
+    // Just cache the attribute if the entity has not loaded
+    // Components are not initialized until the entity has loaded
+    if (!el.hasLoaded) {
+      this.updateCachedAttrValue(attrValue);
+      return;
     }
-    this.data = buildData(el, this.name, this.attrName, this.schema, this.attrValue);
+
+    isSinglePropSchema = isSingleProp(this.schema);
+    // Copy old data since this.data is going to be recreated
+    oldData = extendProperties({}, this.data, isSinglePropSchema);
+    // Disable type checking if the passed attribute is an object and has not changed
+    skipTypeChecking = typeof this.previousAttrValue === 'object' && attrValue === this.previousAttrValue;
+    // Cach previously passed attribute to decide if we skip type checking
+    this.previousAttrValue = attrValue;
+
+    attrValue = this.parseAttrValueForCache(attrValue);
+    if (this.updateSchema) { this.updateSchema(this.buildData(attrValue, false, true)); }
+    this.data = this.buildData(attrValue, clobber, false, skipTypeChecking);
+
+    // Cache current attrValue for future updates
+    this.updateCachedAttrValue(attrValue);
 
     if (!this.initialized) {
       // Component is being already initialized
@@ -236,7 +253,7 @@ Component.prototype = {
       }, false);
     } else {
       // Don't update if properties haven't changed
-      if (utils.deepEqual(oldData, this.data)) { return; }
+      if (!skipTypeChecking && utils.deepEqual(oldData, this.data)) { return; }
 
       // Update component.
       this.update(oldData);
@@ -281,6 +298,75 @@ Component.prototype = {
     utils.extend(extendedSchema, schemaAddon);
     this.schema = processSchema(extendedSchema);
     this.el.emit('schemachanged', {component: this.name});
+  },
+
+  /**
+   * Builds component data from the current state of the entity, ultimately
+   * updating this.data.
+   *
+   * If the component was detached completely, set data to null.
+   *
+   * Precedence:
+   * 1. Defaults data
+   * 2. Mixin data.
+   * 3. Attribute data.
+   *
+   * Finally coerce the data to the types of the defaults.
+   *
+   * @param {object} newData - Element new data.
+   * @param {bolloean} clobber - The previous data is completely replaced by the new one.
+   * @param {boolean} silent - Suppress warning messages.
+   * @param {boolean} skipTypeChecking - Skip type checking and cohercion.
+   * @return {object} The component data
+   */
+  buildData: function (newData, clobber, silent, skipTypeChecking) {
+    var self = this;
+    var componentDefined = newData !== undefined && newData !== null;
+    var data;
+    var schema = this.schema;
+    var isSinglePropSchema = isSingleProp(schema);
+    var mixinEls = this.el.mixinEls;
+    // Preserve previously set properties if clobber not enabled
+    var previousData = !clobber && this.attrValue;
+
+    // 1. Default values (lowest precendence).
+    if (isSinglePropSchema) {
+      data = schema.default;
+    } else {
+      data = typeof previousData === 'object' ? utils.extend({}, previousData) : {};
+      Object.keys(schema).forEach(function applyDefault (key) {
+        var defaultValue = schema[key].default;
+        if (data[key]) { return; }
+        data[key] = defaultValue && defaultValue.constructor === Object
+          ? utils.extend({}, defaultValue)
+          : defaultValue;
+      });
+    }
+
+    // 2. Mixin values.
+    mixinEls.forEach(handleMixinUpdate);
+    function handleMixinUpdate (mixinEl) {
+      var mixinData = mixinEl.getAttribute(self.attrName);
+      if (mixinData) {
+        data = extendProperties(data, mixinData, isSinglePropSchema);
+      }
+    }
+
+    // 3. Attribute values (highest precendence).
+    if (componentDefined) {
+      if (isSinglePropSchema) {
+        if (skipTypeChecking === true) { return newData; }
+        return parseProperty(newData, schema);
+      }
+      data = extendProperties(data, newData, isSinglePropSchema);
+    } else {
+      if (skipTypeChecking === true) { return data; }
+      // Parse and coerce using the schema.
+      if (isSinglePropSchema) { return parseProperty(data, schema); }
+    }
+
+    if (skipTypeChecking === true) { return data; }
+    return parseProperties(data, schema, undefined, this.name, silent);
   }
 };
 
@@ -368,68 +454,6 @@ module.exports.registerComponent = function (name, definition) {
   };
   return NewComponent;
 };
-
-/**
- * Builds component data from the current state of the entity, ultimately
- * updating this.data.
- *
- * If the component was detached completely, set data to null.
- *
- * Precedence:
- * 1. Defaults data
- * 2. Mixin data.
- * 3. Attribute data.
- *
- * Finally coerce the data to the types of the defaults.
- *
- * @param {object} el - Element to build data from.
- * @param {object} name - Component name.
- * @param {object} attrName - Attribute name associated to the component.
- * @param {object} schema - Component schema.
- * @param {object} elData - Element current data.
- * @param {boolean} silent - Suppress warning messages.
- * @return {object} The component data
- */
-function buildData (el, name, attrName, schema, elData, silent) {
-  var componentDefined = elData !== undefined && elData !== null;
-  var data;
-  var isSinglePropSchema = isSingleProp(schema);
-  var mixinEls = el.mixinEls;
-
-  // 1. Default values (lowest precendence).
-  if (isSinglePropSchema) {
-    data = schema.default;
-  } else {
-    data = {};
-    Object.keys(schema).forEach(function applyDefault (key) {
-      var defaultValue = schema[key].default;
-      data[key] = defaultValue && defaultValue.constructor === Object
-        ? utils.extend({}, defaultValue)
-        : defaultValue;
-    });
-  }
-
-  // 2. Mixin values.
-  mixinEls.forEach(handleMixinUpdate);
-  function handleMixinUpdate (mixinEl) {
-    var mixinData = mixinEl.getAttribute(attrName);
-    if (mixinData) {
-      data = extendProperties(data, mixinData, isSinglePropSchema);
-    }
-  }
-
-  // 3. Attribute values (highest precendence).
-  if (componentDefined) {
-    if (isSinglePropSchema) { return parseProperty(elData, schema); }
-    data = extendProperties(data, elData, isSinglePropSchema);
-    return parseProperties(data, schema, undefined, name, silent);
-  } else {
-     // Parse and coerce using the schema.
-    if (isSinglePropSchema) { return parseProperty(data, schema); }
-    return parseProperties(data, schema, undefined, name, silent);
-  }
-}
-module.exports.buildData = buildData;
 
 /**
 * Object extending with checking for single-property schema.

--- a/tests/components/scene/fog.test.js
+++ b/tests/components/scene/fog.test.js
@@ -48,10 +48,13 @@ suite('fog', function () {
 
     test('can update fog type', function () {
       var el = this.el;
-      el.setAttribute('fog', 'type: exponential; density: 0.25');
-      el.setAttribute('fog', 'density: 0.25');
+      assert.equal(el.getAttribute('fog').type, 'linear');
       assert.notOk('density' in el.object3D.fog);
       assert.ok('near' in el.object3D.fog);
+      el.setAttribute('fog', 'type: exponential; density: 0.25');
+      assert.equal(el.getAttribute('fog').type, 'exponential');
+      assert.ok('density' in el.object3D.fog);
+      assert.notOk('near' in el.object3D.fog);
     });
 
     test('can remove and add linear fog', function () {

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -348,20 +348,17 @@ suite('a-entity', function () {
       assert.strictEqual(this.el.getAttribute('test').array, sourceArray);
     });
 
-    test('partial updates of array-type properties do not trigger update', function () {
+    test('partial updates of array-type properties do trigger update', function () {
       // Updates to array do not trigger update handler.
       var updateSpy;
       registerComponent('test', {
         schema: {array: {type: 'array'}},
         update: function () { /* no-op */ }
       });
-      this.el.setAttribute('test', {arr: [1, 2, 3]});
+      this.el.setAttribute('test', {array: [1, 2, 3]});
       updateSpy = this.sinon.spy(this.el.components.test, 'update');
-      // setAttribute does not trigger update because utils.extendDeep
-      // called by componentUpdate assigns the new value directly into the
-      // component data
-      this.el.setAttribute('test', {arr: [4, 5, 6]});
-      assert.isFalse(updateSpy.called);
+      this.el.setAttribute('test', {array: [4, 5, 6]});
+      assert.ok(updateSpy.called);
     });
 
     test('can partially update vec3', function () {
@@ -1214,6 +1211,19 @@ suite('a-entity component lifecycle management', function () {
     sinon.assert.calledOnce(TestComponent.update);
     el.setAttribute('test', 'a: 3');
     sinon.assert.calledOnce(TestComponent.update);
+  });
+
+  test('does not check types if the same object is passed again', function () {
+    var el = this.el;
+    var componentData;
+    var attrValue = {a: 3};
+    el.setAttribute('test', attrValue);
+    componentData = el.getAttribute('test');
+    assert.ok(componentData.a === 3);
+    attrValue.a = '3';
+    el.setAttribute('test', attrValue);
+    componentData = el.getAttribute('test');
+    assert.ok(componentData.a === '3');
   });
 
   test('calls remove on removeAttribute', function () {

--- a/tests/core/a-mixin.test.js
+++ b/tests/core/a-mixin.test.js
@@ -37,7 +37,6 @@ suite('a-mixin', function () {
     var mixinEl = document.createElement('a-mixin');
     el.setAttribute('mixin', 'ring');
     el.setAttribute('geometry', 'buffer: false');
-
     mixinEl.setAttribute('id', 'ring');
     mixinEl.setAttribute('geometry', 'primitive: ring');
     this.assetsEl.appendChild(mixinEl);

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -1,11 +1,9 @@
 /* global AFRAME, assert, process, suite, teardown, test, setup, sinon, HTMLElement */
-var buildData = require('core/component').buildData;
 var Component = require('core/component');
 var components = require('index').components;
 
 var helpers = require('../helpers');
 var registerComponent = require('index').registerComponent;
-var processSchema = require('core/schema').process;
 
 var CloneComponent = {
   init: function () {
@@ -35,33 +33,40 @@ suite('Component', function () {
     });
 
     test('uses default values', function () {
-      var schema = processSchema({
-        color: {default: 'blue'},
-        size: {default: 5}
+      registerComponent('dummy', {
+        schema: {
+          color: {default: 'blue'},
+          size: {default: 5}
+        }
       });
       var el = document.createElement('a-entity');
-      var data = buildData(el, 'dummy', 'dummy', schema, {}, null);
+      el.setAttribute('dummy', '');
+      var data = el.components.dummy.buildData({}, null);
       assert.equal(data.color, 'blue');
       assert.equal(data.size, 5);
     });
 
     test('uses default values for single-property schema', function () {
-      var schema = processSchema({
-        default: 'blue'
+      registerComponent('dummy', {
+        schema: {default: 'blue'}
       });
       var el = document.createElement('a-entity');
-      var data = buildData(el, 'dummy', 'dummy', schema, undefined, null);
+      el.setAttribute('dummy', '');
+      var data = el.components.dummy.buildData(undefined, null);
       assert.equal(data, 'blue');
     });
 
     test('preserves type of default values', function () {
-      var schema = processSchema({
-        list: {default: [1, 2, 3, 4]},
-        none: {default: null},
-        string: {default: ''}
+      registerComponent('dummy', {
+        schema: {
+          list: {default: [1, 2, 3, 4]},
+          none: {default: null},
+          string: {default: ''}
+        }
       });
       var el = document.createElement('a-entity');
-      var data = buildData(el, 'dummy', 'dummy', schema, undefined, null);
+      el.setAttribute('dummy', '');
+      var data = el.components.dummy.buildData(undefined, null);
       assert.shallowDeepEqual(data.list, [1, 2, 3, 4]);
       assert.equal(data.none, null);
       assert.equal(data.string, '');
@@ -69,7 +74,7 @@ suite('Component', function () {
 
     test('uses mixin values', function () {
       var data;
-      var TestComponent = registerComponent('dummy', {
+      registerComponent('dummy', {
         schema: {
           color: {default: 'red'},
           size: {default: 5}
@@ -77,17 +82,17 @@ suite('Component', function () {
       });
       var el = document.createElement('a-entity');
       var mixinEl = document.createElement('a-mixin');
-
       mixinEl.setAttribute('dummy', 'color: blue; size: 10');
       el.mixinEls = [mixinEl];
-      data = buildData(el, 'dummy', 'dummy', TestComponent.prototype.schema, {}, null);
+      el.setAttribute('dummy', '');
+      data = el.components.dummy.buildData({}, null);
       assert.equal(data.color, 'blue');
       assert.equal(data.size, 10);
     });
 
     test('uses mixin values for single-property schema', function () {
       var data;
-      var TestComponent = registerComponent('dummy', {
+      registerComponent('dummy', {
         schema: {
           default: 'red'
         }
@@ -96,13 +101,14 @@ suite('Component', function () {
       var mixinEl = document.createElement('a-mixin');
       mixinEl.setAttribute('dummy', 'blue');
       el.mixinEls = [mixinEl];
-      data = buildData(el, 'dummy', 'dummy', TestComponent.prototype.schema, undefined, null);
+      el.setAttribute('dummy', '');
+      data = el.components.dummy.buildData(undefined, null);
       assert.equal(data, 'blue');
     });
 
     test('uses defined values', function () {
       var data;
-      var TestComponent = registerComponent('dummy', {
+      registerComponent('dummy', {
         schema: {
           color: {default: 'red'},
           size: {default: 5}
@@ -113,35 +119,35 @@ suite('Component', function () {
 
       mixinEl.setAttribute('dummy', 'color: blue; size: 10');
       el.mixinEls = [mixinEl];
-      data = buildData(el, 'dummy', 'dummy', TestComponent.prototype.schema, {
-        color: 'green', size: 20
-      }, 'color: green; size: 20');
+      el.setAttribute('dummy', '');
+      data = el.components.dummy.buildData({color: 'green', size: 20}, 'color: green; size: 20');
       assert.equal(data.color, 'green');
       assert.equal(data.size, 20);
     });
 
     test('uses defined values for single-property schema', function () {
       var data;
-      var TestComponent = registerComponent('dummy', {
+      registerComponent('dummy', {
         schema: {default: 'red'}
       });
       var el = document.createElement('a-entity');
       var mixinEl = document.createElement('a-mixin');
       mixinEl.setAttribute('dummy', 'blue');
       el.mixinEls = [mixinEl];
-      data = buildData(el, 'dummy', 'dummy', TestComponent.prototype.schema, 'green', 'green');
+      el.setAttribute('dummy', '');
+      data = el.components.dummy.buildData('green', 'green');
       assert.equal(data, 'green');
     });
 
     test('returns default value for a single-property schema ' +
          'when the attribute is empty string', function () {
       var data;
-      var TestComponent = registerComponent('dummy', {
+      registerComponent('dummy', {
         schema: {default: 'red'}
       });
       var el = document.createElement('a-entity');
       el.setAttribute('dummy', '');
-      data = buildData(el, 'dummy', 'dummy', TestComponent.prototype.schema, 'red');
+      data = el.components.dummy.buildData('red');
       assert.equal(data, 'red');
     });
 


### PR DESCRIPTION
I'm trying to find ways to optimize `setAttribute` / `getAttribute` calls specially when they're called once per frame like for example in a component's `tick` method.

My first attempt is to disable type checking when `setAttribute` is called twice with the same object. Types are checked the first time and then the object is considered trusted. This would allow to construct your `tick` method in the following way:

````javascript
  tick: (function () {
      var newRotation = {};
      return function () {
      var el = this.el;
      var currentRotation = el.getAttribute('rotation');
      newRotation .x = currentRotation.x + 0.1;
      newRotation.y = currentRotation.y + 0.1;
      newRotation.z = currentRotation.z + 0.1;
      el.setAttribute('rotation', newRotation );
    }
  })()
````
This aligns with the good practice of avoiding object allocations inside your render loop. This optimization yields a 30%-40% percent FPS improvement with respect to master when rotating 2500 cubes using a tick like the above one.

