### PR TITLE
On Daydream devices, use native HMD pose orientation rather than sensor fusion

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -165,14 +165,21 @@ module.exports.Component = registerComponent('look-controls', {
     hmdQuaternion = hmdQuaternion.copy(this.dolly.quaternion);
     hmdEuler.setFromQuaternion(hmdQuaternion, 'YXZ');
 
-    if (sceneEl.isMobile) {
+    if (sceneEl.is('vr-mode') && !isNullVector(hmdEuler) && this.data.hmdEnabled) {
+      // Mouse rotation ignored with an active headset. Use headset rotation.
+      rotation = {
+        x: radToDeg(hmdEuler.x),
+        y: radToDeg(hmdEuler.y),
+        z: radToDeg(hmdEuler.z)
+      };
+    } else if (sceneEl.isMobile) {
       // On mobile, do camera rotation with touch events and sensors.
       rotation = {
         x: radToDeg(hmdEuler.x) + radToDeg(pitchObject.rotation.x),
         y: radToDeg(hmdEuler.y) + radToDeg(yawObject.rotation.y),
         z: radToDeg(hmdEuler.z)
       };
-    } else if (!sceneEl.is('vr-mode') || isNullVector(hmdEuler) || !this.data.hmdEnabled) {
+    } else {
       // Mouse drag if WebVR not active (not connected, no incoming sensor data).
       currentRotation = this.el.getAttribute('rotation');
       deltaRotation = this.calculateDeltaRotation();
@@ -189,13 +196,6 @@ module.exports.Component = registerComponent('look-controls', {
           z: currentRotation.z
         };
       }
-    } else {
-      // Mouse rotation ignored with an active headset. Use headset rotation.
-      rotation = {
-        x: radToDeg(hmdEuler.x),
-        y: radToDeg(hmdEuler.y),
-        z: radToDeg(hmdEuler.z)
-      };
     }
 
     this.el.setAttribute('rotation', rotation);


### PR DESCRIPTION
**Description:**

Due to the `isMobile` check occuring before the `vr-mode` check, when Daydream is in VR mode, as it's also a mobile device, sensor fusion controls take precedence. Is there scenario I'm not considering in this branching logic?

**Changes proposed:**

If in VR mode with HMD data, use that -- fall back to sensor fusion on mobile after.
