### PR TITLE
Support and tests for vrdisplaypointerrestricted events to the a-scene…

### DIFF
--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -403,6 +403,96 @@ suite('a-scene (without renderer)', function () {
     });
   });
 
+  suite('pointerRestricted', function () {
+    setup(function () {
+      var sceneEl = this.el;
+
+      // Stub canvas.
+      sceneEl.canvas = document.createElement('canvas');
+    });
+
+    test('requests pointerlock when restricted', function (done) {
+      var sceneEl = this.el;
+      var event;
+      var requestPointerLockSpy;
+
+      requestPointerLockSpy = this.sinon.spy(sceneEl.canvas, 'requestPointerLock');
+      event = new CustomEvent('vrdisplaypointerrestricted');
+      window.dispatchEvent(event);
+
+      process.nextTick(function () {
+        assert.ok(requestPointerLockSpy.called);
+        done();
+      });
+    });
+
+    test('exits pointerlock when unrestricted', function (done) {
+      var sceneEl = this.el;
+      var event;
+      var exitPointerLockSpy;
+
+      exitPointerLockSpy = this.sinon.spy(document, 'exitPointerLock');
+
+      event = new CustomEvent('vrdisplaypointerunrestricted');
+
+      this.sinon.stub(sceneEl, 'getPointerLockElement', function () {
+        return sceneEl.canvas;
+      });
+      window.dispatchEvent(event);
+
+      process.nextTick(function () {
+        assert.ok(exitPointerLockSpy.called);
+        done();
+      });
+    });
+
+    test('does not exit pointerlock when unrestricted on different locked element', function (done) {
+      var sceneEl = this.el;
+      var event;
+      var exitPointerLockSpy;
+
+      exitPointerLockSpy = this.sinon.spy(document, 'exitPointerLock');
+
+      event = new CustomEvent('vrdisplaypointerunrestricted');
+
+      this.sinon.stub(sceneEl, 'getPointerLockElement', function () {
+        // Mock that pointerlock is taken by the page itself,
+        // independently of the a-scene handler for vrdisplaypointerrestricted event
+        return document.createElement('canvas');
+      });
+      window.dispatchEvent(event);
+
+      process.nextTick(function () {
+        assert.notOk(exitPointerLockSpy.called);
+        done();
+      });
+    });
+
+    test('update existing pointerlock target when restricted', function (done) {
+      var sceneEl = this.el;
+      var event;
+      var exitPointerLockSpy;
+      var requestPointerLockSpy;
+
+      exitPointerLockSpy = this.sinon.spy(document, 'exitPointerLock');
+      requestPointerLockSpy = this.sinon.spy(sceneEl.canvas, 'requestPointerLock');
+      event = new CustomEvent('vrdisplaypointerrestricted');
+
+      this.sinon.stub(sceneEl, 'getPointerLockElement', function () {
+        // Mock that pointerlock is taken by the page itself,
+        // independently of the a-scene handler for vrdisplaypointerrestricted event
+        return document.createElement('canvas');
+      });
+      window.dispatchEvent(event);
+
+      process.nextTick(function () {
+        assert.ok(exitPointerLockSpy.called);
+        assert.ok(requestPointerLockSpy.called);
+        done();
+      });
+    });
+  });
+
   suite('system', function () {
     teardown(function () {
       delete components.test;


### PR DESCRIPTION
…element with the possibility to disable the behavior (on by default)

**Description:**
Support mouse input in WebVR by handling vrdisplaypointerrestricted and vrdisplaypointerunrestricted events in MS Edge. It is by design that mozPointerLock* and webkitPointerLock* implementations are not included.

**Changes proposed:**
- In response to vrdisplaypointerrestricted perform requestPointerLock on the canvas element that is used for WebVR rendering
- In response to vrdisplaypointerunrestricted perform document.exitPointerLock if the locked element is the canvas that is used for WebVR rendering
- Give the developer an option to turn off this behavior by calling disableCanvasPointerLock on the scene object.
