### PR TITLE
[raycaster] Use MutationObserver and object3dset/remove to refresh.

### DIFF
--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -12,7 +12,7 @@ var dummyVec = new THREE.Vector3();
 // refresh the whitelist. Matches classnames, IDs, and presence of attributes.
 // Selectors for the value of an attribute, like [position=0 2 0], cannot be
 // reliably detected and are therefore disallowed.
-var OBSERVER_SELECTOR_RE = /^[\w\s-.[\]#]*$/;
+var OBSERVER_SELECTOR_RE = /^[\w\s-.,[\]#]*$/;
 
 // Configuration for the MutationObserver used to refresh the whitelist.
 // Listens for addition/removal of elements and attributes within the scene.

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -9,6 +9,9 @@ var warn = utils.debug('components:raycaster:warn');
 
 var dummyVec = new THREE.Vector3();
 
+// Defines selectors that should be 'safe' for the MutationObserver used to
+// refresh the whitelist. Less common selectors, like [position=0 2 0], cannot
+// be detected here.
 var SAFE_SELECTOR_RE = /^[\w\s-.[\]#]+$/;
 
 /**
@@ -144,6 +147,7 @@ module.exports.Component = registerComponent('raycaster', {
       // Update check time.
       this.prevCheckTime = time;
 
+      // Refresh the object whitelist if needed.
       if (this.dirty) { this.refreshObjects(); }
 
       // Store old previously intersected entities.

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -12,7 +12,7 @@ var dummyVec = new THREE.Vector3();
 // refresh the whitelist. Matches classnames, IDs, and presence of attributes.
 // Selectors for the value of an attribute, like [position=0 2 0], cannot be
 // reliably detected and are therefore disallowed.
-var OBSERVER_SELECTOR_RE = /^[\w\s-.[\]#]+$/;
+var OBSERVER_SELECTOR_RE = /^[\w\s-.[\]#]*$/;
 
 // Configuration for the MutationObserver used to refresh the whitelist.
 // Listens for addition/removal of elements and attributes within the scene.
@@ -140,7 +140,10 @@ module.exports.Component = registerComponent('raycaster', {
    */
   refreshObjects: function () {
     var data = this.data;
-    var els = data.objects ? this.el.sceneEl.querySelectorAll(data.objects) : null;
+    // If objects not defined, intersect with everything.
+    var els = data.objects
+      ? this.el.sceneEl.querySelectorAll(data.objects)
+      : this.el.sceneEl.children;
     this.objects = flattenChildrenShallow(els);
     this.dirty = false;
   },
@@ -321,13 +324,10 @@ function flattenChildrenShallow (els) {
   var i;
 
   // Push meshes onto list of objects to intersect.
-  if (els) {
-    for (i = 0; i < els.length; i++) {
+  for (i = 0; i < els.length; i++) {
+    if (els[i].object3D) {
       groups.push(els[i].object3D);
     }
-  } else {
-    // If objects not defined, intersect with everything.
-    groups = this.el.sceneEl.object3D.children;
   }
 
   // Each entity's root is a THREE.Group. Return the group's chilrden.

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -103,7 +103,6 @@ module.exports.Component = registerComponent('raycaster', {
   },
 
   pause: function () {
-    if (!this.data.watch) { return; }
     this.observer.disconnect();
     this.el.sceneEl.removeEventListener('object3dset', this.setDirty);
     this.el.sceneEl.removeEventListener('object3dremove', this.setDirty);

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -36,7 +36,8 @@ module.exports.Component = registerComponent('raycaster', {
     origin: {type: 'vec3'},
     recursive: {default: true},
     showLine: {default: false},
-    useWorldCoordinates: {default: false}
+    useWorldCoordinates: {default: false},
+    watch: {default: true}
   },
 
   init: function () {
@@ -83,10 +84,15 @@ module.exports.Component = registerComponent('raycaster', {
       warn('Selector "' + data.objects + '" may not update automatically with DOM changes.');
     }
 
+    if (data.watch !== oldData.watch && el.isPlaying) {
+      data.watch ? this.play() : this.pause();
+    }
+
     this.setDirty();
   },
 
   play: function () {
+    if (!this.data.watch) { return; }
     this.observer.observe(this.el.sceneEl, {
       childList: true,
       attributes: true,
@@ -97,6 +103,7 @@ module.exports.Component = registerComponent('raycaster', {
   },
 
   pause: function () {
+    if (!this.data.watch) { return; }
     this.observer.disconnect();
     this.el.sceneEl.removeEventListener('object3dset', this.setDirty);
     this.el.sceneEl.removeEventListener('object3dremove', this.setDirty);

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -2,7 +2,7 @@
 var entityFactory = require('../helpers').entityFactory;
 
 // TODO(donmccurdy): Implement tests if changes look OK.
-suite.skip('raycaster', function () {
+suite('raycaster', function () {
   var component;
   var el;
   var parentEl;
@@ -68,6 +68,7 @@ suite.skip('raycaster', function () {
       el2.setAttribute('geometry', 'primitive: box');
       el2.addEventListener('loaded', function () {
         el.setAttribute('raycaster', 'objects', '.clickable');
+        component.tick();
         assert.equal(component.objects.length, 1);
         assert.equal(component.objects[0], el2.object3D.children[0]);
         assert.equal(el2, el2.object3D.children[0].el);
@@ -116,13 +117,13 @@ suite.skip('raycaster', function () {
 
     test('refresh objects when new entities are added to the scene', function (done) {
       var newEl = document.createElement('a-entity');
+      component.tick();
       var numObjects = component.objects.length;
       newEl.setAttribute('geometry', 'primitive: box');
       newEl.addEventListener('loaded', function () {
-        setTimeout(() => {
-          assert.equal(component.objects.length, numObjects + 1);
-          done();
-        });
+        component.tick();
+        assert.equal(component.objects.length, numObjects + 1);
+        done();
       });
       sceneEl.appendChild(newEl);
     });

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -1,7 +1,6 @@
 /* global assert, process, setup, suite, test, THREE */
 var entityFactory = require('../helpers').entityFactory;
 
-// TODO(donmccurdy): Implement tests if changes look OK.
 suite('raycaster', function () {
   var component;
   var el;
@@ -130,19 +129,49 @@ suite('raycaster', function () {
 
     test('refresh objects when new entities are removed from the scene', function (done) {
       var newEl = document.createElement('a-entity');
+      component.tick();
       var numObjects = component.objects.length;
       newEl.setAttribute('geometry', 'primitive: box');
       sceneEl.addEventListener('child-detached', function doAssert () {
-        setTimeout(() => {
-          assert.equal(component.objects.length, numObjects);
-          sceneEl.removeEventListener('child-detached', doAssert);
-          done();
-        });
+        component.tick();
+        assert.equal(component.objects.length, numObjects);
+        sceneEl.removeEventListener('child-detached', doAssert);
+        done();
       });
       newEl.addEventListener('loaded', function () {
         sceneEl.removeChild(newEl);
       });
       sceneEl.appendChild(newEl);
+    });
+
+    test('refresh objects when entities are modified', function (done) {
+      el.setAttribute('raycaster', {objects: '[ray-target]'});
+      var newEl = document.createElement('a-entity');
+      newEl.setAttribute('geometry', 'primitive: box');
+      newEl.addEventListener('loaded', function doAssert () {
+        component.tick();
+        assert.equal(component.objects.length, 0);
+        newEl.setAttribute('ray-target', '');
+        setTimeout(function () {
+          component.tick();
+          assert.equal(component.objects.length, 1);
+          sceneEl.removeEventListener('child-attached', doAssert);
+          done();
+        }, 0);
+      });
+      sceneEl.appendChild(newEl);
+    });
+
+    test('refresh objects when setObject3D() or removeObject3D() is called', function () {
+      el.setAttribute('raycaster', {objects: '[ray-target]'});
+      component.tick();
+      assert.equal(component.dirty, false);
+      sceneEl.emit('object3dset');
+      assert.equal(component.dirty, true);
+      component.tick();
+      assert.equal(component.dirty, false);
+      sceneEl.emit('object3dremove');
+      assert.equal(component.dirty, true);
     });
   });
 

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -1,7 +1,8 @@
 /* global assert, process, setup, suite, test, THREE */
 var entityFactory = require('../helpers').entityFactory;
 
-suite('raycaster', function () {
+// TODO(donmccurdy): Implement tests if changes look OK.
+suite.skip('raycaster', function () {
   var component;
   var el;
   var parentEl;


### PR DESCRIPTION
This is a proposed fix for #2980 and #3067. It's not possible to perfectly detect when the whitelist may have changed — direct calls to `el.object3D.add(mesh)` will be missed, for example — but this covers all of the A-Frame API surface I think.

Changes:
- Use a MutationObserver to detect new elements and new attributes. While attribute *values* are not flushed to the DOM, the attribute names are, so this at least covers cases like adding a new component or changing a className.
- Listen for `object3dset` and `object3dremove`. Unlike child-added/removed, these are only triggered after the entity has loaded, so no need for a delay.
- When any of the above listeners fire, just set a dirty flag.
- Before each raycast, if dirty flag is set, refresh the object list.
- Warn users if the `raycaster.objects` selector is exotic, like`[position=0 2 0]`, which will be missed by our MutationObserver.

If this direction looks OK, I'll add tests. It's a bigger change than we should include for 0.7.0, and can wait for 0.7.1 or 0.8.0.