### PR TITLE
handle vrdisplaypresentchange when triggering enter/exit VR outside aframe (fixes #2614)

### DIFF
--- a/src/components/scene/auto-enter-vr.js
+++ b/src/components/scene/auto-enter-vr.js
@@ -2,9 +2,9 @@ var registerComponent = require('../../core/component').registerComponent;
 var utils = require('../../utils');
 
 /**
- * Automatically enter VR, either upon vrdisplayactivate (e.g. putting on Rift headset)
+ * Automatically enter VR either upon `vrdisplayactivate` (e.g. putting on Rift headset)
  * or immediately (if possible) if display name contains data string.
- * The default data string is 'GearVR' for Carmel browser which only does VR.
+ * Default data string is `GearVR` for Carmel browser which only does VR.
  */
 module.exports.Component = registerComponent('auto-enter-vr', {
   schema: {
@@ -16,41 +16,43 @@ module.exports.Component = registerComponent('auto-enter-vr', {
     var scene = this.el;
     var self = this;
 
-    // define methods to allow mock testing
+    // Define methods to allow mock testing.
     this.enterVR = scene.enterVR.bind(scene);
     this.exitVR = scene.exitVR.bind(scene);
     this.shouldAutoEnterVR = this.shouldAutoEnterVR.bind(this);
 
-    // don't do anything if false
     if (utils.getUrlParameter('auto-enter-vr') === 'false') { return; }
 
-    // enter VR on vrdisplayactivate (e.g. putting on Rift headset)
+    // Enter VR on `vrdisplayactivate` (e.g. putting on Rift headset).
     window.addEventListener('vrdisplayactivate', function () { self.enterVR(); }, false);
 
-    // exit VR on vrdisplaydeactivate (e.g. taking off Rift headset)
+    // Exit VR on `vrdisplaydeactivate` (e.g. taking off Rift headset).
     window.addEventListener('vrdisplaydeactivate', function () { self.exitVR(); }, false);
 
-    // check if we should try to enter VR... turns out we need to wait for next tick
-    setTimeout(function () { if (self.shouldAutoEnterVR()) { self.enterVR(); } }, 0);
-  },
-
-  update: function () {
-    return this.shouldAutoEnterVR() ? this.enterVR() : this.exitVR();
+    // Check if we should try to enter VR. Need to wait for next tick.
+    setTimeout(function () {
+      if (self.shouldAutoEnterVR()) {
+        self.enterVR();
+      }
+    });
   },
 
   shouldAutoEnterVR: function () {
-    var scene = this.el;
     var data = this.data;
-    // if false, we should not auto-enter VR
+    var display;
+    var scene = this.el;
+
     if (!data.enabled) { return false; }
-    // if we have a data string to match against display name, try and get it;
-    // if we can't get display name, or it doesn't match, we should not auto-enter VR
+
+    // If we have data string to match against display name, try and get it.
+    // If we can't get display name or it doesn't match, do not auto-enter VR.
     if (data.display && data.display !== 'all') {
-      var display = scene.effect && scene.effect.getVRDisplay && scene.effect.getVRDisplay();
-      if (!display || !display.displayName || display.displayName.indexOf(data.display) < 0) { return false; }
+      display = scene.effect && scene.effect.getVRDisplay && scene.effect.getVRDisplay();
+      if (!display || !display.displayName || display.displayName.indexOf(data.display) < 0) {
+        return false;
+      }
     }
-    // we should auto-enter VR
+
     return true;
   }
 });
-

--- a/src/components/scene/vr-mode-ui.js
+++ b/src/components/scene/vr-mode-ui.js
@@ -42,7 +42,8 @@ module.exports.Component = registerComponent('vr-mode-ui', {
     });
 
     // Modal that tells the user to change orientation if in portrait.
-    window.addEventListener('orientationchange', bind(this.toggleOrientationModalIfNeeded, this));
+    window.addEventListener('orientationchange',
+                            bind(this.toggleOrientationModalIfNeeded, this));
   },
 
   update: function () {
@@ -104,6 +105,7 @@ module.exports.Component = registerComponent('vr-mode-ui', {
  *
  * Structure: <div><button></div>
  *
+ * @param {function} enterVRHandler
  * @returns {Element} Wrapper <div>.
  */
 function createEnterVRButton (enterVRHandler) {
@@ -120,7 +122,9 @@ function createEnterVRButton (enterVRHandler) {
 
   // Insert elements.
   wrapper.appendChild(vrButton);
-  vrButton.addEventListener('click', enterVRHandler);
+  vrButton.addEventListener('click', function (evt) {
+    enterVRHandler();
+  });
   return wrapper;
 }
 

--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -29,7 +29,7 @@ setup(function () {
   this.sinon.stub(AScene.prototype, 'setupRenderer');
 });
 
-teardown(function () {
+teardown(function (done) {
   // Clean up any attached elements.
   var attachedEls = ['canvas', 'a-assets', 'a-scene'];
   var els = document.querySelectorAll(attachedEls.join(','));
@@ -39,4 +39,9 @@ teardown(function () {
   this.sinon.restore();
   delete AFRAME.components.test;
   delete AFRAME.systems.test;
+
+  // Allow detachedCallbacks to clean themselves up.
+  setTimeout(function () {
+    done();
+  });
 });

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -1,4 +1,4 @@
-/* global AFRAME, assert, process, sinon, setup, suite, teardown, test */
+/* global AFRAME, assert, CustomEvent, process, sinon, setup, suite, teardown, test */
 var AEntity = require('core/a-entity');
 var ANode = require('core/a-node');
 var AScene = require('core/scene/a-scene').AScene;
@@ -60,6 +60,25 @@ suite('a-scene (without renderer)', function () {
     });
   });
 
+  suite('vrdisplaypresentchange', function () {
+    test('tells A-Frame about entering VR if now presenting', function (done) {
+      var event;
+      var sceneEl = this.el;
+      console.log('start test');
+
+      sceneEl.setAttribute('id', 'vrdisplay');
+      sceneEl.canvas = document.createElement('canvas');
+      sceneEl.addEventListener('enter-vr', function () {
+        assert.ok(sceneEl.is('vr-mode'));
+        done();
+      });
+
+      event = new CustomEvent('vrdisplaypresentchange');
+      event.display = {isPresenting: true};
+      window.dispatchEvent(event);
+    });
+  });
+
   suite('enterVR', function () {
     setup(function () {
       var sceneEl = this.el;
@@ -107,6 +126,16 @@ suite('a-scene (without renderer)', function () {
       var sceneEl = this.el;
       var requestSpy = this.requestSpy;
       sceneEl.enterVR().then(function () {
+        assert.notOk(requestSpy.called);
+        done();
+      });
+    });
+
+    test('does not call requestPresent if flag passed', function (done) {
+      var sceneEl = this.el;
+      var requestSpy = this.requestSpy;
+      this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(true);
+      sceneEl.enterVR(true).then(function () {
         assert.notOk(requestSpy.called);
         done();
       });
@@ -202,6 +231,16 @@ suite('a-scene (without renderer)', function () {
       var sceneEl = this.el;
       var exitSpy = this.exitSpy;
       sceneEl.exitVR().then(function () {
+        assert.notOk(exitSpy.called);
+        done();
+      });
+    });
+
+    test('does not call exitPresent if flag passed', function (done) {
+      var sceneEl = this.el;
+      var exitSpy = this.exitSpy;
+      this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(true);
+      sceneEl.exitVR(true).then(function () {
         assert.notOk(exitSpy.called);
         done();
       });


### PR DESCRIPTION
**Description:**

>  A user agent MUST dispatch this event type to indicate that a VRDisplay has begun or ended VR presentation. This event should not fire on subsequent calls to requestPresent() after the VRDisplay has already begun VR presentation.

Previously, we only handled exitVR on pressing the escape key. Thanks to @digitec for pointing in the right direction.

**Changes proposed:**
- handle onvrdisplaypresentchange
- [x] tested
- [x] unit tests