### PR TITLE
[docs]

### DIFF
--- a/docs/guides/building-a-basic-scene.md
+++ b/docs/guides/building-a-basic-scene.md
@@ -351,7 +351,7 @@ repeat in the Y direction (commonly referred to as U and V for textures).
 
 [light]: ../primitives/a-light.md
 
-We can change how the scene is lit by using [`<a-light>s`][light]. By default
+We can change how the scene is lit by using [`<a-lights>`][light]. By default
 if we don't specify any lights, A-Frame adds an ambient light and a directional
 light. If A-Frame didn't add lights for us, the scene would be black. Once we
 add lights of our own, however, the default lighting setup is removed and


### PR DESCRIPTION
**Description:**
Fix typo on the [building a basic scene page](https://aframe.io/docs/0.5.0/guides/building-a-basic-scene.html#tweaking-lighting) under the tweaking light title.

**Changes proposed:**
- from `<a-light>s` to `<a-lights>`