### PR TITLE
emit touch events for non-trackpad buttons in vive-controls

### DIFF
--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -206,9 +206,6 @@ module.exports.Component = registerComponent('vive-controls', {
     var i;
     var isTouch = evtName.indexOf('touch') !== -1;
 
-    // Only trackpad has touch. Ignore for the rest, even if Gamepad API says touched.
-    if (isTouch && buttonName !== 'trackpad') { return; }
-
     // Emit events.
     if (Array.isArray(buttonName)) {
       for (i = 0; i < buttonName.length; i++) {


### PR DESCRIPTION
for uniformity with other controller types.

May be worth refactoring later so that buttons that should allow touch events (e.g. analog buttons, touch/trackpads, digital buttons with capacitive touch) are specifically enumerated in mapping or similar construct. 

https://github.com/aframevr/aframe/pull/2772/files#diff-8eb3323319bd9dc995e7909096d022a6R209
```
GitHub
fix vive-controls button colors by ngokevin · Pull Request #2772 · aframevr/aframe
Description: When Vive button was pressed, it would do: handle buttondown -> change to highlight color handle buttonup -> change to default coor handle touchend -> change to highlight color Vive ...
 

[1:39] 
The handlers are there, but the return is before both updating the model AND emitting the events, right?  (I think to preserve the event emitting, the return would go after emits but before update model?) (edited)

ngokevin [3:46 AM] 
hm yeah i guess i removed triggertouched and friends. i think makes sense since it won’t fire on a capacitive touch, it requires a substantial travel on the trigger. the *touched was not documented before and i don’t think anyone’s using it

mchen [11:36 AM] 
Really comes down to - emit for backward compatibility, or see who if anyone complains?  What I don't like is the specificity of change to vive-controls only
```