### PR TITLE
Modified extend to take into account primitive and absent values

### DIFF
--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -101,11 +101,11 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
 
           return data;
 
+          /**
+           * For the base to be extensible, both objects must be pure JavaScript objects.
+           * The function assumes that base is undefined, or null or a pure object.
+           */
           function extend (base, extension) {
-            // XXX: For the base to be extensible, both objects must be pure
-            // JavaScript objects. The function assumes that base is
-            // undefined, or null or a pure JavaScript object.
-
             if (isUndefined(base)) {
               return copy(extension);
             }

--- a/src/extras/primitives/primitives.js
+++ b/src/extras/primitives/primitives.js
@@ -78,7 +78,7 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
             mixins.forEach(function applyMixin (mixinId) {
               var mixinComponents = self.sceneEl.querySelector('#' + mixinId).componentCache;
               Object.keys(mixinComponents).forEach(function setComponent (name) {
-                data[name] = utils.extendDeep(data[name] || {}, mixinComponents[name]);
+                data[name] = extend(data[name], mixinComponents[name]);
               });
             });
           }
@@ -100,6 +100,38 @@ module.exports.registerPrimitive = function registerPrimitive (name, definition)
           }
 
           return data;
+
+          function extend (base, extension) {
+            // XXX: For the base to be extensible, both objects must be pure
+            // JavaScript objects. The function assumes that base is
+            // undefined, or null or a pure JavaScript object.
+
+            if (isUndefined(base)) {
+              return copy(extension);
+            }
+            if (isUndefined(extension)) {
+              return copy(base);
+            }
+            if (isPureObject(base) && isPureObject(extension)) {
+              return utils.extendDeep(base, extension);
+            }
+            return copy(extension);
+          }
+
+          function isUndefined (value) {
+            return typeof value === 'undefined';
+          }
+
+          function copy (value) {
+            if (isPureObject(value)) {
+              return utils.extendDeep({}, value);
+            }
+            return value;
+          }
+
+          function isPureObject (value) {
+            return value !== null && value.constructor === Object;
+          }
         }
       },
 

--- a/tests/extras/primitives/primitives.test.js
+++ b/tests/extras/primitives/primitives.test.js
@@ -146,6 +146,71 @@ suite('registerPrimitive (using innerHTML)', function () {
     });
   });
 
+  test('merges mixin for multi-prop component', function (done) {
+    primitiveFactory({
+      defaultComponents: {
+        material: {color: 'blue'}
+      }
+    }, 'mixin="foo"', function postCreation (el) {
+      assert.equal(el.getAttribute('material').color, 'blue');
+      assert.equal(el.getAttribute('material').shader, 'flat');
+      el.setAttribute('material', {side: 'double'});
+      assert.equal(el.getAttribute('material').color, 'blue');
+      assert.equal(el.getAttribute('material').shader, 'flat');
+      assert.equal(el.getAttribute('material').side, 'double');
+      done();
+    }, function preCreation (sceneEl) {
+      helpers.mixinFactory('foo', {material: 'shader: flat'}, sceneEl);
+    });
+  });
+
+  test('applies boolean mixin', function (done) {
+    primitiveFactory({
+      defaultComponents: {
+        visible: {default: true}
+      }
+    }, 'mixin="foo"', function postCreation (el) {
+      assert.equal(el.getAttribute('visible'), false);
+      el.setAttribute('visible', true);
+      assert.equal(el.getAttribute('visible'), true);
+      done();
+    }, function preCreation (sceneEl) {
+      helpers.mixinFactory('foo', {visible: false}, sceneEl);
+    });
+  });
+
+  test('applies single-prop value mixin', function (done) {
+    AFRAME.registerComponent('test', {
+      schema: {default: 'foo'}
+    });
+    primitiveFactory({
+      defaultComponents: {}
+    }, 'mixin="foo"', function postCreation (el) {
+      assert.equal(el.getAttribute('test'), 'bar');
+      done();
+    }, function preCreation (sceneEl) {
+      helpers.mixinFactory('foo', {test: 'bar'}, sceneEl);
+    });
+  });
+
+  test('applies empty mixin', function (done) {
+    AFRAME.registerComponent('test', {
+      schema: {
+        foo: {default: 'foo'},
+        bar: {default: 'bar'}
+      }
+    });
+    primitiveFactory({
+      defaultComponents: {}
+    }, 'mixin="foo"', function postCreation (el) {
+      assert.equal(el.getAttribute('test').foo, 'foo');
+      assert.equal(el.getAttribute('test').bar, 'bar');
+      done();
+    }, function preCreation (sceneEl) {
+      helpers.mixinFactory('foo', {test: ''}, sceneEl);
+    });
+  });
+
   test('prioritizes mapping over mixin', function (done) {
     primitiveFactory({
       defaultComponents: {


### PR DESCRIPTION
Fix #2809

With the addition of the `extend()` function, the extension mechanism can consider the cases in which the component is absent or is of a primitive type:

1. If both `base` and `extension` are absent, `extend()` will return `undefined`.
2. Else, If `base` or `extension` is absent, `extend()` will returns a copy of the other.
3. Else, If none of them is absent and both are pure JS objects, the second will extend the first as usual.
4. Finally, the `extension` is preferred so a copy of it is returned.