### PR TITLE
flipped the sign on sampleUV.x in the Portal shader used by the link …

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -339,7 +339,7 @@ registerShader('portal', {
       'vec2 sampleUV;',
       'float borderThickness = clamp(exp(-vDistance / 50.0), 0.6, 0.95);',
       'sampleUV.y = saturate(direction.y * 0.5  + 0.5);',
-      'sampleUV.x = atan(direction.z, direction.x) * -RECIPROCAL_PI2 + 0.5;',
+      'sampleUV.x = atan(direction.z, -direction.x) * -RECIPROCAL_PI2 + 0.5;',
       'if (vDistanceToCenter > borderThickness && borderEnabled == 1.0) {',
         'gl_FragColor = vec4(strokeColor, 1.0);',
       '} else {',


### PR DESCRIPTION
Link Component

Fix for issue 3077 https://github.com/aframevr/aframe/issues/3077
Flipped the sign on sampleUV.x in the Portal shader that is used by the link component.
