### PR TITLE
Correcting docs for various primitive attributes

### DIFF
--- a/docs/primitives/a-box.md
+++ b/docs/primitives/a-box.md
@@ -42,7 +42,7 @@ The box primitive creates shapes such as boxes, cubes, or walls.
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
 | env-map                          | material.envMap                        | None          |
 | fog                              | material.fog                           | true          |
-| height                           | material.height                        | 256           |
+| height                           | geometry.height                        | 1             |
 | metalness                        | material.metalness                     | 0             |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
@@ -55,6 +55,6 @@ The box primitive creates shapes such as boxes, cubes, or walls.
 | segments-width                   | geometry.segmentsWidth                 | 1             |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
-| width                            | material.width                         | 512           |
+| width                            | geometry.width                         | 1             |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-cone.md
+++ b/docs/primitives/a-cone.md
@@ -39,7 +39,7 @@ The cone primitive creates a cone shape.
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
 | env-map                          | material.envMap                        | None          |
 | fog                              | material.fog                           | true          |
-| height                           | material.height                        | 256           |
+| height                           | geometry.height                        | 1             |
 | metalness                        | material.metalness                     | 0             |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |

--- a/docs/primitives/a-cylinder.md
+++ b/docs/primitives/a-cylinder.md
@@ -42,7 +42,7 @@ The cylinder primitive is versatile and can be used to create different kinds of
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
 | env-map                          | material.envMap                        | None          |
 | fog                              | material.fog                           | true          |
-| height                           | material.height                        | 256           |
+| height                           | geometry.height                        | 1             |
 | metalness                        | material.metalness                     | 0             |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |

--- a/docs/primitives/a-plane.md
+++ b/docs/primitives/a-plane.md
@@ -43,7 +43,7 @@ component with the type set to `plane`.
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
 | env-map                          | material.envMap                        | None          |
 | fog                              | material.fog                           | true          |
-| height                           | geometry.height                        | 256           |
+| height                           | geometry.height                        | 1             |
 | metalness                        | material.metalness                     | 0             |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
@@ -55,7 +55,7 @@ component with the type set to `plane`.
 | segments-width                   | geometry.segmentsWidth                 | 1             |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
-| width                            | geometry.width                         | 512           |
+| width                            | geometry.width                         | 1             |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |
 


### PR DESCRIPTION
**Description:**
A few of the a-frame primitives use 'height' and 'width' to refer to properties of the geometry, but the docs seem to assume they're referring to properties of the material. (I'm not sure if this suggests an underlying problem with whatever originally generated these tables in the docs, but it was suggested in the Slack that I just go ahead and edit the docs manually, so I have.)

**Changes proposed:**
- Fix the 'component mapping' and 'default value' for the 'height' and (if used in the geometry constructor) the 'width' attributes, in the docs for the 'a-box', 'a-cone', and 'a-cylinder' primitives
- It seems like someone already fixed the component mappings in 'a-plane', but didn't fix the defaults; I've done that now