### PR TITLE
Docs: Corrected Typo changed word semicolon to colon and vice-versa

### DIFF
--- a/docs/introduction/entity-component-system.md
+++ b/docs/introduction/entity-component-system.md
@@ -120,8 +120,8 @@ A-Frame has APIs that represents each piece of ECS:
 
 We create `<a-entity>` and attach components as HTML attributes. Most
 components have multiple properties that are represented by a syntax similar to
-[`HTMLElement.style` CSS][style]. This syntax takes the form with a semicolon
-(`:`) separating property names from property values, and a colon (`;`)
+[`HTMLElement.style` CSS][style]. This syntax takes the form with a colon
+(`:`) separating property names from property values, and a semicolon (`;`)
 separating different property declarations:
 
 `<a-entity ${componentName}="${propertyName1}: ${propertyValue1}; ${propertyName2:}: ${propertyValue2}">`


### PR DESCRIPTION
Description:
Documentation Issue
The paragraph (described below) in section indicated by link below has a typo:
https://aframe.io/docs/0.5.0/introduction/entity-component-system.html#syntax

Excerpt of passage which needs correction:

...This syntax takes the form with a semicolon (:) separating property names from property values, and a colon (;) separating different property declarations: ...

Correction should be:

...This syntax takes the form with a colon (:) separating property names from property values, and a semicolon (;) separating different property declarations: ...

**Description:**

**Changes proposed:**
-
-
-
