### PR TITLE
Preserving the render callback when cancelling the VR animation frame

### DIFF
--- a/vendor/VREffect.js
+++ b/vendor/VREffect.js
@@ -26,12 +26,14 @@ THREE.VREffect = function( renderer, onError ) {
 
 	window.addEventListener('vrdisplayconnect', function (evt) { vrDisplay = evt.display; });
 	window.addEventListener('vrdisplaydisconnect', function (evt) {
+		var f;
+		
 		scope.exitPresent();
 		// Cancels current request animation frame.
-		scope.cancelAnimationFrame();
+		f = scope.cancelAnimationFrame();
 		vrDisplay = undefined;
 		// Resumes the request animation frame.
-		scope.requestAnimationFrame();
+		scope.requestAnimationFrame(f);
 	});
 
 	function gotVRDisplays( displays ) {
@@ -209,6 +211,8 @@ THREE.VREffect = function( renderer, onError ) {
 
 	this.cancelAnimationFrame = function( h ) {
 
+		var f = scope.f;
+
 		scope.f = undefined;
 
 		if ( vrDisplay !== undefined ) {
@@ -221,6 +225,7 @@ THREE.VREffect = function( renderer, onError ) {
 
 		}
 
+		return f;
 	};
 
 	this.submitFrame = function() {


### PR DESCRIPTION
**Description:**
Since [#0dba182](https://github.com/aframevr/aframe/commit/0dba1828118eed1f69edb9c2bc403b587e3399be#diff-2bf1de3dd522db1514c4c8ff0e3256a8) the 2D render loop does not restart once the headset is disconnected, as `scope.f` is set to undefined in the `cancelAnimationFrame` function.

**Changes proposed:**
- Return the old value for `f` from the `cancelAnimationFrame` function
- Pass that returned value into the new `requestAnimationFrame` function