### PR TITLE
don't clobber previous component attrValue (fixes #2725)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -156,12 +156,25 @@ Component.prototype = {
   /**
    * Update the cache of the pre-parsed attribute value.
    *
-   * @param {string} value - HTML attribute value.
+   * @param {string} value - New data.
+   * @param {boolean } clobber - Whether to wipe out and replace previous data.
    */
-  updateCachedAttrValue: function (value) {
-    var isSinglePropSchema = isSingleProp(this.schema);
+  updateCachedAttrValue: function (value, clobber) {
     var attrValue = this.parseAttrValueForCache(value);
+    var isSinglePropSchema = isSingleProp(this.schema);
+    var property;
+
     if (value === undefined) { return; }
+
+    // Merge new data with previous `attrValue` if updating and not clobbering.
+    if (!isSinglePropSchema && !clobber && this.attrValue) {
+      for (property in this.attrValue) {
+        if (!(property in attrValue)) {
+          attrValue[property] = this.attrValue[property];
+        }
+      }
+    }
+
     this.attrValue = extendProperties({}, attrValue, isSinglePropSchema);
   },
 
@@ -239,7 +252,7 @@ Component.prototype = {
     this.data = this.buildData(attrValue, clobber, false, skipTypeChecking);
 
     // Cache current attrValue for future updates.
-    this.updateCachedAttrValue(attrValue);
+    this.updateCachedAttrValue(attrValue, clobber);
 
     if (!this.initialized) {
       // Component is being already initialized.

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -431,6 +431,46 @@ suite('a-entity', function () {
         baz: 'url(test.jpg)'
       });
     });
+
+    test('merges updates with previous data', function (done) {
+      var el = this.el;
+      el.addEventListener('child-attached', evt => {
+        el = evt.detail.el;
+        el.addEventListener('loaded', evt => {
+          var geometry;
+
+          assert.shallowDeepEqual(el.components.geometry.attrValue, {width: 5});
+          assert.shallowDeepEqual(el.components.geometry.previousAttrValue, {});
+
+          // First setAttribute.
+          el.setAttribute('geometry', {depth: 10, height: 20});
+          geometry = el.getAttribute('geometry');
+          assert.equal(geometry.depth, 10);
+          assert.equal(geometry.height, 20);
+          assert.equal(geometry.width, 5, 'First setAttribute');
+          assert.shallowDeepEqual(el.components.geometry.attrValue, {
+            depth: 10,
+            height: 20,
+            width: 5
+          });
+          assert.shallowDeepEqual(el.components.geometry.previousAttrValue, {width: 5});
+
+          // Second setAttribute.
+          el.setAttribute('geometry', {depth: 20, height: 10});
+          geometry = el.getAttribute('geometry');
+          assert.shallowDeepEqual(el.components.geometry.attrValue, {
+            depth: 20,
+            height: 10,
+            width: 5
+          });
+          assert.equal(geometry.width, 5, 'Second setAttribute');
+          done();
+        });
+      });
+
+      // Initial data.
+      el.innerHTML = '<a-entity geometry="primitive: box; width: 5">';
+    });
   });
 
   suite('flushToDOM', function () {


### PR DESCRIPTION
**Description:**

Previous attempt at https://github.com/aframevr/aframe/pull/2726

There was previously logic at the Entity level for updates to merge the existing properties into the new data set. That logic was removed since more data-building logic now lives in the component. But there was no logic to merge the existing properties when it came to the cached `attrValue`.

In the future, I think it might be nice to rename that to `rawData`.

**Changes proposed:**
- When updating `this.attrValue`, merge in the previous data if not clobbering.
