### PR TITLE
Bumps polyfill that fixes Firefox for Android tracking issue (fix #2825)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "style-attr": "^1.0.2",
     "three": "^0.84.0",
     "three-bmfont-text": "^2.1.0",
-    "webvr-polyfill": "^0.9.35"
+    "webvr-polyfill": "^0.9.36"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
A fix has landed on the `webvr-poyfill` https://github.com/googlevr/webvr-polyfill/pull/270