### PR TITLE
delay VRControls initialization for node

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -1,12 +1,23 @@
 var THREE = require('../lib/three');
 var dolly = new THREE.Object3D();
-var controls = new THREE.VRControls(dolly);
+
+var getControls = (function () {
+  var controls;
+  return function () {
+    if (!controls) {
+      // Lazy-instantiate VRControls to not break in Node.
+      controls = new THREE.VRControls(dolly);
+    }
+    return controls;
+  };
+})();
 
 /**
  * Determine if a headset is connected by checking if the orientation is available.
  */
 function checkHeadsetConnected () {
   var orientation;
+  var controls = getControls();
   var vrDisplay = controls.getVRDisplay();
 
   // If `isConnected` is available, just use that.
@@ -25,6 +36,7 @@ module.exports.checkHeadsetConnected = checkHeadsetConnected;
  * Check for positional tracking.
  */
 function checkHasPositionalTracking () {
+  var controls = getControls();
   var vrDisplay = controls.getVRDisplay();
   if (isMobile() || isGearVR()) { return false; }
   return vrDisplay && vrDisplay.capabilities.hasPosition;


### PR DESCRIPTION
In response to https://github.com/aframevr/aframe/pull/2755#discussion_r121292464.

This makes running in node more happy and eliminates the need for this change https://github.com/aframevr/aframe/pull/2755/files#diff-97c6b758b49a87147586d2d87795312aR38.

cc @ngokevin