### PR TITLE
add armModel and tests for daydream-controls and gearvr-controls

### DIFF
--- a/docs/components/daydream-controls.md
+++ b/docs/components/daydream-controls.md
@@ -41,6 +41,7 @@ and/or pressed buttons (trackpad).
 
 | Event Name         | Description           |
 | ----------         | -----------           |
+| trackpadchanged    | Trackpad changed.     |
 | trackpaddown       | Trackpad pressed.     |
 | trackpadup         | Trackpad released.    |
 | trackpadtouchstart | Trackpad touched.     |

--- a/docs/components/daydream-controls.md
+++ b/docs/components/daydream-controls.md
@@ -29,6 +29,7 @@ and/or pressed buttons (trackpad).
 
 | Property             | Description                                        | Default |
 |----------------------|----------------------------------------------------|---------|
+| armModel             | Whether the arm model is used for positional data. | true    |
 | buttonColor          | Button colors when not pressed.                    | #000000 |
 | buttonTouchedColor   | Button colors when touched.                        | #777777 |
 | buttonHighlightColor | Button colors when pressed and active.             | #FFFFFF |

--- a/docs/components/gearvr-controls.md
+++ b/docs/components/gearvr-controls.md
@@ -39,10 +39,12 @@ and/or pressed buttons (trackpad, trigger).
 
 | Event Name         | Description           |
 | ----------         | -----------           |
+| trackpadchanged    | Trackpad changed.     |
 | trackpaddown       | Trackpad pressed.     |
 | trackpadup         | Trackpad released.    |
 | trackpadtouchstart | Trackpad touched.     |
 | trackpadtouchend   | Trackpad not touched. |
+| triggerchanged     | Trigger changed.      |
 | triggerdown        | Trigger pressed.      |
 | triggerup          | Trigger released.     |
 

--- a/docs/components/gearvr-controls.md
+++ b/docs/components/gearvr-controls.md
@@ -27,6 +27,7 @@ and/or pressed buttons (trackpad, trigger).
 
 | Property             | Description                                        | Default |
 |----------------------|----------------------------------------------------|---------|
+| armModel             | Whether the arm model is used for positional data. | true    |
 | buttonColor          | Button colors when not pressed.                    | #000000 |
 | buttonTouchedColor   | Button colors when touched.                        | #777777 |
 | buttonHighlightColor | Button colors when pressed and active.             | #FFFFFF |

--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -34,15 +34,13 @@ so using idPrefix for Vive / OpenVR controllers is recommended.
 
 | Property          | Description                                                     | Default Value              |
 |-------------------|-----------------------------------------------------------------|----------------------------|
+| armModel          | Whether the arm model is used for positional data if absent.    | true                       |
 | controller        | Index of the controller in array returned by the Gamepad API.   | 0                          |
 | id                | Selects the controller from the Gamepad API using exact match.  |                            |
 | idPrefix          | Selects the controller from the Gamepad API using prefix match. |                            |
 | rotationOffset    | Offset to add to model rotation.                                | 0                          |
 | headElement       | Head element for arm model if needed (if not active camera).    |                            |
 | hand              | Which hand to use, if arm model is needed.  (left negates X)    | right                      |
