### PR TITLE
eliminate need to mock navigator in node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ if (window.location.protocol === 'file:') {
 window.Promise = window.Promise || require('promise-polyfill');
 
 // Check before the polyfill runs.
-window.hasNativeWebVRImplementation = !!navigator.getVRDisplays || !!navigator.getVRDevices;
+window.hasNativeWebVRImplementation = !!window.navigator.getVRDisplays || !!window.navigator.getVRDevices;
 
 window.WebVRConfig = window.WebVRConfig || {
   BUFFER_SCALE: 1,
@@ -36,7 +36,7 @@ window.WebVRConfig = window.WebVRConfig || {
 
 // Workaround for iOS Safari canvas sizing issues in stereo (webvr-polyfill/issues/102).
 // Only for iOS on versions older than 10.
-if (utils.device.isIOSOlderThan10(navigator.userAgent)) {
+if (utils.device.isIOSOlderThan10(window.navigator.userAgent)) {
   window.WebVRConfig.BUFFER_SCALE = 1 / window.devicePixelRatio;
 }
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -60,7 +60,7 @@ var isMobile = (function () {
     if (isGearVR()) {
       _isMobile = false;
     }
-  })(navigator.userAgent || navigator.vendor || window.opera);
+  })(window.navigator.userAgent || window.navigator.vendor || window.opera);
 
   return function () { return _isMobile; };
 })();
@@ -71,18 +71,18 @@ module.exports.isMobile = isMobile;
  *  @param {string} mockUserAgent - Allow passing a mock user agent for testing.
  */
 function isTablet (mockUserAgent) {
-  var userAgent = mockUserAgent || navigator.userAgent;
+  var userAgent = mockUserAgent || window.navigator.userAgent;
   return /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
 }
 module.exports.isTablet = isTablet;
 
 function isIOS () {
-  return /iPad|iPhone|iPod/.test(navigator.platform);
+  return /iPad|iPhone|iPod/.test(window.navigator.platform);
 }
 module.exports.isIOS = isIOS;
 
 function isGearVR () {
-  return /SamsungBrowser.+Mobile VR/i.test(navigator.userAgent);
+  return /SamsungBrowser.+Mobile VR/i.test(window.navigator.userAgent);
 }
 module.exports.isGearVR = isGearVR;
 

--- a/tests/node/test.js
+++ b/tests/node/test.js
@@ -7,13 +7,11 @@ const jsdom = require('jsdom');
 
 suite('node acceptance tests', function () {
   setup(function () {
-    let _window = global.window = jsdom.jsdom().defaultView;
-    global.navigator = _window.navigator;
+    global.window = jsdom.jsdom().defaultView;
   });
 
   teardown(function () {
     delete global.window;
-    delete global.navigator;
   });
 
   test('can run in node', function () {


### PR DESCRIPTION
similar to #2747 and #2752.

This is the last piece. After this, using aframe in node will only require a `global.window` mock.