### PR TITLE
Improved image check in src-loader by sending a head request and chec…

### DIFF
--- a/src/utils/src-loader.js
+++ b/src/utils/src-loader.js
@@ -93,7 +93,30 @@ function checkIsImage (src, onResult) {
     onResult(src.tagName === 'IMG');
     return;
   }
+  var request = new XMLHttpRequest();
 
+  request.open("HEAD", src);
+  request.addEventListener('load', function(event) {
+    if (request.status >= 200 && request.status < 300) {
+      var contentType = request.getResponseHeader("Content-Type");
+      if(contentType == null) {
+        checkIsImageFallback(src, onResult);
+      } else {
+        if(contentType.startsWith("image")){
+          onResult(true);
+        } else {
+          onResult(false);
+        }
+      }
+    } else {
+      checkIsImageFallback(src, onResult);
+    }
+    request.abort();
+  });
+  request.send();
+}
+
+function checkIsImageFallback(src, onResult){
   var tester = new Image();
   tester.addEventListener('load', onLoad);
   function onLoad () { onResult(true); }

--- a/src/utils/src-loader.js
+++ b/src/utils/src-loader.js
@@ -1,4 +1,4 @@
-/* global Image */
+/* global Image, XMLHttpRequest */
 var debug = require('./debug');
 
 var warn = debug('utils:src-loader:warn');
@@ -89,20 +89,24 @@ function parseUrl (src) {
  * @param {function} onResult - Callback with whether `src` is an image.
  */
 function checkIsImage (src, onResult) {
+  var request;
+
   if (src.tagName) {
     onResult(src.tagName === 'IMG');
     return;
   }
-  var request = new XMLHttpRequest();
+  request = new XMLHttpRequest();
 
-  request.open("HEAD", src);
-  request.addEventListener('load', function(event) {
+  // Try to send HEAD request to check if image first.
+  request.open('HEAD', src);
+  request.addEventListener('load', function (event) {
+    var contentType;
     if (request.status >= 200 && request.status < 300) {
-      var contentType = request.getResponseHeader("Content-Type");
-      if(contentType == null) {
+      contentType = request.getResponseHeader('Content-Type');
+      if (contentType == null) {
         checkIsImageFallback(src, onResult);
       } else {
-        if(contentType.startsWith("image")){
+        if (contentType.startsWith('image')) {
           onResult(true);
         } else {
           onResult(false);
@@ -116,7 +120,7 @@ function checkIsImage (src, onResult) {
   request.send();
 }
 
-function checkIsImageFallback(src, onResult){
+function checkIsImageFallback (src, onResult) {
   var tester = new Image();
   tester.addEventListener('load', onLoad);
   function onLoad () { onResult(true); }


### PR DESCRIPTION
…king content-type - using old method as a fallback if head is not supported

In Safari I had the problem that the event listeners on the image-object in the checkIsImage()-function would not be called until the source file was fully loaded. In my case it was a 70 MB video file, and a-frame was not rendering the video until the onResult(false) callback was called.
Therefore I replaced the check with a HEAD XHR request checking for the content-type. The old method is still included as a fallback.