### PR TITLE
[docs] Escape <a> tag with code blocks

### DIFF
--- a/docs/primitives/a-link.md
+++ b/docs/primitives/a-link.md
@@ -6,7 +6,7 @@ parent_section: primitives
 ---
 
 The link primitive provides a compact API to define links that resembles
-the <a> traditional tag.
+the traditional `<a>` tag.
 
 ## Attributes
 


### PR DESCRIPTION
**Description:**
Right now this is being rendered on the docs page as a link that goes no where so the sentence doesn't make sense and clicking on the link doesn't go anywhere.

<img width="708" alt="screen shot 2017-07-09 at 9 54 53 pm" src="https://user-images.githubusercontent.com/15314629/28000127-cbaa53c4-64f1-11e7-85cc-6ea2170fa20e.png">

**Changes proposed:**
Escape the code block with back ticks and restructure sentence to be clearer.

