### PR TITLE
Adding position offset for 3DoF controllers

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -183,6 +183,7 @@
     <h2>Showcase</h2>
 
     <ul class="links">
+      <li><a href="showcase/3dof-controllers/">3DOF Controllers</a></li>
       <li><a href="showcase/anime-UI/">Anime UI</a></li>
       <li><a href="showcase/composite/">Composite</a></li>
       <li><a href="showcase/curved-mockups/">Curved Mockups</a></li>

--- a/examples/showcase/3dof-controllers/components/geometry-changer.js
+++ b/examples/showcase/3dof-controllers/components/geometry-changer.js
@@ -1,0 +1,15 @@
+/* global AFRAME */
+AFRAME.registerComponent('geometry-changer', {
+  init: function () {
+    this.el.addEventListener('raycaster-intersected', this.onIntersected.bind(this));
+    this.el.addEventListener('raycaster-intersected-cleared', this.onIntersectedCleared.bind(this));
+  },
+
+  onIntersected: function () {
+    this.el.setAttribute('color', 'red');
+  },
+
+  onIntersectedCleared: function () {
+    this.el.setAttribute('color', 'blue');
+  }
+});

--- a/examples/showcase/3dof-controllers/index.html
+++ b/examples/showcase/3dof-controllers/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Tracked Controls</title>
+    <meta name="description" content="Tracked Controls – A-Frame">
+    <script src="../../../dist/aframe-master.js"></script>
+    <script src="./components/geometry-changer.js"></script>
+</head>
+<body>
+<a-scene>
+    <a-sky color="gray"></a-sky>
+
+    <a-entity camera look-controls position="0 0 0"></a-entity>
+    <a-box position="1 1 -8" color="blue" geometry-changer></a-box>
+    <a-entity position="0 0 0" gearvr-controls>
+        <a-entity position=".1 -.1 -.275" raycaster="showLine: true; far: 100" line="color: red; opacity: 0.5">
+        </a-entity>
+    </a-entity>
+</a-scene>
+</body>
+</html>


### PR DESCRIPTION
**Description:**
I've only started working with the Gear controller and AFrame a few days ago, and the first thing I noticed was that the GearVR Controller wasn't exactly working as I expected. Instead of turning around the camera like most applications do, the controller was just rotating in place. 

While this makes sense, I felt that it was a bit confusing and had to work around the component to get the controller to show up in its right place. I think that the GearVR controller should be in a default position just in front of the camera and rotate around the viewer instead of just staying in one spot.

I haven't tested it yet, but I'm assuming that the Daydream has the exact same issue.

**Changes proposed:**
- Add a ```positionOffset``` vector3 value to schema of the ```daydream-controls``` and ```gearvr-controls``` components.
- A child entity will be generated with its position set to the value in the schema
- This child entity will contain the controller model. Because the ```tracked-controls``` will be its parent, the controller will automatically spin around the camera.
- If no position offset is given, the default will be set to ```0.1 -0.1 -0.275```. X will be set to ```-0.1``` if the ```hand``` attribute is set to ```left```.


The PR currently already had the changes mentioned above implemented for the ```gearvr-controls```. Before putting more effort into creating a proper example and changing the ```daydream-controls``` component as well, I first would like to get some feedback before moving on.