### PR TITLE
Bump THREE to r86

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "present": "0.0.6",
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
-    "three": "^0.84.0",
+    "three": "^0.86.0",
     "three-bmfont-text": "^2.1.0",
     "webvr-polyfill": "^0.9.36"
   },

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -419,6 +419,11 @@ module.exports.AScene = registerElement('a-scene', {
           antialias: shouldAntiAlias(this),
           alpha: true
         });
+        // r86 shipped with a bug fixed in https://github.com/mrdoob/three.js/pull/11970
+        // We need to setup a dummy VRDevice to avoid a TypeError
+        // when vrdisplaypresentchange fires.
+        // This line can be removed after updating to THREE r87.
+        renderer.vr.setDevice({});
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
         this.effect = new THREE.VREffect(renderer);


### PR DESCRIPTION
Bump THREE to `r86`
- This will unblock `glTF2` support (cc @donmccurdy)
- @mrdoob recommended to wait until `r87` to move from `VREffect` / `VRControls` to the new `renderer.vr` API