### PR TITLE
have default light cast shadows by default

### DIFF
--- a/examples/boilerplate/hello-world/index.html
+++ b/examples/boilerplate/hello-world/index.html
@@ -8,10 +8,10 @@
   </head>
   <body>
     <a-scene>
-      <a-box position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
-      <a-sphere position="0 1.25 -5" radius="1.25" color="#EF2D5E"></a-sphere>
-      <a-cylinder position="1 0.75 -3" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
-      <a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
+      <a-box position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9" shadow></a-box>
+      <a-sphere position="0 1.25 -5" radius="1.25" color="#EF2D5E" shadow></a-sphere>
+      <a-cylinder position="1 0.75 -3" radius="0.5" height="1.5" color="#FFC65D" shadow></a-cylinder>
+      <a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4" shadow></a-plane>
       <a-sky color="#ECECEC"></a-sky>
     </a-scene>
   </body>

--- a/src/systems/light.js
+++ b/src/systems/light.js
@@ -65,14 +65,15 @@ module.exports.System = registerSystem('light', {
     if (this.userDefinedLights || this.defaultLights || !this.data.defaultLightsEnabled) {
       return;
     }
+
     ambientLight = document.createElement('a-entity');
-    directionalLight = document.createElement('a-entity');
     ambientLight.setAttribute('light', {color: '#BBB', type: 'ambient'});
     ambientLight.setAttribute(DEFAULT_LIGHT_ATTR, '');
     ambientLight.setAttribute(constants.AFRAME_INJECTED, '');
     sceneEl.appendChild(ambientLight);
 
-    directionalLight.setAttribute('light', {color: '#FFF', intensity: 0.6});
+    directionalLight = document.createElement('a-entity');
+    directionalLight.setAttribute('light', {color: '#FFF', intensity: 0.6, castShadow: true});
     directionalLight.setAttribute('position', {x: -0.5, y: 1, z: 1});
     directionalLight.setAttribute(DEFAULT_LIGHT_ATTR, '');
     directionalLight.setAttribute(constants.AFRAME_INJECTED, '');


### PR DESCRIPTION
**Description:**

Doesn't hurt to set `castShadow` on the default light. I think it will only be used if any objects have the shadow component.

I also set the shadows on the Hello, World example.

<img width="847" alt="screen shot 2017-07-18 at 4 45 22 pm" src="https://user-images.githubusercontent.com/674727/28344489-8183995c-6bd8-11e7-93eb-45f406567872.png">