### PR TITLE
In Python 3 SimpleHTTPServer is called http.server

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -58,8 +58,8 @@ files are properly served. Options of local servers include:
 
 - Downloading the [Mongoose](https://www.cesanta.com/products/binary) application
   and opening it from the same directory as your HTML file.
-- Running `python -m SimpleHTTPServer` in a terminal in the same directory as your
-  HTML file.
+- Running `python -m SimpleHTTPServer` (or `python -m http.server` for Python 3)
+  in a terminal in the same directory as your HTML file.
 - Running `npm install -g live-server && live-server` in a terminal in the same
   directory as your HTML file.
 


### PR DESCRIPTION
**Description:**

In Windows (arguably a popular beginner environment), Python 3 installs the `python` binary, same as Python 2. The `python -m SimpleHTTPServer` command mentioned in the docs will not work in Python 3, which can be mildly confusing to people unfamiliar with the change.

**Changes proposed:**

- Add the alternative command for Py3.
