### PR TITLE
Enable touch input for cursor click

### DIFF
--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -26,11 +26,11 @@ traditional web development for now. Under the hood, the cursor component uses
 the `raycaster-intersected` and `raycaster-intersection-cleared` events,
 capturing the closest visible intersected entity.
 
-By default, the cursor is configured to be used in a gaze-based mode
-and will register user input via mouse or touch.
-Specifying the `downEvents` and `upEvents` properties allows the cursor to work
-with controllers.  The [laser-controls component][laser-controls] automatically
-configures those.
+By default, the cursor is configured to be used in a gaze-based mode and will
+register user input via mouse or touch. Specifying the `downEvents` and
+`upEvents` properties allows the cursor to work with controllers. For example,
+the [laser-controls component][laser-controls] automatically configures these
+properties to work with most controllers..
 
 [geometry]: ./geometry.md
 [line]: ./line.md

--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -26,7 +26,8 @@ traditional web development for now. Under the hood, the cursor component uses
 the `raycaster-intersected` and `raycaster-intersection-cleared` events,
 capturing the closest visible intersected entity.
 
-By default, the cursor is configured to be used in a gaze-based mode.
+By default, the cursor is configured to be used in a gaze-based mode
+and will register user input via mouse or touch.
 Specifying the `downEvents` and `upEvents` properties allows the cursor to work
 with controllers.  The [laser-controls component][laser-controls] automatically
 configures those.

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -19,6 +19,11 @@ var STATES = {
   HOVERED: 'cursor-hovered'
 };
 
