### PR TITLE
add look-controls new attribute and default "tiltEnabled: true" so th…

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -17,7 +17,8 @@ module.exports.Component = registerComponent('look-controls', {
     enabled: {default: true},
     hmdEnabled: {default: true},
     reverseMouseDrag: {default: false},
-    standing: {default: true}
+    standing: {default: true},
+    tiltEnabled: {default: true}
   },
 
   init: function () {
@@ -167,7 +168,7 @@ module.exports.Component = registerComponent('look-controls', {
     hmdQuaternion = hmdQuaternion.copy(this.dolly.quaternion);
     hmdEuler.setFromQuaternion(hmdQuaternion, 'YXZ');
 
-    if (sceneEl.isMobile) {
+    if (sceneEl.isMobile && this.data.tiltEnabled) {
       // On mobile, do camera rotation with touch events and sensors.
       rotation.x = radToDeg(hmdEuler.x) + radToDeg(pitchObject.rotation.x);
       rotation.y = radToDeg(hmdEuler.y) + radToDeg(yawObject.rotation.y);

--- a/tests/core/controls.test.js
+++ b/tests/core/controls.test.js
@@ -219,6 +219,21 @@ suite('rotation controls on camera with VRControls (integration unit test)', fun
       done();
     });
   });
+
+  test('does not rotate camera if tilt is disabled on mobile while not in VR', function (done) {
+    var el = this.el;
+    el.sceneEl.isMobile = true;
+    el.setAttribute('look-controls', 'tiltEnabled', false);
+    this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 2, PI / 6, PI / 2));
+    el.sceneEl.tick();
+    process.nextTick(function () {
+      var rotation = el.getAttribute('rotation');
+      assert.equal(rotation.x, 0);
+      assert.equal(rotation.y, 0);
+      assert.equal(rotation.z, 0);
+      done();
+    });
+  });
 });
 
 suite('rotation controls on camera with mouse drag (integration unit test)', function () {


### PR DESCRIPTION
…at mobile tilt can be disabled

**Description:**
This adds to the component look-controls schema: "tiltEnabled: false/true (default)"

**Changes proposed:**
This allows disabling the current default behavior that tilting a mobile device changes the orientation of the camera--while not in VR mode--i.e. "look around with your phone" mode. The current behavior (tilting) remains the default.
-
-
