### PR TITLE
Do not resize the canvas while presenting in immersive mode or on mobile

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -456,11 +456,13 @@ module.exports.AScene = registerElement('a-scene', {
         var canvas = this.canvas;
         var embedded = this.getAttribute('embedded') && !this.is('vr-mode');
         var size;
+        var isEffectPresenting = this.effect && this.effect.isPresenting;
         // Do not update renderer, if a camera or a canvas have not been injected.
         // In VR mode, VREffect handles canvas resize based on the dimensions returned by
         // the getEyeParameters function of the WebVR API. These dimensions are independent of
-        // the window size, therefore should not be overwritten with the window's width and height.
-        if (!camera || !canvas || this.is('vr-mode')) { return; }
+        // the window size, therefore should not be overwritten with the window's width and height,
+        // except when in fullscreen mode.
+        if (!camera || !canvas || (this.is('vr-mode') && (this.isMobile || isEffectPresenting))) { return; }
         // Update camera.
         size = getCanvasSize(canvas, embedded);
         camera.aspect = size.width / size.height;

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -388,6 +388,58 @@ suite('a-scene (without renderer)', function () {
     });
   });
 
+  suite.only('resize', function () {
+    var sceneEl;
+    var setSizeSpy;
+
+    setup(function () {
+      sceneEl = this.el;
+      AScene.prototype.resize.restore();
+      sceneEl.camera = { updateProjectionMatrix: function () {} };
+      sceneEl.canvas = document.createElement('canvas');
+      sceneEl.renderer = { setSize: function () {} };
+
+      setSizeSpy = this.sinon.spy(sceneEl.renderer, 'setSize');
+    });
+
+    test('resize renderer when not in vr mode', function () {
+      sceneEl.resize();
+
+      assert.ok(setSizeSpy.called);
+    });
+
+    test('resize renderer when in vr mode in fullscreen presentation (desktop, no headset)', function () {
+      sceneEl.effect = {
+        isPresenting: false
+      };
+      sceneEl.addState('vr-mode');
+
+      sceneEl.resize();
+
+      assert.ok(setSizeSpy.called);
+    });
+
+    test('does not resize renderer when in vr mode on mobile', function () {
+      sceneEl.isMobile = true;
+      sceneEl.addState('vr-mode');
+
+      sceneEl.resize();
+
+      assert.notOk(setSizeSpy.called);
+    });
+
+    test('does not resize renderer when in vr mode and presenting in a headset', function () {
+      sceneEl.effect = {
+        isPresenting: true
+      };
+      sceneEl.addState('vr-mode');
+
+      sceneEl.resize();
+
+      assert.notOk(setSizeSpy.called);
+    });
+  });
+
   suite('pointerRestricted', function () {
     setup(function () {
       var sceneEl = this.el;


### PR DESCRIPTION
Renderer size should only be updated on desktop in fullscreen mode.
Resizing the browser window while presenting leads to the canvas being resized accordingly, which updates resolution in the headset, causing a bad experience. Since Aframe does not rely on Three.js built-in mechanism for resizing the canvas this needs to be handled explicitly in a-scene.js.
Alternative to #3075, follow-up of #3031 
