### PR TITLE
pivot should respond to entityEl.setAttribute

### DIFF
--- a/src/extras/components/pivot.js
+++ b/src/extras/components/pivot.js
@@ -12,8 +12,14 @@ registerComponent('pivot', {
 
   schema: {type: 'vec3'},
 
-  init: function () {
-    var data = this.data;
+  update: function (oldData) {
+    var data = oldData
+    ? {
+      x: this.data.x - oldData.x,
+      y: this.data.y - oldData.y,
+      z: this.data.z - oldData.z,
+    }
+    : this.data;
     var el = this.el;
     var originalParent = el.object3D.parent;
     var originalGroup = el.object3D;

--- a/src/extras/components/pivot.js
+++ b/src/extras/components/pivot.js
@@ -17,7 +17,7 @@ registerComponent('pivot', {
     ? {
       x: this.data.x - oldData.x,
       y: this.data.y - oldData.y,
-      z: this.data.z - oldData.z,
+      z: this.data.z - oldData.z
     }
     : this.data;
     var el = this.el;


### PR DESCRIPTION
**Description:**
Currently the `pivot` component doesn't respond to entityEl.setAttribute because it has no `update` handler.

**Changes proposed:**

- Replacing `init` with `update` to respond to changes
- Taking `oldData` into calculation to yield a desired `pivot` value

Plus, why is `pivot` not in the documentation? Am I missing anything or is it not ready for us to use? Thanks.
