### PR TITLE
remove invalid schema warnings for selector and custom prop types

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -179,8 +179,10 @@ function isValidDefaultValue (type, defaultVal) {
   if (type === 'number' && typeof defaultVal !== 'number') { return false; }
   if (type === 'map' && typeof defaultVal !== 'string') { return false; }
   if (type === 'model' && typeof defaultVal !== 'string') { return false; }
-  if (type === 'selector' && typeof defaultVal !== 'string') { return false; }
-  if (type === 'selectorAll' && typeof defaultVal !== 'string') { return false; }
+  if (type === 'selector' && typeof defaultVal !== 'string' &&
+      defaultVal !== null) { return false; }
+  if (type === 'selectorAll' && typeof defaultVal !== 'string' &&
+      defaultVal !== null) { return false; }
   if (type === 'src' && typeof defaultVal !== 'string') { return false; }
   if (type === 'string' && typeof defaultVal !== 'string') { return false; }
   if (type === 'time' && typeof defaultVal !== 'number') { return false; }

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -49,6 +49,7 @@ module.exports.process = function (schema, componentName) {
  */
 function processPropertyDefinition (propDefinition, componentName) {
   var defaultVal = propDefinition.default;
+  var isCustomType;
   var propType;
   var typeName = propDefinition.type;
 
@@ -75,6 +76,7 @@ function processPropertyDefinition (propDefinition, componentName) {
   }
 
   // Fill in parse and stringify using property types.
+  isCustomType = !!propDefinition.parse;
   propDefinition.parse = propDefinition.parse || propType.parse;
   propDefinition.stringify = propDefinition.stringify || propType.stringify;
 
@@ -84,8 +86,7 @@ function processPropertyDefinition (propDefinition, componentName) {
   // Check that default value exists.
   if ('default' in propDefinition) {
     // Check that default values are valid.
-    if (!isValidDefaultValue(typeName, defaultVal) &&
-        typeName !== 'selector' && typeName !== 'selectorAll') {
+    if (!isCustomType && !isValidDefaultValue(typeName, defaultVal)) {
       warn('Default value `' + defaultVal + '` does not match type `' + typeName +
            '` in component `' + componentName + '`');
     }


### PR DESCRIPTION
**Description:**

**Changes proposed:**
- Should be able to pass null for selector prop types.
- Don't try to validate a custom property type as a string