### PR TITLE
remove material dependency from obj-model component (fixes #2464)

### DIFF
--- a/src/components/obj-model.js
+++ b/src/components/obj-model.js
@@ -5,8 +5,6 @@ var THREE = require('../lib/three');
 var warn = debug('components:obj-model:warn');
 
 module.exports.Component = registerComponent('obj-model', {
-  dependencies: ['material'],
-
   schema: {
     mtl: {type: 'model'},
     obj: {type: 'model'}
@@ -57,7 +55,7 @@ module.exports.Component = registerComponent('obj-model', {
     }
 
     // .OBJ only.
-    objLoader.load(objUrl, function (objModel) {
+    objLoader.load(objUrl, function loadObjOnly (objModel) {
       // Apply material.
       var material = el.components.material;
       if (material) {


### PR DESCRIPTION
**Description:**

Also caused an issue with raycasters where the obj-model would inject material component. A lone material component would create a Mesh with an empty BufferGeometry. This would cause an error during raycasting because the empty BufferGeometry had no `attributes`.