### PR TITLE
Fix fullscreen problem on pc browser

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -460,6 +460,7 @@ module.exports.AScene = registerElement('a-scene', {
         // In VR mode, VREffect handles canvas resize based on the dimensions returned by
         // the getEyeParameters function of the WebVR API. These dimensions are independent of
         // the window size, therefore should not be overwritten with the window's width and height.
+        // if (!camera || !canvas || this.is('vr-mode') && isMobile) { return; }
         if (!camera || !canvas || this.is('vr-mode')) { return; }
         // Update camera.
         size = getCanvasSize(canvas, embedded);

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -460,8 +460,7 @@ module.exports.AScene = registerElement('a-scene', {
         // In VR mode, VREffect handles canvas resize based on the dimensions returned by
         // the getEyeParameters function of the WebVR API. These dimensions are independent of
         // the window size, therefore should not be overwritten with the window's width and height.
-        // if (!camera || !canvas || this.is('vr-mode') && isMobile) { return; }
-        if (!camera || !canvas || this.is('vr-mode')) { return; }
+        if (!camera || !canvas || this.is('vr-mode') && isMobile) { return; }
         // Update camera.
         size = getCanvasSize(canvas, embedded);
         camera.aspect = size.width / size.height;


### PR DESCRIPTION
**Description:**

I can't get a "full" fullscreen on pc. The canvas keep the same size as normal state, with black background. After I add `this.is('vr-mode')` back, everything is fine.

Related: https://github.com/aframevr/aframe/pull/3031#issuecomment-331105971

**Changes proposed:**
- Fix fullscreen problem on pc browser
