### PR TITLE
no longer auto-enter-vr

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -43,8 +43,7 @@ module.exports.AScene = registerElement('a-scene', {
         'inspector': '',
         'keyboard-shortcuts': '',
         'screenshot': '',
-        'vr-mode-ui': '',
-        'auto-enter-vr': ''
+        'vr-mode-ui': ''
       }
     },
 


### PR DESCRIPTION
Now that Oculus Browser has a user interface both out of VR and inside VR, and effectively deprecates the previous Carmel Developer Preview which only worked in VR (and thus required auto-entering VR to be usable), remove the `auto-enter-vr` component from the default list of scene components.  To keep the prior behavior, authors need only specify the component explicitly e.g. `a-scene auto-enter-vr`

Hopefully this will fix issues encountered such as https://github.com/aframevr/aframe/issues/2614#issuecomment-304334866