### PR TITLE
have setAttribute wait for existing DOM data to init component

### DIFF
--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1048,6 +1048,51 @@ suite('a-entity', function () {
       assert.ok(el.components.sound__1 instanceof components.sound.Component);
       assert.ok(el.components.sound__2 instanceof components.sound.Component);
     });
+
+    test('waits for DOM data to init before setAttribute data', function (done) {
+      // Test component.
+      AFRAME.registerComponent('test', {
+        schema: {
+          foo: {default: 5},
+          bar: {default: 'red'},
+          qux: {default: true}
+        },
+
+        init: function () {
+          var data = this.data;
+          assert.equal(data.foo, 10);
+          assert.equal(data.bar, 'red');
+          assert.equal(data.qux, true);
+        },
+
+        update: function (oldData) {
+          var data = this.data;
+          if (Object.keys(oldData).length) {
+            // Second update via setAttribute.
+            assert.equal(data.foo, 10);
+            assert.equal(data.bar, 'orange');
+            assert.equal(data.qux, true);
+            delete AFRAME.components['test-setter'];
+            done();
+          } else {
+            // First update via initialization.
+            assert.equal(data.foo, 10);
+            assert.equal(data.bar, 'red');
+            assert.equal(data.qux, true);
+          }
+        }
+      });
+
+      // Component that will do the setAttribute, without dependency.
+      AFRAME.registerComponent('test-setter', {
+        init: function () {
+          this.el.setAttribute('test', {bar: 'orange'});
+        }
+      });
+
+      // Create the entity.
+      this.el.innerHTML = '<a-entity test-setter test="foo: 10">';
+    });
   });
 
   suite('removeComponent', function () {


### PR DESCRIPTION
**Description:**

(reopened to update GitHub after last outage)

Consider `<a-entity foo bar="a: 10">` where `foo` does `setAttribute('bar', {b: 20})`. The resulting data should be `{a: 10, b: 20}`, but the data ends up `{b: 20}` because the `setAttribute` takes over the initialization process and the DOM data gets ignored.

Ran into this when I had `raycaster` set a `line` component with `start` and `end`. I was trying to set the `color` and `width` via HTML, but that data was wiped out. `<a-entity raycaster="showLine: true" line="color: red; width: 0.05">`.

This would have also helped cases where we were setting `dependencies` to satisfy this lifecycle. But that would initialize the component in cases we might not want to (e.g., `raycaster` might not always want a line). Before we had `obj-model` set a dependency on `material` to use its data *if* defined. We ended up having to remove that.

**Changes proposed:**
- In setAttribute, check if the component is defined in the DOM and has not yet been initialized. If so, then initialize it immediately using DOM data before applying new data.