### PR TITLE
5x faster utils.bind function

### DIFF
--- a/src/components/light.js
+++ b/src/components/light.js
@@ -1,4 +1,3 @@
-var bind = require('../utils/bind');
 var diff = require('../utils').diff;
 var debug = require('../utils/debug');
 var registerComponent = require('../core/component').registerComponent;
@@ -90,7 +89,7 @@ module.exports.Component = registerComponent('light', {
               if (value.hasLoaded) {
                 self.onSetTarget(value, light);
               } else {
-                value.addEventListener('loaded', bind(self.onSetTarget, self, value, light));
+                value.addEventListener('loaded', self.onSetTarget.bind(self, value, light));
               }
             }
             break;
@@ -221,7 +220,7 @@ module.exports.Component = registerComponent('light', {
           if (target.hasLoaded) {
             this.onSetTarget(target, light);
           } else {
-            target.addEventListener('loaded', bind(this.onSetTarget, this, target, light));
+            target.addEventListener('loaded', this.onSetTarget.bind(this, target, light));
           }
         }
         return light;
@@ -242,7 +241,7 @@ module.exports.Component = registerComponent('light', {
           if (target.hasLoaded) {
             this.onSetTarget(target, light);
           } else {
-            target.addEventListener('loaded', bind(this.onSetTarget, this, target, light));
+            target.addEventListener('loaded', this.onSetTarget.bind(this, target, light));
           }
         }
         return light;

--- a/src/utils/bind.js
+++ b/src/utils/bind.js
@@ -1,15 +1,11 @@
 /**
- * Faster version of Function.prototype.bind
+ * Simple and faster version of Function.prototype.bind.
+ *
  * @param {Function} fn - Function to wrap.
  * @param {Object} ctx - What to bind as context.
- * @param {...*} arguments - Arguments to pass through.
  */
-module.exports = function bind (fn, ctx/* , arg1, arg2 */) {
-  return (function (prependedArgs) {
-    return function bound () {
-      // Concat the bound function arguments with those passed to original bind
-      var args = prependedArgs.concat(Array.prototype.slice.call(arguments, 0));
-      return fn.apply(ctx, args);
-    };
-  })(Array.prototype.slice.call(arguments, 2));
+module.exports = function bind (fn, ctx) {
+  return function bound () {
+    return fn.apply(ctx, arguments);
+  };
 };

--- a/tests/utils/bind.test.js
+++ b/tests/utils/bind.test.js
@@ -22,26 +22,9 @@ suite('utils.bind', function () {
         return cb();
       }
     };
-    var obj2 = {
-      propName: 'webvr'
-    };
+    var obj2 = {propName: 'webvr'};
     var bound = bind(obj.getProp, obj2);
     assert.equal(obj2.propName, bound());
     assert.equal(obj2.propName, obj.getPropByCallback(bound));
-  });
-
-  test('utils.bind accepts and handles additional arguments properly', function () {
-    var firstArg = 'awesome';
-    var secondArg = {};
-    var obj = {
-      propName: 'aframe',
-      getPropertyByCallback: function (arg1, arg2, arg3) {
-        assert.equal(arg1, firstArg);
-        assert.equal(arg2, secondArg);
-        assert.equal(arg3, obj.propName);
-      }
-    };
-    var bound = bind(obj.getPropertyByCallback, obj, firstArg, secondArg);
-    bound(obj.propName);
   });
 });


### PR DESCRIPTION
**Description:**

https://jsperf.com/bind1-vs-bind2

We only care about binding the `this`/context. The additional argument binding we don't need, else just use vanilla bind for that.

**Changes proposed:**
- Simpler and fast bind function.