### PR TITLE
setAttribute: partial update with strings [fix #2651]

### DIFF
--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -45,6 +45,7 @@ suite('material', function () {
     });
 
     test('defaults to standard material', function () {
+      this.el.removeAttribute('material'); // setup creates a non-default component
       this.el.setAttribute('material', '');
       assert.equal(this.el.getObject3D('mesh').material.type, 'MeshStandardMaterial');
     });

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -309,6 +309,28 @@ suite('a-entity', function () {
       assert.equal(material.roughness, 0.75);
     });
 
+    test('can update a single component attribute with a string', function () {
+      var el = this.el;
+      var material;
+      el.setAttribute('material', 'color: #F0F; roughness: 0.25');
+      assert.equal(el.getAttribute('material').roughness, 0.25);
+      el.setAttribute('material', 'roughness: 0.75');
+      material = el.getAttribute('material');
+      assert.equal(material.color, '#F0F');
+      assert.equal(material.roughness, 0.75);
+    });
+
+    test('can clobber component attributes with a string and flag', function () {
+      var el = this.el;
+      var material;
+      el.setAttribute('material', 'color: #F0F; roughness: 0.25');
+      el.setAttribute('material', 'color: #000', true);
+      material = el.getAttribute('material');
+      assert.equal(material.color, '#000');
+      assert.equal(material.roughness, 0.5);
+      assert.equal(el.getDOMAttribute('material').roughness, undefined);
+    });
+
     test('transforms object to string before setting on DOM', function () {
       var el = this.el;
       var positionObj = {x: 10, y: 20, z: 30};
@@ -1133,25 +1155,6 @@ suite('a-entity', function () {
       assert.equal(el.getAttribute('material').color, 'red');
       el.updateComponent('material', null);
       assert.equal(el.components.material, undefined);
-    });
-  });
-
-  suite('updateComponentAttribute', function () {
-    test('initialize a component', function () {
-      var el = this.el;
-      assert.equal(el.components.material, undefined);
-      el.updateComponentProperty('material', 'color', 'blue');
-      assert.equal(el.getAttribute('material').color, 'blue');
-    });
-
-    test('update a property of an existing component', function () {
-      var el = this.el;
-      var component = new components.material.Component(el, {color: 'red'});
-      el.components.material = component;
-      assert.equal(el.getAttribute('material').color, 'red');
-      el.updateComponentProperty('material', 'color', 'blue');
-      assert.equal(component, el.components.material);
-      assert.equal(el.getAttribute('material').color, 'blue');
     });
   });
 


### PR DESCRIPTION
* Enable the entity setAttribute API to accept partial updates of multi-property components when using a CSS-style property string
* Enable the use of the `clobber` flag under same scenario
* Remove single-use helper functions in a-entity for updating a single property of multi-property components
* Add unit tests and update a test where behavior changed

Details:

Previously, it was only possible to do partial updates when passing objects. Extending this behavior (and the clobber flag) to CSS-style strings requires differentiating those strings from simple property names, as a string in the second parameter could be either one.

This is handled by calling out to `utils.styleParser` and checking the return type, which is redundant to work done inside the component. This inefficiency could be reduced perhaps by reworking slightly the interface between the entity and component to pass the parsed result down; or a different mechanism of differentiation could be devised.

However, using strings in either capacity (CSS-style or the single property update form) is inherently a less efficient convenience for the object form, and their use should be discouraged when performance matters (e.g. `tick`).

The `clobber` flag (third parameter to setAttribute) behavior in this scenaro has now changed: previously, any time the second parameter was anything other than an object, `clobber` was treated internally as true. Now, CSS-style strings are treated the same as objects, where it defaults to false but is configurable by parameter.

This means that `el.setAttribute(‘myComponent’, ‘’)` previously would reset the component to its default values (because it was clobbering and not passing any new values). To get the same behavior as before, use `el.setAttribute(‘myComponent’, ‘’, true)`. One unit test was updated to reflect this change.

Finally, `entity.updateComponentProperty` has very little logic, is not a public API, and was only called by `setAttribute`; so it was simply merged in and its unit tests removed.