### PR TITLE
Expose emissive and emissiveIntensity Three.js properties to the standard material

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -95,6 +95,8 @@ These properties are available on top of the base material properties.
 | displacementBias              | The zero point of the displacement map.                                                                                                         | 0.5           |
 | displacementTextureRepeat     | How many times the displacement texture repeats in the X and Y direction.                                                                       | 1 1           |
 | displacementTextureOffset     | How the displacement texture is offset in the x y direction.                                                                                    | 0 0           |
+| emissive                      | The color of the emissive lighting component. Used to make objects produce light even without other lighting in the scene.                      | #000
+| emissiveIntensity             | Intensity of the emissive lighting component.                                                                                                   | 1
 | height                        | Height of video (in pixels), if defining a video texture.                                                                                       | 360           |
 | envMap                        | Environment cubemap texture for reflections. Can be a selector to <a-cubemap> or a comma-separated list of URLs.                                | None          |
 | fog                           | Whether or not material is affected by [fog][fog].                                                                                              | true          |

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -22,6 +22,8 @@ module.exports.Shader = registerShader('standard', {
     displacementBias: {default: 0.5},
     displacementTextureOffset: {type: 'vec2'},
     displacementTextureRepeat: {type: 'vec2', default: {x: 1, y: 1}},
+    emissive: {type: 'color', default: '#000'},
+    emissiveIntensity: {default: 1},
     envMap: {default: ''},
 
     fog: {default: true},
@@ -143,6 +145,8 @@ module.exports.Shader = registerShader('standard', {
 function getMaterialData (data) {
   var newData = {
     color: new THREE.Color(data.color),
+    emissive: new THREE.Color(data.emissive),
+    emissiveIntensity: data.emissiveIntensity,
     fog: data.fog,
     metalness: data.metalness,
     roughness: data.roughness,


### PR DESCRIPTION
**Description:**

The standard Three.js material has settings to make a material be emissive, meaning it can project light even when the rest of the scene is dark. Currently the emissive property is not exposed inside AFrame. This patch adds the property to the standard Aframe material.

**Changes proposed:**
-
-
-
