### PR TITLE
clone default array property type, use default array value if not defined (fixes #3092)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -325,7 +325,7 @@ Component.prototype = {
    * @return {object} The component data
    */
   buildData: function (newData, clobber, silent, skipTypeChecking) {
-    var componentDefined = newData !== undefined && newData !== null;
+    var componentDefined;
     var data;
     var defaultValue;
     var keys;
@@ -336,11 +336,17 @@ Component.prototype = {
     var isSinglePropSchema = isSingleProp(schema);
     var mixinEls = this.el.mixinEls;
     var previousData;
+
+    // Whether component has a defined value. For arrays, treat empty as not defined.
+    componentDefined = newData && newData.constructor === Array
+      ? newData.length
+      : newData !== undefined && newData !== null;
+
     // 1. Default values (lowest precendence).
     if (isSinglePropSchema) {
       // Clone default value if plain object so components don't share the same object
       // that might be modified by the user.
-      data = (schema.default && schema.default.constructor === Object) ? utils.clone(schema.default) : schema.default;
+      data = isObjectOrArray(schema.default) ? utils.clone(schema.default) : schema.default;
     } else {
       // Preserve previously set properties if clobber not enabled.
       previousData = !clobber && this.attrValue;
@@ -353,9 +359,7 @@ Component.prototype = {
         defaultValue = schema[keys[i]].default;
         if (data[keys[i]] !== undefined) { continue; }
         // Clone default value if object so components don't share object
-        data[keys[i]] = defaultValue && defaultValue.constructor === Object
-          ? utils.clone(defaultValue)
-          : defaultValue;
+        data[keys[i]] = isObjectOrArray(defaultValue) ? utils.clone(defaultValue) : defaultValue;
       }
     }
 
@@ -483,9 +487,7 @@ function cloneData (data) {
   var key;
   for (key in data) {
     parsedProperty = data[key];
-    clone[key] = parsedProperty && parsedProperty.constructor === Object
-      ? utils.clone(parsedProperty)
-      : parsedProperty;
+    clone[key] = isObjectOrArray(parsedProperty) ? utils.clone(parsedProperty) : parsedProperty;
   }
   return clone;
 }
@@ -546,4 +548,8 @@ function wrapPlay (playMethod) {
     if (!hasBehavior(this)) { return; }
     sceneEl.addBehavior(this);
   };
+}
+
+function isObjectOrArray (value) {
+  return value && (value.constructor === Object || value.constructor === Array);
 }

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -210,6 +210,18 @@ suite('Component', function () {
       assert.equal(el.components.test.buildData({foo: null}).foo, null);
       assert.equal(el.components.test.buildData({foo: 'foo'}).foo, 'foo');
     });
+
+    test('clones array property type', function () {
+      var array = ['a'];
+      var data;
+      var el;
+      registerComponent('test', {schema: {default: array}});
+      el = document.createElement('a-entity');
+      el.setAttribute('test', '');
+      data = el.components.test.buildData();
+      assert.equal(data[0], 'a');
+      assert.notEqual(data, array);
+    });
   });
 
   suite('updateProperties', function () {
@@ -434,8 +446,7 @@ suite('Component', function () {
       var attrValue = el.components.dummy.attrValue;
       assert.notEqual(data, attrValue);
       assert.equal(data.color, attrValue.color);
-      // The HTMLElement is not cloned in attrValue
-      // a reference is shared instead.
+      // HTMLElement not cloned in attrValue, reference is shared instead.
       assert.equal(data.el, attrValue.el);
       assert.equal(data.el.constructor, HTMLHeadElement);
       assert.notEqual(data.direction, attrValue.direction);
@@ -446,8 +457,7 @@ suite('Component', function () {
         direction: {x: 1, y: 1, z: 1}
       });
       data = el.getAttribute('dummy');
-      // The HTMLElement is not cloned in attrValue
-      // a reference is shared instead.
+      // HTMLElement not cloned in attrValue, reference is shared instead.
       assert.equal(data.el.constructor, HTMLHeadElement);
       assert.equal(data.el, el.components.dummy.attrValue.el);
     });
@@ -947,6 +957,20 @@ suite('Component', function () {
       dummyComponent.pause();
       sinon.assert.calledOnce(this.pauseStub);
     });
+  });
+
+  test('applies default array property types with no defined value', function (done) {
+    var el;
+    registerComponent('test', {
+      schema: {default: ['foo']},
+
+      update: function () {
+        assert.equal(this.data[0], 'foo');
+        done();
+      }
+    });
+    el = entityFactory();
+    el.setAttribute('test', '');
   });
 });
 


### PR DESCRIPTION
**Description:**

1. Arrays were not getting cloned.
2. Default arrays value were not being used if no data was explicitly defined...since array parser will parse `''` to `[]`. `buildData` would then treat `[]` as a defined value.

**Changes proposed:**
- Apply several checks used by Object type also to the Array type for cloning.
- Add a case in `buildData` to treat `[]` not as a defined component value.
