### PR TITLE
link component releasted, using past tense

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -208,7 +208,7 @@ to serve, but that is against their terms of service.
 Browsers provide the ability to go from WebVR page to WebVR page via the
 `vrdisplayactivate` event described in the WebVR specification. Currently, not
 all browsers implement this. Firefox with WebVR implements this. A link
-component for link traversal will be released with A-Frame 0.6.1:
+component for link traversal was released with A-Frame 0.6.1:
 
 ```html
 <a-entity link="on: click; href: https://aframe-aincraft.glitch.me"></a-entity>


### PR DESCRIPTION
**Description:** link component releasted, using past tense

**Changes proposed:**
- link component for link traversal was (instead of will be) released with A-Frame 0.6.1
