### PR TITLE
avoid error when schema.default is null

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -340,7 +340,7 @@ Component.prototype = {
     if (isSinglePropSchema) {
       // Clone default value if plain object so components don't share the same object
       // that might be modified by the user.
-      data = schema.default.constructor === Object ? utils.clone(schema.default) : schema.default;
+      data = (schema.default && schema.default.constructor === Object) ? utils.clone(schema.default) : schema.default;
     } else {
       // Preserve previously set properties if clobber not enabled.
       previousData = !clobber && this.attrValue;

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -24,8 +24,10 @@ var TestComponent = {
 };
 
 suite('a-entity', function () {
+  var el;
+
   setup(function (done) {
-    var el = this.el = entityFactory();
+    el = this.el = entityFactory();
     var onLoaded = function () {
       done();
       el.removeEventListener('loaded', onLoaded);

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -185,6 +185,17 @@ suite('Component', function () {
       assert.equal(data.depthTest, false);
       assert.equal(data.color, 'red');
     });
+
+    test('returns data for single-prop if default is null', function () {
+      var el = document.createElement('a-entity');
+      registerComponent('test', {
+        schema: {default: null}
+      });
+      el.setAttribute('test', '');
+      assert.equal(el.components.test.buildData(), null);
+      assert.equal(el.components.test.buildData(null), null);
+      assert.equal(el.components.test.buildData('foo'), 'foo');
+    });
   });
 
   suite('updateProperties', function () {


### PR DESCRIPTION
check schema.default before trying to access constructor
to avoid these errors
```component.js:343 Uncaught (in promise) TypeError: Cannot read property 'constructor' of null
    at NewComponent.buildData (component.js:343)
    at NewComponent.updateProperties (component.js:239)
    at NewComponent.module.exports.Component (component.js:50)
    at new NewComponent (component.js:449)
    at HTMLElement.value (a-entity.js:391)
    at HTMLElement.value (a-entity.js:558)
    at HTMLElement.Object.create.updateComponents.value (a-entity.js:525)
    at entityLoadCallback (a-entity.js:320)
    at emitLoaded (a-node.js:117)
    at <anonymous>```