### PR TITLE
Wait for entities to load when the a-node has not been yet initialized (fix #2802)

### DIFF
--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -1,5 +1,6 @@
 /* global MutationObserver */
 var registerElement = require('./a-register-element').registerElement;
+var isNode = require('./a-register-element').isNode;
 var utils = require('../utils/');
 
 var bind = utils.bind;
@@ -101,8 +102,7 @@ module.exports = registerElement('a-node', {
         if (this.hasLoaded) { return; }
 
         // Default to waiting for all nodes.
-        childFilter = childFilter || function (el) { return el.isNode; };
-
+        childFilter = childFilter || isNode;
         // Wait for children to load (if any), then load.
         children = this.getChildren();
         childrenLoaded = children.filter(childFilter).map(function (child) {

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -26,9 +26,11 @@ var TestComponent = {
 suite('a-entity', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
-    el.addEventListener('loaded', function () {
+    var onLoaded = function () {
       done();
-    });
+      el.removeEventListener('loaded', onLoaded);
+    };
+    el.addEventListener('loaded', onLoaded);
   });
 
   teardown(function () {
@@ -639,6 +641,64 @@ suite('a-entity', function () {
       setTimeout(function () {
         assert.notOk(nodeLoadSpy.called);
         done();
+      });
+    });
+
+    test('wait for all the children nodes that are not yet nodes to load', function (done) {
+      var el = this.el;
+      var a = document.createElement('a-entity');
+      var b = document.createElement('a-entity');
+      var aLoaded = false;
+      var bLoaded = false;
+      el.appendChild(a);
+      el.appendChild(b);
+      process.nextTick(function () {
+        a.isNode = false;
+        a.hasLoaded = false;
+        b.isNode = false;
+        b.hasLoaded = false;
+        el.hasLoaded = false;
+        el.addEventListener('loaded', function () {
+          assert.ok(el.hasLoaded);
+          assert.ok(aLoaded);
+          assert.ok(bLoaded);
+          done();
+        });
+        a.addEventListener('loaded', function () { aLoaded = true; });
+        b.addEventListener('loaded', function () { bLoaded = true; });
+        el.load();
+        assert.notOk(el.hasLoaded);
+        a.load();
+        b.load();
+      });
+    });
+
+    test('wait for all the children primitives that are not yet nodes to load', function (done) {
+      var el = this.el;
+      var a = document.createElement('a-sphere');
+      var b = document.createElement('a-box');
+      var aLoaded = false;
+      var bLoaded = false;
+      el.appendChild(a);
+      el.appendChild(b);
+      process.nextTick(function () {
+        a.isNode = false;
+        a.hasLoaded = false;
+        b.isNode = false;
+        b.hasLoaded = false;
+        el.hasLoaded = false;
+        el.addEventListener('loaded', function () {
+          assert.ok(el.hasLoaded);
+          assert.ok(aLoaded);
+          assert.ok(bLoaded);
+          done();
+        });
+        a.addEventListener('loaded', function () { aLoaded = true; });
+        b.addEventListener('loaded', function () { bLoaded = true; });
+        el.load();
+        assert.notOk(el.hasLoaded);
+        a.load();
+        b.load();
       });
     });
   });


### PR DESCRIPTION
It checks for the tagName to be `a-node` , `a-entity` or a registered primitive. 