-| eyesToElbow       | Arm model vector from eyes to elbow as user height ratio.       | {x:0.175, y:-0.3, z:-0.03} |
-| forearm           | Arm model vector for forearm as user height ratio.              | {x:0, y:0, z:-0.175}       |
-| defaultUserHeight | Default user height (for cameras with zero).                    | 1.6                        |
 
 ## Events
 

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -22,7 +22,8 @@ module.exports.Component = registerComponent('gearvr-controls', {
     buttonTouchedColor: {type: 'color', default: '#777777'},
     buttonHighlightColor: {type: 'color', default: '#FFFFFF'},
     model: {default: true},
-    rotationOffset: {default: 0} // use -999 as sentinel value to auto-determine based on hand
+    rotationOffset: {default: 0}, // use -999 as sentinel value to auto-determine based on hand
+    armModel: {default: true}
   },
 
   // buttonId
@@ -49,6 +50,7 @@ module.exports.Component = registerComponent('gearvr-controls', {
   init: function () {
     var self = this;
     this.animationActive = 'pointing';
+    this.onButtonChanged = bind(this.onButtonChanged, this);
     this.onButtonDown = function (evt) { self.onButtonEvent(evt.detail.id, 'down'); };
     this.onButtonUp = function (evt) { self.onButtonEvent(evt.detail.id, 'up'); };
     this.onButtonTouchStart = function (evt) { self.onButtonEvent(evt.detail.id, 'touchstart'); };
@@ -64,6 +66,7 @@ module.exports.Component = registerComponent('gearvr-controls', {
 
   addEventListeners: function () {
     var el = this.el;
+    el.addEventListener('buttonchanged', this.onButtonChanged);
     el.addEventListener('buttondown', this.onButtonDown);
     el.addEventListener('buttonup', this.onButtonUp);
     el.addEventListener('touchstart', this.onButtonTouchStart);
@@ -76,6 +79,7 @@ module.exports.Component = registerComponent('gearvr-controls', {
 
   removeEventListeners: function () {
     var el = this.el;
+    el.removeEventListener('buttonchanged', this.onButtonChanged);
     el.removeEventListener('buttondown', this.onButtonDown);
     el.removeEventListener('buttonup', this.onButtonUp);
     el.removeEventListener('touchstart', this.onButtonTouchStart);
@@ -111,7 +115,7 @@ module.exports.Component = registerComponent('gearvr-controls', {
   injectTrackedControls: function () {
     var el = this.el;
     var data = this.data;
-    el.setAttribute('tracked-controls', {idPrefix: GAMEPAD_ID_PREFIX, rotationOffset: data.rotationOffset});
+    el.setAttribute('tracked-controls', {idPrefix: GAMEPAD_ID_PREFIX, rotationOffset: data.rotationOffset, armModel: data.armModel});
     if (!this.data.model) { return; }
     this.el.setAttribute('obj-model', {
       obj: GEARVR_CONTROLLER_MODEL_OBJ_URL,
@@ -141,6 +145,13 @@ module.exports.Component = registerComponent('gearvr-controls', {
     buttonMeshes = this.buttonMeshes = {};
     buttonMeshes.trigger = controllerObject3D.getObjectByName('Trigger');
     buttonMeshes.trackpad = controllerObject3D.getObjectByName('Touchpad');
+  },
+
+  onButtonChanged: function (evt) {
+    var button = this.mapping.buttons[evt.detail.id];
+    if (!button) return;
+    // Pass along changed event with button state, using button mapping for convenience.
+    this.el.emit(button + 'changed', evt.detail.state);
   },
 
   onButtonEvent: function (id, evtName) {

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -22,6 +22,7 @@ module.exports.Component = registerComponent('tracked-controls', {
     idPrefix: {type: 'string', default: ''},
     rotationOffset: {default: 0},
     // Arm model parameters, to use when not 6DOF. (pose hasPosition false, no position)
+    armModel: {default: true},
     headElement: {type: 'selector'}
   },
 
@@ -153,8 +154,10 @@ module.exports.Component = registerComponent('tracked-controls', {
     if (pose.position) {
       dolly.position.fromArray(pose.position);
     } else {
-      // The controller is not 6DOF, so apply arm model.
-      this.applyArmModel(controllerPosition);
+      if (this.data.armModel) {
+        // The controller is not 6DOF, so apply arm model.
+        this.applyArmModel(controllerPosition);
+      }
       dolly.position.copy(controllerPosition);
     }
     dolly.updateMatrix();

--- a/tests/components/daydream-controls.test.js
+++ b/tests/components/daydream-controls.test.js
@@ -1,0 +1,239 @@
+/* global assert, process, setup, suite, test, CustomEvent, Event */
+var entityFactory = require('../helpers').entityFactory;
+var controllerComponentName = 'daydream-controls';
+
+suite(controllerComponentName, function () {
+  setup(function (done) {
+    var el = this.el = entityFactory();
+    el.setAttribute(controllerComponentName, 'hand: right'); // to ensure index = 0
+    el.addEventListener('loaded', function () {
+      var controllerComponent = el.components[controllerComponentName];
+      controllerComponent.controllersWhenPresent = [{
+        id: 'Daydream Controller',
+        index: 0,
+        hand: 'right',
+        axes: [0, 0],
+        buttons: [{value: 0, pressed: false, touched: false}],
+        pose: {orientation: [1, 0, 0, 0]}
+      }];
+      done();
+    });
+  });
+
+  suite('checkIfControllerPresent', function () {
+    test('first-time, if no controllers, remember not present', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+
+      // reset so we don't think we've looked before
+      controllerComponent.controllerPresent = false;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+    });
+
+    test('if no controllers again, do not remove event listeners', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+
+      // pretend we've looked before
+      controllerComponent.controllerPresent = false;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.notOk(removeEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+    });
+
+    test('attach events if controller is newly present', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+
+      // reset so we don't think we've looked before
+      controllerComponent.controllerPresent = false;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.ok(injectTrackedControlsSpy.called);
+      assert.ok(addEventListenersSpy.called);
+      assert.notOk(removeEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent);
+    });
+
+    test('do not inject or attach events again if controller is already present', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+
+      // pretend we've looked before
+      controllerComponent.controllerPresent = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.notOk(removeEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent);
+    });
+
+    test('if controller disappears, remove event listeners', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+
+      // pretend we've looked before
+      controllerComponent.controllerPresent = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.ok(removeEventListenersSpy.called);
+      assert.notOk(controllerComponent.controllerPresent);
+    });
+  });
+
+  suite('axismove', function () {
+    var name = 'trackpad';
+    test('if we get axismove, emit ' + name + 'moved', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for thumbstickmoved
+      this.el.addEventListener(name + 'moved', function (evt) {
+        assert.equal(evt.detail.x, 0.1);
+        assert.equal(evt.detail.y, 0.2);
+        assert.ok(evt.detail);
+        done();
+      });
+      // emit axismove
+      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [true, false]}});
+      this.el.dispatchEvent(evt);
+    });
+
+    test('if we get axismove with no changes, do not emit ' + name + 'moved', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for thumbstickmoved
+      this.el.addEventListener(name + 'moved', function (evt) {
+        assert.notOk(evt.detail);
+      });
+      // emit axismove
+      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [false, false]}});
+      this.el.dispatchEvent(evt);
+      // finish next tick
+      setTimeout(function () { done(); }, 0);
+    });
+  });
+
+  suite('buttonchanged', function () {
+    var name = 'trackpad';
+    var id = 0;
+    test('if we get buttonchanged, emit ' + name + 'changed', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for triggerchanged
+      this.el.addEventListener(name + 'changed', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+      // emit buttonchanged
+      evt = new CustomEvent('buttonchanged', {'detail': {id: id, state: {value: 0.5, pressed: true, touched: true}}});
+      this.el.dispatchEvent(evt);
+    });
+  });
+
+  suite('gamepaddisconnected', function () {
+    // Due to an apparent bug in FF Nightly
+    // where only one gamepadconnected / disconnected event is fired,
+    // which makes it difficult to handle in individual controller entities,
+    // we no longer remove the controllersupdate listener as a result.
+    test('if we get gamepaddisconnected, check if present', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var checkIfControllerPresentSpy = this.sinon.spy(controllerComponent, 'checkIfControllerPresent');
+      // Because checkIfControllerPresent may be used in bound form, bind and reinstall.
+      controllerComponent.checkIfControllerPresent = controllerComponent.checkIfControllerPresent.bind(controllerComponent);
+      controllerComponent.pause();
+      controllerComponent.play();
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+      // reset everGotGamepadEvent so we don't think we've looked before
+      delete controllerComponent.everGotGamepadEvent;
+      // fire emulated gamepaddisconnected event
+      window.dispatchEvent(new Event('gamepaddisconnected'));
+      // check assertions
+      assert.ok(checkIfControllerPresentSpy.called);
+    });
+  });
+
+  suite('armModel', function () {
+    function makePresent (el) {
+      var controllerComponent = el.components[controllerComponentName];
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+    }
+
+    test('if armModel false, do not apply', function () {
+      var el = this.el;
+      el.setAttribute(controllerComponentName, 'armModel', false);
+      makePresent(el);
+      var trackedControls = el.components['tracked-controls'];
+      var applyArmModelSpy = this.sinon.spy(trackedControls, 'applyArmModel');
+      trackedControls.tick();
+      assert.notOk(applyArmModelSpy.called);
+    });
+
+    test('if armModel true, apply', function () {
+      var el = this.el;
+      el.setAttribute(controllerComponentName, 'armModel', true);
+      makePresent(el);
+      var trackedControls = el.components['tracked-controls'];
+      var applyArmModelSpy = this.sinon.spy(trackedControls, 'applyArmModel');
+      trackedControls.tick();
+      assert.ok(applyArmModelSpy.called);
+    });
+  });
+});

--- a/tests/components/gearvr-controls.test.js
+++ b/tests/components/gearvr-controls.test.js
@@ -1,0 +1,259 @@
+/* global assert, process, setup, suite, test, CustomEvent, Event */
+var entityFactory = require('../helpers').entityFactory;
+var controllerComponentName = 'gearvr-controls';
+
+suite(controllerComponentName, function () {
+  setup(function (done) {
+    var el = this.el = entityFactory();
+    el.setAttribute(controllerComponentName, 'hand: right'); // to ensure index = 0
+    el.addEventListener('loaded', function () {
+      var controllerComponent = el.components[controllerComponentName];
+      controllerComponent.controllersWhenPresent = [{
+        id: 'Gear VR Controller',
+        index: 0,
+        hand: 'right',
+        axes: [0, 0],
+        buttons: [{value: 0, pressed: false, touched: false}, {value: 0, pressed: false, touched: false}],
+        pose: {orientation: [1, 0, 0, 0]}
+      }];
+      done();
+    });
+  });
+
+  suite('checkIfControllerPresent', function () {
+    test('first-time, if no controllers, remember not present', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+
+      // reset so we don't think we've looked before
+      controllerComponent.controllerPresent = false;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+    });
+
+    test('if no controllers again, do not remove event listeners', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+
+      // pretend we've looked before
+      controllerComponent.controllerPresent = false;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.notOk(removeEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+    });
+
+    test('attach events if controller is newly present', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+
+      // reset so we don't think we've looked before
+      controllerComponent.controllerPresent = false;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.ok(injectTrackedControlsSpy.called);
+      assert.ok(addEventListenersSpy.called);
+      assert.notOk(removeEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent);
+    });
+
+    test('do not inject or attach events again if controller is already present', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+
+      // pretend we've looked before
+      controllerComponent.controllerPresent = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.notOk(removeEventListenersSpy.called);
+      assert.ok(controllerComponent.controllerPresent);
+    });
+
+    test('if controller disappears, remove event listeners', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+
+      // pretend we've looked before
+      controllerComponent.controllerPresent = true;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // check assertions
+      assert.notOk(injectTrackedControlsSpy.called);
+      assert.notOk(addEventListenersSpy.called);
+      assert.ok(removeEventListenersSpy.called);
+      assert.notOk(controllerComponent.controllerPresent);
+    });
+  });
+
+  suite('axismove', function () {
+    var name = 'trackpad';
+    test('if we get axismove, emit ' + name + 'moved', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for thumbstickmoved
+      this.el.addEventListener(name + 'moved', function (evt) {
+        assert.equal(evt.detail.x, 0.1);
+        assert.equal(evt.detail.y, 0.2);
+        assert.ok(evt.detail);
+        done();
+      });
+      // emit axismove
+      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [true, false]}});
+      this.el.dispatchEvent(evt);
+    });
+
+    test('if we get axismove with no changes, do not emit ' + name + 'moved', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for thumbstickmoved
+      this.el.addEventListener(name + 'moved', function (evt) {
+        assert.notOk(evt.detail);
+      });
+      // emit axismove
+      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [false, false]}});
+      this.el.dispatchEvent(evt);
+      // finish next tick
+      setTimeout(function () { done(); }, 0);
+    });
+  });
+
+  suite('buttonchanged', function () {
+    var name = 'trackpad';
+    var id = 0;
+    test('if we get buttonchanged, emit ' + name + 'changed', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for triggerchanged
+      this.el.addEventListener(name + 'changed', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+      // emit buttonchanged
+      evt = new CustomEvent('buttonchanged', {'detail': {id: id, state: {value: 0.5, pressed: true, touched: true}}});
+      this.el.dispatchEvent(evt);
+    });
+
+    name = 'trigger';
+    id = 1;
+    test('if we get buttonchanged, emit ' + name + 'changed', function (done) {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var evt;
+
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+      // install event handler listening for triggerchanged
+      this.el.addEventListener(name + 'changed', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+      // emit buttonchanged
+      evt = new CustomEvent('buttonchanged', {'detail': {id: id, state: {value: 0.5, pressed: true, touched: true}}});
+      this.el.dispatchEvent(evt);
+    });
+  });
+
+  suite('gamepaddisconnected', function () {
+    // Due to an apparent bug in FF Nightly
+    // where only one gamepadconnected / disconnected event is fired,
+    // which makes it difficult to handle in individual controller entities,
+    // we no longer remove the controllersupdate listener as a result.
+    test('if we get gamepaddisconnected, check if present', function () {
+      var el = this.el;
+      var controllerComponent = el.components[controllerComponentName];
+      var checkIfControllerPresentSpy = this.sinon.spy(controllerComponent, 'checkIfControllerPresent');
+      // Because checkIfControllerPresent may be used in bound form, bind and reinstall.
+      controllerComponent.checkIfControllerPresent = controllerComponent.checkIfControllerPresent.bind(controllerComponent);
+      controllerComponent.pause();
+      controllerComponent.play();
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+      // reset everGotGamepadEvent so we don't think we've looked before
+      delete controllerComponent.everGotGamepadEvent;
+      // fire emulated gamepaddisconnected event
+      window.dispatchEvent(new Event('gamepaddisconnected'));
+      // check assertions
+      assert.ok(checkIfControllerPresentSpy.called);
+    });
+  });
+
+  suite('armModel', function () {
+    function makePresent (el) {
+      var controllerComponent = el.components[controllerComponentName];
+      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // do the check
+      controllerComponent.checkIfControllerPresent();
+    }
+
+    test('if armModel false, do not apply', function () {
+      var el = this.el;
+      el.setAttribute(controllerComponentName, 'armModel', false);
+      makePresent(el);
+      var trackedControls = el.components['tracked-controls'];
+      var applyArmModelSpy = this.sinon.spy(trackedControls, 'applyArmModel');
+      trackedControls.tick();
+      assert.notOk(applyArmModelSpy.called);
+    });
+
+    test('if armModel true, apply', function () {
+      var el = this.el;
+      el.setAttribute(controllerComponentName, 'armModel', true);
+      makePresent(el);
+      var trackedControls = el.components['tracked-controls'];
+      var applyArmModelSpy = this.sinon.spy(trackedControls, 'applyArmModel');
+      trackedControls.tick();
+      assert.ok(applyArmModelSpy.called);
+    });
+  });
+});

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test, THREE */
+/* global assert, process, setup, suite, teardown, test, THREE */
 const entityFactory = require('../helpers').entityFactory;
 
 const PI = Math.PI;
@@ -414,6 +414,31 @@ suite('tracked-controls', function () {
       component.tick();
       assert.equal(component.buttonStates[0].value, 0.25);
       assert.equal(component.buttonStates[1].value, 0.75);
+    });
+  });
+
+  suite('armModel', function () {
+    setup(function () {
+      delete controller.pose.position;
+    });
+
+    el = entityFactory();
+    test('if armModel false, do not apply', function () {
+      var applyArmModelSpy = this.sinon.spy(component, 'applyArmModel');
+      component.data.armModel = false;
+      component.tick();
+      assert.notOk(applyArmModelSpy.called);
+    });
+
+    test('if armModel true, apply', function () {
+      var applyArmModelSpy = this.sinon.spy(component, 'applyArmModel');
+      component.data.armModel = true;
+      component.tick();
+      assert.ok(applyArmModelSpy.called);
+    });
+
+    teardown(function () {
+      controller.pose.position = [0, 0, 0];
     });
   });
 });


### PR DESCRIPTION
Addresses #2711 by allowing one to disable the 3DOF arm model for `tracked-controls`, `daydream-controls` and `gearvr-controls` using the property `armModel`.