### PR TITLE
Description of color not mentioned in hemispherical light

### DIFF
--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -103,6 +103,7 @@ sky).
 
 | Property    | Description             | Default Value |
 |-------------|-------------------------|---------------|
+| color       | Light color from above. | #fff          |
 | groundColor | Light color from below. | #fff          |
 
 ### Point


### PR DESCRIPTION

**Description:**
color is for light from above and groundColor is for light from below. The description of the former isn't mentioned in the table.

**Changes proposed:**
- Added `color` description
-
-
