### PR TITLE
Point polyfill back to the aframevr with https://github.com/googl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "three": "^0.84.0",
     "three-bmfont-text": "^2.1.0",
     "tween.js": "^15.0.0",
-    "webvr-polyfill": "^0.9.34"
+    "webvr-polyfill": "aframevr/webvr-polyfill#vrFrameDataPolyfill"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
…evr/webvr-polyfill/pull/267 fix

Point the `webvr-polyfill` back to the aframevr until https://github.com/googlevr/webvr-polyfill/pull/267 lands in the central repo. 
