### PR TITLE
object pooling in component core, optimize style parser to reuse object

### DIFF
--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -158,8 +158,8 @@ module.exports.Component = registerComponent('camera', {
     if (this.savedPose || !hasPositionalTracking) { return; }
 
     this.savedPose = {
-      position: el.getAttribute('position'),
-      rotation: el.getAttribute('rotation')
+      position: utils.clone(el.getAttribute('position')),
+      rotation: utils.clone(el.getAttribute('rotation'))
     };
   },
 

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -104,12 +104,10 @@ module.exports.Component = registerComponent('geometry', {
 
   /**
    * Update geometry component schema based on geometry type.
-   *
-   * @param {object} data - New data passed by Component.
    */
   updateSchema: function (data) {
+    var currentGeometryType = this.oldData && this.oldData.primitive;
     var newGeometryType = data.primitive;
-    var currentGeometryType = this.data && this.data.primitive;
     var schema = geometries[newGeometryType] && geometries[newGeometryType].schema;
 
     // Geometry has no schema.

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -52,10 +52,16 @@ module.exports.Component = registerComponent('material', {
   },
 
   updateSchema: function (data) {
-    var newShader = data.shader;
-    var currentShader = this.data && this.data.shader;
-    var shader = newShader || currentShader;
-    var schema = shaders[shader] && shaders[shader].schema;
+    var currentShader;
+    var newShader;
+    var schema;
+    var shader;
+
+    newShader = data && data.shader;
+    currentShader = this.oldData && this.oldData.shader;
+    shader = newShader || currentShader;
+    schema = shaders[shader] && shaders[shader].schema;
+
     if (!schema) { error('Unknown shader schema ' + shader); }
     if (currentShader && newShader === currentShader) { return; }
     this.extendSchema(schema);

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -16,6 +16,7 @@ var warn = utils.debug('core:component:warn');
 
 var aframeScript = document.currentScript;
 var upperCaseRegExp = new RegExp('[A-Z]+');
+var objectPool = utils.objectPool.createPool();
 
 /**
  * Component class definition.
@@ -37,13 +38,22 @@ var Component = module.exports.Component = function (el, attrValue, id) {
   this.attrName = this.name + (id ? '__' + id : '');
   this.evtDetail = {id: this.id, name: this.name};
   this.initialized = false;
+  this.isSingleProperty = isSingleProp(this.schema);
+  this.isSinglePropertyObject = this.isSingleProperty &&
+                                isObject(parseProperty(undefined, this.schema));
+  this.isObjectBased = !this.isSingleProperty || this.isSinglePropertyObject;
   this.el.components[this.attrName] = this;
 
   // Store component data from previous update call.
-  this.oldData = undefined;
+  this.attrValue = undefined;
+  this.nextData = this.isObjectBased ? objectPool.use() : undefined;
+  this.oldData = this.isObjectBased ? objectPool.use() : undefined;
+  this.previousOldData = this.isObjectBased ? objectPool.use() : undefined;
+  this.parsingAttrValue = this.isObjectBased ? objectPool.use() : undefined;
+  // Purely for deciding to skip type checking.
+  this.previousAttrValue = undefined;
 
   // Last value passed to updateProperties.
-  this.previousAttrValue = undefined;
   this.throttledEmitComponentChanged = utils.throttle(function emitChange () {
     el.emit('componentchanged', self.evtDetail, false);
   }, 200);
@@ -122,7 +132,7 @@ Component.prototype = {
    */
   parse: function (value, silent) {
     var schema = this.schema;
-    if (isSingleProp(schema)) { return parseProperty(value, schema); }
+    if (this.isSingleProperty) { return parseProperty(value, schema); }
     return parseProperties(styleParser.parse(value), schema, true, this.name, silent);
   },
 
@@ -138,7 +148,7 @@ Component.prototype = {
   stringify: function (data) {
     var schema = this.schema;
     if (typeof data === 'string') { return data; }
-    if (isSingleProp(schema)) { return stringifyProperty(data, schema); }
+    if (this.isSingleProperty) { return stringifyProperty(data, schema); }
     data = stringifyProperties(data, schema);
     return styleParser.stringify(data);
   },
@@ -149,29 +159,52 @@ Component.prototype = {
    * @param {string} value - New data.
    * @param {boolean } clobber - Whether to wipe out and replace previous data.
    */
-  updateCachedAttrValue: function (value, clobber) {
-    var attrValue = this.parseAttrValueForCache(value);
-    var isSinglePropSchema = isSingleProp(this.schema);
-    var property;
-    if (value === undefined) { return; }
+  updateCachedAttrValue: (function () {
+    var tempObject = {};
 
-    // Merge new data with previous `attrValue` if updating and not clobbering.
-    if (!isSinglePropSchema && !clobber) {
-      this.attrValue = this.attrValue ? cloneData(this.attrValue) : {};
-      for (property in attrValue) {
-        this.attrValue[property] = attrValue[property];
+    return function (value, clobber) {
+      var newAttrValue;
+      var property;
+
+      if (value === undefined) { return; }
+
+      // If null value is the new attribute value, make the attribute value falsy.
+      if (value === null) {
+        if (this.isObjectBased && this.attrValue) {
+          objectPool.recycle(this.attrValue);
+        }
+        this.attrValue = undefined;
+        return;
       }
-      return;
-    }
 
-    // If single-prop schema or clobber.
-    this.attrValue = attrValue;
-  },
+      if (value instanceof Object) {
+        // If value is an object, copy it to our pooled newAttrValue object to use to update
+        // the attrValue.
+        objectPool.clear(tempObject);
+        newAttrValue = utils.extend(tempObject, value);
+      } else {
+        newAttrValue = this.parseAttrValueForCache(value);
+      }
+
+      // Merge new data with previous `attrValue` if updating and not clobbering.
+      if (this.isObjectBased && !clobber && this.attrValue) {
+        for (property in this.attrValue) {
+          if (!(property in newAttrValue)) {
+            newAttrValue[property] = this.attrValue[property];
+          }
+        }
+      }
+
+      // Update attrValue.
+      if (this.isObjectBased && !this.attrValue) { this.attrValue = objectPool.use(); }
+      objectPool.clear(this.attrValue);
+      this.attrValue = extendProperties(this.attrValue, newAttrValue, this.isObjectBased);
+    };
+  })(),
 
   /**
-   * Given an HTML attribute value parses the string
-   * based on the component schema. To avoid double parsings of
-   * strings into strings we store the original instead
+   * Given an HTML attribute value parses the string based on the component schema.
+   * To avoid double parsings of strings into strings we store the original instead
    * of the parsed one
    *
    * @param {string} value - HTML attribute value
@@ -179,7 +212,7 @@ Component.prototype = {
   parseAttrValueForCache: function (value) {
     var parsedValue;
     if (typeof value !== 'string') { return value; }
-    if (isSingleProp(this.schema)) {
+    if (this.isSingleProperty) {
       parsedValue = this.schema.parse(value);
       /**
        * To avoid bogus double parsings. Cached values will be parsed when building
@@ -190,7 +223,8 @@ Component.prototype = {
       if (typeof parsedValue === 'string') { parsedValue = value; }
     } else {
       // Parse using the style parser to avoid double parsing of individual properties.
-      parsedValue = styleParser.parse(value);
+      objectPool.clear(this.parsingAttrValue);
+      parsedValue = styleParser.parse(value, this.parsingAttrValue);
     }
     return parsedValue;
   },
@@ -205,7 +239,7 @@ Component.prototype = {
     var attrValue = isDefault ? this.data : this.attrValue;
     if (!attrValue) { return; }
     window.HTMLElement.prototype.setAttribute.call(this.el, this.attrName,
-                                            this.stringify(attrValue));
+                                                   this.stringify(attrValue));
   },
 
   /**
@@ -217,10 +251,10 @@ Component.prototype = {
    */
   updateProperties: function (attrValue, clobber) {
     var el = this.el;
-    var isSinglePropSchema;
     var key;
+    var initialOldData;
+    var isSinglePropSchema;
     var skipTypeChecking;
-    var oldData = this.oldData;
 
     // Just cache the attribute if the entity has not loaded
     // Components are not initialized until the entity has loaded
@@ -252,7 +286,12 @@ Component.prototype = {
     // Cache previously passed attribute to decide if we skip type checking.
     this.previousAttrValue = attrValue;
 
+    // Parse the attribute value.
     attrValue = this.parseAttrValueForCache(attrValue);
+
+    // Update previous attribute value to later decide if we skip type checking.
+    this.previousAttrValue = attrValue;
+
     if (this.updateSchema) { this.updateSchema(this.buildData(attrValue, false, true)); }
     this.data = this.buildData(attrValue, clobber, false, skipTypeChecking);
 
@@ -268,23 +307,39 @@ Component.prototype = {
       this.init();
       this.initialized = true;
       delete el.initializingComponents[this.name];
+
+      // Store current data as previous data for future updates.
+      this.oldData = extendProperties(this.oldData, this.data, this.isObjectBased);
+
       // For oldData, pass empty object to multiple-prop schemas or object single-prop schema.
       // Pass undefined to rest of types.
-      oldData = (!isSinglePropSchema ||
-                 typeof parseProperty(undefined, this.schema) === 'object') ? {} : undefined;
-      // Store current data as previous data for future updates.
-      this.oldData = extendProperties({}, this.data, isSinglePropSchema);
-      this.update(oldData);
+      initialOldData = this.isObjectBased ? objectPool.use() : undefined;
+      this.update(initialOldData);
+      if (this.isObjectBased) { objectPool.recycle(initialOldData); }
+
       // Play the component if the entity is playing.
       if (el.isPlaying) { this.play(); }
       el.emit('componentinitialized', this.evtDetail, false);
     } else {
       // Don't update if properties haven't changed
       if (utils.deepEqual(this.oldData, this.data)) { return; }
-     // Store current data as previous data for future updates.
-      this.oldData = extendProperties({}, this.data, isSinglePropSchema);
+
+      // Store the previous old data before we calculate the new oldData.
+      if (this.previousOldData instanceof Object) { objectPool.clear(this.previousOldData); }
+      if (this.isObjectBased) {
+        copyData(this.oldData, this.previousOldData);
+      } else {
+        this.previousOldData = this.oldData;
+      }
+
+      // Store current data as previous data for future updates.
+      // Reuse `this.oldData` object to try not to allocate another one.
+      if (this.oldData instanceof Object) { objectPool.clear(this.oldData); }
+      this.oldData = extendProperties(this.oldData, this.data, this.isObjectBased);
+
       // Update component.
-      this.update(oldData);
+      this.update(this.previousOldData);
+
       this.throttledEmitComponentChanged();
     }
   },
@@ -296,7 +351,7 @@ Component.prototype = {
    * @param {string} propertyName - Name of property to reset.
    */
   resetProperty: function (propertyName) {
-    if (isSingleProp(this.schema)) {
+    if (!this.isObjectBased) {
       this.attrValue = undefined;
     } else {
       if (!(propertyName in this.attrValue)) { return; }
@@ -315,16 +370,17 @@ Component.prototype = {
    * @param {object} schemaAddon - Schema chunk that extend base schema.
    */
   extendSchema: function (schemaAddon) {
+    var extendedSchema;
     // Clone base schema.
-    var extendedSchema = utils.extend({}, components[this.name].schema);
+    extendedSchema = utils.extend(objectPool.use(), components[this.name].schema);
     // Extend base schema with new schema chunk.
     utils.extend(extendedSchema, schemaAddon);
     this.schema = processSchema(extendedSchema);
-    this.el.emit('schemachanged', {component: this.name});
+    this.el.emit('schemachanged', this.evtDetail);
   },
 
   /**
-   * Builds component data from the current state of the entity, ultimately
+   * Build component data from the current state of the entity, ultimately
    * updating this.data.
    *
    * If the component was detached completely, set data to null.
@@ -339,19 +395,18 @@ Component.prototype = {
    * @param {object} newData - Element new data.
    * @param {boolean} clobber - The previous data is completely replaced by the new one.
    * @param {boolean} silent - Suppress warning messages.
-   * @param {boolean} skipTypeChecking - Skip type checking and cohercion.
+   * @param {boolean} skipTypeChecking - Skip type checking and coercion.
    * @return {object} The component data
    */
   buildData: function (newData, clobber, silent, skipTypeChecking) {
     var componentDefined;
     var data;
     var defaultValue;
-    var keys;
-    var keysLength;
+    var key;
     var mixinData;
+    var nextData = this.nextData;
     var schema = this.schema;
     var i;
-    var isSinglePropSchema = isSingleProp(schema);
     var mixinEls = this.el.mixinEls;
     var previousData;
 
@@ -360,46 +415,57 @@ Component.prototype = {
       ? newData.length
       : newData !== undefined && newData !== null;
 
+    if (this.isObjectBased) { objectPool.clear(this.nextData); }
+
     // 1. Default values (lowest precendence).
-    if (isSinglePropSchema) {
-      // Clone default value if plain object so components don't share the same object
-      // that might be modified by the user.
-      data = isObjectOrArray(schema.default) ? utils.clone(schema.default) : schema.default;
+    if (this.isSingleProperty) {
+      if (this.isObjectBased) {
+        // If object-based single-prop, then copy over the data to our pooled object.
+        data = copyData(schema.default, nextData);
+      } else {
+        // If is plain single-prop, copy by value the default.
+        data = schema.default;
+      }
     } else {
       // Preserve previously set properties if clobber not enabled.
       previousData = !clobber && this.attrValue;
-      // Clone previous data to prevent sharing references with attrValue that might be
-      // modified by the user.
-      data = typeof previousData === 'object' ? cloneData(previousData) : {};
+
+      // Clone default value if object so components don't share object
+      data = previousData instanceof Object
+        ? copyData(previousData, nextData)
+        : nextData;
 
       // Apply defaults.
-      for (i = 0, keys = Object.keys(schema), keysLength = keys.length; i < keysLength; i++) {
-        defaultValue = schema[keys[i]].default;
-        if (data[keys[i]] !== undefined) { continue; }
+      for (key in schema) {
+        defaultValue = schema[key].default;
+        if (data[key] !== undefined) { continue; }
         // Clone default value if object so components don't share object
-        data[keys[i]] = isObjectOrArray(defaultValue) ? utils.clone(defaultValue) : defaultValue;
+        data[keys] = isObjectOrArray(defaultValue) ? utils.clone(defaultValue) : defaultValue;
       }
     }
 
     // 2. Mixin values.
     for (i = 0; i < mixinEls.length; i++) {
       mixinData = mixinEls[i].getAttribute(this.attrName);
-      if (mixinData) {
-        data = extendProperties(data, mixinData, isSinglePropSchema);
-      }
+      if (mixinData) { data = extendProperties(data, mixinData, this.isObjectBased); }
     }
 
     // 3. Attribute values (highest precendence).
     if (componentDefined) {
-      if (isSinglePropSchema) {
-        if (skipTypeChecking === true) { return newData; }
-        return parseProperty(newData, schema);
+      if (this.isSingleProperty) {
+        if (skipTypeChecking === true) { return attrValue; }
+        // If object-based, copy the value to not modify the original.
+        if (this.isObjectBased) {
+          copyData(attrValue, this.parsingAttrValue);
+          return parseProperty(this.parsingAttrValue, schema);
+        }
+        return parseProperty(attrValue, schema);
       }
-      data = extendProperties(data, newData, isSinglePropSchema);
+      data = extendProperties(data, attrValue, this.isObjectBased);
     } else {
       if (skipTypeChecking === true) { return data; }
       // Parse and coerce using the schema.
-      if (isSinglePropSchema) { return parseProperty(data, schema); }
+      if (this.isSingleProperty) { return parseProperty(data, schema); }
     }
 
     if (skipTypeChecking === true) { return data; }
@@ -477,6 +543,7 @@ module.exports.registerComponent = function (name, definition) {
   NewComponent.prototype.system = systems && systems.systems[name];
   NewComponent.prototype.play = wrapPlay(NewComponent.prototype.play);
   NewComponent.prototype.pause = wrapPause(NewComponent.prototype.pause);
+  NewComponent.prototype.remove = wrapRemove(NewComponent.prototype.remove);
 
   components[name] = {
     Component: NewComponent,
@@ -485,7 +552,8 @@ module.exports.registerComponent = function (name, definition) {
     multiple: NewComponent.prototype.multiple,
     parse: NewComponent.prototype.parse,
     parseAttrValueForCache: NewComponent.prototype.parseAttrValueForCache,
-    schema: utils.extend(processSchema(NewComponent.prototype.schema, NewComponent.prototype.name)),
+    schema: utils.extend(processSchema(NewComponent.prototype.schema,
+                                       NewComponent.prototype.name)),
     stringify: NewComponent.prototype.stringify,
     type: NewComponent.prototype.type
   };
@@ -499,15 +567,16 @@ module.exports.registerComponent = function (name, definition) {
 * @param data - Component data to clone.
 * @returns Cloned data.
 */
-function cloneData (data) {
-  var clone = {};
+function copyData (sourceData, dest) {
   var parsedProperty;
   var key;
-  for (key in data) {
-    parsedProperty = data[key];
-    clone[key] = isObjectOrArray(parsedProperty) ? utils.clone(parsedProperty) : parsedProperty;
+  for (key in sourceData) {
+    parsedProperty = sourceData[key];
+    dest[key] = isObjectOrArray(parsedProperty)
+      ? utils.clone(parsedProperty)
+      : parsedProperty;
   }
-  return clone;
+  return dest;
 }
 
 /**
@@ -515,12 +584,14 @@ function cloneData (data) {
 *
 * @param dest - Destination object or value.
 * @param source - Source object or value
-* @param {boolean} isSinglePropSchema - Whether or not schema is only a single property.
+* @param {boolean} isObjectBased - Whether values are objects.
 * @returns Overridden object or value.
 */
-function extendProperties (dest, source, isSinglePropSchema) {
-  if (isSinglePropSchema && (source === null || typeof source !== 'object')) { return source; }
-  return utils.extend(dest, source);
+function extendProperties (dest, source, isObjectBased) {
+  if (isObjectBased && source instanceof Object) {
+    return utils.extend(dest, source);
+  }
+  return source;
 }
 
 /**
@@ -531,10 +602,10 @@ function hasBehavior (component) {
 }
 
 /**
- * Wrapper for user defined pause method
+ * Wrapper for defined pause method.
  * Pause component by removing tick behavior and calling user's pause method.
  *
- * @param pauseMethod {function} - user defined pause method
+ * @param pauseMethod {function}
  */
 function wrapPause (pauseMethod) {
   return function pause () {
@@ -549,11 +620,10 @@ function wrapPause (pauseMethod) {
 }
 
 /**
- * Wrapper for user defined play method
+ * Wrapper for defined play method.
  * Play component by adding tick behavior and calling user's play method.
  *
- * @param playMethod {function} - user defined play method
- *
+ * @param playMethod {function}
  */
 function wrapPlay (playMethod) {
   return function play () {
@@ -566,6 +636,25 @@ function wrapPlay (playMethod) {
     if (!hasBehavior(this)) { return; }
     sceneEl.addBehavior(this);
   };
+}
+
+/**
+ * Wrapper for defined remove method.
+ * Clean up memory.
+ *
+ * @param removeMethod {function} - Defined remove method.
+ */
+function wrapRemove (removeMethod) {
+  return function remove () {
+    removeMethod.call(this);
+    objectPool.recycle(this.attrValue);
+    objectPool.recycle(this.oldData);
+    objectPool.recycle(this.parsingAttrValue);
+  };
+}
+
+function isObject (value) {
+  return value && value.constructor === Object;
 }
 
 function isObjectOrArray (value) {

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -16,7 +16,9 @@ var warn = utils.debug('core:component:warn');
 
 var aframeScript = document.currentScript;
 var upperCaseRegExp = new RegExp('[A-Z]+');
-var objectPool = utils.objectPool.createPool();
+
+// Object pools by component, created upon registration.
+var objectPools = {};
 
 /**
  * Component class definition.
@@ -43,13 +45,14 @@ var Component = module.exports.Component = function (el, attrValue, id) {
                                 isObject(parseProperty(undefined, this.schema));
   this.isObjectBased = !this.isSingleProperty || this.isSinglePropertyObject;
   this.el.components[this.attrName] = this;
+  this.objectPool = objectPools[this.name];
 
   // Store component data from previous update call.
   this.attrValue = undefined;
-  this.nextData = this.isObjectBased ? objectPool.use() : undefined;
-  this.oldData = this.isObjectBased ? objectPool.use() : undefined;
-  this.previousOldData = this.isObjectBased ? objectPool.use() : undefined;
-  this.parsingAttrValue = this.isObjectBased ? objectPool.use() : undefined;
+  this.nextData = this.isObjectBased ? this.objectPool.use() : undefined;
+  this.oldData = this.isObjectBased ? this.objectPool.use() : undefined;
+  this.previousOldData = this.isObjectBased ? this.objectPool.use() : undefined;
+  this.parsingAttrValue = this.isObjectBased ? this.objectPool.use() : undefined;
   // Purely for deciding to skip type checking.
   this.previousAttrValue = undefined;
 
@@ -159,48 +162,48 @@ Component.prototype = {
    * @param {string} value - New data.
    * @param {boolean } clobber - Whether to wipe out and replace previous data.
    */
-  updateCachedAttrValue: (function () {
-    var tempObject = {};
+  updateCachedAttrValue: function (value, clobber) {
+    var newAttrValue;
+    var tempObject;
+    var property;
 
-    return function (value, clobber) {
-      var newAttrValue;
-      var property;
+    if (value === undefined) { return; }
 
-      if (value === undefined) { return; }
-
-      // If null value is the new attribute value, make the attribute value falsy.
-      if (value === null) {
-        if (this.isObjectBased && this.attrValue) {
-          objectPool.recycle(this.attrValue);
-        }
-        this.attrValue = undefined;
-        return;
+    // If null value is the new attribute value, make the attribute value falsy.
+    if (value === null) {
+      if (this.isObjectBased && this.attrValue) {
+        this.objectPool.recycle(this.attrValue);
       }
+      this.attrValue = undefined;
+      return;
+    }
 
-      if (value instanceof Object) {
-        // If value is an object, copy it to our pooled newAttrValue object to use to update
-        // the attrValue.
-        objectPool.clear(tempObject);
-        newAttrValue = utils.extend(tempObject, value);
-      } else {
-        newAttrValue = this.parseAttrValueForCache(value);
-      }
+    if (value instanceof Object) {
+      // If value is an object, copy it to our pooled newAttrValue object to use to update
+      // the attrValue.
+      tempObject = this.objectPool.use();
+      newAttrValue = utils.extend(tempObject, value);
+    } else {
+      newAttrValue = this.parseAttrValueForCache(value);
+    }
 
-      // Merge new data with previous `attrValue` if updating and not clobbering.
-      if (this.isObjectBased && !clobber && this.attrValue) {
-        for (property in this.attrValue) {
-          if (!(property in newAttrValue)) {
-            newAttrValue[property] = this.attrValue[property];
-          }
+    // Merge new data with previous `attrValue` if updating and not clobbering.
+    if (this.isObjectBased && !clobber && this.attrValue) {
+      for (property in this.attrValue) {
+        if (!(property in newAttrValue)) {
+          newAttrValue[property] = this.attrValue[property];
         }
       }
+    }
 
-      // Update attrValue.
-      if (this.isObjectBased && !this.attrValue) { this.attrValue = objectPool.use(); }
-      objectPool.clear(this.attrValue);
-      this.attrValue = extendProperties(this.attrValue, newAttrValue, this.isObjectBased);
-    };
-  })(),
+    // Update attrValue.
+    if (this.isObjectBased && !this.attrValue) {
+      this.attrValue = this.objectPool.use();
+    }
+    utils.objectPool.clearObject(this.attrValue);
+    this.attrValue = extendProperties(this.attrValue, newAttrValue, this.isObjectBased);
+    utils.objectPool.clearObject(tempObject);
+  },
 
   /**
    * Given an HTML attribute value parses the string based on the component schema.
@@ -223,7 +226,7 @@ Component.prototype = {
       if (typeof parsedValue === 'string') { parsedValue = value; }
     } else {
       // Parse using the style parser to avoid double parsing of individual properties.
-      objectPool.clear(this.parsingAttrValue);
+      utils.objectPool.clearObject(this.parsingAttrValue);
       parsedValue = styleParser.parse(value, this.parsingAttrValue);
     }
     return parsedValue;
@@ -313,9 +316,9 @@ Component.prototype = {
 
       // For oldData, pass empty object to multiple-prop schemas or object single-prop schema.
       // Pass undefined to rest of types.
-      initialOldData = this.isObjectBased ? objectPool.use() : undefined;
+      initialOldData = this.isObjectBased ? this.objectPool.use() : undefined;
       this.update(initialOldData);
-      if (this.isObjectBased) { objectPool.recycle(initialOldData); }
+      if (this.isObjectBased) { this.objectPool.recycle(initialOldData); }
 
       // Play the component if the entity is playing.
       if (el.isPlaying) { this.play(); }
@@ -325,7 +328,9 @@ Component.prototype = {
       if (utils.deepEqual(this.oldData, this.data)) { return; }
 
       // Store the previous old data before we calculate the new oldData.
-      if (this.previousOldData instanceof Object) { objectPool.clear(this.previousOldData); }
+      if (this.previousOldData instanceof Object) {
+        utils.objectPool.clearObject(this.previousOldData);
+      }
       if (this.isObjectBased) {
         copyData(this.oldData, this.previousOldData);
       } else {
@@ -334,7 +339,7 @@ Component.prototype = {
 
       // Store current data as previous data for future updates.
       // Reuse `this.oldData` object to try not to allocate another one.
-      if (this.oldData instanceof Object) { objectPool.clear(this.oldData); }
+      if (this.oldData instanceof Object) { utils.objectPool.clearObject(this.oldData); }
       this.oldData = extendProperties(this.oldData, this.data, this.isObjectBased);
 
       // Update component.
@@ -372,7 +377,7 @@ Component.prototype = {
   extendSchema: function (schemaAddon) {
     var extendedSchema;
     // Clone base schema.
-    extendedSchema = utils.extend(objectPool.use(), components[this.name].schema);
+    extendedSchema = utils.extend({}, components[this.name].schema);
     // Extend base schema with new schema chunk.
     utils.extend(extendedSchema, schemaAddon);
     this.schema = processSchema(extendedSchema);
@@ -415,7 +420,7 @@ Component.prototype = {
       ? newData.length
       : newData !== undefined && newData !== null;
 
-    if (this.isObjectBased) { objectPool.clear(this.nextData); }
+    if (this.isObjectBased) { utils.objectPool.clearObject(nextData); }
 
     // 1. Default values (lowest precendence).
     if (this.isSingleProperty) {
@@ -545,11 +550,15 @@ module.exports.registerComponent = function (name, definition) {
   NewComponent.prototype.pause = wrapPause(NewComponent.prototype.pause);
   NewComponent.prototype.remove = wrapRemove(NewComponent.prototype.remove);
 
+  // Create object pool for class of components.
+  objectPools[name] = utils.objectPool.createPool();
+
   components[name] = {
     Component: NewComponent,
     dependencies: NewComponent.prototype.dependencies,
     isSingleProp: isSingleProp(NewComponent.prototype.schema),
     multiple: NewComponent.prototype.multiple,
+    name: name,
     parse: NewComponent.prototype.parse,
     parseAttrValueForCache: NewComponent.prototype.parseAttrValueForCache,
     schema: utils.extend(processSchema(NewComponent.prototype.schema,
@@ -647,9 +656,9 @@ function wrapPlay (playMethod) {
 function wrapRemove (removeMethod) {
   return function remove () {
     removeMethod.call(this);
-    objectPool.recycle(this.attrValue);
-    objectPool.recycle(this.oldData);
-    objectPool.recycle(this.parsingAttrValue);
+    this.objectPool.recycle(this.attrValue);
+    this.objectPool.recycle(this.oldData);
+    this.objectPool.recycle(this.parsingAttrValue);
   };
 }
 

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -190,7 +190,7 @@ Component.prototype = {
     // Merge new data with previous `attrValue` if updating and not clobbering.
     if (this.isObjectBased && !clobber && this.attrValue) {
       for (property in this.attrValue) {
-        if (!(property in newAttrValue)) {
+        if (newAttrValue[property] === undefined) {
           newAttrValue[property] = this.attrValue[property];
         }
       }
@@ -256,7 +256,6 @@ Component.prototype = {
     var el = this.el;
     var key;
     var initialOldData;
-    var isSinglePropSchema;
     var skipTypeChecking;
 
     // Just cache the attribute if the entity has not loaded
@@ -265,8 +264,6 @@ Component.prototype = {
       this.updateCachedAttrValue(attrValue);
       return;
     }
-
-    isSinglePropSchema = isSingleProp(this.schema);
 
     // Disable type checking if the passed attribute is an object and has not changed.
     skipTypeChecking = attrValue !== null && typeof this.previousAttrValue === 'object' &&
@@ -332,7 +329,7 @@ Component.prototype = {
         utils.objectPool.clearObject(this.previousOldData);
       }
       if (this.isObjectBased) {
-        copyData(this.oldData, this.previousOldData);
+        copyData(this.previousOldData, this.oldData);
       } else {
         this.previousOldData = this.oldData;
       }
@@ -426,10 +423,12 @@ Component.prototype = {
     if (this.isSingleProperty) {
       if (this.isObjectBased) {
         // If object-based single-prop, then copy over the data to our pooled object.
-        data = copyData(schema.default, nextData);
+        data = copyData(nextData, schema.default);
       } else {
         // If is plain single-prop, copy by value the default.
-        data = schema.default;
+        data = isObjectOrArray(schema.default)
+          ? utils.clone(schema.default)
+          : schema.default;
       }
     } else {
       // Preserve previously set properties if clobber not enabled.
@@ -437,7 +436,7 @@ Component.prototype = {
 
       // Clone default value if object so components don't share object
       data = previousData instanceof Object
-        ? copyData(previousData, nextData)
+        ? copyData(nextData, previousData)
         : nextData;
 
       // Apply defaults.
@@ -445,28 +444,31 @@ Component.prototype = {
         defaultValue = schema[key].default;
         if (data[key] !== undefined) { continue; }
         // Clone default value if object so components don't share object
-        data[keys] = isObjectOrArray(defaultValue) ? utils.clone(defaultValue) : defaultValue;
+        data[key] = isObjectOrArray(defaultValue)
+          ? utils.clone(defaultValue)
+          : defaultValue;
       }
     }
 
     // 2. Mixin values.
     for (i = 0; i < mixinEls.length; i++) {
       mixinData = mixinEls[i].getAttribute(this.attrName);
-      if (mixinData) { data = extendProperties(data, mixinData, this.isObjectBased); }
+      if (!mixinData) { continue; }
+      data = extendProperties(data, mixinData, this.isObjectBased);
     }
 
     // 3. Attribute values (highest precendence).
     if (componentDefined) {
       if (this.isSingleProperty) {
-        if (skipTypeChecking === true) { return attrValue; }
+        if (skipTypeChecking === true) { return newData; }
         // If object-based, copy the value to not modify the original.
         if (this.isObjectBased) {
-          copyData(attrValue, this.parsingAttrValue);
+          copyData(this.parsingAttrValue, newData);
           return parseProperty(this.parsingAttrValue, schema);
         }
-        return parseProperty(attrValue, schema);
+        return parseProperty(newData, schema);
       }
-      data = extendProperties(data, attrValue, this.isObjectBased);
+      data = extendProperties(data, newData, this.isObjectBased);
     } else {
       if (skipTypeChecking === true) { return data; }
       // Parse and coerce using the schema.
@@ -576,10 +578,11 @@ module.exports.registerComponent = function (name, definition) {
 * @param data - Component data to clone.
 * @returns Cloned data.
 */
-function copyData (sourceData, dest) {
+function copyData (dest, sourceData) {
   var parsedProperty;
   var key;
   for (key in sourceData) {
+    if (sourceData[key] === undefined) { continue; }
     parsedProperty = sourceData[key];
     dest[key] = isObjectOrArray(parsedProperty)
       ? utils.clone(parsedProperty)
@@ -597,8 +600,13 @@ function copyData (sourceData, dest) {
 * @returns Overridden object or value.
 */
 function extendProperties (dest, source, isObjectBased) {
+  var key;
   if (isObjectBased && source instanceof Object) {
-    return utils.extend(dest, source);
+    for (key in source) {
+      if (source[key] === undefined) { continue; }
+      dest[key] = source[key];
+    }
+    return dest;
   }
   return source;
 }

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -128,7 +128,7 @@ module.exports.parseProperties = (function () {
 
     // Validation errors.
     for (propName in propData) {
-      if (!schema[propName] && !silent) {
+      if (propData[propName] !== undefined && !schema[propName] && !silent) {
         warn('Unknown property `' + propName +
              '` for component/system `' + componentName + '`.');
       }

--- a/src/utils/object-pool.js
+++ b/src/utils/object-pool.js
@@ -72,7 +72,7 @@ module.exports.createPool = function createPool (objectFactory) {
 
 function clearObject (obj) {
   var key;
-  if (!(obj.constructor === Object)) { return; }
+  if (!obj || obj.constructor !== Object)) { return; }
   for (key in obj) { obj[key] = undefined; }
 }
 module.exports.clearObject = clearObject;

--- a/src/utils/object-pool.js
+++ b/src/utils/object-pool.js
@@ -72,7 +72,7 @@ module.exports.createPool = function createPool (objectFactory) {
 
 function clearObject (obj) {
   var key;
-  if (!obj || obj.constructor !== Object)) { return; }
+  if (!obj || obj.constructor !== Object) { return; }
   for (key in obj) { obj[key] = undefined; }
 }
 module.exports.clearObject = clearObject;

--- a/src/utils/styleParser.js
+++ b/src/utils/styleParser.js
@@ -1,16 +1,20 @@
-/* Utils for parsing style-like strings (e.g., "primitive: box; width: 5; height: 4.5"). */
-var styleParser = require('style-attr');
+/**
+ * Utils for parsing style-like strings (e.g., "primitive: box; width: 5; height: 4.5").
+ * Some code adapted from `style-attr` (https://github.com/joshwnj/style-attr)
+ * by Josh Johnston (MIT License).
+ */
 
 /**
- * Deserializes style-like string into an object of properties.
+ * Deserialize style-like string into an object of properties.
  *
  * @param {string} value - HTML attribute value.
+ * @param {object} obj - Reused object for object pooling.
  * @returns {object} Property data.
  */
-module.exports.parse = function (value) {
+module.exports.parse = function (value, obj) {
   var parsedData;
   if (typeof value !== 'string') { return value; }
-  parsedData = styleParser.parse(value);
+  parsedData = styleParse(value, obj);
   // The style parser returns an object { "" : "test"} when fed a string
   if (parsedData['']) { return value; }
   return transformKeysToCamelCase(parsedData);
@@ -24,7 +28,7 @@ module.exports.parse = function (value) {
  */
 module.exports.stringify = function (data) {
   if (typeof data === 'string') { return data; }
-  return styleParser.stringify(data);
+  return styleStringify(data);
 };
 
 /**
@@ -34,8 +38,7 @@ module.exports.stringify = function (data) {
  * @return {string} CamelCased string.
  */
 function toCamelCase (str) {
-  return str.replace(/-([a-z])/g, camelCase);
-  function camelCase (g) { return g[1].toUpperCase(); }
+  return str.replace(/-([a-z])/g, upperCase);
 }
 module.exports.toCamelCase = toCamelCase;
 
@@ -47,12 +50,101 @@ module.exports.toCamelCase = toCamelCase;
  * @return {object} The object with keys camelCased.
  */
 function transformKeysToCamelCase (obj) {
-  var keys = Object.keys(obj);
-  var camelCaseObj = {};
-  keys.forEach(function (key) {
-    var camelCaseKey = toCamelCase(key);
-    camelCaseObj[camelCaseKey] = obj[key];
-  });
-  return camelCaseObj;
+  var camelKey;
+  var key;
+  for (key in obj) {
+    camelKey = toCamelCase(key);
+    if (key === camelKey) { continue; }
+    obj[camelKey] = obj[key];
+    delete obj[key];
+  }
+  return obj;
 }
 module.exports.transformKeysToCamelCase = transformKeysToCamelCase;
+
+/**
+ * Split a string into chunks matching `<key>: <value>`
+ */
+var getKeyValueChunks = (function () {
+  var chunks = [];
+  var hasUnclosedUrl = /url\([^)]+$/;
+
+  return function getKeyValueChunks (raw) {
+    var chunk = '';
+    var nextSplit;
+    var offset = 0;
+    var sep = ';';
+
+    chunks.length = 0;
+
+    while (offset < raw.length) {
+      nextSplit = raw.indexOf(sep, offset);
+      if (nextSplit === -1) { nextSplit = raw.length; }
+
+      chunk += raw.substring(offset, nextSplit);
+
+      // data URIs can contain semicolons, so make sure we get the whole thing
+      if (hasUnclosedUrl.test(chunk)) {
+        chunk += ';';
+        offset = nextSplit + 1;
+        continue;
+      }
+
+      chunks.push(chunk.trim());
+      chunk = '';
+      offset = nextSplit + 1;
+    }
+
+    return chunks;
+  };
+})();
+
+/**
+ * Convert a style attribute string to an object.
+ *
+ * @param {object} str - Attribute string.
+ * @param {object} obj - Object to reuse as a base, else a new one will be allocated.
+ */
+function styleParse (str, obj) {
+  var chunks;
+  var i;
+  var item;
+  var pos;
+  var key;
+  var val;
+
+  obj = obj || {};
+
+  chunks = getKeyValueChunks(str);
+  for (i = 0; i < chunks.length; i++) {
+    item = chunks[i];
+    if (!item) { continue; }
+    // Split with `.indexOf` rather than `.split` because the value may also contain colons.
+    pos = item.indexOf(':');
+    key = item.substr(0, pos).trim();
+    val = item.substr(pos + 1).trim();
+    obj[key] = val;
+  }
+  return obj;
+}
+
+/**
+ * Convert an object into an attribute string
+ **/
+function styleStringify (obj) {
+  var key;
+  var keyCount = 0;
+  var i = 0;
+  var str = '';
+
+  for (key in obj) { keyCount++; }
+
+  for (key in obj) {
+    str += (key + ': ' + obj[key]);
+    if (i < keyCount - 1) { str += '; '; }
+    i++;
+  }
+  return str;
+}
+
+function upperCase (str) { return str[1].toUpperCase(); }

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -18,6 +18,7 @@ suite('geometry', function () {
   suite('update', function () {
     test('allows empty geometry', function () {
       this.el.setAttribute('geometry', '');
+      this.el.setAttribute('geometry', '');
     });
 
     test('creates geometry', function () {

--- a/tests/components/text.test.js
+++ b/tests/components/text.test.js
@@ -49,24 +49,22 @@ suite('text', function () {
 
   suite('update', function () {
     test('updates value', function (done) {
-      var updateSpy = this.sinon.spy(component, 'updateGeometry');
       el.addEventListener('textfontset', evt => {
+        assert.equal(component.data.value, '');
         el.setAttribute('text', {value: 'foo', font: 'mozillavr'});
+        assert.equal(component.data.value, 'foo');
         el.setAttribute('text', {value: 'bar', font: 'mozillavr'});
-        assert.equal(updateSpy.getCalls()[0].args[1].value, '');
-        assert.equal(updateSpy.getCalls()[1].args[1].value, 'foo');
-        assert.equal(updateSpy.getCalls()[2].args[1].value, 'bar');
+        assert.equal(component.data.value, 'bar');
         done();
       });
       el.setAttribute('text', {font: 'mozillavr'});
     });
 
     test('updates value with number', function (done) {
-      var updateSpy = this.sinon.spy(component, 'updateGeometry');
       el.addEventListener('textfontset', evt => {
+        assert.equal(component.data.value, '');
         el.setAttribute('text', {value: 10, font: 'mozillavr'});
-        assert.equal(updateSpy.getCalls()[0].args[1].value, '');
-        assert.equal(updateSpy.getCalls()[1].args[1].value, '10');
+        assert.equal(component.data.value, '10');
         done();
       });
       el.setAttribute('text', {font: 'mozillavr'});

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -485,8 +485,9 @@ suite('a-entity', function () {
           assert.shallowDeepEqual(el.components.geometry.attrValue, {
             depth: 20,
             height: 10,
+            primitive: 'box',
             width: 5
-          });
+          }, 'Second attrValue');
           assert.equal(geometry.width, 5, 'Second setAttribute');
           done();
         });
@@ -500,7 +501,7 @@ suite('a-entity', function () {
   suite('flushToDOM', function () {
     test('updates DOM attributes', function () {
       var el = this.el;
-      var materialStr = 'color:#F0F;metalness:0.75';
+      var materialStr = 'color: #F0F; metalness: 0.75';
       var material;
       el.setAttribute('material', materialStr);
       material = HTMLElement.prototype.getAttribute.call(el, 'material');
@@ -512,7 +513,7 @@ suite('a-entity', function () {
 
     test('updates DOM attributes of a multiple component', function () {
       var el = this.el;
-      var soundStr = 'src:url(mysoundfile.mp3);autoplay:true';
+      var soundStr = 'src: url(mysoundfile.mp3); autoplay: true';
       var soundAttrValue;
       el.setAttribute('sound__1', {'src': 'url(mysoundfile.mp3)', autoplay: true});
       soundAttrValue = HTMLElement.prototype.getAttribute.call(el, 'sound__1');
@@ -527,7 +528,7 @@ suite('a-entity', function () {
       var childEl = document.createElement('a-entity');
       var childMaterialStr = 'color:pink';
       var materialAttr;
-      var materialStr = 'color:#F0F;metalness:0.75';
+      var materialStr = 'color: #F0F; metalness: 0.75';
       childEl.addEventListener('loaded', function () {
         materialAttr = HTMLElement.prototype.getAttribute.call(el, 'material');
         assert.equal(materialAttr, null);
@@ -537,7 +538,7 @@ suite('a-entity', function () {
         childEl.setAttribute('material', childMaterialStr);
         el.flushToDOM(true);
         materialAttr = HTMLElement.prototype.getAttribute.call(el, 'material');
-        assert.equal(materialAttr, 'color:#F0F;metalness:0.75');
+        assert.equal(materialAttr, 'color: #F0F; metalness: 0.75');
         materialAttr = HTMLElement.prototype.getAttribute.call(childEl, 'material');
         assert.equal(childMaterialStr, 'color:pink');
         done();
@@ -717,9 +718,9 @@ suite('a-entity', function () {
       assert.shallowDeepEqual(el.getDOMAttribute('material'), {});
     });
 
-    test('returns null for a default component if it is not set', function () {
+    test('returns attrValue for a default component', function () {
       var el = this.el;
-      assert.shallowDeepEqual(el.getDOMAttribute('position'), null);
+      assert.shallowDeepEqual(el.getDOMAttribute('position'), {});
     });
 
     test('returns parsed data if default component is set', function () {
@@ -949,7 +950,7 @@ suite('a-entity', function () {
       var el = this.el;
       assert.ok('position' in el.components);
       el.removeAttribute('position');
-      assert.equal(el.getDOMAttribute('position'), null);
+      assert.shallowDeepEqual(el.getDOMAttribute('position'), {});
       assert.ok('position' in el.components);
     });
 
@@ -976,21 +977,26 @@ suite('a-entity', function () {
 
     test('can clear mixins', function () {
       var el = this.el;
+      el.setAttribute('id', 'test');
       mixinFactory('foo', {position: '1 2 3'});
       mixinFactory('bar', {scale: '1 2 3'});
       el.setAttribute('mixin', 'foo bar');
-      assert.shallowDeepEqual(el.getAttribute('position'), {x: 1, y: 2, z: 3});
-      assert.shallowDeepEqual(el.getAttribute('scale'), {x: 1, y: 2, z: 3});
+      assert.shallowDeepEqual(el.getAttribute('position'), {x: 1, y: 2, z: 3},
+                              'Position mixin');
+      assert.shallowDeepEqual(el.getAttribute('scale'), {x: 1, y: 2, z: 3},
+                              'Scale mixin');
       el.removeAttribute('mixin');
-      assert.shallowDeepEqual(el.getAttribute('position'), {x: 0, y: 0, z: 0});
-      assert.shallowDeepEqual(el.getAttribute('scale'), {x: 1, y: 1, z: 1});
+      assert.shallowDeepEqual(el.getAttribute('position'), {x: 0, y: 0, z: 0},
+                              'Position without mixin');
+      assert.shallowDeepEqual(el.getAttribute('scale'), {x: 1, y: 1, z: 1},
+                              'Scale without mixin');
     });
   });
 
   suite('initComponent', function () {
     test('initializes component', function () {
       var el = this.el;
-      el.initComponent('material', false, 'color: #F0F; transparent: true');
+      el.initComponent('material', 'color: #F0F; transparent: true', false);
       assert.ok(el.components.material);
     });
 
@@ -1005,7 +1011,7 @@ suite('a-entity', function () {
 
     test('initializes dependency component and can set attribute', function () {
       var el = this.el;
-      el.initComponent('material', undefined, true);
+      el.initComponent('material', '', true);
       assert.shallowDeepEqual(el.getAttribute('material'), {});
     });
 
@@ -1118,7 +1124,7 @@ suite('a-entity', function () {
       this.sinon.stub(el, 'setAttribute', nativeSetAttribute);
       this.sinon.stub(el, 'getAttribute', nativeGetAttribute);
       el.setAttribute('material', materialAttribute);
-      el.initComponent('material', true);
+      el.initComponent('material', '', true);
       assert.equal(el.getAttribute('material'), materialAttribute);
     });
 

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -395,22 +395,24 @@ suite('Component', function () {
       el.setAttribute('material', '');
     });
 
-    test('a selector property default is not cloned into data', function () {
+    test('does not clone selector property default into data', function () {
+      var el;
       registerComponent('dummy', {
         schema: {type: 'selector', default: document.body}
       });
-      var el = document.createElement('a-entity');
+      el = document.createElement('a-entity');
       el.hasLoaded = true;
       el.setAttribute('dummy', 'head');
       el.components.dummy.updateProperties('');
       assert.equal(el.components.dummy.data, el.components.dummy.schema.default);
     });
 
-    test('a plain object schema default is cloned into data', function () {
+    test('clones plain object schema default into data', function () {
+      var el;
       registerComponent('dummy', {
         schema: {type: 'vec3', default: {x: 1, y: 1, z: 1}}
       });
-      var el = document.createElement('a-entity');
+      el = document.createElement('a-entity');
       el.hasLoaded = true;
       el.setAttribute('dummy', '2 2 2');
       el.components.dummy.updateProperties('');
@@ -418,7 +420,10 @@ suite('Component', function () {
       assert.deepEqual(el.components.dummy.data, {x: 1, y: 1, z: 1});
     });
 
-    test('do not clone properties from attrValue into data that are not plain objects', function () {
+    test('does not clone props from attrValue into data that are not plain objects', function () {
+      var attrValue;
+      var el;
+      var data;
       registerComponent('dummy', {
         schema: {
           color: {default: 'blue'},
@@ -426,13 +431,12 @@ suite('Component', function () {
           el: {type: 'selector', default: 'body'}
         }
       });
-      var el = document.createElement('a-entity');
+      el = document.createElement('a-entity');
       el.hasLoaded = true;
       el.setAttribute('dummy', '');
       assert.notOk(el.components.dummy.attrValue.el);
-      // The direction property will be preserved
-      // across updateProperties calls but cloned
-      // into a different object
+      // The direction property will be preserved across updateProperties calls but cloned
+      // into a different object.
       el.components.dummy.updateProperties({
         color: 'green',
         direction: {x: 1, y: 1, z: 1},
@@ -442,8 +446,8 @@ suite('Component', function () {
         color: 'red',
         el: document.head
       });
-      var data = el.getAttribute('dummy');
-      var attrValue = el.components.dummy.attrValue;
+      data = el.getAttribute('dummy');
+      attrValue = el.components.dummy.attrValue;
       assert.notEqual(data, attrValue);
       assert.equal(data.color, attrValue.color);
       // HTMLElement not cloned in attrValue, reference is shared instead.
@@ -629,7 +633,7 @@ suite('Component', function () {
       var component = new TestComponent(el);
       var componentObj = {position: {x: 1, y: 2, z: 3}};
       var componentString = component.stringify(componentObj);
-      assert.deepEqual(componentString, 'position:1 2 3');
+      assert.equal(componentString, 'position: 1 2 3');
     });
   });
 
@@ -749,7 +753,9 @@ suite('Component', function () {
     });
 
     test('emit componentchanged when update calls setAttribute', function (done) {
-      var TestComponent = registerComponent('dummy', {
+      var component;
+      var TestComponent;
+      TestComponent = registerComponent('dummy', {
         schema: {color: {default: 'red'}},
         update: function () { this.el.setAttribute('dummy', 'color', 'blue'); }
       });
@@ -758,11 +764,11 @@ suite('Component', function () {
         assert.equal(this.el.getAttribute('dummy').color, 'blue');
         done();
       });
-      var component = new TestComponent(this.el);
+      component = new TestComponent(this.el);
       assert.equal(component.data.color, 'blue');
     });
 
-    test('oldData is empty object on the first call when a single property component with an object as default initializes', function () {
+    test('makes oldData empty object on first call when single property component with an object as default initializes', function () {
       var updateStub = sinon.stub();
       registerComponent('dummy', {
         schema: {type: 'vec3'},
@@ -774,7 +780,7 @@ suite('Component', function () {
       assert.deepEqual(updateStub.getCalls()[0].args[0], {});
     });
 
-    test('oldData is empty object on the first call when a multiple property component initializes', function () {
+    test('makes oldData empty object on first call when multiple property component initializes', function () {
       var updateStub = sinon.stub();
       registerComponent('dummy', {
         schema: {
@@ -823,7 +829,7 @@ suite('Component', function () {
       assert.deepEqual(el.components.dummy.data, {x: 2, y: 2, z: 2});
     });
 
-    test('oldData and data is properly passed on recursive calls to setAttribute', function () {
+    test('properly passes oldData and data properly on recursive calls to setAttribute', function () {
       var el = this.el;
       registerComponent('dummy', {
         schema: {
@@ -857,7 +863,7 @@ suite('Component', function () {
       el.setAttribute('dummy', {color: 'blue'});
       assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), '');
       el.components.dummy.flushToDOM();
-      assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), 'color:blue');
+      assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), 'color: blue');
     });
 
     test('init and update are not called for a not loaded entity', function () {
@@ -875,7 +881,7 @@ suite('Component', function () {
       el.components.dummy.flushToDOM();
       sinon.assert.notCalled(initStub);
       sinon.assert.notCalled(updateStub);
-      assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), 'color:blue');
+      assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), 'color: blue');
     });
   });
 

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -823,8 +823,10 @@ suite('Component', function () {
       direction.z += 1;
       el.setAttribute('dummy', direction);
       sinon.assert.calledTwice(updateStub);
-      // old Data passed to the update method
-      assert.deepEqual(updateStub.getCalls()[0].args[0], {});
+      // oldData passed to the update method.
+      assert.equal(updateStub.getCalls()[0].args[0].x, undefined);
+      assert.equal(updateStub.getCalls()[0].args[0].y, undefined);
+      assert.equal(updateStub.getCalls()[0].args[0].z, undefined);
       assert.deepEqual(updateStub.getCalls()[1].args[0], {x: 1, y: 1, z: 1});
       assert.deepEqual(el.components.dummy.data, {x: 2, y: 2, z: 2});
     });

--- a/tests/core/controls.test.js
+++ b/tests/core/controls.test.js
@@ -1,4 +1,4 @@
-/* global Event, assert, process, setup, suite, test */
+/* global AFRAME, Event, assert, process, setup, suite, test */
 var helpers = require('../helpers');
 var THREE = require('lib/three');
 
@@ -22,7 +22,7 @@ suite('position controls on camera with WASD controls (integration unit test)', 
     var keydownEvent;
     var position;
 
-    position = el.getAttribute('position');
+    position = AFRAME.utils.clone(el.getAttribute('position'));
     keydownEvent = new Event('keydown');
     keydownEvent.code = 'KeyW';
     window.dispatchEvent(keydownEvent);
@@ -44,7 +44,7 @@ suite('position controls on camera with WASD controls (integration unit test)', 
     var keydownEvent;
     var position;
 
-    position = el.getAttribute('position');
+    position = AFRAME.utils.clone(el.getAttribute('position'));
     keydownEvent = new Event('keydown');
     keydownEvent.code = 'KeyA';
     window.dispatchEvent(keydownEvent);
@@ -66,7 +66,7 @@ suite('position controls on camera with WASD controls (integration unit test)', 
     var keydownEvent;
     var position;
 
-    position = el.getAttribute('position');
+    position = AFRAME.utils.clone(el.getAttribute('position'));
     keydownEvent = new Event('keydown');
     keydownEvent.code = 'KeyS';
     window.dispatchEvent(keydownEvent);
@@ -88,7 +88,7 @@ suite('position controls on camera with WASD controls (integration unit test)', 
     var keydownEvent;
     var position;
 
-    position = el.getAttribute('position');
+    position = AFRAME.utils.clone(el.getAttribute('position'));
     keydownEvent = new Event('keydown');
     keydownEvent.code = 'KeyD';
     window.dispatchEvent(keydownEvent);
@@ -111,7 +111,7 @@ suite('position controls on camera with WASD controls (integration unit test)', 
     var position;
 
     el.setAttribute('rotation', '0 90 0');
-    position = el.getAttribute('position');
+    position = AFRAME.utils.clone(el.getAttribute('position'));
     keydownEvent = new Event('keydown');
     keydownEvent.code = 'KeyW';
     window.dispatchEvent(keydownEvent);


### PR DESCRIPTION
**Description:**

Rather than create a new object each time to create a new `oldData`, just have two objects representing `oldData` and `data`. Also when updating, rather than create a new `data` object, have a `newData` object that is used for holding the new data which then gets copied into `data`. So in total, only use three objects: `oldData`, `data`, `newData`.

**Changes proposed:**
- Adapt `style-attr` implementation to be able to pass in an object for reuse instead of creating a new one each time. Also remove lots of callbacks, `Object.keys()` array creations from their code.  Also tweaked to do prettier stringifies. We manage this forked dependency now. 
- Use object pooling in core component code to reduce object allocations. Recycle them when component is removed.
  - 1. Remove object allocation on each update for creating object for `oldData`.
  - 2. Remove object allocation on initialization for initial `oldData`.
  - 3. Remove object allocation on each update during `buildData` for default value copying.  
- Add some helper properties to component (`isSingleProp`, `isSinglePropObject`, `isObjectBased`)
- Update our `styleParser` utils a bit to not allocate object + array + use callbacks to convert keys to camelCase. 