### PR TITLE
fix missing detail property in a-scene onVRPresentChange

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -305,8 +305,10 @@ module.exports.AScene = registerElement('a-scene', {
      */
     onVRPresentChange: {
       value: function (evt) {
+        // Polyfill places display inside the detail property
+        var display = evt.display || evt.detail.display;
         // Entering VR.
-        if (evt.detail.display.isPresenting) {
+        if (display.isPresenting) {
           this.enterVR(true);
           return;
         }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -306,7 +306,7 @@ module.exports.AScene = registerElement('a-scene', {
     onVRPresentChange: {
       value: function (evt) {
         // Entering VR.
-        if (evt.display.isPresenting) {
+        if (evt.detail.display.isPresenting) {
           this.enterVR(true);
           return;
         }


### PR DESCRIPTION
**Description:** `onVRPresentChange` throws error that `evt.display` is undefined. The `display` property exists under `CustomEvent#detail` property and not directly on `CustomEvent`.

**Changes proposed:**
- look for the `isPresenting` at `evt.detail.display.isPresenting`
