### PR TITLE
when selecting element by id in selectorParse, use getElementById instead of querySelector for better performance

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -122,6 +122,9 @@ function numberParse (value) {
 function selectorParse (value) {
   if (!value) { return null; }
   if (typeof value !== 'string') { return value; }
+  if(value[0] === '#') {
+    return document.getElementById(value.substring(1));
+  }
   return document.querySelector(value);
 }
 

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -123,7 +123,7 @@ function selectorParse (value) {
   if (!value) { return null; }
   if (typeof value !== 'string') { return value; }
   if (value[0] === '#' && !/[.,[: ]/.test(value)) {
-    //when selecting element by id only, use getElementById for better performance
+    // when selecting element by id only, use getElementById for better performance
     return document.getElementById(value.substring(1));
   }
   return document.querySelector(value);

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -122,7 +122,7 @@ function numberParse (value) {
 function selectorParse (value) {
   if (!value) { return null; }
   if (typeof value !== 'string') { return value; }
-  if (value[0] === '#' && !/[.,[: ]/.test(value)) {
+  if (value[0] === '#' && !/[,> ]/.test(value)) {
     // when selecting element by id only, use getElementById for better performance
     return document.getElementById(value.substring(1));
   }

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -122,7 +122,8 @@ function numberParse (value) {
 function selectorParse (value) {
   if (!value) { return null; }
   if (typeof value !== 'string') { return value; }
-  if(value[0] === '#') {
+  if (value[0] === '#' && !/[.,[: ]/.test(value)) {
+    //when selecting element by id only, use getElementById for better performance
     return document.getElementById(value.substring(1));
   }
   return document.querySelector(value);

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -5,6 +5,7 @@ var error = debug('core:propertyTypes:warn');
 var warn = debug('core:propertyTypes:warn');
 
 var propertyTypes = module.exports.propertyTypes = {};
+var nonCharRegex = /[,> .[\]:]/;
 
 // Built-in property types.
 registerPropertyType('audio', '', assetParse);
@@ -122,8 +123,9 @@ function numberParse (value) {
 function selectorParse (value) {
   if (!value) { return null; }
   if (typeof value !== 'string') { return value; }
-  if (value[0] === '#' && !/[,> ]/.test(value)) {
-    // when selecting element by id only, use getElementById for better performance
+  if (value[0] === '#' && !nonCharRegex.test(value)) {
+    // When selecting element by ID only, use getElementById for better performance.
+    // Don't match like #myId .child.
     return document.getElementById(value.substring(1));
   }
   return document.querySelector(value);

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -109,8 +109,31 @@ suite('propertyTypes', function () {
       this.el.parentNode.removeChild(this.el);
     });
 
+    test('parses ID only', function () {
+      assert.equal(parse('#hello'), this.el);
+    });
+
+    test('parses id with hyphen', function () {
+      this.el.setAttribute('id', 'hello-world');
+      assert.equal(parse('#hello-world'), this.el);
+    });
+
     test('parses valid selector', function () {
       assert.equal(parse('#hello.itsme'), this.el);
+    });
+
+    test('parses valid selector with child', function () {
+      document.body.setAttribute('id', 'body');
+      assert.equal(parse('#body #hello'), this.el);
+      document.body.setAttribute('id', '');
+    });
+
+    test('parses valid selector with attribute selector', function () {
+      assert.equal(parse('#hello[id]'), this.el);
+    });
+
+    test('parses valid selector with last-child', function () {
+      assert.equal(parse('#hello:last-child'), this.el);
     });
 
     test('parses null selector', function () {


### PR DESCRIPTION
when selecting element by id in selectorParse, use getElementById instead of querySelector for better performance (https://jsperf.com/getelementbyid-vs-queryselector), and this way it also support id that starts with a digit (querySelector doesn’t support that)