### PR TITLE
removed position

### DIFF
--- a/docs/primitives/a-sound.md
+++ b/docs/primitives/a-sound.md
@@ -11,7 +11,7 @@ The sound primitive wraps the [sound component](../components/sound.md).
 
 ```html
 <a-scene>
-  <a-sound src="src: url(click.mp3)" autoplay="true" position="0 2 5"></a-sound>
+  <a-sound src="src: url(click.mp3)" autoplay="true"></a-sound>
 </a-scene>
 ```
 


### PR DESCRIPTION
The position attribute implies that this component alone can do positional audio, which is not true (as of 0.5)
To have positional audio, you need to attach this to another entity.

**Description:**

**Changes proposed:**
-
-
-
