### PR TITLE
`reload` should restart scene components

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "snazzy": "^5.0.0",
     "too-wordy": "ngokevin/too-wordy",
     "uglifyjs": "^2.4.10",
+    "watchify": "^3.9.0",
     "write-good": "^0.9.1"
   },
   "link": true,

--- a/src/components/scene/canvas.js
+++ b/src/components/scene/canvas.js
@@ -39,5 +39,8 @@ module.exports.Component = registerComponent('canvas', {
       document.activeElement.blur();
       document.body.focus();
     }
+  },
+  remove: function () {
+    this.el.canvas = undefined;
   }
 });

--- a/src/components/scene/vr-mode-ui.js
+++ b/src/components/scene/vr-mode-ui.js
@@ -66,7 +66,7 @@ module.exports.Component = registerComponent('vr-mode-ui', {
 
   remove: function () {
     [this.enterVREl, this.orientationModalEl].forEach(function (uiElement) {
-      if (uiElement) {
+      if (uiElement && uiElement.parentNode) {
         uiElement.parentNode.removeChild(uiElement);
       }
     });

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -300,6 +300,8 @@ var proto = Object.create(ANode.prototype, {
       if (this.hasLoaded || !this.parentEl) { return; }
 
       ANode.prototype.load.call(this, function entityLoadCallback () {
+        /* if you change this callback, update a-scene.reload appropriately. */
+
         // Check if entity was detached while it was waiting to load.
         if (!self.parentEl) { return; }
 
@@ -423,7 +425,7 @@ var proto = Object.create(ANode.prototype, {
   },
 
   removeComponent: {
-    value: function (name) {
+    value: function (name, force) {
       var component;
       var isDefault;
       var isMixedIn;
@@ -431,7 +433,7 @@ var proto = Object.create(ANode.prototype, {
       // Don't remove default or mixed-in components.
       isDefault = name in this.defaultComponents;
       isMixedIn = isComponentMixedIn(name, this.mixinEls);
-      if (isDefault || isMixedIn) { return; }
+      if ((isDefault || isMixedIn) && !force) { return; }
 
       component = this.components[name];
       if (!component) { return; }

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -19,9 +19,10 @@ var helpers = require('../../helpers');
  */
 suite('a-scene (without renderer)', function () {
   setup(function (done) {
-    var el = this.el = document.createElement('a-scene');
-    el.addEventListener('nodeready', function () { done(); });
-    document.body.appendChild(el);
+    var body = document.body;
+    body.addEventListener('nodeready', function () { done(); }, {capture: true, once: true});
+    body.insertAdjacentHTML('beforeend', '<a-scene test="test"></a-scene>');
+    this.el = body.children[body.children.length - 1];
   });
 
   teardown(function () {
@@ -298,6 +299,15 @@ suite('a-scene (without renderer)', function () {
       sceneEl.innerHTML = 'NEW';
       sceneEl.reload();
       assert.equal(sceneEl.innerHTML, '');
+    });
+
+    test('reload scene attributes to original values', function () {
+      var sceneEl = this.el;
+      sceneEl.removeAttribute('test');
+      sceneEl.setAttribute('foo', 'bar');
+      sceneEl.reload();
+      assert.notOk(sceneEl.hasAttribute('foo'));
+      assert.equal(sceneEl.getAttribute('test'), 'test');
     });
 
     test('reloads the scene and pauses', function () {


### PR DESCRIPTION
**Description:**
`AScene.reload` doesn't currently reset attributes and components on the scene element, which is different behavior from every other element in the scene.

**Changes proposed:**
While we can't destroy and re-create the entire scene element like we do for every other element, we can:
-  remove the current components
- delete the current attributes
- re-add the original attributes

This patch fixes #2239.
