### PR TITLE
check if component is initialized before removing

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -436,6 +436,16 @@ var proto = Object.create(ANode.prototype, {
       component = this.components[name];
       if (!component) { return; }
 
+      // Wait for component to initialize.
+      if (!component.initialized) {
+        this.addEventListener('componentinitialized', function tryRemoveLater (evt) {
+          if (evt.detail.name !== name) { return; }
+          this.removeComponent(name);
+          this.removeEventListener('componentinitialized', tryRemoveLater);
+        });
+        return;
+      }
+
       component.pause();
       component.remove();
       delete this.components[name];
@@ -443,7 +453,8 @@ var proto = Object.create(ANode.prototype, {
         id: component.id,
         name: name
       });
-    }
+    },
+    writable: window.debug
   },
 
   /**

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -35,6 +35,7 @@ var Component = module.exports.Component = function (el, attrValue, id) {
   this.el = el;
   this.id = id;
   this.attrName = this.name + (id ? '__' + id : '');
+  this.initialized = false;
   this.el.components[this.attrName] = this;
   // Last value passed to updateProperties.
   this.previousAttrValue = undefined;

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -603,6 +603,15 @@ suite('a-entity', function () {
         done();
       });
     });
+
+    test('handles detaching with with uninitialized components', function () {
+      var box = document.createElement('a-entity');
+      var el = this.el;
+      box.setAttribute('geometry', {primitive: 'box'});
+      el.sceneEl.appendChild(box);
+      el.sceneEl.removeChild(box);
+      // Just check it doesn't error.
+    });
   });
 
   suite('load', function () {
@@ -1128,6 +1137,26 @@ suite('a-entity', function () {
       assert.notEqual(sceneEl.behaviors.tick.indexOf(component), -1);
       el.removeAttribute('look-controls');
       assert.equal(sceneEl.behaviors.tick.indexOf(component), -1);
+    });
+
+    test('waits for component to initialize', function (done) {
+      var box = document.createElement('a-entity');
+      var component;
+      var removeSpy;
+
+      box.setAttribute('geometry', {primitive: 'box'});
+      component = box.components.geometry;
+      removeSpy = this.sinon.stub(component, 'remove', () => {});
+
+      box.removeComponent('geometry');
+      assert.notOk(removeSpy.called);
+
+      component.initialized = true;
+      box.emit('componentinitialized', {name: 'geometry'});
+      setTimeout(() => {
+        assert.ok(removeSpy.called);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
**Description:**

Was running into errors in unit test if you detached an entity while one of its components was still initializing. Its data would be `null` because it had not yet built data, and `.removeComponent` would be called. Geometry would then be calling `system.unuseGeometry(data)` where `data` was null, causing an error.

**Changes proposed:**
- Wait for `componentinitialized` in `removeComponent` if not initialized.
