### PR TITLE
Replace 'replace' dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "minifyify": "^7.3.3",
     "mocha": "^3.0.2",
     "mozilla-download": "^1.1.1",
-    "replace": "^0.3.0",
+    "replace-in-file": "^2.5.3",
     "semistandard": "^9.0.0",
     "shelljs": "^0.7.7",
     "shx": "^0.2.2",

--- a/scripts/preghpages.js
+++ b/scripts/preghpages.js
@@ -3,7 +3,7 @@
 const path = require('path');
 
 const shell = require('shelljs');
-const replace = require('replace');
+const replace = require('replace-in-file');
 
 // Inject `<meta>` tag for Chrome for Android's WebVR Origin Trial:
 // https://webvr.rocks/chrome_for_android#what_is_the_webvr_origin_trial
@@ -26,15 +26,10 @@ shell.cp('-r', [
 ], 'gh-pages');
 
 function htmlReplace (before, after) {
-  replace({
-    regex: before,
-    replacement: after,
-    paths: [
-      'gh-pages'
-    ],
-    include: '*.html',
-    recursive: true,
-    silent: true
+  replace.sync({
+    from: before,
+    to: after,
+    files: 'gh-pages/**/*.html'
   });
 }
 


### PR DESCRIPTION
It's unmaintained, and has an insecure dependency on an older version of `minimatch`.