### PR TITLE
[material] Update material flat shading for three.js r87.

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -116,7 +116,7 @@ module.exports.Component = registerComponent('material', {
     material.depthTest = data.depthTest !== false;
     material.depthWrite = data.depthWrite !== false;
     material.opacity = data.opacity;
-    material.shading = data.flatShading ? THREE.FlatShading : THREE.SmoothShading;
+    material.flatShading = data.flatShading;
     material.side = parseSide(data.side);
     material.transparent = data.transparent !== false || data.opacity < 1.0;
     material.vertexColors = parseVertexColors(data.vertexColors);


### PR DESCRIPTION
This syntax:

```js
material.shading = THREE.FlatShading;
```

has been replaced in r87 with:

```
material.flatShading = true;
```