### PR TITLE
Reduce copying during setAttribute of one prop

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -544,13 +544,9 @@ var proto = Object.create(ANode.prototype, {
    */
   updateComponentProperty: {
     value: function (name, property, propertyValue) {
-      var component = this.components[name];
-      // Cached attribute value
-      var attrValue = component && component.attrValue;
-      // Copy cached value
-      var componentObj = attrValue ? utils.extend({}, attrValue) : {};
-      componentObj[property] = propertyValue;
-      this.updateComponent(name, componentObj);
+      var attrValue = {};
+      attrValue[property] = propertyValue;
+      this.updateComponent(name, attrValue);
     }
   },
 


### PR DESCRIPTION
Changes 1a45e04 and 7e459ed refactored the relationship of `entity.setAttribute`, `component.updateProperties`, and the responsibility of merging new attributes with earlier ones (provided a clobber isn’t explicitly requested).

The component now has that responsibility, but `entity.updateComponentProperty`, the function responsible for the updating of a single component property, still maintains logic that merges attribute values.

This change simplifes the logic of that method to only pass the new attribute down to the component, which will then perform the merge itself.

This isn’t likely to yield any performance improvements, because a new object is allocated either way and redundant copies were already protected against, but it makes the logic of these files more consistent.

See https://github.com/aframevr/aframe/pull/2729

**note** on my machine I am only able to run the tests in Firefox