### PR TITLE
fix case if text data is updated while font is loading (#2808)

### DIFF
--- a/src/components/text.js
+++ b/src/components/text.js
@@ -106,7 +106,7 @@ module.exports.Component = registerComponent('text', {
 
     // Update geometry and layout.
     if (font) {
-      updateGeometry(this.geometry, data, font);
+      this.updateGeometry(this.geometry, data, font);
       this.updateLayout(data);
     }
   },
@@ -209,7 +209,7 @@ module.exports.Component = registerComponent('text', {
 
       // Update geometry given font metrics.
       coercedData = coerceData(data);
-      updateGeometry(geometry, data, font);
+      self.updateGeometry(geometry, self.data, font);
 
       // Set font and update layout.
       self.currentFont = font;
@@ -313,6 +313,18 @@ module.exports.Component = registerComponent('text', {
    */
   lookupFont: function (key) {
     return FONTS[key];
+  },
+
+  /**
+   * Update the text geometry using `three-bmfont-text.update`.
+   */
+  updateGeometry: function (geometry, data, font) {
+    geometry.update(utils.extend({}, data, {
+      font: font,
+      width: computeWidth(data.wrapPixels, data.wrapCount, font.widthFactor),
+      text: data.value.replace(/\\n/g, '\n').replace(/\\t/g, '\t'),
+      lineHeight: data.lineHeight || font.common.lineHeight
+    }));
   }
 });
 
@@ -408,18 +420,6 @@ function createShader (el, shaderName, data) {
  */
 function updateBaseMaterial (material, data) {
   material.side = data.side;
-}
-
-/**
- * Update the text geometry using `three-bmfont-text.update`.
- */
-function updateGeometry (geometry, data, font) {
-  geometry.update(utils.extend({}, data, {
-    font: font,
-    width: computeWidth(data.wrapPixels, data.wrapCount, font.widthFactor),
-    text: data.value.replace(/\\n/g, '\n').replace(/\\t/g, '\t'),
-    lineHeight: data.lineHeight || font.common.lineHeight
-  }));
 }
 
 /**

--- a/tests/components/text.test.js
+++ b/tests/components/text.test.js
@@ -50,6 +50,19 @@ suite('text', function () {
   });
 
   suite('update', function () {
+    test('updates value', function (done) {
+      var updateSpy = this.sinon.spy(component, 'updateGeometry');
+      el.addEventListener('textfontset', evt => {
+        el.setAttribute('text', {value: 'foo', font: 'mozillavr'});
+        el.setAttribute('text', {value: 'bar', font: 'mozillavr'});
+        assert.equal(updateSpy.getCalls()[0].args[1].value, '');
+        assert.equal(updateSpy.getCalls()[1].args[1].value, 'foo');
+        assert.equal(updateSpy.getCalls()[2].args[1].value, 'bar');
+        done();
+      });
+      el.setAttribute('text', {font: 'mozillavr'});
+    });
+
     test('updates geometry with value', function (done) {
       // There are two paths by which geometry update can happen:
       // 1. As after-effect of font change.
@@ -193,6 +206,16 @@ suite('text', function () {
         done();
       });
       el.setAttribute('text', {font: 'mozillavr', fontImage: '/base/tests/assets/test2.png'});
+    });
+
+    test('uses up-to-date data once loaded', function (done) {
+      var updateSpy = this.sinon.spy(component, 'updateGeometry');
+      el.addEventListener('textfontset', evt => {
+        assert.equal(updateSpy.getCalls()[0].args[1].value, 'bar');
+        done();
+      });
+      el.setAttribute('text', {value: 'foo', font: 'mozillavr'});
+      el.setAttribute('text', {value: 'bar', font: 'mozillavr'});
     });
   });
 


### PR DESCRIPTION
**Description:**

What was happening:

1. Text component initializes.
2. Text component sets to load font.
3. Tick function tries to change text value, but font not loaded so nothing happens.
4. Font loads.
5. Tick function tries to change text value, but since the data did not change from step 3, nothing ever happens no matter how many ticks.

**Changes proposed:**
- Reference `self` for the component rather than referencing old data in case it changes.

