### PR TITLE
Set this.throttledEmitComponentChanged before calling updateProperties

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -38,7 +38,6 @@ var Component = module.exports.Component = function (el, attrValue, id) {
   this.el.components[this.attrName] = this;
   // Last value passed to updateProperties.
   this.previousAttrValue = undefined;
-  this.updateProperties(attrValue);
   this.throttledEmitComponentChanged = utils.throttle(function emitComponentChange (oldData) {
     el.emit('componentchanged', {
       id: self.id,
@@ -47,6 +46,7 @@ var Component = module.exports.Component = function (el, attrValue, id) {
       oldData: oldData
     }, false);
   }, 200);
+  this.updateProperties(attrValue);
 };
 
 Component.prototype = {

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -585,6 +585,19 @@ suite('Component', function () {
       component.updateProperties({list: ['b']});
       sinon.assert.calledOnce(updateStub);
     });
+
+    test('emit componentchanged when update calls setAttribute', function (done) {
+      var TestComponent = registerComponent('dummy', {
+        schema: {color: {default: 'red'}},
+        update: function () { this.el.setAttribute('dummy', 'color', 'blue'); }
+      });
+      this.el.addEventListener('componentchanged', function (evt) {
+        assert.equal('blue', evt.detail.newData.color);
+        done();
+      });
+      var component = new TestComponent(this.el);
+      assert.equal(component.data.color, 'blue');
+    });
   });
 
   suite('flushToDOM', function () {


### PR DESCRIPTION
If the `update` method calls `setAttribute` on the same component the `componentChanged` is emitted but the method is not properly set when `updateProperties` is called in the component constructor.