### PR TITLE
Handle vrdisplayconnect/vrdisplaydisconnect events in VREffect and VRControls (fix #3019)

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -128,8 +128,8 @@ module.exports.AScene = registerElement('a-scene', {
         // Exit VR on `vrdisplaydeactivate` (e.g. taking off Rift headset).
         window.addEventListener('vrdisplaydeactivate', this.exitVRBound);
 
-        // Enter VR on `vrdisplayconnect` (e.g. plugging on Rift headset).
-        window.addEventListener('vrdisplayconnect', this.enterVRBound);
+        // Exit VR on `vrdisplaydisconnect` (e.g. unplugging Rift headset).
+        window.addEventListener('vrdisplaydisconnect', this.exitVRTrueBound);
 
         // Exit VR on `vrdisplaydisconnect` (e.g. unplugging Rift headset).
         window.addEventListener('vrdisplaydisconnect', this.exitVRTrueBound);

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -61,21 +61,6 @@ suite('a-scene (without renderer)', function () {
     });
   });
 
-  suite('vrdisplayconnect', function () {
-    test('tells A-Frame about entering VR when the headset is connected', function (done) {
-      var event;
-      var sceneEl = this.el;
-      var enterVRStub = this.sinon.stub(sceneEl, 'enterVR');
-      sceneEl.effect = {requestPresent: function () { return Promise.resolve(); }};
-      event = new CustomEvent('vrdisplayconnect');
-      window.dispatchEvent(event);
-      process.nextTick(function () {
-        assert.ok(enterVRStub.called);
-        done();
-      });
-    });
-  });
-
   suite('vrdisplaydisconnect', function () {
     test('tells A-Frame about entering VR when the headset is disconnected', function (done) {
       var event;

--- a/vendor/VRControls.js
+++ b/vendor/VRControls.js
@@ -19,6 +19,9 @@ THREE.VRControls = function ( object, onError ) {
 
 	}
 
+	window.addEventListener('vrdisplayconnect', function (evt) { vrDisplay = evt.display; });
+	window.addEventListener('vrdisplaydisconnect', function () { vrDisplay = undefined });
+
 	function gotVRDisplays( displays ) {
 
 		vrDisplays = displays;

--- a/vendor/VREffect.js
+++ b/vendor/VREffect.js
@@ -24,6 +24,16 @@ THREE.VREffect = function( renderer, onError ) {
 
 	}
 
+	window.addEventListener('vrdisplayconnect', function (evt) { vrDisplay = evt.display; });
+	window.addEventListener('vrdisplaydisconnect', function (evt) {
+		scope.exitPresent();
+		// Cancels current request animation frame.
+		scope.cancelAnimationFrame();
+		vrDisplay = undefined;
+		// Resumes the request animation frame.
+		scope.requestAnimationFrame();
+	});
+
 	function gotVRDisplays( displays ) {
 
 		vrDisplays = displays;
@@ -183,10 +193,12 @@ THREE.VREffect = function( renderer, onError ) {
 
 	this.requestAnimationFrame = function( f ) {
 
+		var f = scope.f = f || scope.f;
+
+		if (!f) { return; }
+
 		if ( vrDisplay !== undefined ) {
-
 			return vrDisplay.requestAnimationFrame( f );
-
 		} else {
 
 			return window.requestAnimationFrame( f );
@@ -196,6 +208,8 @@ THREE.VREffect = function( renderer, onError ) {
 	};
 
 	this.cancelAnimationFrame = function( h ) {
+
+		scope.f = undefined;
 
 		if ( vrDisplay !== undefined ) {
 


### PR DESCRIPTION
I think this is the proper solution for https://github.com/aframevr/aframe/issues/3019 but I have not tested yet on headset. I can do a pass tomorrow on Oculus / Vive and Microsoft Mixed Reality headsets. @leweaver Can you also verify on your side that this fixes the problem?
