### PR TITLE
Hide the controller model instead of the whole entity

### DIFF
--- a/src/components/windows-motion-controls.js
+++ b/src/components/windows-motion-controls.js
@@ -130,8 +130,8 @@ module.exports.Component = registerComponent('windows-motion-controls', {
       index: this.data.pair
     });
 
-    if (this.data.hideDisconnected) {
-      this.el.setAttribute('visible', this.controllerPresent);
+    if (this.data.hideDisconnected && this.controllerModel) {
+      this.controllerModel.visible = false;
     }
   },
 
@@ -227,15 +227,20 @@ module.exports.Component = registerComponent('windows-motion-controls', {
   },
 
   loadModel: function (url) {
-    debug('Loading asset from: ' + url);
+    // Make model visible if there's already one loaded.
+    if (this.controllerModel) {
+      this.controllerModel.visible = true;
+      return;
+    }
 
+    debug('Loading asset from: ' + url);
     // The model is loaded by the gltf-model compoent when this attribute is initially set,
     // removed and re-loaded if the given url changes.
     this.el.setAttribute('gltf-model', 'url(' + url + ')');
   },
 
   onModelLoaded: function (evt) {
-    var rootNode = evt.detail.model;
+    var rootNode = this.controllerModel = evt.detail.model;
     var loadedMeshInfo = this.loadedMeshInfo;
     var i;
     var meshName;


### PR DESCRIPTION
`windows-motion-controllers` hides the whole entity if the expected controllers are not present. This will also make any other controllers (Vive, Oculus...) invisible. I replaced the change in visibility of the controllers entity with the visiblity of just the windows motion controllers model if there's one already loaded. I tested more thoroughly the windows motion controllers in Edge and I find inconsistencies: I ofthen see just one controller when starting Edge and switching it on/off does not help. Also switching off and back on when the controllers are properly tracked does not seem to work. Not sure yet if the problem is Edge or A-Frame but Vive + Firefox seem to work more reliably when it comes to detect and track the controllers. Are you experiencing the same problems on Edge? @leweaver @olga-microsoft 
