### PR TITLE
[doc] geometry translate property obsolete

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -203,7 +203,7 @@ Read more about [component-to-DOM serialization][component-to-dom-serialization]
 // <a-entity geometry="primitive: box; width: 3">
 
 entity.getAttribute('geometry');
-// >> {primitive: "box", depth: 2, height: 2, translate: "0 0 0", width: 3, ...}
+// >> {primitive: "box", depth: 2, height: 2, width: 3, ...}
 
 entity.getAttribute('geometry').primitive;
 // >> "box"


### PR DESCRIPTION
translate: "0 0 0" does not apply anymore for a geometry component, I believe.

**Description:**
geometry translate property obsolete
**Changes proposed:**
- see commit
-
-
