### PR TITLE
fix component build data when previousData is object with null prop

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -471,9 +471,8 @@ module.exports.registerComponent = function (name, definition) {
 };
 
 /**
-* Clones component data.
-* Clone only the properties that are plain objects while
-* keeping a reference for the rest.
+* Clone component data.
+* Clone only the properties that are plain objects while keeping a reference for the rest.
 *
 * @param data - Component data to clone.
 * @returns Cloned data.
@@ -484,7 +483,9 @@ function cloneData (data) {
   var key;
   for (key in data) {
     parsedProperty = data[key];
-    clone[key] = parsedProperty.constructor === Object ? utils.clone(parsedProperty) : parsedProperty;
+    clone[key] = parsedProperty && parsedProperty.constructor === Object
+      ? utils.clone(parsedProperty)
+      : parsedProperty;
   }
   return clone;
 }

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -196,6 +196,20 @@ suite('Component', function () {
       assert.equal(el.components.test.buildData(null), null);
       assert.equal(el.components.test.buildData('foo'), 'foo');
     });
+
+    test('returns data for multi-prop if default is null with previousData', function () {
+      var el = document.createElement('a-entity');
+      registerComponent('test', {
+        schema: {
+          foo: {default: null}
+        }
+      });
+      el.setAttribute('test', '');
+      el.components.test.attrValue = {foo: null};
+      assert.equal(el.components.test.buildData().foo, null);
+      assert.equal(el.components.test.buildData({foo: null}).foo, null);
+      assert.equal(el.components.test.buildData({foo: 'foo'}).foo, 'foo');
+    });
   });
 
   suite('updateProperties', function () {


### PR DESCRIPTION
**Description:**

Fixes `null has no properties` type error.

**Changes proposed:**
- Check for truthiness before running `.constructor`.

