### PR TITLE
fix vive-controls button colors

### DIFF
--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -1,7 +1,9 @@
 var registerComponent = require('../core/component').registerComponent;
-var bind = require('../utils/bind');
-var checkControllerPresentAndSetup = require('../utils/tracked-controls').checkControllerPresentAndSetup;
-var emitIfAxesChanged = require('../utils/tracked-controls').emitIfAxesChanged;
+var utils = require('../utils/');
+
+var bind = utils.bind;
+var checkControllerPresentAndSetup = utils.trackedControls.checkControllerPresentAndSetup;
+var emitIfAxesChanged = utils.trackedControls.emitIfAxesChanged;
 
 var VIVE_CONTROLLER_MODEL_OBJ_URL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.obj';
 var VIVE_CONTROLLER_MODEL_OBJ_MTL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.mtl';
@@ -9,10 +11,10 @@ var VIVE_CONTROLLER_MODEL_OBJ_MTL = 'https://cdn.aframe.io/controllers/vive/vr_c
 var GAMEPAD_ID_PREFIX = 'OpenVR ';
 
 /**
- * Vive Controls Component
- * Interfaces with vive controllers and maps Gamepad events to
- * common controller buttons: trackpad, trigger, grip, menu and system
- * It loads a controller model and highlights the pressed buttons
+ * Vive controls.
+ * Interface with Vive controllers and map Gamepad events to controller buttons:
+ * trackpad, trigger, grip, menu, system
+ * Load a controller model and highlight the pressed buttons.
  */
 module.exports.Component = registerComponent('vive-controls', {
   schema: {
@@ -20,78 +22,43 @@ module.exports.Component = registerComponent('vive-controls', {
     buttonColor: {type: 'color', default: '#FAFAFA'},  // Off-white.
     buttonHighlightColor: {type: 'color', default: '#22D1EE'},  // Light blue.
     model: {default: true},
-    rotationOffset: {default: 0} // use -999 as sentinel value to auto-determine based on hand
+    rotationOffset: {default: 0}
   },
 
-  // buttonId
-  // 0 - trackpad
-  // 1 - trigger ( intensity value from 0.5 to 1 )
-  // 2 - grip
-  // 3 - menu ( dispatch but better for menu options )
-  // 4 - system ( never dispatched on this layer )
+  /**
+   * Button IDs:
+   * 0 - trackpad
+   * 1 - trigger (intensity value from 0.5 to 1)
+   * 2 - grip
+   * 3 - menu (dispatch but better for menu options)
+   * 4 - system (never dispatched on this layer)
+   */
   mapping: {
     axes: {'trackpad': [0, 1]},
     buttons: ['trackpad', 'trigger', 'grip', 'menu', 'system']
   },
 
-  // Use these labels for detail on axis events such as thumbstickmoved.
-  // e.g. for thumbstickmoved detail, the first axis returned is labeled x, and the second is labeled y.
+  /**
+   * Labels for detail on axis events such as `thumbstickmoved`.
+   * For example, on `thumbstickmoved` detail, the first axis returned is labeled x, and the
+   * second is labeled y.
+   */
   axisLabels: ['x', 'y', 'z', 'w'],
-
-  bindMethods: function () {
-    this.onModelLoaded = bind(this.onModelLoaded, this);
-    this.onControllersUpdate = bind(this.onControllersUpdate, this);
-    this.checkIfControllerPresent = bind(this.checkIfControllerPresent, this);
-    this.removeControllersUpdateListener = bind(this.removeControllersUpdateListener, this);
-    this.onAxisMoved = bind(this.onAxisMoved, this);
-  },
 
   init: function () {
     var self = this;
     this.animationActive = 'pointing';
+    this.checkControllerPresentAndSetup = checkControllerPresentAndSetup;  // To allow mock.
+    this.controllerPresent = false;
+    this.emitIfAxesChanged = emitIfAxesChanged;  // To allow mock.
+    this.lastControllerCheck = 0;
     this.onButtonChanged = bind(this.onButtonChanged, this);
     this.onButtonDown = function (evt) { self.onButtonEvent(evt.detail.id, 'down'); };
     this.onButtonUp = function (evt) { self.onButtonEvent(evt.detail.id, 'up'); };
-    this.onButtonTouchStart = function (evt) { self.onButtonEvent(evt.detail.id, 'touchstart'); };
-    this.onButtonTouchEnd = function (evt) { self.onButtonEvent(evt.detail.id, 'touchend'); };
     this.onAxisMoved = bind(this.onAxisMoved, this);
-    this.controllerPresent = false;
-    this.lastControllerCheck = 0;
     this.previousButtonValues = {};
+
     this.bindMethods();
-    this.checkControllerPresentAndSetup = checkControllerPresentAndSetup; // to allow mock
-    this.emitIfAxesChanged = emitIfAxesChanged; // to allow mock
-  },
-
-  addEventListeners: function () {
-    var el = this.el;
-    el.addEventListener('buttonchanged', this.onButtonChanged);
-    el.addEventListener('buttondown', this.onButtonDown);
-    el.addEventListener('buttonup', this.onButtonUp);
-    el.addEventListener('touchstart', this.onButtonTouchStart);
-    el.addEventListener('touchend', this.onButtonTouchEnd);
-    el.addEventListener('model-loaded', this.onModelLoaded);
-    el.addEventListener('axismove', this.onAxisMoved);
-  },
-
-  removeEventListeners: function () {
-    var el = this.el;
-    el.removeEventListener('buttonchanged', this.onButtonChanged);
-    el.removeEventListener('buttondown', this.onButtonDown);
-    el.removeEventListener('buttonup', this.onButtonUp);
-    el.removeEventListener('touchstart', this.onButtonTouchStart);
-    el.removeEventListener('touchend', this.onButtonTouchEnd);
-    el.removeEventListener('model-loaded', this.onModelLoaded);
-    el.removeEventListener('axismove', this.onAxisMoved);
-  },
-
-  checkIfControllerPresent: function () {
-    var data = this.data;
-    // Once OpenVR / SteamVR return correct hand data in the supporting browsers, we can use hand property.
-    // var isPresent = this.checkControllerPresentAndSetup(this.el.sceneEl, GAMEPAD_ID_PREFIX, { hand: data.hand });
-    // Until then, use hardcoded index.
-    var controllerIndex = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
-    this.checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX, { index: controllerIndex });
   },
 
   play: function () {
@@ -108,13 +75,57 @@ module.exports.Component = registerComponent('vive-controls', {
     window.removeEventListener('gamepaddisconnected', this.checkIfControllerPresent, false);
   },
 
+  bindMethods: function () {
+    this.onModelLoaded = bind(this.onModelLoaded, this);
+    this.onControllersUpdate = bind(this.onControllersUpdate, this);
+    this.checkIfControllerPresent = bind(this.checkIfControllerPresent, this);
+    this.removeControllersUpdateListener = bind(this.removeControllersUpdateListener, this);
+    this.onAxisMoved = bind(this.onAxisMoved, this);
+  },
+
+  addEventListeners: function () {
+    var el = this.el;
+    el.addEventListener('buttonchanged', this.onButtonChanged);
+    el.addEventListener('buttondown', this.onButtonDown);
+    el.addEventListener('buttonup', this.onButtonUp);
+    el.addEventListener('model-loaded', this.onModelLoaded);
+    el.addEventListener('axismove', this.onAxisMoved);
+  },
+
+  removeEventListeners: function () {
+    var el = this.el;
+    el.removeEventListener('buttonchanged', this.onButtonChanged);
+    el.removeEventListener('buttondown', this.onButtonDown);
+    el.removeEventListener('buttonup', this.onButtonUp);
+    el.removeEventListener('model-loaded', this.onModelLoaded);
+    el.removeEventListener('axismove', this.onAxisMoved);
+  },
+
+  /**
+   * Once OpenVR returns correct hand data in supporting browsers, we can use hand property.
+   * var isPresent = this.checkControllerPresentAndSetup(this.el.sceneEl, GAMEPAD_ID_PREFIX,
+                                                        { hand: data.hand });
+   * Until then, use hardcoded index.
+   */
+  checkIfControllerPresent: function () {
+    var data = this.data;
+    var controllerIndex = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
+    this.checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX, {index: controllerIndex});
+  },
+
   injectTrackedControls: function () {
     var el = this.el;
     var data = this.data;
-    // handId: 0 - right, 1 - left, 2 - anything else...
-    var controller = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
-    // if we have an OpenVR Gamepad, use the fixed mapping
-    el.setAttribute('tracked-controls', {idPrefix: GAMEPAD_ID_PREFIX, controller: controller, rotationOffset: data.rotationOffset});
+
+    // If we have an OpenVR Gamepad, use the fixed mapping.
+    el.setAttribute('tracked-controls', {
+      idPrefix: GAMEPAD_ID_PREFIX,
+      // Hand IDs: 0 = right, 1 = left, 2 = anything else.
+      controller: data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2,
+      rotationOffset: data.rotationOffset
+    });
+
+    // Load model.
     if (!this.data.model) { return; }
     this.el.setAttribute('obj-model', {
       obj: VIVE_CONTROLLER_MODEL_OBJ_URL,
@@ -130,17 +141,23 @@ module.exports.Component = registerComponent('vive-controls', {
     this.el.sceneEl.removeEventListener('controllersupdated', this.onControllersUpdate, false);
   },
 
-  onControllersUpdate: function () { this.checkIfControllerPresent(); },
+  onControllersUpdate: function () {
+    this.checkIfControllerPresent();
+  },
 
+  /**
+   * Rotate the trigger button based on how hard the trigger is pressed.
+   */
   onButtonChanged: function (evt) {
     var button = this.mapping.buttons[evt.detail.id];
     var buttonMeshes = this.buttonMeshes;
     var analogValue;
+
     if (!button) { return; }
 
     if (button === 'trigger') {
       analogValue = evt.detail.state.value;
-      // Update button mesh, if any.
+      // Update trigger rotation depending on button value.
       if (buttonMeshes && buttonMeshes.trigger) {
         buttonMeshes.trigger.rotation.x = -analogValue * (Math.PI / 12);
       }
@@ -151,9 +168,13 @@ module.exports.Component = registerComponent('vive-controls', {
   },
 
   onModelLoaded: function (evt) {
-    var controllerObject3D = evt.detail.model;
     var buttonMeshes;
+    var controllerObject3D = evt.detail.model;
+    var self = this;
+
     if (!this.data.model) { return; }
+
+    // Store button meshes object to be able to change their colors.
     buttonMeshes = this.buttonMeshes = {};
     buttonMeshes.grip = {
       left: controllerObject3D.getObjectByName('leftgrip'),
@@ -163,15 +184,26 @@ module.exports.Component = registerComponent('vive-controls', {
     buttonMeshes.system = controllerObject3D.getObjectByName('systembutton');
     buttonMeshes.trackpad = controllerObject3D.getObjectByName('touchpad');
     buttonMeshes.trigger = controllerObject3D.getObjectByName('trigger');
-    // Offset pivot point
+
+    // Set default colors.
+    Object.keys(buttonMeshes).forEach(function (buttonName) {
+      self.setButtonColor(buttonName, self.data.buttonColor);
+    });
+
+    // Offset pivot point.
     controllerObject3D.position.set(0, -0.015, 0.04);
   },
 
-  onAxisMoved: function (evt) { this.emitIfAxesChanged(this, this.mapping.axes, evt); },
+  onAxisMoved: function (evt) {
+    this.emitIfAxesChanged(this, this.mapping.axes, evt);
+  },
 
   onButtonEvent: function (id, evtName) {
     var buttonName = this.mapping.buttons[id];
+    var color;
     var i;
+
+    // Emit events.
     if (Array.isArray(buttonName)) {
       for (i = 0; i < buttonName.length; i++) {
         this.el.emit(buttonName[i] + evtName);
@@ -179,25 +211,26 @@ module.exports.Component = registerComponent('vive-controls', {
     } else {
       this.el.emit(buttonName + evtName);
     }
-    this.updateModel(buttonName, evtName);
-  },
 
-  updateModel: function (buttonName, evtName) {
-    var i;
     if (!this.data.model) { return; }
+
+    // Update colors.
+    color = evtName === 'up' ? this.data.buttonColor : this.data.buttonHighlightColor;
     if (Array.isArray(buttonName)) {
       for (i = 0; i < buttonName.length; i++) {
-        this.updateButtonModel(buttonName[i], evtName);
+        this.setButtonColor(buttonName[i], color);
       }
     } else {
-      this.updateButtonModel(buttonName, evtName);
+      this.setButtonColor(buttonName, color);
     }
   },
 
-  updateButtonModel: function (buttonName, state) {
-    var color = state === 'up' ? this.data.buttonColor : this.data.buttonHighlightColor;
+  setButtonColor: function (buttonName, color) {
     var buttonMeshes = this.buttonMeshes;
+
     if (!buttonMeshes) { return; }
+
+    // Need to do both left and right sides for grip.
     if (buttonName === 'grip') {
       buttonMeshes.grip.left.material.color.set(color);
       buttonMeshes.grip.right.material.color.set(color);

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -55,6 +55,8 @@ module.exports.Component = registerComponent('vive-controls', {
     this.onButtonChanged = bind(this.onButtonChanged, this);
     this.onButtonDown = function (evt) { self.onButtonEvent(evt.detail.id, 'down'); };
     this.onButtonUp = function (evt) { self.onButtonEvent(evt.detail.id, 'up'); };
+    this.onButtonTouchEnd = function (evt) { self.onButtonEvent(evt.detail.id, 'touchend'); };
+    this.onButtonTouchStart = function (evt) { self.onButtonEvent(evt.detail.id, 'touchstart'); };
     this.onAxisMoved = bind(this.onAxisMoved, this);
     this.previousButtonValues = {};
 
@@ -202,6 +204,10 @@ module.exports.Component = registerComponent('vive-controls', {
     var buttonName = this.mapping.buttons[id];
     var color;
     var i;
+    var isTouch = evtName.indexOf('touch') !== -1;
+
+    // Only trackpad has touch. Ignore for the rest, even if Gamepad API says touched.
+    if (isTouch && buttonName !== 'trackpad') { return; }
 
     // Emit events.
     if (Array.isArray(buttonName)) {
@@ -213,6 +219,9 @@ module.exports.Component = registerComponent('vive-controls', {
     }
 
     if (!this.data.model) { return; }
+
+    // Don't change color for trackpad touch.
+    if (isTouch) { return; }
 
     // Update colors.
     color = evtName === 'up' ? this.data.buttonColor : this.data.buttonHighlightColor;

--- a/tests/components/vive-controls.test.js
+++ b/tests/components/vive-controls.test.js
@@ -282,5 +282,31 @@ suite('vive-controls', function () {
       });
       component.injectTrackedControls();
     });
+
+    test('does not change color for trigger touch', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        el.emit('touchstart', {id: 1, state: {}});
+        setTimeout(() => {
+          var color = component.buttonMeshes.trigger.material.color;
+          assert.equal(new THREE.Color(color).getHexString(), 'fafafa');
+          done();
+        });
+      });
+      component.injectTrackedControls();
+    });
+
+    test('does not change color for trackpad touch', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        el.emit('touchstart', {id: 0, state: {}});
+        setTimeout(() => {
+          var color = component.buttonMeshes.trackpad.material.color;
+          assert.equal(new THREE.Color(color).getHexString(), 'fafafa');
+          done();
+        });
+      });
+      component.injectTrackedControls();
+    });
   });
 });

--- a/tests/components/vive-controls.test.js
+++ b/tests/components/vive-controls.test.js
@@ -1,203 +1,286 @@
-/* global assert, process, setup, suite, test, CustomEvent, Event */
+/* global assert, Event, process, setup, suite, test, THREE */
 var entityFactory = require('../helpers').entityFactory;
-var controllerComponentName = 'vive-controls';
 
-suite(controllerComponentName, function () {
+suite('vive-controls', function () {
+  var component;
+  var controlsSystem;
+  var el;
+
   setup(function (done) {
-    var el = this.el = entityFactory();
-    el.setAttribute(controllerComponentName, 'hand: right'); // to ensure index = 0
-    el.addEventListener('loaded', function () {
-      var controllerComponent = el.components[controllerComponentName];
-      controllerComponent.controllersWhenPresent = [{id: 'OpenVR Gamepad', index: 0, hand: 'right', pose: {}}];
+    el = entityFactory();
+    el.setAttribute('vive-controls', 'hand: right');  // To ensure index = 0.
+    el.addEventListener('componentinitialized', function (evt) {
+      if (evt.detail.name !== 'vive-controls') { return; }
+      component = el.components['vive-controls'];
+      component.controllersWhenPresent = [
+        {id: 'OpenVR Gamepad', index: 0, hand: 'right', pose: {}}
+      ];
+      controlsSystem = el.sceneEl.systems['tracked-controls'];
       done();
     });
   });
 
   suite('checkIfControllerPresent', function () {
-    test('first-time, if no controllers, remember not present', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
+    test('remember not present if no controllers on first call', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      controlsSystem.controllers = [];
 
-      el.sceneEl.systems['tracked-controls'].controllers = [];
+      // Mock not looked before.
+      component.controllerPresent = false;
 
-      // reset so we don't think we've looked before
-      controllerComponent.controllerPresent = false;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // check assertions
+      component.checkIfControllerPresent();
+
       assert.notOk(injectTrackedControlsSpy.called);
       assert.notOk(addEventListenersSpy.called);
-      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+      assert.strictEqual(component.controllerPresent, false);  // Not undefined.
     });
 
-    test('if no controllers again, do not remove event listeners', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+    test('does not remove event listeners if no controllers again', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      controlsSystem.controllers = [];
 
-      el.sceneEl.systems['tracked-controls'].controllers = [];
+      // Mock not looked before.
+      component.controllerPresent = false;
 
-      // pretend we've looked before
-      controllerComponent.controllerPresent = false;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // check assertions
+      component.checkIfControllerPresent();
+
       assert.notOk(injectTrackedControlsSpy.called);
       assert.notOk(addEventListenersSpy.called);
       assert.notOk(removeEventListenersSpy.called);
-      assert.ok(controllerComponent.controllerPresent === false); // not undefined
+      assert.strictEqual(component.controllerPresent, false);  // Not undefined.
     });
 
-    test('attach events if controller is newly present', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+    test('attaches events if controller is newly present', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      controlsSystem.controllers = component.controllersWhenPresent;
 
-      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // Mock not looked before.
+      component.controllerPresent = false;
 
-      // reset so we don't think we've looked before
-      controllerComponent.controllerPresent = false;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // check assertions
+      component.checkIfControllerPresent();
+
       assert.ok(injectTrackedControlsSpy.called);
       assert.ok(addEventListenersSpy.called);
       assert.notOk(removeEventListenersSpy.called);
-      assert.ok(controllerComponent.controllerPresent);
+      assert.ok(component.controllerPresent);
     });
 
-    test('do not inject or attach events again if controller is already present', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+    test('does not inject/attach events again if controller is already present', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      controlsSystem.controllers = component.controllersWhenPresent;
 
-      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
+      // Mock looked before.
+      component.controllerPresent = true;
 
-      // pretend we've looked before
-      controllerComponent.controllerPresent = true;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // check assertions
+      component.checkIfControllerPresent();
+
       assert.notOk(injectTrackedControlsSpy.called);
       assert.notOk(addEventListenersSpy.called);
       assert.notOk(removeEventListenersSpy.called);
-      assert.ok(controllerComponent.controllerPresent);
+      assert.ok(component.controllerPresent);
     });
 
-    test('if controller disappears, remove event listeners', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var addEventListenersSpy = this.sinon.spy(controllerComponent, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(controllerComponent, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(controllerComponent, 'removeEventListeners');
+    test('remove event listeners if controller disappears', function () {
+      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      controlsSystem.controllers = [];
 
-      el.sceneEl.systems['tracked-controls'].controllers = [];
+      // Mock looked before.
+      component.controllerPresent = true;
 
-      // pretend we've looked before
-      controllerComponent.controllerPresent = true;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // check assertions
+      component.checkIfControllerPresent();
+
       assert.notOk(injectTrackedControlsSpy.called);
       assert.notOk(addEventListenersSpy.called);
       assert.ok(removeEventListenersSpy.called);
-      assert.notOk(controllerComponent.controllerPresent);
+      assert.notOk(component.controllerPresent);
     });
   });
 
   suite('axismove', function () {
-    var name = 'trackpad';
-    test('if we get axismove, emit ' + name + 'moved', function (done) {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var evt;
+    test('emits trackpadmoved on axismove', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
 
-      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // install event handler listening for thumbstickmoved
-      this.el.addEventListener(name + 'moved', function (evt) {
+      component.checkIfControllerPresent();
+
+      // Install event handler listening for trackpad.
+      el.addEventListener('trackpadmoved', function (evt) {
         assert.equal(evt.detail.x, 0.1);
         assert.equal(evt.detail.y, 0.2);
         assert.ok(evt.detail);
         done();
       });
-      // emit axismove
-      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [true, false]}});
-      this.el.dispatchEvent(evt);
+
+      // Emit axismove.
+      el.emit('axismove', {axis: [0.1, 0.2], changed: [true, false]});
     });
 
-    test('if we get axismove with no changes, do not emit ' + name + 'moved', function (done) {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var evt;
+    test('does not emit trackpadmoved on axismove with no changes', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
+      component.checkIfControllerPresent();
 
-      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // install event handler listening for thumbstickmoved
-      this.el.addEventListener(name + 'moved', function (evt) {
+      // Install event handler listening for trackpadmoved.
+      el.addEventListener('trackpadmoved', function (evt) {
         assert.notOk(evt.detail);
       });
-      // emit axismove
-      evt = new CustomEvent('axismove', {'detail': {axis: [0.1, 0.2], changed: [false, false]}});
-      this.el.dispatchEvent(evt);
-      // finish next tick
-      setTimeout(function () { done(); }, 0);
+
+      // Emit axismove.
+      el.emit('axismove', {axis: [0.1, 0.2], changed: [false, false]});
+
+      setTimeout(function () { done(); });
     });
   });
 
   suite('buttonchanged', function () {
-    var name = 'trigger';
-    var id = 1;
-    test('if we get buttonchanged, emit ' + name + 'changed', function (done) {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var evt;
+    test('emits triggerchanged on buttonchanged', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
+      component.checkIfControllerPresent();
 
-      el.sceneEl.systems['tracked-controls'].controllers = controllerComponent.controllersWhenPresent;
-      // do the check
-      controllerComponent.checkIfControllerPresent();
-      // install event handler listening for triggerchanged
-      this.el.addEventListener(name + 'changed', function (evt) {
+      // Install event handler listening for triggerchanged.
+      el.addEventListener('triggerchanged', function (evt) {
         assert.ok(evt.detail);
         done();
       });
-      // emit buttonchanged
-      evt = new CustomEvent('buttonchanged', {'detail': {id: id, state: {value: 0.5, pressed: true, touched: true}}});
-      this.el.dispatchEvent(evt);
+
+      // Emit buttonchanged.
+      el.emit('buttonchanged', {id: 1, state: {value: 0.5, pressed: true, touched: true}});
+    });
+
+    test('emits triggerdown on buttonchanged', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
+      component.checkIfControllerPresent();
+      el.addEventListener('triggerdown', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+      el.emit('buttondown', {id: 1});
+    });
+
+    test('emits triggerup on buttonchanged', function (done) {
+      controlsSystem.controllers = component.controllersWhenPresent;
+      component.checkIfControllerPresent();
+      el.addEventListener('triggerup', function (evt) {
+        assert.ok(evt.detail);
+        done();
+      });
+      el.emit('buttonup', {id: 1});
     });
   });
 
   suite('gamepaddisconnected', function () {
-    // Due to an apparent bug in FF Nightly
-    // where only one gamepadconnected / disconnected event is fired,
-    // which makes it difficult to handle in individual controller entities,
-    // we no longer remove the controllersupdate listener as a result.
-    test('if we get gamepaddisconnected, check if present', function () {
-      var el = this.el;
-      var controllerComponent = el.components[controllerComponentName];
-      var checkIfControllerPresentSpy = this.sinon.spy(controllerComponent, 'checkIfControllerPresent');
+    /*
+      Apparent bug in FF Nightly where only one gamepadconnected/disconnected event is
+      fired which makes it difficult to handle in individual controller entities. We no
+      longer remove the controllersupdate listener as a result.
+    */
+    test('checks if controller present on gamepaddisconnected', function () {
+      var checkIfControllerPresentSpy = this.sinon.spy(component, 'checkIfControllerPresent');
       // Because checkIfControllerPresent may be used in bound form, bind and reinstall.
-      controllerComponent.checkIfControllerPresent = controllerComponent.checkIfControllerPresent.bind(controllerComponent);
-      controllerComponent.pause();
-      controllerComponent.play();
+      component.checkIfControllerPresent = component.checkIfControllerPresent.bind(component);
+      component.pause();
+      component.play();
 
-      el.sceneEl.systems['tracked-controls'].controllers = [];
-      // reset everGotGamepadEvent so we don't think we've looked before
-      delete controllerComponent.everGotGamepadEvent;
-      // fire emulated gamepaddisconnected event
+      controlsSystem.controllers = [];
+      // Reset everGotGamepadEvent to mock not looked before.
+      delete component.everGotGamepadEvent;
+      // Fire emulated gamepaddisconnected event.
       window.dispatchEvent(new Event('gamepaddisconnected'));
-      // check assertions
       assert.ok(checkIfControllerPresentSpy.called);
+    });
+  });
+
+  suite('model', function () {
+    test('loads', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        assert.ok(component.buttonMeshes);
+        assert.ok(component.buttonMeshes.trigger);
+        assert.ok(el.getObject3D('mesh'));
+        done();
+      });
+      component.injectTrackedControls();
+    });
+  });
+
+  suite('button colors', function () {
+    test('has trigger at default color', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        var color = component.buttonMeshes.trigger.material.color;
+        assert.equal(new THREE.Color(color).getHexString(), 'fafafa');
+        done();
+      });
+      component.injectTrackedControls();
+    });
+
+    test('has trackpad at default color', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        var color = component.buttonMeshes.trackpad.material.color;
+        assert.equal(new THREE.Color(color).getHexString(), 'fafafa');
+        done();
+      });
+      component.injectTrackedControls();
+    });
+
+    test('has grips at default colors', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        var color = component.buttonMeshes.grip.left.material.color;
+        assert.equal(new THREE.Color(color).getHexString(), 'fafafa');
+        color = component.buttonMeshes.grip.right.material.color;
+        assert.equal(new THREE.Color(color).getHexString(), 'fafafa');
+        done();
+      });
+      component.injectTrackedControls();
+    });
+
+    test('sets trigger to highlight color when down', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        el.emit('buttondown', {id: 1, state: {}});
+        setTimeout(() => {
+          var color = component.buttonMeshes.trigger.material.color;
+          assert.equal(new THREE.Color(color).getHexString(), '22d1ee');
+          done();
+        });
+      });
+      component.injectTrackedControls();
+    });
+
+    test('sets trigger back to default color when up', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        component.buttonMeshes.trigger.material.color.set('#22d1ee');
+        el.emit('buttonup', {id: 1, state: {}});
+        setTimeout(() => {
+          var color = component.buttonMeshes.trigger.material.color;
+          assert.equal(new THREE.Color(color).getHexString(), 'fafafa');
+          done();
+        });
+      });
+      component.injectTrackedControls();
+    });
+
+    test('sets trackpad to highlight color when down', function (done) {
+      component.addEventListeners();
+      el.addEventListener('model-loaded', function (evt) {
+        el.emit('buttondown', {id: 0, state: {}});
+        setTimeout(() => {
+          var color = component.buttonMeshes.trackpad.material.color;
+          assert.equal(new THREE.Color(color).getHexString(), '22d1ee');
+          done();
+        });
+      });
+      component.injectTrackedControls();
     });
   });
 });


### PR DESCRIPTION
**Description:**

When Vive button was pressed, it would do:

- handle buttondown -> change to highlight color 
- handle buttonup -> change to default coor
- handle touchend -> change to highlight color

Vive buttons don't have capacitive touch, remove touch-related handlers.

**Changes proposed:**
- Remove touch related handlers from Vive controls. PR has lots of extra changes, but removing those few lines of code is all that's needed to fix the original issue.
- Clean code, tests, add tests
- [x] Tested on Vive/Windows/FF Nightly
