### PR TITLE
Throttle componentchanged event firing

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -31,11 +31,20 @@ var upperCaseRegExp = new RegExp('[A-Z]+');
  *         mapped attribute of the component plus applying defaults and mixins.
  */
 var Component = module.exports.Component = function (el, attrValue, id) {
+  var self = this;
   this.el = el;
   this.id = id;
   this.attrName = this.name + (id ? '__' + id : '');
   this.el.components[this.attrName] = this;
   this.updateProperties(attrValue);
+  this.throttledEmitComponentChanged = utils.throttle(function emitComponentChanged (oldData) {
+    el.emit('componentchanged', {
+      id: self.id,
+      name: self.name,
+      newData: self.data,
+      oldData: oldData
+    }, false);
+  }, 200);
 };
 
 Component.prototype = {
@@ -240,12 +249,8 @@ Component.prototype = {
 
       // Update component.
       this.update(oldData);
-      el.emit('componentchanged', {
-        id: this.id,
-        name: this.name,
-        newData: this.getData(),
-        oldData: oldData
-      }, false);
+      // Limit event to fire once every 200ms.
+      this.throttledEmitComponentChanged(oldData);
     }
   },
 


### PR DESCRIPTION
**Description:**
Second Optimization to try to optimize `setAttribute` calls. emitting events is expensive and if `setAttribute` is call on a `tick` method we don't need to fire the `componentchanged` event 60 or 90 times per second. This patch throttles down the `componentchanged` event firing to once every 200ms. 