### PR TITLE
fix controller update issue #2975

### DIFF
--- a/src/systems/tracked-controls.js
+++ b/src/systems/tracked-controls.js
@@ -11,7 +11,8 @@ module.exports.System = registerSystem('tracked-controls', {
     this.controllers = [];
 
     // For non-Firefox browsers, the gamepad poses only seem to update if getGamepads() is called.
-    // Therefore, don't throttle the tick frequency; instead, optimize the update check.
+    // Therefore, don't throttle the tick frequency.
+
     this.updateControllerList();
 
     if (!navigator.getVRDisplays) { return; }
@@ -35,24 +36,10 @@ module.exports.System = registerSystem('tracked-controls', {
     var gamepad;
     var gamepads;
     var i;
-    var prevCount;
-    var thisCount;
 
     gamepads = navigator.getGamepads && navigator.getGamepads();
     if (!gamepads) { return; }
 
-    // Count first, and only actually update controller list if length changes.
-    prevCount = controllers.length;
-    thisCount = 0;
-    for (i = 0; i < gamepads.length; ++i) {
-      gamepad = gamepads[i];
-      if (gamepad && gamepad.pose) {
-        thisCount++;
-      }
-    }
-    if (prevCount === thisCount) { return; }
-
-    // Update controller list.
     controllers.length = 0;
     for (i = 0; i < gamepads.length; ++i) {
       gamepad = gamepads[i];
@@ -61,8 +48,6 @@ module.exports.System = registerSystem('tracked-controls', {
       }
     }
 
-    if (controllers.length !== prevCount) {
-      this.el.emit('controllersupdated', undefined, false);
-    }
+    this.el.emit('controllersupdated', undefined, false);
   }
 });


### PR DESCRIPTION
Don't throttle tick; instead, only update controllers list when number of gamepads changes.

Fixes #2975.