### PR TITLE
use Oculus Browser instead of Oculus Carmel

### DIFF
--- a/docs/introduction/vr-headsets-and-webvr-browsers.md
+++ b/docs/introduction/vr-headsets-and-webvr-browsers.md
@@ -134,7 +134,7 @@ specification][w3c]:
 - [Firefox 55+ for Windows](https://www.mozilla.org/en-US/firefox/desktop/)
 - [Experimental builds of Chromium](https://webvr.info/get-chrome/)
 - Chrome for Android (Daydream)
-- Oculus Carmel (GearVR)
+- Oculus Browser (GearVR)
 - Samsung Internet (GearVR)
 - Microsoft Edge
 


### PR DESCRIPTION
Use Oculus Browser instead of Oculus Carmel that is the old browser. I installed myself the Carmel Developer Preview app and found out later that it was actually an old version of the now called Oculus Browser, and Oculus Browser is installed by default with GearVR.
So the change is to avoid confusion.
