### PR TITLE
look controls integration unit tests

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -1,12 +1,15 @@
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
-var isMobile = require('../utils/').device.isMobile();
 var bind = require('../utils/bind');
 
 // To avoid recalculation at every mouse movement tick
+var GRABBING_CLASS = 'a-grabbing';
 var PI_2 = Math.PI / 2;
 var radToDeg = THREE.Math.radToDeg;
 
+/**
+ * look-controls. Update entity pose, factoring mouse, touch, and WebVR API data.
+ */
 module.exports.Component = registerComponent('look-controls', {
   dependencies: ['position', 'rotation'],
 
@@ -20,7 +23,6 @@ module.exports.Component = registerComponent('look-controls', {
   init: function () {
     var sceneEl = this.el.sceneEl;
 
-    // Aux variables
     this.previousHMDPosition = new THREE.Vector3();
     this.hmdQuaternion = new THREE.Quaternion();
     this.hmdEuler = new THREE.Euler();
@@ -29,52 +31,32 @@ module.exports.Component = registerComponent('look-controls', {
     this.setupHMDControls();
     this.bindMethods();
 
-    this.setEnabled(this.data.enabled);
-
     // Reset previous HMD position when we exit VR.
     sceneEl.addEventListener('exit-vr', this.onExitVR);
   },
 
   update: function (oldData) {
     var data = this.data;
-    var hmdEnabled = data.hmdEnabled;
-    if (oldData && data.enabled !== oldData.enabled) {
-      this.setEnabled(data.enabled);
+
+    // Disable grab cursor classes if no longer enabled.
+    if (data.enabled !== oldData.enabled) {
+      this.updateGrabCursor(data.enabled);
     }
-    if (!data.enabled) { return; }
-    if (!hmdEnabled && oldData && hmdEnabled !== oldData.hmdEnabled) {
+
+    // Reset pitch and yaw if disabling HMD.
+    if (oldData && !data.hmdEnabled && !oldData.hmdEnabled) {
       this.pitchObject.rotation.set(0, 0, 0);
       this.yawObject.rotation.set(0, 0, 0);
     }
+  },
+
+  tick: function (t) {
+    var data = this.data;
+    if (!data.enabled) { return; }
     this.controls.standing = data.standing;
     this.controls.update();
     this.updateOrientation();
     this.updatePosition();
-  },
-
-  setEnabled: function (enabled) {
-    var sceneEl = this.el.sceneEl;
-
-    function enableGrabCursor () {
-      sceneEl.canvas.classList.add('a-grab-cursor');
-    }
-    function disableGrabCursor () {
-      sceneEl.canvas.classList.remove('a-grab-cursor');
-    }
-
-    if (!sceneEl.canvas) {
-      if (enabled) {
-        sceneEl.addEventListener('render-target-loaded', enableGrabCursor);
-      } else {
-        sceneEl.addEventListener('render-target-loaded', disableGrabCursor);
-      }
-    } else {
-      if (enabled) {
-        enableGrabCursor();
-      } else {
-        disableGrabCursor();
-      }
-    }
   },
 
   play: function () {
@@ -85,26 +67,24 @@ module.exports.Component = registerComponent('look-controls', {
     this.removeEventListeners();
   },
 
-  tick: function (t) {
-    this.update();
-  },
-
   remove: function () {
-    this.pause();
+    this.removeEventListeners();
   },
 
   bindMethods: function () {
     this.onMouseDown = bind(this.onMouseDown, this);
     this.onMouseMove = bind(this.onMouseMove, this);
-    this.releaseMouse = bind(this.releaseMouse, this);
+    this.onMouseUp = bind(this.onMouseUp, this);
     this.onTouchStart = bind(this.onTouchStart, this);
     this.onTouchMove = bind(this.onTouchMove, this);
     this.onTouchEnd = bind(this.onTouchEnd, this);
     this.onExitVR = bind(this.onExitVR, this);
   },
 
+ /**
+  * Set up states and Object3Ds needed to store rotation data.
+  */
   setupMouseControls: function () {
-    // The canvas where the scene is painted
     this.mouseDown = false;
     this.pitchObject = new THREE.Object3D();
     this.yawObject = new THREE.Object3D();
@@ -112,6 +92,9 @@ module.exports.Component = registerComponent('look-controls', {
     this.yawObject.add(this.pitchObject);
   },
 
+  /**
+   * Set up VR controls that will copy data to the dolly.
+   */
   setupHMDControls: function () {
     this.dolly = new THREE.Object3D();
     this.euler = new THREE.Euler();
@@ -119,66 +102,80 @@ module.exports.Component = registerComponent('look-controls', {
     this.controls.userHeight = 0.0;
   },
 
+  /**
+   * Add mouse and touch event listeners to canvas.
+   */
   addEventListeners: function () {
     var sceneEl = this.el.sceneEl;
     var canvasEl = sceneEl.canvas;
 
-    // listen for canvas to load.
+    // Wait for canvas to load.
     if (!canvasEl) {
       sceneEl.addEventListener('render-target-loaded', bind(this.addEventListeners, this));
       return;
     }
 
-    // Mouse Events
+    // Mouse events.
     canvasEl.addEventListener('mousedown', this.onMouseDown, false);
     window.addEventListener('mousemove', this.onMouseMove, false);
-    window.addEventListener('mouseup', this.releaseMouse, false);
+    window.addEventListener('mouseup', this.onMouseUp, false);
 
-    // Touch events
+    // Touch events.
     canvasEl.addEventListener('touchstart', this.onTouchStart);
     window.addEventListener('touchmove', this.onTouchMove);
     window.addEventListener('touchend', this.onTouchEnd);
   },
 
+  /**
+   * Remove mouse and touch event listeners from canvas.
+   */
   removeEventListeners: function () {
     var sceneEl = this.el.sceneEl;
     var canvasEl = sceneEl && sceneEl.canvas;
+
     if (!canvasEl) { return; }
 
-    // Mouse Events
+    // Mouse events.
     canvasEl.removeEventListener('mousedown', this.onMouseDown);
     canvasEl.removeEventListener('mousemove', this.onMouseMove);
-    canvasEl.removeEventListener('mouseup', this.releaseMouse);
-    canvasEl.removeEventListener('mouseout', this.releaseMouse);
+    canvasEl.removeEventListener('mouseup', this.onMouseUp);
+    canvasEl.removeEventListener('mouseout', this.onMouseUp);
 
-    // Touch events
+    // Touch events.
     canvasEl.removeEventListener('touchstart', this.onTouchStart);
     canvasEl.removeEventListener('touchmove', this.onTouchMove);
     canvasEl.removeEventListener('touchend', this.onTouchEnd);
   },
 
+  /**
+   * Update orientation for mobile, mouse drag, and headset.
+   * Mouse-drag only enabled if HMD is not active.
+   */
   updateOrientation: function () {
     var currentRotation;
     var deltaRotation;
     var hmdEuler = this.hmdEuler;
+    var hmdQuaternion = this.hmdQuaternion;
     var pitchObject = this.pitchObject;
     var yawObject = this.yawObject;
-    var hmdQuaternion = this.calculateHMDQuaternion();
     var sceneEl = this.el.sceneEl;
     var rotation;
 
+    // Calculate HMD quaternion.
+    hmdQuaternion = hmdQuaternion.copy(this.dolly.quaternion);
     hmdEuler.setFromQuaternion(hmdQuaternion, 'YXZ');
-    if (isMobile) {
-      // In mobile we allow camera rotation with touch events and sensors
+
+    if (sceneEl.isMobile) {
+      // On mobile, do camera rotation with touch events and sensors.
       rotation = {
         x: radToDeg(hmdEuler.x) + radToDeg(pitchObject.rotation.x),
         y: radToDeg(hmdEuler.y) + radToDeg(yawObject.rotation.y),
         z: radToDeg(hmdEuler.z)
       };
     } else if (!sceneEl.is('vr-mode') || isNullVector(hmdEuler) || !this.data.hmdEnabled) {
+      // Mouse drag if WebVR not active (not connected, no incoming sensor data).
       currentRotation = this.el.getAttribute('rotation');
       deltaRotation = this.calculateDeltaRotation();
-      // Mouse look only if HMD disabled or no info coming from the sensors
       if (this.data.reverseMouseDrag) {
         rotation = {
           x: currentRotation.x - deltaRotation.x,
@@ -193,51 +190,57 @@ module.exports.Component = registerComponent('look-controls', {
         };
       }
     } else {
-      // Mouse rotation ignored with an active headset. User head rotation takes priority.
+      // Mouse rotation ignored with an active headset. Use headset rotation.
       rotation = {
         x: radToDeg(hmdEuler.x),
         y: radToDeg(hmdEuler.y),
         z: radToDeg(hmdEuler.z)
       };
     }
+
     this.el.setAttribute('rotation', rotation);
   },
 
+  /**
+   * Calculate delta rotation for mouse-drag and touch-drag.
+   */
   calculateDeltaRotation: function () {
     var currentRotationX = radToDeg(this.pitchObject.rotation.x);
     var currentRotationY = radToDeg(this.yawObject.rotation.y);
     var deltaRotation;
-    this.previousRotationX = this.previousRotationX || currentRotationX;
-    this.previousRotationY = this.previousRotationY || currentRotationY;
     deltaRotation = {
-      x: currentRotationX - this.previousRotationX,
-      y: currentRotationY - this.previousRotationY
+      x: currentRotationX - (this.previousRotationX || 0),
+      y: currentRotationY - (this.previousRotationY || 0)
     };
+    // Store current rotation for next tick.
     this.previousRotationX = currentRotationX;
     this.previousRotationY = currentRotationY;
     return deltaRotation;
   },
 
-  calculateHMDQuaternion: function () {
-    var hmdQuaternion = this.hmdQuaternion;
-    hmdQuaternion.copy(this.dolly.quaternion);
-    return hmdQuaternion;
-  },
-
+  /**
+   * Handle positional tracking.
+   */
   updatePosition: (function () {
     var deltaHMDPosition = new THREE.Vector3();
+
     return function () {
       var el = this.el;
       var currentPosition = el.getAttribute('position');
       var currentHMDPosition;
       var previousHMDPosition = this.previousHMDPosition;
       var sceneEl = this.el.sceneEl;
+
+      if (!sceneEl.is('vr-mode')) { return; }
+
+      // Calculate change in position.
       currentHMDPosition = this.calculateHMDPosition();
       deltaHMDPosition.copy(currentHMDPosition).sub(previousHMDPosition);
-      if (!sceneEl.is('vr-mode') || isNullVector(deltaHMDPosition)) { return; }
+
+      if (isNullVector(deltaHMDPosition)) { return; }
+
       previousHMDPosition.copy(currentHMDPosition);
-      // Do nothing if we have not moved.
-      if (!sceneEl.is('vr-mode')) { return; }
+
       el.setAttribute('position', {
         x: currentPosition.x + deltaHMDPosition.x,
         y: currentPosition.y + deltaHMDPosition.y,
@@ -246,78 +249,135 @@ module.exports.Component = registerComponent('look-controls', {
     };
   })(),
 
-  calculateHMDPosition: function () {
-    var dolly = this.dolly;
+  /**
+   * Get headset position from VRControls.
+   */
+  calculateHMDPosition: (function () {
     var position = new THREE.Vector3();
-    dolly.updateMatrix();
-    position.setFromMatrixPosition(dolly.matrix);
-    return position;
-  },
+    return function () {
+      this.dolly.updateMatrix();
+      position.setFromMatrixPosition(this.dolly.matrix);
+      return position;
+    };
+  })(),
 
+  /**
+   * Translate mouse drag into rotation.
+   *
+   * Dragging up and down rotates the camera around the X-axis (yaw).
+   * Dragging left and right rotates the camera around the Y-axis (pitch).
+   */
   onMouseMove: function (event) {
     var pitchObject = this.pitchObject;
     var yawObject = this.yawObject;
     var previousMouseEvent = this.previousMouseEvent;
+    var movementX;
+    var movementY;
 
+    // Not dragging or not enabled.
     if (!this.mouseDown || !this.data.enabled) { return; }
 
-    var movementX = event.movementX || event.mozMovementX;
-    var movementY = event.movementY || event.mozMovementY;
-
+     // Calculate delta.
+    movementX = event.movementX || event.mozMovementX;
+    movementY = event.movementY || event.mozMovementY;
     if (movementX === undefined || movementY === undefined) {
       movementX = event.screenX - previousMouseEvent.screenX;
       movementY = event.screenY - previousMouseEvent.screenY;
     }
     this.previousMouseEvent = event;
 
+    // Calculate rotation.
     yawObject.rotation.y -= movementX * 0.002;
     pitchObject.rotation.x -= movementY * 0.002;
     pitchObject.rotation.x = Math.max(-PI_2, Math.min(PI_2, pitchObject.rotation.x));
   },
 
-  onMouseDown: function (event) {
+  /**
+   * Register mouse down to detect mouse drag.
+   */
+  onMouseDown: function (evt) {
     if (!this.data.enabled) { return; }
     // Handle only primary button.
-    if (event.button !== 0) { return; }
+    if (evt.button !== 0) { return; }
     this.mouseDown = true;
-    this.previousMouseEvent = event;
-    document.body.classList.add('a-grabbing');
+    this.previousMouseEvent = evt;
+    document.body.classList.add(GRABBING_CLASS);
   },
 
-  releaseMouse: function () {
+  /**
+   * Register mouse up to detect release of mouse drag.
+   */
+  onMouseUp: function () {
     this.mouseDown = false;
-    document.body.classList.remove('a-grabbing');
+    document.body.classList.remove(GRABBING_CLASS);
   },
 
-  onTouchStart: function (e) {
-    if (e.touches.length !== 1) { return; }
+  /**
+   * Register touch down to detect touch drag.
+   */
+  onTouchStart: function (evt) {
+    if (evt.touches.length !== 1) { return; }
     this.touchStart = {
-      x: e.touches[0].pageX,
-      y: e.touches[0].pageY
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
     };
     this.touchStarted = true;
   },
 
-  onTouchMove: function (e) {
+  /**
+   * Translate touch move to Y-axis rotation.
+   */
+  onTouchMove: function (evt) {
+    var canvas = this.el.sceneEl.canvas;
     var deltaY;
     var yawObject = this.yawObject;
+
     if (!this.touchStarted) { return; }
-    deltaY = 2 * Math.PI * (e.touches[0].pageX - this.touchStart.x) /
-            this.el.sceneEl.canvas.clientWidth;
-    // Limits touch orientaion to to yaw (y axis)
+
+    deltaY = 2 * Math.PI * (evt.touches[0].pageX - this.touchStart.x) / canvas.clientWidth;
+
+    // Limit touch orientaion to to yaw (y axis).
     yawObject.rotation.y -= deltaY * 0.5;
     this.touchStart = {
-      x: e.touches[0].pageX,
-      y: e.touches[0].pageY
+      x: evt.touches[0].pageX,
+      y: evt.touches[0].pageY
     };
   },
 
+  /**
+   * Register touch end to detect release of touch drag.
+   */
   onTouchEnd: function () {
     this.touchStarted = false;
   },
 
   onExitVR: function () {
     this.previousHMDPosition.set(0, 0, 0);
+  },
+
+  /**
+   * Toggle the feature of showing/hiding the grab cursor.
+   */
+  updateGrabCursor: function (enabled) {
+    var sceneEl = this.el.sceneEl;
+
+    function enableGrabCursor () { sceneEl.canvas.classList.add('a-grab-cursor'); }
+    function disableGrabCursor () { sceneEl.canvas.classList.remove('a-grab-cursor'); }
+
+    if (!sceneEl.canvas) {
+      if (enabled) {
+        sceneEl.addEventListener('render-target-loaded', enableGrabCursor);
+      } else {
+        sceneEl.addEventListener('render-target-loaded', disableGrabCursor);
+      }
+      return;
+    }
+
+    if (enabled) {
+      enableGrabCursor();
+      return;
+    }
+    disableGrabCursor();
   }
 });
 

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -35,7 +35,7 @@ var proto = Object.create(ANode.prototype, {
   createdCallback: {
     value: function () {
       this.components = {};
-      // to avoid double initializations and infinite loops
+      // To avoid double initializations and infinite loops.
       this.initializingComponents = {};
       this.isEntity = true;
       this.isPlaying = false;

--- a/tests/core/controls.test.js
+++ b/tests/core/controls.test.js
@@ -1,5 +1,8 @@
 /* global Event, assert, process, setup, suite, test */
 var helpers = require('../helpers');
+var THREE = require('lib/three');
+
+var PI = Math.PI;
 
 suite('position controls on camera with WASD controls (integration unit test)', function () {
   setup(function (done) {
@@ -122,6 +125,332 @@ suite('position controls on camera with WASD controls (integration unit test)', 
         assert.equal(Math.round(newPos.z), position.z);
         done();
       });
+    });
+  });
+});
+
+suite('rotation controls on camera with VRControls (integration unit test)', function () {
+  setup(function (done) {
+    var el = helpers.entityFactory();
+    var self = this;
+
+    function StubVRControls (dolly) {
+      var sceneEl = el.sceneEl;
+      self.dolly = dolly;
+      self.el = sceneEl.querySelector('[camera]');
+      self.el.addEventListener('componentinitialized', function (evt) {
+        if (evt.detail.name !== 'look-controls') { return; }
+        done();
+      });
+    }
+
+    el.addEventListener('loaded', function () {
+      StubVRControls.prototype.update = function () { /* no-op */ };
+      self.sinon.stub(THREE, 'VRControls', StubVRControls);
+    });
+  });
+
+  test('rotates camera around Y', function (done) {
+    var el = this.el;
+    el.sceneEl.addState('vr-mode');
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(0, PI, 0));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(Math.round(rotation.x), 0);
+      assert.equal(Math.round(rotation.y), 180);
+      assert.equal(Math.round(rotation.z), 0);
+      done();
+    });
+  });
+
+  test('rotates camera composing X and Y', function (done) {
+    var el = this.el;
+    el.sceneEl.addState('vr-mode');
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 4, PI, 0));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(Math.round(rotation.x), -45);
+      assert.equal(Math.round(rotation.y), 180);
+      assert.equal(Math.round(rotation.z), 0);
+      done();
+    });
+  });
+
+  test('rotates camera composing X and Y and Z', function (done) {
+    var el = this.el;
+    el.sceneEl.addState('vr-mode');
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 2, PI / 6, PI / 2));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(Math.round(rotation.x), 60);
+      assert.equal(Math.round(rotation.y), 90);
+      assert.equal(Math.round(rotation.z), 180);
+      done();
+    });
+  });
+
+  test('replaces previous rotation', function (done) {
+    var el = this.el;
+    el.sceneEl.addState('vr-mode');
+    el.setAttribute('rotation', {x: -10000, y: -10000, z: -10000});
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 2, PI / 6, PI / 2));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(Math.round(rotation.x), 60);
+      assert.equal(Math.round(rotation.y), 90);
+      assert.equal(Math.round(rotation.z), 180);
+      done();
+    });
+  });
+
+  test('does not rotate camera if not in VR', function (done) {
+    var el = this.el;
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(0, PI, 0));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(rotation.x, 0);
+      assert.equal(rotation.y, 0);
+      assert.equal(rotation.z, 0);
+      done();
+    });
+  });
+});
+
+suite('rotation controls on camera with mouse drag (integration unit test)', function () {
+  setup(function (done) {
+    var el = helpers.entityFactory();
+    var self = this;
+
+    function StubVRControls (dolly) {
+      self.dolly = dolly;
+      self.el = el.sceneEl.querySelector('[camera]');  // Default camera.
+      process.nextTick(function () {
+        done();  // Done once we get a grip on VRControls created through the default camera.
+      });
+    }
+    StubVRControls.prototype.update = function () { /* no-op */ };
+    this.sinon.stub(THREE, 'VRControls', StubVRControls);
+  });
+
+  test('rotates camera on dragging mouse around X', function (done) {
+    var el = this.el;
+    var mousedownEvent = new Event('mousedown');
+    mousedownEvent.button = 0;
+    el.sceneEl.canvas.dispatchEvent(mousedownEvent);
+
+    process.nextTick(function afterMousedown () {
+      var mouseMoveEvent = new Event('mousemove');
+      mouseMoveEvent.movementX = 1000;
+      mouseMoveEvent.movementY = 1;
+      mouseMoveEvent.screenX = 1000;
+      mouseMoveEvent.screenY = 1000;
+      window.dispatchEvent(mouseMoveEvent);
+      process.nextTick(function afterMousemove () {
+        el.sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.ok(Math.abs(Math.round(rotation.y)) > 0);
+          done();
+        });
+      });
+    });
+  });
+
+  test('rotates camera on dragging mouse along Y', function (done) {
+    var el = this.el;
+    var mousedownEvent = new Event('mousedown');
+    mousedownEvent.button = 0;
+    el.sceneEl.canvas.dispatchEvent(mousedownEvent);
+
+    process.nextTick(function afterMousedown () {
+      var mouseMoveEvent = new Event('mousemove');
+      mouseMoveEvent.movementX = 1;
+      mouseMoveEvent.movementY = 1000;
+      mouseMoveEvent.screenX = 1000;
+      mouseMoveEvent.screenY = 1000;
+      window.dispatchEvent(mouseMoveEvent);
+      process.nextTick(function afterMousemove () {
+        el.sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.equal(Math.round(rotation.x), -90);
+          done();
+        });
+      });
+    });
+  });
+
+  test('rotates camera dragging mouse on already rotated camera', function (done) {
+    var el = this.el;
+    var mousedownEvent = new Event('mousedown');
+    mousedownEvent.button = 0;
+    el.sceneEl.canvas.dispatchEvent(mousedownEvent);
+
+    el.setAttribute('rotation', {x: 0, y: -360, z: 0});
+
+    process.nextTick(function afterMousedown () {
+      var mouseMoveEvent = new Event('mousemove');
+      mouseMoveEvent.movementX = 1000;
+      mouseMoveEvent.movementY = 1;
+      mouseMoveEvent.screenX = 1000;
+      mouseMoveEvent.screenY = 1000;
+      window.dispatchEvent(mouseMoveEvent);
+      process.nextTick(function afterMousemove () {
+        el.sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.ok(rotation.y < -360, 'Drag applies delta to current rotation.');
+          done();
+        });
+      });
+    });
+  });
+
+  test('does not rotate camera when dragging in VR with headset', function (done) {
+    var el = this.el;
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(0, PI, 0));
+    el.sceneEl.addState('vr-mode');
+    el.sceneEl.canvas.dispatchEvent(new Event('mousedown'));
+
+    process.nextTick(function afterMousedown () {
+      var mouseMoveEvent = new Event('mousemove');
+      mouseMoveEvent.movementX = 1000;
+      mouseMoveEvent.movementY = 1000;
+      mouseMoveEvent.screenX = 1000;
+      mouseMoveEvent.screenY = 1000;
+      window.dispatchEvent(mouseMoveEvent);
+      process.nextTick(function afterMousemove () {
+        el.sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.equal(Math.round(rotation.x), 0);
+          assert.equal(Math.round(rotation.y), 180, 'Use VR controls rotation');
+          assert.equal(Math.round(rotation.z), 0);
+          done();
+        });
+      });
+    });
+  });
+});
+
+suite('rotation controls on camera with touch drag (integration unit test)', function () {
+  setup(function (done) {
+    var el = helpers.entityFactory();
+    var self = this;
+
+    function StubVRControls (dolly) {
+      self.dolly = dolly;
+      self.el = el.sceneEl.querySelector('[camera]');  // Default camera.
+      process.nextTick(function () {
+        done();  // Done once we get a grip on VRControls created through the default camera.
+      });
+    }
+    StubVRControls.prototype.update = function () { /* no-op */ };
+    this.sinon.stub(THREE, 'VRControls', StubVRControls);
+  });
+
+  test('rotates camera on touch dragging around X', function (done) {
+    var canvas;
+    var el = this.el;
+    var sceneEl = el.sceneEl;
+    var touchStartEvent;
+
+    canvas = sceneEl.canvas;
+    sceneEl.isMobile = true;
+    canvas.clientWidth = 1000;
+
+    // Dispatch touchstart event.
+    touchStartEvent = new Event('touchstart');
+    touchStartEvent.touches = [{pageX: 0, pageY: 0}];
+    canvas.dispatchEvent(touchStartEvent);
+
+    process.nextTick(function afterTouchstart () {
+      var touchMoveEvent = new Event('touchmove');
+      touchMoveEvent.touches = [{pageX: 500, pageY: 0}];
+      window.dispatchEvent(touchMoveEvent);
+      process.nextTick(function afterTouchmove () {
+        sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.ok(Math.abs(Math.round(rotation.y)) > 0);
+          done();
+        });
+      });
+    });
+  });
+
+  test('does not rotate camera on touch dragging along Y', function (done) {
+    var canvas;
+    var el = this.el;
+    var sceneEl = el.sceneEl;
+    var touchStartEvent;
+
+    canvas = sceneEl.canvas;
+    sceneEl.isMobile = true;
+    canvas.clientWidth = 1000;
+
+    // Dispatch touchstart event.
+    touchStartEvent = new Event('touchstart');
+    touchStartEvent.touches = [{pageX: 0, pageY: 0}];
+    canvas.dispatchEvent(touchStartEvent);
+
+    process.nextTick(function afterTouchstart () {
+      var touchMoveEvent = new Event('touchmove');
+      touchMoveEvent.touches = [{pageX: 0, pageY: 500}];
+      window.dispatchEvent(touchMoveEvent);
+      process.nextTick(function afterTouchmove () {
+        sceneEl.tick();
+        process.nextTick(function doAssert () {
+          var rotation = el.getAttribute('rotation');
+          assert.equal(Math.round(rotation.x), 0);
+          assert.equal(Math.round(rotation.y), 0);
+          done();
+        });
+      });
+    });
+  });
+});
+
+suite('position controls on camera with VRControls (integration unit test)', function () {
+  setup(function (done) {
+    var el = helpers.entityFactory();
+    var self = this;
+
+    function StubVRControls (dolly) {
+      self.dolly = dolly;
+      self.el = el.sceneEl.querySelector('[camera]');  // Default camera.
+      process.nextTick(function () {
+        done();  // Done once we get a grip on VRControls created through the default camera.
+      });
+    }
+    StubVRControls.prototype.update = function () { /* no-op */ };
+    this.sinon.stub(THREE, 'VRControls', StubVRControls);
+  });
+
+  test('copies matrix to camera in VR mode', function (done) {
+    var el = this.el;
+    var sceneEl = el.sceneEl;
+    var dolly = this.dolly;
+
+    sceneEl.addState('vr-mode');
+    el.components.camera.hasPositionalTracking = true;
+    el.components.camera.removeHeightOffset();
+
+    process.nextTick(function () {
+      var position;
+      dolly.position.set(-1, 2, 3);
+      sceneEl.tick();
+
+      position = el.getAttribute('position');
+      assert.equal(position.x, -1);
+      assert.equal(position.y, 2);
+      assert.equal(position.z, 3);
+      done();
     });
   });
 });


### PR DESCRIPTION
**Description:**

Updated from #1853

**Changes proposed:**
- Tests for mouse, touch, headset
- Cleanup includes comments, not calling handlers from another handler, renaming `setEnabled` to `updateGrabCursor`
- Save a `Vector3` being created on each tick
- [x] Tested in Vive
- [x] Tested on desktop with mouse drag
- [x] Tested on mobile with polyfill + touch drag
