### PR TITLE
optimize tracked controls tick, discovery, and various utils

### DIFF
--- a/src/components/daydream-controls.js
+++ b/src/components/daydream-controls.js
@@ -29,13 +29,9 @@ module.exports.Component = registerComponent('daydream-controls', {
   // 1 - menu (never dispatched on this layer)
   // 2 - system (never dispatched on this layer)
   mapping: {
-    axes: {'trackpad': [0, 1]},
+    axes: {trackpad: [0, 1]},
     buttons: ['trackpad', 'menu', 'system']
   },
-
-  // Use these labels for detail on axis events such as thumbstickmoved.
-  // e.g. for thumbstickmoved detail, the first axis returned is labeled x, and the second is labeled y.
-  axisLabels: ['x', 'y', 'z', 'w'],
 
   bindMethods: function () {
     this.onModelLoaded = bind(this.onModelLoaded, this);
@@ -59,8 +55,8 @@ module.exports.Component = registerComponent('daydream-controls', {
     this.everGotGamepadEvent = false;
     this.lastControllerCheck = 0;
     this.bindMethods();
-    this.checkControllerPresentAndSetup = checkControllerPresentAndSetup; // to allow mock
-    this.emitIfAxesChanged = emitIfAxesChanged; // to allow mock
+    this.checkControllerPresentAndSetup = checkControllerPresentAndSetup;  // To allow mock.
+    this.emitIfAxesChanged = emitIfAxesChanged;  // To allow mock.
   },
 
   addEventListeners: function () {
@@ -117,7 +113,12 @@ module.exports.Component = registerComponent('daydream-controls', {
   injectTrackedControls: function () {
     var el = this.el;
     var data = this.data;
-    el.setAttribute('tracked-controls', {idPrefix: GAMEPAD_ID_PREFIX, hand: data.hand, rotationOffset: data.rotationOffset, armModel: data.armModel});
+    el.setAttribute('tracked-controls', {
+      armModel: data.armModel,
+      hand: data.hand,
+      idPrefix: GAMEPAD_ID_PREFIX,
+      rotationOffset: data.rotationOffset
+    });
     if (!this.data.model) { return; }
     this.el.setAttribute('obj-model', {
       obj: DAYDREAM_CONTROLLER_MODEL_OBJ_URL,
@@ -137,8 +138,6 @@ module.exports.Component = registerComponent('daydream-controls', {
     if (!this.everGotGamepadEvent) { this.checkIfControllerPresent(); }
   },
 
-  // No need for onButtonChanged, since Daydream controller has no analog buttons.
-
   onModelLoaded: function (evt) {
     var controllerObject3D = evt.detail.model;
     var buttonMeshes;
@@ -147,11 +146,13 @@ module.exports.Component = registerComponent('daydream-controls', {
     buttonMeshes.menu = controllerObject3D.getObjectByName('AppButton_AppButton_Cylinder.004');
     buttonMeshes.system = controllerObject3D.getObjectByName('HomeButton_HomeButton_Cylinder.005');
     buttonMeshes.trackpad = controllerObject3D.getObjectByName('TouchPad_TouchPad_Cylinder.003');
-    // Offset pivot point
+    // Offset pivot point.
     controllerObject3D.position.set(0, 0, -0.04);
   },
 
-  onAxisMoved: function (evt) { this.emitIfAxesChanged(this, this.mapping.axes, evt); },
+  onAxisMoved: function (evt) {
+    this.emitIfAxesChanged(this, this.mapping.axes, evt);
+  },
 
   onButtonChanged: function (evt) {
     var button = this.mapping.buttons[evt.detail.id];

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -22,7 +22,7 @@ module.exports.Component = registerComponent('gearvr-controls', {
     buttonTouchedColor: {type: 'color', default: '#777777'},
     buttonHighlightColor: {type: 'color', default: '#FFFFFF'},
     model: {default: true},
-    rotationOffset: {default: 0}, // use -999 as sentinel value to auto-determine based on hand
+    rotationOffset: {default: 0},
     armModel: {default: true}
   },
 
@@ -30,13 +30,9 @@ module.exports.Component = registerComponent('gearvr-controls', {
   // 0 - trackpad
   // 1 - triggeri
   mapping: {
-    axes: {'trackpad': [0, 1]},
+    axes: {trackpad: [0, 1]},
     buttons: ['trackpad', 'trigger']
   },
-
-  // Use these labels for detail on axis events such as thumbstickmoved.
-  // e.g. for thumbstickmoved detail, the first axis returned is labeled x, and the second is labeled y.
-  axisLabels: ['x', 'y', 'z', 'w'],
 
   bindMethods: function () {
     this.onModelLoaded = bind(this.onModelLoaded, this);
@@ -60,8 +56,8 @@ module.exports.Component = registerComponent('gearvr-controls', {
     this.everGotGamepadEvent = false;
     this.lastControllerCheck = 0;
     this.bindMethods();
-    this.checkControllerPresentAndSetup = checkControllerPresentAndSetup; // to allow mock
-    this.emitIfAxesChanged = emitIfAxesChanged; // to allow mock
+    this.checkControllerPresentAndSetup = checkControllerPresentAndSetup;  // To allow mock.
+    this.emitIfAxesChanged = emitIfAxesChanged;  // To allow mock.
   },
 
   addEventListeners: function () {
@@ -91,7 +87,8 @@ module.exports.Component = registerComponent('gearvr-controls', {
   },
 
   checkIfControllerPresent: function () {
-    this.checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX, this.data.hand ? {hand: this.data.hand} : {});
+    this.checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX,
+                                        this.data.hand ? {hand: this.data.hand} : {});
   },
 
   onGamepadConnectionEvent: function (evt) {
@@ -115,7 +112,11 @@ module.exports.Component = registerComponent('gearvr-controls', {
   injectTrackedControls: function () {
     var el = this.el;
     var data = this.data;
-    el.setAttribute('tracked-controls', {idPrefix: GAMEPAD_ID_PREFIX, rotationOffset: data.rotationOffset, armModel: data.armModel});
+    el.setAttribute('tracked-controls', {
+      armModel: data.armModel,
+      idPrefix: GAMEPAD_ID_PREFIX,
+      rotationOffset: data.rotationOffset
+    });
     if (!this.data.model) { return; }
     this.el.setAttribute('obj-model', {
       obj: GEARVR_CONTROLLER_MODEL_OBJ_URL,
@@ -167,7 +168,9 @@ module.exports.Component = registerComponent('gearvr-controls', {
     this.updateModel(buttonName, evtName);
   },
 
-  onAxisMoved: function (evt) { this.emitIfAxesChanged(this, this.mapping.axes, evt); },
+  onAxisMoved: function (evt) {
+    this.emitIfAxesChanged(this, this.mapping.axes, evt);
+  },
 
   updateModel: function (buttonName, evtName) {
     var i;

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -13,19 +13,19 @@ var GAMEPAD_ID_PREFIX = 'Oculus Touch';
 var PIVOT_OFFSET = {x: 0, y: -0.015, z: 0.04};
 
 /**
- * Oculus Touch Controls Component
- * Interfaces with Oculus Touch controllers and maps Gamepad events to
+ * Oculus Touch controls component.
+ * Interface with Oculus Touch controllers and maps Gamepad events to
  * common controller buttons: trackpad, trigger, grip, menu and system
- * It loads a controller model and highlights the pressed buttons
+ * Load a controller model and highlights the pressed buttons
  */
 module.exports.Component = registerComponent('oculus-touch-controls', {
   schema: {
     hand: {default: 'left'},
-    buttonColor: {type: 'color', default: '#999'},          // Off-white.
+    buttonColor: {type: 'color', default: '#999'},  // Off-white.
     buttonTouchColor: {type: 'color', default: '#8AB'},
-    buttonHighlightColor: {type: 'color', default: '#2DF'}, // Light blue.
+    buttonHighlightColor: {type: 'color', default: '#2DF'},  // Light blue.
     model: {default: true},
-    rotationOffset: {default: 0} // no default offset; -999 is sentinel value to auto-determine based on hand
+    rotationOffset: {default: 0}
   },
 
   // buttonId
@@ -37,18 +37,14 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   // 5 - surface (touch only)
   mapping: {
     left: {
-      axes: {'thumbstick': [0, 1]},
+      axes: {thumbstick: [0, 1]},
       buttons: ['thumbstick', 'trigger', 'grip', 'xbutton', 'ybutton', 'surface']
     },
     right: {
-      axes: {'thumbstick': [0, 1]},
+      axes: {thumbstick: [0, 1]},
       buttons: ['thumbstick', 'trigger', 'grip', 'abutton', 'bbutton', 'surface']
     }
   },
-
-  // Use these labels for detail on axis events such as thumbstickmoved.
-  // e.g. for thumbstickmoved detail, the first axis returned is labeled x, and the second is labeled y.
-  axisLabels: ['x', 'y', 'z', 'w'],
 
   bindMethods: function () {
     this.onModelLoaded = bind(this.onModelLoaded, this);
@@ -69,8 +65,9 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     this.previousButtonValues = {};
     this.bindMethods();
 
-    this.emitIfAxesChanged = controllerUtils.emitIfAxesChanged;   // Allow mock.
-    this.checkControllerPresentAndSetup = controllerUtils.checkControllerPresentAndSetup;  // Allow mock.
+    // Allow mock.
+    this.emitIfAxesChanged = controllerUtils.emitIfAxesChanged;
+    this.checkControllerPresentAndSetup = controllerUtils.checkControllerPresentAndSetup;
   },
 
   addEventListeners: function () {

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -34,16 +34,9 @@ module.exports.Component = registerComponent('vive-controls', {
    * 4 - system (never dispatched on this layer)
    */
   mapping: {
-    axes: {'trackpad': [0, 1]},
+    axes: {trackpad: [0, 1]},
     buttons: ['trackpad', 'trigger', 'grip', 'menu', 'system']
   },
-
-  /**
-   * Labels for detail on axis events such as `thumbstickmoved`.
-   * For example, on `thumbstickmoved` detail, the first axis returned is labeled x, and the
-   * second is labeled y.
-   */
-  axisLabels: ['x', 'y', 'z', 'w'],
 
   init: function () {
     var self = this;

--- a/src/systems/tracked-controls.js
+++ b/src/systems/tracked-controls.js
@@ -1,19 +1,23 @@
 var registerSystem = require('../core/system').registerSystem;
-var trackedControlsUtils = require('../utils/tracked-controls');
 var utils = require('../utils');
 
 /**
  * Tracked controls system.
- * It maintains a list with the available tracked controllers
+ * Maintain list with available tracked controllers.
  */
 module.exports.System = registerSystem('tracked-controls', {
   init: function () {
     var self = this;
+
     this.controllers = [];
-    this.lastControllersUpdate = 0;
-    // Throttle the (renamed) tick handler to minimum 10ms interval.
-    this.tick = utils.throttle(this.throttledTick, 10, this);
+
+    // Throttle to every 500ms.
+    this.tick = utils.throttle(this.tick, 500, this);
+
+    this.updateControllerList();
+
     if (!navigator.getVRDisplays) { return; }
+
     this.sceneEl.addEventListener('enter-vr', function () {
       navigator.getVRDisplays().then(function (displays) {
         if (displays.length) { self.vrDisplay = displays[0]; }
@@ -21,20 +25,34 @@ module.exports.System = registerSystem('tracked-controls', {
     });
   },
 
-  updateControllerList: function () {
-    var controllers = this.controllers = [];
-    var gamepads = trackedControlsUtils.getGamepadsByPrefix('');
-    for (var i = 0; i < gamepads.length; i++) {
-      var gamepad = gamepads[i];
-      if (gamepad && gamepad.pose) { controllers.push(gamepad); }
-    }
+  tick: function () {
+    this.updateControllerList();
   },
 
   /**
-   * Update controller list every 10 miliseconds.
+   * Update controller list.
    */
-  throttledTick: function () {
-    this.updateControllerList();
-    this.sceneEl.emit('controllersupdated', { controllers: this.controllers });
+  updateControllerList: function () {
+    var controllers = this.controllers;
+    var gamepad;
+    var gamepads;
+    var i;
+    var prevCount;
+
+    gamepads = navigator.getGamepads && navigator.getGamepads();
+    if (!gamepads) { return; }
+
+    prevCount = controllers.length;
+    controllers.length = 0;
+    for (i = 0; i < gamepads.length; ++i) {
+      gamepad = gamepads[i];
+      if (gamepad && gamepad.pose) {
+        controllers.push(gamepad);
+      }
+    }
+
+    if (controllers.length !== prevCount) {
+      this.el.emit('controllersupdated', undefined, false);
+    }
   }
 });

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -2,37 +2,14 @@ var DEFAULT_HANDEDNESS = require('../constants').DEFAULT_HANDEDNESS;
 var AXIS_LABELS = ['x', 'y', 'z', 'w'];
 
 /**
- * Return enumerated gamepads matching id prefix.
- *
- * @param {object} idPrefix - prefix to match in gamepad id, if any.
- */
-module.exports.getGamepadsByPrefix = function (idPrefix) {
-  var gamepadsList = [];
-  var gamepad;
-  var gamepads = navigator.getGamepads && navigator.getGamepads();
-  if (!gamepads) { return gamepadsList; }
-
-  for (var i = 0; i < gamepads.length; ++i) {
-    gamepad = gamepads[i];
-    // need to check that gamepad is valid, since browsers may return array of null values
-    if (gamepad) {
-      if (!idPrefix || gamepad.id.indexOf(idPrefix) === 0) {
-        gamepadsList.push(gamepad);
-      }
-    }
-  }
-  return gamepadsList;
-};
-
-/**
  * Called on controller component `.play` handlers.
  * Check if controller matches parameters and inject tracked-controls component.
  * Handle event listeners.
  * Generate controllerconnected or controllerdisconnected events.
  *
- * @param {object} component - the tracked controls component.
- * @param {object} idPrefix - prefix to match in gamepad id, if any.
- * @param {object} queryObject - map of values to match (hand; index among controllers with idPrefix)
+ * @param {object} component - Tracked controls component.
+ * @param {object} idPrefix - Prefix to match in gamepad id if any.
+ * @param {object} queryObject - Map of values to match.
  */
 module.exports.checkControllerPresentAndSetup = function (component, idPrefix, queryObject) {
   var el = component.el;
@@ -62,31 +39,29 @@ module.exports.checkControllerPresentAndSetup = function (component, idPrefix, q
 };
 
 /**
- * Enumerate controllers (as built by system tick, e.g. that have pose) and check if they match parameters.
+ * Enumerate controller (that have pose) and check if they match parameters.
  *
- * @param {object} component - the tracked controls component.
- * @param {object} idPrefix - prefix to match in gamepad id, if any.
- * @param {object} queryObject - map of values to match (hand; index among controllers with idPrefix)
+ * @param {object} component - Tracked controls component.
+ * @param {object} idPrefix - Prefix to match in gamepad id if any.
+ * @param {object} queryObject - Map of values to match.
  */
 function isControllerPresent (component, idPrefix, queryObject) {
-  var isPresent = false;
-  var index = 0;
   var gamepad;
-  var isPrefixMatch;
   var gamepads;
+  var i;
+  var index = 0;
+  var isPrefixMatch;
+  var isPresent = false;
   var sceneEl = component.el.sceneEl;
+  var trackedControlsSystem;
 
-  var trackedControlsSystem = sceneEl && sceneEl.systems['tracked-controls'];
-  if (!trackedControlsSystem) { return isPresent; }
+  trackedControlsSystem = sceneEl && sceneEl.systems['tracked-controls'];
+  if (!trackedControlsSystem) { return false; }
+
   gamepads = trackedControlsSystem.controllers;
-  if (!gamepads || gamepads.length === 0) {
-    trackedControlsSystem.updateControllerList();
-    gamepads = trackedControlsSystem.controllers;
-  }
+  if (!gamepads.length) { return false; }
 
-  if (!gamepads) { return isPresent; }
-
-  for (var i = 0; i < gamepads.length; ++i) {
+  for (i = 0; i < gamepads.length; ++i) {
     gamepad = gamepads[i];
     isPrefixMatch = (!idPrefix || idPrefix === '' || gamepad.id.indexOf(idPrefix) === 0);
     isPresent = isPrefixMatch;
@@ -94,10 +69,12 @@ function isControllerPresent (component, idPrefix, queryObject) {
       isPresent = (gamepad.hand || DEFAULT_HANDEDNESS) === queryObject.hand;
     }
     if (isPresent && queryObject.index) {
-      isPresent = index === queryObject.index; // need to use count of gamepads with idPrefix
+      // Need to use count of gamepads with idPrefix.
+      isPresent = index === queryObject.index;
     }
     if (isPresent) { break; }
-    if (isPrefixMatch) { index++; } // update count of gamepads with idPrefix
+    // Update count of gamepads with idPrefix.
+    if (isPrefixMatch) { index++; }
   }
 
   return isPresent;
@@ -106,23 +83,36 @@ function isControllerPresent (component, idPrefix, queryObject) {
 module.exports.isControllerPresent = isControllerPresent;
 
 /**
- * Emit specific moved event(s) if axes changed, based on original axismoved event.
+ * Emit specific `moved` event(s) if axes changed based on original axismoved event.
  *
- * @param {object} self - the component in use (e.g. oculus-touch-controls, vive-controls...)
- * @param {array} axesMapping - the axes mapping to process
- * @param {object} evt - the event to process
+ * @param {object} component - Controller component in use.
+ * @param {array} axesMapping - For example `{thumbstick: [0, 1]}`.
+ * @param {object} evt - Event to process.
  */
-module.exports.emitIfAxesChanged = function (self, axesMapping, evt) {
-  Object.keys(axesMapping).forEach(function (key) {
-    var axes = axesMapping[key];
-    var changed = evt.detail.changed;
-    // If no changed axes given at all, or at least one changed value is true in the array,
-    if (axes.reduce(function (b, axis) { return b || changed[axis]; }, !changed)) {
-      // An axis has changed, so emit the specific moved event, detailing axis values.
-      var detail = {};
-      axes.forEach(function (axis) { detail[AXIS_LABELS[axis]] = evt.detail.axis[axis]; });
-      self.el.emit(key + 'moved', detail);
-      // If we updated the model based on axis values, that call would go here.
+module.exports.emitIfAxesChanged = function (component, axesMapping, evt) {
+  var axes;
+  var buttonTypes;
+  var changed;
+  var detail;
+  var i;
+  var j;
+
+  buttonTypes = Object.keys(axesMapping);
+  for (i = 0; i < buttonTypes.length; i++) {
+    axes = axesMapping[buttonTypes[i]];
+
+    changed = false;
+    for (j = 0; j < axes.length; j++) {
+      if (evt.detail.changed[j]) { changed = true; }
     }
-  });
+
+    if (!changed) { continue; }
+
+    // Axis has changed. Emit the specific moved event with axis values in detail.
+    detail = {};
+    for (j = 0; j < axes.length; j++) {
+      detail[AXIS_LABELS[axes[j]]] = evt.detail.axis[axes[j]];
+    }
+    component.el.emit(buttonTypes[i] + 'moved', detail);
+  }
 };


### PR DESCRIPTION
**Description:**

There was some messy/dirty/redundant code. Tested with Vive controllers.

**Changes proposed:**
- Limit the tracked-controls tick to every 500ms. Before it was every 10ms which does not help much since it usually takes more time to render a single frame. Pretty much, it was getting called on every frame. I don't think this polling needs to be called so often.
- Don't emit an event and allocate an object every single controller poll. Only emit if the number of controllers change. Before this was emitting every tick, and then possibly handled by 4 controller components at once, for each hand. Save 2 event emissions, 2 object allocations, and 8 event handler calls per tick.
- Remove `getGamepadsByPrefix` util. This was only being used in the tracked controls tick, and tracked controls never used the prefix feature. We call the `navigator.gamePads` now directly in the controls tick. Previously, we were creating a string and array on each tick, and then re-looping over that array and copying it to another array.
- Clean up axismove event abstraction, removing callbacks, and object/array creations.
- Don't need to call `updateControllersList` in the `isControllerPresent` util. This didn't really do anything since controllers were picked up through the `controllersupdate` event rather than within here.
- Various cleanups include removing unused properties (`axisLabels`), fixing 95-char lengths, and cleaner comments.
