### PR TITLE
added Google Blocks in Where can I find assets?

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -185,6 +185,7 @@ For 360&deg; images, search for [equirectangular images on Flickr][flickr].
 
 For 3D models, check out:
 
+- [Google Blocks](https://vr.google.com/objects)
 - [Sketchfab](https://sketchfab.com)
 - [Clara.io](http://clara.io)
 - [Archive3D](http://archive3d.net)


### PR DESCRIPTION
**Description:** added Google Blocks in Where can I find assets?

**Changes proposed:**
- added links to Google Blocks on top since it's the largest easiest to use library already (using more complex assets with textures for example from TurboSquid usually brings newcomers to a world of pain)