### PR TITLE
Allow MediaStream to be sound sources.

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -72,6 +72,7 @@ function arrayStringify (value) {
 function assetParse (value) {
   var el;
   var parsedUrl;
+  var mediaTags = ['CANVAS', 'VIDEO', 'IMG', 'AUDIO'];
 
   // If an element was provided (e.g. canvas or video), just return it.
   if (typeof value !== 'string') { return value; }
@@ -86,7 +87,7 @@ function assetParse (value) {
     if (el) {
       // Pass through media elements. If we have the elements, we don't have to call
       // three.js loaders which would re-request the assets.
-      if (el.tagName === 'CANVAS' || el.tagName === 'VIDEO' || el.tagName === 'IMG') {
+      if (mediaTags.indexOf(el.tagName) >= 0) {
         return el;
       }
       return el.getAttribute('src');


### PR DESCRIPTION
Fix #3041 

To be consistent with the A-Frame API, the patch allows the use of an `<audio>`
tag with a `MediaStream` object in the `srcObject` attribute. E.g.:

```js
// <a-assets></a-assets>
// <a-entity id="speaker"></a-entity>
const speaker = document.getElementById('speaker');
const assets = document.querySelector('a-assets');
navigator.mediaDevices.getUserMedia({ audio: true })
.then(stream => {
  const voice = new Audio();
  voice.id = 'speaker-voice';
  voice.srcObject = stream;
  assets.appendChild(voice);
  speaker.setAttribute('sound', `src:${voice.id}`);
});
```