+var CANVASEVENTS = {
+  DOWN: ['mousedown', 'touchstart'],
+  UP: ['mouseup', 'touchend']
+};
+
 /**
  * Cursor component. Applies the raycaster component specifically for starting the raycaster
  * from the camera and pointing from camera's facing direction, and then only returning the
@@ -91,17 +96,21 @@ module.exports.Component = registerComponent('cursor', {
     var data = this.data;
     var el = this.el;
     var self = this;
+    function addCanvasListeners () {
+      canvas = el.sceneEl.canvas;
+      CANVASEVENTS.DOWN.forEach(function (downEvent) {
+        canvas.addEventListener(downEvent, self.onCursorDown);
+      });
+      CANVASEVENTS.UP.forEach(function (upEvent) {
+        canvas.addEventListener(upEvent, self.onCursorUp);
+      });
+    }
 
     canvas = el.sceneEl.canvas;
     if (canvas) {
-      canvas.addEventListener('mousedown', this.onCursorDown);
-      canvas.addEventListener('mouseup', this.onCursorUp);
+      addCanvasListeners();
     } else {
-      el.sceneEl.addEventListener('render-target-loaded', function () {
-        canvas = el.sceneEl.canvas;
-        canvas.addEventListener('mousedown', self.onCursorDown);
-        canvas.addEventListener('mouseup', self.onCursorUp);
-      });
+      el.sceneEl.addEventListener('render-target-loaded', addCanvasListeners);
     }
 
     data.downEvents.forEach(function (downEvent) {
@@ -124,8 +133,12 @@ module.exports.Component = registerComponent('cursor', {
 
     canvas = el.sceneEl.canvas;
     if (canvas) {
-      canvas.removeEventListener('mousedown', this.onCursorDown);
-      canvas.removeEventListener('mouseup', this.onCursorUp);
+      CANVASEVENTS.DOWN.forEach(function (downEvent) {
+        canvas.removeEventListener(downEvent, self.onCursorDown);
+      });
+      CANVASEVENTS.UP.forEach(function (upEvent) {
+        canvas.removeEventListener(upEvent, self.onCursorUp);
+      });
     }
 
     data.downEvents.forEach(function (downEvent) {

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -19,7 +19,7 @@ var STATES = {
   HOVERED: 'cursor-hovered'
 };
 
-var CANVASEVENTS = {
+var CANVAS_EVENTS = {
   DOWN: ['mousedown', 'touchstart'],
   UP: ['mouseup', 'touchend']
 };
@@ -96,12 +96,13 @@ module.exports.Component = registerComponent('cursor', {
     var data = this.data;
     var el = this.el;
     var self = this;
+
     function addCanvasListeners () {
       canvas = el.sceneEl.canvas;
-      CANVASEVENTS.DOWN.forEach(function (downEvent) {
+      CANVAS_EVENTS.DOWN.forEach(function (downEvent) {
         canvas.addEventListener(downEvent, self.onCursorDown);
       });
-      CANVASEVENTS.UP.forEach(function (upEvent) {
+      CANVAS_EVENTS.UP.forEach(function (upEvent) {
         canvas.addEventListener(upEvent, self.onCursorUp);
       });
     }
@@ -133,10 +134,10 @@ module.exports.Component = registerComponent('cursor', {
 
     canvas = el.sceneEl.canvas;
     if (canvas) {
-      CANVASEVENTS.DOWN.forEach(function (downEvent) {
+      CANVAS_EVENTS.DOWN.forEach(function (downEvent) {
         canvas.removeEventListener(downEvent, self.onCursorDown);
       });
-      CANVASEVENTS.UP.forEach(function (upEvent) {
+      CANVAS_EVENTS.UP.forEach(function (upEvent) {
         canvas.removeEventListener(upEvent, self.onCursorUp);
       });
     }

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -431,9 +431,10 @@ suite('cursor', function () {
       });
     });
   });
-  suite('user input', function () {
+
+  suite('canvas events', function () {
     test('cursor responds to mouse events on canvas', function () {
-      // cannot spy on onCursorDown/Up directly due to binding
+      // Cannot spy on onCursorDown/Up directly due to binding.
       var cursorEmitSpy = this.sinon.spy(component, 'twoWayEmit');
       var downEvt = new CustomEvent('mousedown');
       var upEvt = new CustomEvent('mouseup');
@@ -444,8 +445,9 @@ suite('cursor', function () {
       el.sceneEl.canvas.dispatchEvent(upEvt);
       assert.isTrue(cursorEmitSpy.calledWith('mouseup'));
     });
+
     test('cursor responds to touch events on canvas', function () {
-      // cannot spy on onCursorDown/Up directly due to binding
+      // Cannot spy on onCursorDown/Up directly due to binding.
       var cursorEmitSpy = this.sinon.spy(component, 'twoWayEmit');
       var downEvt = new CustomEvent('touchstart');
       var upEvt = new CustomEvent('touchend');

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -431,6 +431,32 @@ suite('cursor', function () {
       });
     });
   });
+  suite('user input', function () {
+    test('cursor responds to mouse events on canvas', function () {
+      // cannot spy on onCursorDown/Up directly due to binding
+      var cursorEmitSpy = this.sinon.spy(component, 'twoWayEmit');
+      var downEvt = new CustomEvent('mousedown');
+      var upEvt = new CustomEvent('mouseup');
+      assert.isFalse(cursorEmitSpy.calledWith('mousedown'));
+      el.sceneEl.canvas.dispatchEvent(downEvt);
+      assert.isTrue(cursorEmitSpy.calledWith('mousedown'));
+      assert.isFalse(cursorEmitSpy.calledWith('mouseup'));
+      el.sceneEl.canvas.dispatchEvent(upEvt);
+      assert.isTrue(cursorEmitSpy.calledWith('mouseup'));
+    });
+    test('cursor responds to touch events on canvas', function () {
+      // cannot spy on onCursorDown/Up directly due to binding
+      var cursorEmitSpy = this.sinon.spy(component, 'twoWayEmit');
+      var downEvt = new CustomEvent('touchstart');
+      var upEvt = new CustomEvent('touchend');
+      assert.isFalse(cursorEmitSpy.calledWith('mousedown'));
+      el.sceneEl.canvas.dispatchEvent(downEvt);
+      assert.isTrue(cursorEmitSpy.calledWith('mousedown'));
+      assert.isFalse(cursorEmitSpy.calledWith('mouseup'));
+      el.sceneEl.canvas.dispatchEvent(upEvt);
+      assert.isTrue(cursorEmitSpy.calledWith('mouseup'));
+    });
+  });
 });
 
 suite('cursor + raycaster', function () {


### PR DESCRIPTION
**Description:**

I recently received a sweet Mozilla brand corrugated paperboard mobile VR viewer (no trademark issues here), and I was sad to learn that the nifty touch button/lever didnt't work with `cursor`.

This PR modifies `cursor` to listen for touch input events in addition to mouse events. With this small change, mobile users can have the same level of control as mouse users. This is especially useful in situations where gaze fusing is not optimal, like dragging an object around the scene to move it. (Here's an example of this with this modified version of `cursor` & `super-hands`: https://deserted-ladybug.glitch.me/)

**Changes proposed:**

- Register 'touchstart' and `touchend' listeners on the canvas alongside 'mousedown' and 'mouseup'

**Notes:**

f2bff70 is optional, it centralizes the listing of event types to facilitate future maintenance, but that might be unnecessary 

**Concerns:**

* It's not smart about multiple touches - the first 'touchend' will terminate the `cursor` interaction even if more touches remain active. I'd be happy to add handling for this, but didn't want to add complications unnecessarily. 
* It does not implement 'touchmove' alongside 'mousemove'. Since the event APIs for each are structured slightly differently, this would be more than a simple change. Again, happy to add this if you think it's worth the additional complication
* This might cause some unexpected behavior for projects using `cursor` for gaze fusing and capturing touch input manually for other purposes. If preferred, I could extend the schema make this configurable, either as a flag or as a list of event types.

Thanks to @andrewvee on slack for a discussion that prompted
