### PR TITLE
Fixed issue where light fails to set already loaded target

### DIFF
--- a/src/components/light.js
+++ b/src/components/light.js
@@ -88,9 +88,9 @@ module.exports.Component = registerComponent('light', {
             } else {
               // Target specified, set target to entity's `object3D` when it is loaded.
               if (value.hasLoaded) {
-                self.onSetTarget(value);
+                self.onSetTarget(value, light);
               } else {
-                value.addEventListener('loaded', bind(self.onSetTarget, self, value));
+                value.addEventListener('loaded', bind(self.onSetTarget, self, value, light));
               }
             }
             break;
@@ -219,9 +219,9 @@ module.exports.Component = registerComponent('light', {
         this.defaultTarget = light.target;
         if (target) {
           if (target.hasLoaded) {
-            this.onSetTarget(target);
+            this.onSetTarget(target, light);
           } else {
-            target.addEventListener('loaded', bind(this.onSetTarget, this, target));
+            target.addEventListener('loaded', bind(this.onSetTarget, this, target, light));
           }
         }
         return light;
@@ -240,9 +240,9 @@ module.exports.Component = registerComponent('light', {
         this.defaultTarget = light.target;
         if (target) {
           if (target.hasLoaded) {
-            this.onSetTarget(target);
+            this.onSetTarget(target, light);
           } else {
-            target.addEventListener('loaded', bind(this.onSetTarget, this, target));
+            target.addEventListener('loaded', bind(this.onSetTarget, this, target, light));
           }
         }
         return light;
@@ -255,8 +255,8 @@ module.exports.Component = registerComponent('light', {
     }
   },
 
-  onSetTarget: function (targetEl) {
-    this.light.target = targetEl.object3D;
+  onSetTarget: function (targetEl, light) {
+    light.target = targetEl.object3D;
   },
 
   /**

--- a/tests/components/light.test.js
+++ b/tests/components/light.test.js
@@ -205,7 +205,7 @@ suite('light', function () {
   });
 
   suite('light target', function () {
-    test('spotlight: set light target with selector when light is created', function (done) {
+    test('spotlight: set unloaded light target with selector when light is created', function (done) {
       var sceneEl = this.el.sceneEl;
       var lightEl = this.el;
       var targetEl = document.createElement('a-entity');
@@ -222,6 +222,21 @@ suite('light', function () {
           done();
         });
       }
+    });
+
+    test('spotlight: set loaded light target with selector when light is created', function (done) {
+      var sceneEl = this.el.sceneEl;
+      var lightEl = this.el;
+      var targetEl = document.createElement('a-entity');
+
+      sceneEl.appendChild(targetEl);
+      targetEl.setAttribute('id', 'target');
+
+      targetEl.addEventListener('loaded', function () {
+        lightEl.setAttribute('light', 'type: spot; target: #target');
+        assert.equal(lightEl.getObject3D('light').target.uuid, targetEl.object3D.uuid);
+        done();
+      });
     });
 
     test('spotlight: change light target with selector', function (done) {
@@ -285,7 +300,7 @@ suite('light', function () {
       assert.equal(lightTarget.position.z, -1);
     });
 
-    test('directional: set light target with selector when light is created', function (done) {
+    test('directional: set unloaded light target with selector when light is created', function (done) {
       var sceneEl = this.el.sceneEl;
       var lightEl = this.el;
       var targetEl = document.createElement('a-entity');
@@ -302,6 +317,21 @@ suite('light', function () {
           done();
         });
       }
+    });
+
+    test('directional: set loaded light target with selector when light is created', function (done) {
+      var sceneEl = this.el.sceneEl;
+      var lightEl = this.el;
+      var targetEl = document.createElement('a-entity');
+
+      sceneEl.appendChild(targetEl);
+      targetEl.setAttribute('id', 'target');
+
+      targetEl.addEventListener('loaded', function () {
+        lightEl.setAttribute('light', 'type: directional; target: #target');
+        assert.equal(lightEl.getObject3D('light').target.uuid, targetEl.object3D.uuid);
+        done();
+      });
     });
 
     test('directional: change light target with selector', function (done) {


### PR DESCRIPTION
**Description:**

By switching out models and lights dynamically in a scene, I have exposed an issue in the light component where a null reference exception occurs when creating a new spot or directional light where the target is already loaded.

`setLight` calls `getLight` which calls `onSetTarget`. `onSetTarget` expects `this.light` to be present, which works as long as the target is not loaded, since an event listener is set up in `getLight`, giving `this.light` time to get set in `setLight`. When the target is not loaded, however, `onSetTarget` is called immediately and `this.light` is undefined.

**Changes proposed:**
- Added tests to expose the issue
- Call `onSetTarget` with the new light to set the target on, instead of relying on `this.light`
- ~~Continue to also set target on `this.light` if present (this was necessary to get all tests passing, not sure why)~~
