### PR TITLE
tracked-controls referring to undefined constant

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -1,6 +1,6 @@
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
-var DEFAULT_USER_HEIGHT = require('../constants').DEFAULT_USER_HEIGHT;
+var DEFAULT_CAMERA_HEIGHT = require('../constants').DEFAULT_CAMERA_HEIGHT;
 
 var DEFAULT_HANDEDNESS = require('../constants').DEFAULT_HANDEDNESS;
 var EYES_TO_ELBOW = {x: 0.175, y: -0.3, z: -0.03}; // vector from eyes to elbow (divided by user height)
@@ -54,7 +54,7 @@ module.exports.Component = registerComponent('tracked-controls', {
   /**
    * Return default user height to use for non-6DOF arm model.
    */
-  defaultUserHeight: function () { return DEFAULT_USER_HEIGHT; }, // default user height (for cameras with zero)
+  defaultUserHeight: function () { return DEFAULT_CAMERA_HEIGHT; }, // default camera height (for cameras with zero)
 
   /**
    * Return head element to use for non-6DOF arm model.


### PR DESCRIPTION
**Description:**
In `tracked-controls`, the `defaultUserHeight` is pointing to an undefined variable, causing 3DoF controllers to remain stuck in position `0 0 0` if no `userHeight` parameter is set in the `camera`'s schema.

**Changes proposed:**
- Change DEFAULT_USER_HEIGHT to DEFAULT_CAMERA_HEIGHT