### PR TITLE
[material] Add metalnessMap and roughnessMap.

### DIFF
--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -26,7 +26,11 @@ module.exports.Shader = registerShader('standard', {
 
     fog: {default: true},
     height: {default: 256},
+
     metalness: {default: 0.0, min: 0.0, max: 1.0},
+    metalnessMap: {type: 'map'},
+    metalnessTextureOffset: {type: 'vec2'},
+    metalnessTextureRepeat: {type: 'vec2', default: {x: 1, y: 1}},
 
     normalMap: {type: 'map'},
     normalScale: {type: 'vec2', default: {x: 1, y: 1}},
@@ -35,7 +39,12 @@ module.exports.Shader = registerShader('standard', {
 
     offset: {type: 'vec2', default: {x: 0, y: 0}},
     repeat: {type: 'vec2', default: {x: 1, y: 1}},
+
     roughness: {default: 0.5, min: 0.0, max: 1.0},
+    roughnessMap: {type: 'map'},
+    roughnessTextureOffset: {type: 'vec2'},
+    roughnessTextureRepeat: {type: 'vec2', default: {x: 1, y: 1}},
+
     sphericalEnvMap: {type: 'map'},
     src: {type: 'map'},
     width: {default: 512},
@@ -53,6 +62,8 @@ module.exports.Shader = registerShader('standard', {
     if (data.normalMap) { utils.material.updateDistortionMap('normal', this, data); }
     if (data.displacementMap) { utils.material.updateDistortionMap('displacement', this, data); }
     if (data.ambientOcclusionMap) { utils.material.updateDistortionMap('ambientOcclusion', this, data); }
+    if (data.metalnessMap) { utils.material.updateDistortionMap('metalness', this, data); }
+    if (data.roughnessMap) { utils.material.updateDistortionMap('roughness', this, data); }
     this.updateEnvMap(data);
   },
 
@@ -62,6 +73,8 @@ module.exports.Shader = registerShader('standard', {
     if (data.normalMap) { utils.material.updateDistortionMap('normal', this, data); }
     if (data.displacementMap) { utils.material.updateDistortionMap('displacement', this, data); }
     if (data.ambientOcclusionMap) { utils.material.updateDistortionMap('ambientOcclusion', this, data); }
+    if (data.metalnessMap) { utils.material.updateDistortionMap('metalness', this, data); }
+    if (data.roughnessMap) { utils.material.updateDistortionMap('roughness', this, data); }
     this.updateEnvMap(data);
   },
 


### PR DESCRIPTION
Fixes #2709.

But, maybe this needs more discussion. See #2721. 

1) The occlusion in my sample model doesn't actually work until you duplicate the UV channel.
2) The metalness and roughness in my sample aren't visible, but definitely were applied to `mesh.material`. That _probably_ just means I exported the texture wrong (I suck at Substance Painter) but it would be nice if someone could verify with a known-correct texture.

All in all, mixed feelings about whether these more advanced textures should be in the `material` component or just left to three.js loaders. Documenting good export processes for well-defined model formats is hard enough. 🙃

[metal-rough-cube.zip](https://github.com/aframevr/aframe/files/1050019/metal-rough-cube.zip)
