### PR TITLE
fix page-reloads on iOS (#2782)

### DIFF
--- a/vendor/wakelock/wakelock.js
+++ b/vendor/wakelock/wakelock.js
@@ -47,9 +47,9 @@ function iOSWakeLock() {
   this.request = function() {
     if (!timer) {
       timer = setInterval(function() {
-        window.location = window.location;
+        window.location.href = '/';
         setTimeout(window.stop, 0);
-      }, 30000);
+      }, 15000);
     }
   }
 


### PR DESCRIPTION
**Description:**
On iOS devices, the application seems to randomly reload. This has been pinpointed to a reload after 30 seconds of inactivity while in VR mode, caused by the iOS wakelock feature. As seen in other wakelock-implementations and issues, the `window.location = window.location` creates this issue.

**Changes proposed:**
Update the wakelock implementation to match other implementation which don't cause this reload-bug.

One thing to mention is the wakelock does not work on iOS (11), however I think it's better to have an application which will sleep after X seconds, instead of an application which will reload every X seconds.