### PR TITLE
Cursor demo improvement

### DIFF
--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -62,13 +62,14 @@ When the cursor clicks on the box, we can listen to the click event.
 ```
 
 ```js
-// Component to change to random color on click.
+// Component to change to a sequential color on click.
 AFRAME.registerComponent('cursor-listener', {
   init: function () {
+    var lastIndex = -1;
     var COLORS = ['red', 'green', 'blue'];
     this.el.addEventListener('click', function (evt) {
-      var randomIndex = Math.floor(Math.random() * COLORS.length);
-      this.setAttribute('material', 'color', COLORS[randomIndex]);
+      lastIndex = (lastIndex + 1) % COLORS.length;
+      this.setAttribute('material', 'color', COLORS[lastIndex]);
       console.log('I was clicked at: ', evt.detail.intersection.point);
     });
   }


### PR DESCRIPTION
**Description:**
Relying on the random selection to change the color runs the risk of users being unsure if their interactions are sparking a response. For a simple test case (especially when in VR and no console log is available) a guaranteed change is much better. I made this change myself to ensure that the interactions were actually reliable and not glitchy and unresponsive as it seemed with the random selection re-picking the existing color. This should improve first run perceptions of the interaction API.

**Changes proposed:**
- Switch random selection to simple progression through array
