### PR TITLE
Do not resize the canvas while presenting (leads to resolution drop)

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -459,12 +459,11 @@ module.exports.AScene = registerElement('a-scene', {
         var canvas = this.canvas;
         var embedded = this.getAttribute('embedded') && !this.is('vr-mode');
         var size;
-        // Possible camera or canvas not injected yet.
-        // ON MOBILE the webvr-polyfill relies on the fullscreen API to enter
-        // VR mode. The canvas is resized by VREffect following the values returned
-        // by getEyeParameters. We don't want to overwrite the size with the
-        // windows width and height.
-        if (!camera || !canvas || this.is('vr-mode') && isMobile) { return; }
+        // Do not update renderer, if a camera or a canvas have not been injected.
+        // In VR mode, VREffect handles canvas resize based on the dimensions returned by
+        // the getEyeParameters function of the WebVR API. These dimensions are independent of
+        // the window size, therefore should not be overwritten with the window's width and height.
+        if (!camera || !canvas || this.is('vr-mode')) { return; }
         // Update camera.
         size = getCanvasSize(canvas, embedded);
         camera.aspect = size.width / size.height;
@@ -484,11 +483,6 @@ module.exports.AScene = registerElement('a-scene', {
           antialias: shouldAntiAlias(this),
           alpha: true
         });
-        // r86 shipped with a bug fixed in https://github.com/mrdoob/three.js/pull/11970
-        // We need to setup a dummy VRDevice to avoid a TypeError
-        // when vrdisplaypresentchange fires.
-        // This line can be removed after updating to THREE r87.
-        renderer.vr.setDevice({});
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
         this.effect = new THREE.VREffect(renderer);


### PR DESCRIPTION
Do not resize canvas in VR mode (not only for mobile, but for desktop too)
Tested on Edge + WMR, Firefox + Vive and Gear VR

Resizing the browser window while presenting leads to the canvas being resized accordingly, which updates resolution in the headset, causing a bad experience. Since Aframe does not rely on Three.js built-in mechanism for resizing the canvas this needs to be handled explicitly in a-scene.js.