### PR TITLE
Correct property name for whitespace

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -87,7 +87,7 @@ Inspector, and play with all the possible values to see the effects instantly!
 | tabSize       | Tab size in spaces.                                                                                                                                   | 4                                 |
 | transparent   | Whether text is transparent.                                                                                                                          | true                              |
 | **value**     | The actual content of the text. Line breaks and tabs are supported with `\n` and `\t`.                                                                | ''                                |
-| whitespace    | How whitespace should be handled (i.e., normal, pre, nowrap). [Read more about whitespace][whitespace].                                               | normal                            |
+| mode    | How whitespace should be handled (i.e., normal, pre, nowrap). [Read more about whitespace][whitespace].                                               | normal                            |
 | width         | Width in meters.                                                                                                                                      | *derived from geometry if exists* |
 | wrapCount     | Number of characters before wrapping text (more or less).                                                                                             | 40                                |
 | wrapPixels    | Number of pixels before wrapping text.                                                                                                                | *derived from wrapCount*          |


### PR DESCRIPTION
**Description:**
three-bmfont-text uses the "mode" property to specify the whitespace mode. The text component just passes its component data directly to the bmfont library. 

Perhaps the component should be changed to rename the property before sending it to the library instead?

**Changes proposed:**
- Change the docs to use the actual bmfont property name.
