### PR TITLE
hand-controls bugfixes

### DIFF
--- a/examples/showcase/tracked-controls/components/grab.js
+++ b/examples/showcase/tracked-controls/components/grab.js
@@ -1,4 +1,4 @@
-/* global AFRAME */
+/* global AFRAME, THREE */
 
 /**
 * Handles events coming from the hand-controls.
@@ -74,13 +74,17 @@ AFRAME.registerComponent('grab', {
 
   updateDelta: function () {
     var currentPosition = this.el.getAttribute('position');
-    var previousPosition = this.previousPosition || currentPosition;
+    if (!this.previousPosition) {
+      this.previousPosition = new THREE.Vector3();
+      this.previousPosition.copy(currentPosition);
+    }
+    var previousPosition = this.previousPosition;
     var deltaPosition = {
       x: currentPosition.x - previousPosition.x,
       y: currentPosition.y - previousPosition.y,
       z: currentPosition.z - previousPosition.z
     };
-    this.previousPosition = currentPosition;
+    this.previousPosition.copy(currentPosition);
     this.deltaPosition = deltaPosition;
   }
 });

--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -88,7 +88,7 @@ module.exports.Component = registerComponent('hand-controls', {
   tick: function (time, delta) {
     var mesh = this.el.getObject3D('mesh');
 
-    if (!mesh) { return; }
+    if (!mesh || !mesh.mixer) { return; }
 
     mesh.mixer.update(delta / 1000);
   },
@@ -174,6 +174,8 @@ module.exports.Component = registerComponent('hand-controls', {
         mesh.material.skinning = true;
         mesh.mixer = new THREE.AnimationMixer(mesh);
         el.setObject3D('mesh', mesh);
+        mesh.position.set(0, 0, 0);
+        mesh.rotation.set(0, 0, 0);
       });
     }
   },


### PR DESCRIPTION
**Description:**
The cubes in the tracked-controls example do not move when grabbed by Windows Motion Controllers. Additionally, the hand-controls meshes are incorrectly offset from the element center when initially loaded, as they inherit the parent transform (which has been set by the tracked-controls component). Lastly, there is a race condition somewhere, such that sometimes for a single frame `mesh.mixer` does not exist causing a null reference exception.

**Changes proposed:**
- Set the hand-controls mesh position and rotation to zero to ensure it is not offset from the element center
- In the grab component, make a copy of the position rather than pointing to an object reference for use in delta calculations.
- Added a null check to mesh.mixer prior to use.
