### PR TITLE
optimize vec3 parse

### DIFF
--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -18,22 +18,24 @@ module.exports.regex = regex;
  */
 function parse (value, defaultVec) {
   var coordinate;
-  var vec = {};
+  var vec;
 
-  if (value && typeof value === 'object') {
-    return vecParseFloat({
-      x: value.x !== undefined ? value.x : (defaultVec && defaultVec.x),
-      y: value.y !== undefined ? value.y : (defaultVec && defaultVec.y),
-      z: value.z !== undefined ? value.z : (defaultVec && defaultVec.z),
-      w: value.w !== undefined ? value.w : (defaultVec && defaultVec.w)
-    });
+  if (value && value instanceof Object) {
+    if (defaultVec) {
+      value.x = value.x === undefined ? defaultVec.x : value.x;
+      value.y = value.y === undefined ? defaultVec.y : value.y;
+      value.z = value.z === undefined ? defaultVec.z : value.z;
+      value.w = value.w === undefined ? defaultVec.w : value.w;
+    }
+    return vecParseFloat(value);
   }
 
-  if (typeof value !== 'string' || value === null) {
+  if (value === null || value === undefined) {
     return typeof defaultVec === 'object' ? extend({}, defaultVec) : defaultVec;
   }
 
   coordinate = value.trim().replace(/\s+/g, ' ').split(' ');
+  vec = {};
   vec.x = coordinate[0] || defaultVec && defaultVec.x;
   vec.y = coordinate[1] || defaultVec && defaultVec.y;
   vec.z = coordinate[2] || defaultVec && defaultVec.z;
@@ -43,7 +45,7 @@ function parse (value, defaultVec) {
 module.exports.parse = parse;
 
 /**
- * Stringifies coordinates from an object with keys [x y z].
+ * Stringify coordinates from an object with keys [x y z].
  * Example: {x: 3, y: 10, z: -5} to "3 10 -5".
  *
  * @param {object|string} data - An object with keys [x y z].
@@ -69,18 +71,21 @@ module.exports.isCoordinate = function (value) {
 };
 
 function vecParseFloat (vec) {
-  Object.keys(vec).forEach(function (key) {
+  var key;
+  for (key in vec) {
     if (vec[key] === undefined) {
       delete vec[key];
-      return;
+      continue;
     }
-    vec[key] = parseFloat(vec[key], 10);
-  });
+    if (vec[key].constructor === String) {
+      vec[key] = parseFloat(vec[key], 10);
+    }
+  }
   return vec;
 }
 
 /**
- * Converts {x, y, z} object to three.js Vector3.
+ * Convert {x, y, z} object to three.js Vector3.
  */
 module.exports.toVector3 = function (vec3) {
   return new THREE.Vector3(vec3.x, vec3.y, vec3.z);


### PR DESCRIPTION
**Description:**

Doing a performance profile on allocations using that in-VR perf demo, I found `vecParseFloat` was the 2nd biggest object allocator, and `vecParse` was the 6th biggest object allocator. Seems right given how often `setAttribute` on a `vec3` is called, although I would've though `skipTypeChecking` should've prevented these calls at all.

**Changes proposed:**
- In `vecParseFloat`, don't create an Array (`Object.keys`) and callback. Don't need to call `parseFloat` on a number.
- In `vecParse`, move an object allocation down to only when it's needed (string parsing). And save an object allocation by modifying existing object.
