### PR TITLE
Prevent cloning objects into previousData that are not plain objects

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -336,21 +336,23 @@ Component.prototype = {
     var isSinglePropSchema = isSingleProp(schema);
     var mixinEls = this.el.mixinEls;
     var previousData;
-
     // 1. Default values (lowest precendence).
     if (isSinglePropSchema) {
-      // Clone default value if object so components don't share object.
-      data = typeof schema.default === 'object' ? utils.clone(schema.default) : schema.default;
+      // Clone default value if plain object so components don't share the same object
+      // that might be modified by the user.
+      data = schema.default.constructor === Object ? utils.clone(schema.default) : schema.default;
     } else {
       // Preserve previously set properties if clobber not enabled.
       previousData = !clobber && this.attrValue;
-      // Clone default value if object so components don't share object
-      data = typeof previousData === 'object' ? utils.clone(previousData) : {};
+      // Clone previous data to prevent sharing references with attrValue that might be
+      // modified by the user.
+      data = typeof previousData === 'object' ? cloneData(previousData) : {};
 
       // Apply defaults.
       for (i = 0, keys = Object.keys(schema), keysLength = keys.length; i < keysLength; i++) {
         defaultValue = schema[keys[i]].default;
         if (data[keys[i]] !== undefined) { continue; }
+        // Clone default value if object so components don't share object
         data[keys[i]] = defaultValue && defaultValue.constructor === Object
           ? utils.clone(defaultValue)
           : defaultValue;
@@ -467,6 +469,25 @@ module.exports.registerComponent = function (name, definition) {
   };
   return NewComponent;
 };
+
+/**
+* Clones component data.
+* Clone only the properties that are plain objects while
+* keeping a reference for the rest.
+*
+* @param data - Component data to clone.
+* @returns Cloned data.
+*/
+function cloneData (data) {
+  var clone = {};
+  var parsedProperty;
+  var key;
+  for (key in data) {
+    parsedProperty = data[key];
+    clone[key] = parsedProperty.constructor === Object ? utils.clone(parsedProperty) : parsedProperty;
+  }
+  return clone;
+}
 
 /**
 * Object extending with checking for single-property schema.


### PR DESCRIPTION
`a-saturday-night` uses `selector` properties that change at run time. This triggered `Converted circular structure to JSON` errors when trying to clone into previousData A-Frame entity elements that hold references to other A-Frame entities via components .We should only be cloning plain objects.