### PR TITLE
Do not use deltas to update headset and controllers. Use absolute values instead

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -28,7 +28,7 @@ module.exports.Component = registerComponent('look-controls', {
     this.previousHMDPosition = new THREE.Vector3();
     this.hmdQuaternion = new THREE.Quaternion();
     this.hmdEuler = new THREE.Euler();
-    this.position = {};
+    this.position = new THREE.Vector3();
     this.rotation = {};
 
     this.setupMouseControls();
@@ -227,34 +227,25 @@ module.exports.Component = registerComponent('look-controls', {
   /**
    * Handle positional tracking.
    */
-  updatePosition: (function () {
-    var deltaHMDPosition = new THREE.Vector3();
+  updatePosition: function () {
+    var el = this.el;
+    var currentHMDPosition;
+    var currentPosition;
+    var position = this.position;
+    var previousHMDPosition = this.previousHMDPosition;
+    var sceneEl = this.el.sceneEl;
 
-    return function () {
-      var el = this.el;
-      var currentHMDPosition;
-      var currentPosition;
-      var position = this.position;
-      var previousHMDPosition = this.previousHMDPosition;
-      var sceneEl = this.el.sceneEl;
+    if (!sceneEl.is('vr-mode')) { return; }
 
-      if (!sceneEl.is('vr-mode')) { return; }
+    // Calculate change in position.
+    currentHMDPosition = this.calculateHMDPosition();
 
-      // Calculate change in position.
-      currentHMDPosition = this.calculateHMDPosition();
-      deltaHMDPosition.copy(currentHMDPosition).sub(previousHMDPosition);
+    currentPosition = el.getAttribute('position');
 
-      if (isNullVector(deltaHMDPosition)) { return; }
-
-      previousHMDPosition.copy(currentHMDPosition);
-
-      currentPosition = el.getAttribute('position');
-      position.x = currentPosition.x + deltaHMDPosition.x;
-      position.y = currentPosition.y + deltaHMDPosition.y;
-      position.z = currentPosition.z + deltaHMDPosition.z;
-      el.setAttribute('position', position);
-    };
-  })(),
+    position.copy(currentPosition).sub(previousHMDPosition).add(currentHMDPosition);
+    el.setAttribute('position', position);
+    previousHMDPosition.copy(currentHMDPosition);
+  },
 
   /**
    * Get headset position from VRControls.

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -42,7 +42,7 @@ module.exports.Component = registerComponent('tracked-controls', {
     this.controllerPosition = new THREE.Vector3();
     this.controllerQuaternion = new THREE.Quaternion();
     this.deltaControllerPosition = new THREE.Vector3();
-    this.position = {};
+    this.position = new THREE.Vector3();
     this.rotation = {};
     this.standingMatrix = new THREE.Matrix4();
 
@@ -149,8 +149,8 @@ module.exports.Component = registerComponent('tracked-controls', {
     var controller = this.controller;
     var controllerEuler = this.controllerEuler;
     var controllerPosition = this.controllerPosition;
-    var currentPosition;
-    var deltaControllerPosition = this.deltaControllerPosition;
+    var elPosition;
+    var previousControllerPosition = this.previousControllerPosition;
     var dolly = this.dolly;
     var el = this.el;
     var pose;
@@ -198,20 +198,17 @@ module.exports.Component = registerComponent('tracked-controls', {
     controllerEuler.setFromRotationMatrix(dolly.matrix);
     controllerPosition.setFromMatrixPosition(dolly.matrix);
 
-    // Apply rotation (as absolute, with rotation offset).
+    // Apply rotation.
     this.rotation.x = THREE.Math.radToDeg(controllerEuler.x);
     this.rotation.y = THREE.Math.radToDeg(controllerEuler.y);
     this.rotation.z = THREE.Math.radToDeg(controllerEuler.z) + this.data.rotationOffset;
     el.setAttribute('rotation', this.rotation);
 
-    // Apply position (as delta from previous Gamepad position).
-    deltaControllerPosition.copy(controllerPosition).sub(this.previousControllerPosition);
-    this.previousControllerPosition.copy(controllerPosition);
-    currentPosition = el.getAttribute('position');
-    this.position.x = currentPosition.x + deltaControllerPosition.x;
-    this.position.y = currentPosition.y + deltaControllerPosition.y;
-    this.position.z = currentPosition.z + deltaControllerPosition.z;
+    // Apply position.
+    elPosition = el.getAttribute('position');
+    this.position.copy(elPosition).sub(previousControllerPosition).add(controllerPosition);
     el.setAttribute('position', this.position);
+    previousControllerPosition.copy(controllerPosition);
   },
 
   /**

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, teardown, test, THREE */
+/* global assert, process, setup, sinon, suite, teardown, test, THREE */
 const entityFactory = require('../helpers').entityFactory;
 
 const PI = Math.PI;
@@ -94,30 +94,7 @@ suite('tracked-controls', function () {
     test('applies position from gamepad pose', function () {
       controller.pose.position = [1, 2, 3];
       component.tick();
-      assertVec3(component.previousControllerPosition, [1, 2, 3]);
       assertVec3(el.getAttribute('position'), [1, 2, 3]);
-    });
-
-    test('applies position using deltas', function () {
-      controller.pose.position = [0, 0, 0];
-      el.setAttribute('position', '1 2 3');
-      component.tick();
-      assertVec3(el.getAttribute('position'), [1, 2, 3]);
-
-      assertVec3(component.previousControllerPosition, [0, 0, 0]);
-      controller.pose.position = [1, 1, 1];
-      component.tick();
-      assertVec3(el.getAttribute('position'), [2, 3, 4]);
-    });
-
-    test('applies position using deltas with non-zero pose', function () {
-      assertVec3(component.previousControllerPosition, [0, 0, 0]);
-      controller.pose.position = [4, 5, -6];
-      el.setAttribute('position', '-1 2 -3');
-      component.tick();
-      // A-Frame position + (Gamepad position - previous Gamepad position).
-      // [-1, 2, -3] + ([4, 5, -6] - [0, 0, 0]).
-      assertVec3(el.getAttribute('position'), [3, 7, -9]);
     });
 
     test('handles unchanged Gamepad position', function () {
@@ -217,7 +194,8 @@ suite('tracked-controls', function () {
       const emitSpy = this.sinon.spy(el, 'emit');
       component.tick();
       assert.notOk(component.handleAxes());
-      assert.notOk(emitSpy.called);
+      sinon.assert.calledOnce(emitSpy);
+      assert.equal(emitSpy.getCalls()[0].args[0], 'componentchanged');
     });
 
     test('emits axismove on first touch', function () {
@@ -226,9 +204,11 @@ suite('tracked-controls', function () {
       assert.deepEqual(component.axis, [0, 0, 0]);
       component.tick();
       assert.deepEqual(component.axis, [0.5, 0.5, 0.5]);
-      assert.equal(emitSpy.getCalls()[0].args[0], 'axismove');
-      assert.deepEqual(emitSpy.getCalls()[0].args[1].axis, [0.5, 0.5, 0.5]);
-      assert.deepEqual(emitSpy.getCalls()[0].args[1].changed, [true, true, true]);
+      assert.notOk(component.handleAxes());
+      sinon.assert.calledTwice(emitSpy);
+      assert.equal(emitSpy.getCalls()[1].args[0], 'axismove');
+      assert.deepEqual(emitSpy.getCalls()[1].args[1].axis, [0.5, 0.5, 0.5]);
+      assert.deepEqual(emitSpy.getCalls()[1].args[1].changed, [true, true, true]);
     });
 
     test('emits axismove if axis changed', function () {
@@ -264,7 +244,8 @@ suite('tracked-controls', function () {
     test('does not emit if button not pressed', function () {
       const emitSpy = this.sinon.spy(el, 'emit');
       component.tick();
-      assert.notOk(emitSpy.called);
+      sinon.assert.calledOnce(emitSpy);
+      assert.equal(emitSpy.getCalls()[0].args[0], 'componentchanged');
     });
 
     test('emits buttonchanged if button pressed', function () {
@@ -302,7 +283,8 @@ suite('tracked-controls', function () {
     test('does not emit anything if button not pressed', function () {
       const emitSpy = this.sinon.spy(el, 'emit');
       component.tick();
-      assert.notOk(emitSpy.called);
+      sinon.assert.calledOnce(emitSpy);
+      assert.equal(emitSpy.getCalls()[0].args[0], 'componentchanged');
       assert.notOk(component.handlePress(0, {pressed: false, touched: false, value: 0}));
     });
 
@@ -364,7 +346,8 @@ suite('tracked-controls', function () {
     test('does not do anything if button not touched', function () {
       const emitSpy = this.sinon.spy(el, 'emit');
       component.tick();
-      assert.notOk(emitSpy.called);
+      sinon.assert.calledOnce(emitSpy);
+      assert.equal(emitSpy.getCalls()[0].args[0], 'componentchanged');
       assert.notOk(component.handleTouch(0, {pressed: false, touched: false, value: 0}));
     });
 


### PR DESCRIPTION
This solves a lot of issues with controllers connecting / disconnecting and the cases where the camera starts on the floor or unexpected position. We should have done this a loooooong time ago 😄 @olga-microsoft this improves a lot the behavior of the `windows motion controllers` in Edge.