### PR TITLE
Mention that primitive names require dashes

### DIFF
--- a/docs/introduction/html-and-primitives.md
+++ b/docs/introduction/html-and-primitives.md
@@ -146,7 +146,7 @@ the physics components via HTML attributes:
 ## Registering a Primitive
 
 We can register our own primitives (i.e., register an element) using
-`AFRAME.registerPrimitive(name, definition)`. `definition` is a JavaScript
+`AFRAME.registerPrimitive(name, definition)`. `name` is a string and must contain a dash (i.e. `'a-foo'`). `definition` is a JavaScript
 object defining these properties:
 
 | Property          | Description                                                                                                                                                                                                                                                                               | Example                          |


### PR DESCRIPTION
**Description:**
I had never used document.registerElement, so I didn't understand why my AFRAME.registerPrimitive calls were failing.

**Changes proposed:**
- Specify the requirement that strings provided as the 'name' argument to AFRAME.registerPrimitive must include a dash.