### PR TITLE
Use googlevr/webvr-polyfill with changes from aframe fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "three": "^0.84.0",
     "three-bmfont-text": "^2.1.0",
     "tween.js": "^15.0.0",
-    "webvr-polyfill": "dmarcos/webvr-polyfill#a02a8089b"
+    "webvr-polyfill": "^0.9.34"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
**Description:**

This uses the [googlevr/webvr-polyfill] directly again instead of the aframe fork after talking with @dmarcos on what things needed to be fixed to eliminate the need for Aframe to maintain their own fork, in addition to general support and communication from us on the polyfill end. Did lots of triaging this week and cleared out some low hanging fruit in addition to:

* [support Android Webview in polyfill](https://github.com/googlevr/webvr-polyfill/issues/114)
* [Syncing the dpdb with polyfill, and consolidating all information regarding the dpdb](https://github.com/webvrrocks/webvr-polyfill-dpdb)
* [Clearing out PRs that were in aframe fork and not in the master](https://github.com/googlevr/webvr-polyfill/commit/d873027a71d07f3d2154fa599d49764a515c73e3)

There are outstanding issues in the polyfill, of course, so please let me know if you're aware of any bad bugs and to help out with priority, because Aframe is by far the biggest consumer of the polyfill (I'm guessing, anyway), so try it out and let me know if there's anything else on our end needed to no longer need a fork.

Thanks!