### PR TITLE
Fixing 2 issues with GearVR

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -49,9 +49,6 @@ var isMobile = (function () {
     if (isIOS()) {
       _isMobile = true;
     }
-    if (isGearVR()) {
-      _isMobile = false;
-    }
   })(navigator.userAgent || navigator.vendor || window.opera);
 
   return function () { return _isMobile; };


### PR DESCRIPTION
**Description:**

1) EnterVR button didn't work at all
2) EnterVR button worked only once, since exitVR from external cause wasn't handled.

**Changes proposed:**
- Remove check if isGearVR from utils.isMobile (already done in 0.6.0)
- Add vrdisplaypresentchange callback to a-scene and exit VR correctly on external cause (already done in 0.6.0)
