### PR TITLE
optimize wasd-controls (add early return, skip type checking)

### DIFF
--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -8,6 +8,10 @@ var shouldCaptureKeyEvent = utils.shouldCaptureKeyEvent;
 
 var CLAMP_VELOCITY = 0.00001;
 var MAX_DELTA = 0.2;
+var KEYS = [
+  'KeyW', 'KeyA', 'KeyS', 'KeyD',
+  'ArrowUp', 'ArrowLeft', 'ArrowRight', 'ArrowDown'
+];
 
 /**
  * WASD component to control entities using WASD keys.
@@ -30,6 +34,7 @@ module.exports.Component = registerComponent('wasd-controls', {
     // To keep track of the pressed keys.
     this.keys = {};
 
+    this.position = {};
     this.velocity = new THREE.Vector3();
 
     // Bind methods and add event listeners.
@@ -42,27 +47,29 @@ module.exports.Component = registerComponent('wasd-controls', {
   },
 
   tick: function (time, delta) {
+    var currentPosition;
     var data = this.data;
     var el = this.el;
     var movementVector;
-    var position;
+    var position = this.position;
     var velocity = this.velocity;
 
-    // Use seconds.
-    delta = delta / 1000;
+    if (!velocity[data.adAxis] && !velocity[data.wsAxis] &&
+        isEmptyObject(this.keys)) { return; }
 
-    // Get velocity.
+    // Update velocity.
+    delta = delta / 1000;
     this.updateVelocity(delta);
+
     if (!velocity[data.adAxis] && !velocity[data.wsAxis]) { return; }
 
     // Get movement vector and translate position.
+    currentPosition = el.getAttribute('position');
     movementVector = this.getMovementVector(delta);
-    position = el.getAttribute('position');
-    el.setAttribute('position', {
-      x: position.x + movementVector.x,
-      y: position.y + movementVector.y,
-      z: position.z + movementVector.z
-    });
+    position.x = currentPosition.x + movementVector.x;
+    position.y = currentPosition.y + movementVector.y;
+    position.z = currentPosition.z + movementVector.z;
+    el.setAttribute('position', position);
   },
 
   remove: function () {
@@ -193,12 +200,18 @@ module.exports.Component = registerComponent('wasd-controls', {
     var code;
     if (!shouldCaptureKeyEvent(event)) { return; }
     code = event.code || KEYCODE_TO_CODE[event.keyCode];
-    this.keys[code] = true;
+    if (KEYS.indexOf(code) !== -1) { this.keys[code] = true; }
   },
 
   onKeyUp: function (event) {
     var code;
     code = event.code || KEYCODE_TO_CODE[event.keyCode];
-    this.keys[code] = false;
+    delete this.keys[code];
   }
 });
+
+function isEmptyObject (keys) {
+  var key;
+  for (key in keys) { return false; }
+  return true;
+}


### PR DESCRIPTION
**Description:**

Shouldn't try to run any WASD controls code if we're not using WASD (e.g., in real VR).

**Changes proposed:**
- Add early return to `wasd-controls` tick to not run `updateVelocity` if no keys have been pressed and no velocity to decay. Keep better track of what relevant keys have been pressed to be able to detect this.
- Re-use object for updating `position`. 