### PR TITLE
bugfix: fix visualAspectEnabled in link component

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -34,7 +34,9 @@ module.exports.Component = registerComponent('link', {
     var strokeColor = data.highlighted ? data.highlightedColor : data.color;
     el.setAttribute('material', 'strokeColor', strokeColor);
     if (data.on !== oldData.on) { this.updateEventListener(); }
-    if (data.peekMode !== oldData.peekMode) { this.updatePeekMode(); }
+    if (data.visualAspectEnabled && oldData.peekMode !== undefined && data.peekMode !== oldData.peekMode) {
+      this.updatePeekMode();
+    }
     if (!data.image || oldData.image === data.image) { return; }
     el.setAttribute('material', 'pano',
                     typeof data.image === 'string' ? data.image : data.image.src);
@@ -167,6 +169,7 @@ module.exports.Component = registerComponent('link', {
     var scale = new THREE.Vector3();
     var quaternion = new THREE.Quaternion();
     return function () {
+      if (!this.data.visualAspectEnabled) { return; }
       var el = this.el;
       var object3D = el.object3D;
       var camera = el.sceneEl.camera;


### PR DESCRIPTION
**Description:**
Currently, creating a link from an entity and using `visualAspectEnabled: false` (to control the styling yourself) throws two errors.

The first one is from the `tick` lifecycle method trying to adjust elements that have never been setup.

The second is a check in `update` considering an `undefined` => `false` being a "new" peekMode and thus calling the `updatePeekMode` function which again, tries to adjust elements that have never been setup.

reproduce:

```
<a-entity link="href: location.html; visualAspectEnabled: false" geometry="primitive: box"></a-entity>
```

**Changes proposed:**
Harden the checks in both functions so you can safely create links with `visualAspectEnabled: false`.