### PR TITLE
add customizeable colors to link portal and title (fixes #2930)

### DIFF
--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -60,18 +60,17 @@ We also provide a link primitive with a different syntax:
 
 | Property            | Description                                                                                                                                  | Default Value |
 |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| backgroundColor     | Inner (background) color of the portal.                                                                                                      | red           |
 | borderColor         | Border color of the portal.                                                                                                                  | white         |
-| innerColor          | Inner (background) color of the portal.                                                                                                      | red           |
 | highlighted         | Boolean to toggle link highlight color.                                                                                                      | false         |
 | highlightedColor    | Border color when highlighted.                                                                                                               | '#24CAFF'     |
 | href                | Destination URL where the link points to.                                                                                                    | ''            |
-| on                  | Event to listen to that triggers link traversal.                                                                                             | ''            |
 | image               | 360&deg; image used as scene preview in the portal. Can be a selector to an `<img>` element or a URL.                                        | ''            |
+| on                  | Event to listen to that triggers link traversal.                                                                                             | ''            |
 | peekMode            | Whether the 360&deg; image is fully expanded for preview.                                                                                    | false         |
 | title               | Text displayed on the link. The `href` or page URL is used if not defined.                                                                   | ''            |
 | titleColor          | Color of the text displayed on the link.                                                                                                     | white         |
 | visualAspectEnabled | Whether to enable the default visual appearance of a portal. Set to false if we want to implement our own pattern or form of link traversal. | true          |
-
 
 ## Methods
 

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -60,7 +60,8 @@ We also provide a link primitive with a different syntax:
 
 | Property            | Description                                                                                                                                  | Default Value |
 |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| color               | Background color of the portal.                                                                                                              | white         |
+| borderColor         | Border color of the portal.                                                                                                                  | white         |
+| innerColor          | Inner (background) color of the portal.                                                                                                      | red           |
 | highlighted         | Boolean to toggle link highlight color.                                                                                                      | false         |
 | highlightedColor    | Border color when highlighted.                                                                                                               | '#24CAFF'     |
 | href                | Destination URL where the link points to.                                                                                                    | ''            |
@@ -68,6 +69,7 @@ We also provide a link primitive with a different syntax:
 | image               | 360&deg; image used as scene preview in the portal. Can be a selector to an `<img>` element or a URL.                                        | ''            |
 | peekMode            | Whether the 360&deg; image is fully expanded for preview.                                                                                    | false         |
 | title               | Text displayed on the link. The `href` or page URL is used if not defined.                                                                   | ''            |
+| titleColor          | Color of the text displayed on the link.                                                                                                     | white         |
 | visualAspectEnabled | Whether to enable the default visual appearance of a portal. Set to false if we want to implement our own pattern or form of link traversal. | true          |
 
 

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -5,21 +5,21 @@ var THREE = require('../lib/three');
 /**
  * Link component. Connect experiences and traverse between them in VR
  *
- * @member {object} hiddenEls - Stores the hidden elements during peek mode.
+ * @member {object} hiddenEls - Store the hidden elements during peek mode.
  */
 module.exports.Component = registerComponent('link', {
   schema: {
-    titleColor: { default: 'white', type: 'color' },
-    borderColor: { default: 'white', type: 'color' },
-    innerColor: { default: 'red', type: 'color' },
-    highlighted: { default: false },
-    highlightedColor: { default: '#24CAFF', type: 'color' },
-    href: { default: '' },
-    image: { type: 'asset' },
-    on: { default: 'click' },
-    peekMode: { default: false },
-    title: { default: '' },
-    visualAspectEnabled: { default: true }
+    backgroundColor: {default: 'red', type: 'color'},
+    borderColor: {default: 'white', type: 'color'},
+    highlighted: {default: false},
+    highlightedColor: {default: '#24CAFF', type: 'color'},
+    href: {default: ''},
+    image: {type: 'asset'},
+    on: {default: 'click'},
+    peekMode: {default: false},
+    title: {default: ''},
+    titleColor: {default: 'white', type: 'color'},
+    visualAspectEnabled: {default: true}
   },
 
   init: function () {
@@ -33,22 +33,27 @@ module.exports.Component = registerComponent('link', {
   update: function (oldData) {
     var data = this.data;
     var el = this.el;
-    var strokeColor = data.highlighted ? data.highlightedColor : data.borderColor;
-    var innerColor = data.highlighted ? data.highlightedColor : data.innerColor;
+    var backgroundColor;
+    var strokeColor;
+
+    backgroundColor = data.highlighted ? data.highlightedColor : data.backgroundColor;
+    strokeColor = data.highlighted ? data.highlightedColor : data.borderColor;
+    el.setAttribute('material', 'backgroundColor', backgroundColor);
     el.setAttribute('material', 'strokeColor', strokeColor);
-    el.setAttribute('material', 'innerColor', innerColor);
+
     if (data.on !== oldData.on) { this.updateEventListener(); }
-    if (data.visualAspectEnabled && oldData.peekMode !== undefined && data.peekMode !== oldData.peekMode) {
-      this.updatePeekMode();
-    }
+
+    if (data.visualAspectEnabled && oldData.peekMode !== undefined &&
+        data.peekMode !== oldData.peekMode) { this.updatePeekMode(); }
+
     if (!data.image || oldData.image === data.image) { return; }
+
     el.setAttribute('material', 'pano',
-      typeof data.image === 'string' ? data.image : data.image.src);
+                    typeof data.image === 'string' ? data.image : data.image.src);
   },
 
   /*
-   * Hide / Show all elements and Hide / Show the full 360 preview
-   * of the linked page.
+   * Toggle all elements and full 360 preview of the linked page.
    */
   updatePeekMode: function () {
     var el = this.el;
@@ -87,22 +92,21 @@ module.exports.Component = registerComponent('link', {
 
   initVisualAspect: function () {
     var el = this.el;
-    var textEl;
-    var sphereEl;
     var semiSphereEl;
+    var sphereEl;
+    var textEl;
+
     if (!this.data.visualAspectEnabled) { return; }
+
     textEl = this.textEl = this.textEl || document.createElement('a-entity');
     sphereEl = this.sphereEl = this.sphereEl || document.createElement('a-entity');
     semiSphereEl = this.semiSphereEl = this.semiSphereEl || document.createElement('a-entity');
 
-    // Set Portal
-    el.setAttribute('geometry', { primitive: 'circle', radius: 1.0, segments: 64 });
-    el.setAttribute('material', {
-      shader: 'portal',
-      pano: this.data.image,
-      side: 'double'
-    });
-    // Set text that displays the link title / url
+    // Set portal.
+    el.setAttribute('geometry', {primitive: 'circle', radius: 1.0, segments: 64});
+    el.setAttribute('material', {shader: 'portal', pano: this.data.image, side: 'double'});
+
+    // Set text that displays the link title and URL.
     textEl.setAttribute('text', {
       color: this.data.titleColor,
       align: 'center',
@@ -113,8 +117,7 @@ module.exports.Component = registerComponent('link', {
     textEl.setAttribute('position', '0 1.5 0');
     el.appendChild(textEl);
 
-    // Set the sphere that is rendered when the camera is close
-    // to the portal to allow the user peek inside
+    // Set sphere rendered when camera is close to portal to allow user to peek inside.
     semiSphereEl.setAttribute('geometry', {
       primitive: 'sphere',
       radius: 1.0,
@@ -136,8 +139,7 @@ module.exports.Component = registerComponent('link', {
     semiSphereEl.setAttribute('visible', false);
     el.appendChild(semiSphereEl);
 
-    // Set the sphere that is rendered when the camera is close
-    // to the portal to allow the user peek inside
+    // Set sphere rendered when camera is close to portal to allow user to peek inside.
     sphereEl.setAttribute('geometry', {
       primitive: 'sphere',
       radius: 10,
@@ -159,27 +161,28 @@ module.exports.Component = registerComponent('link', {
   },
 
   /**
-   * The tick handles:
-   * 1. Swap the plane the represents the portal with a sphere with a hole when the camera is close
-   * so the user can peek inside the portal. The sphere is rendered on the oposite side of the portal
-   * from where the user enters.
-   * 2. It places the url / title above or inside the portal depending on the distance to the camera.
-   * 3. The portal faces the camera when it's far away from the user.
-   *
+   * 1. Swap plane that represents portal with sphere with a hole when the camera is close
+   * so user can peek inside portal. Sphere is rendered on oposite side of portal
+   * from where user enters.
+   * 2. Place the url/title above or inside portal depending on distance to camera.
+   * 3. Face portal to camera when far away from user.
    */
   tick: (function () {
-    var elWorldPosition = new THREE.Vector3();
     var cameraWorldPosition = new THREE.Vector3();
-    var scale = new THREE.Vector3();
+    var elWorldPosition = new THREE.Vector3();
     var quaternion = new THREE.Quaternion();
+    var scale = new THREE.Vector3();
+
     return function () {
-      if (!this.data.visualAspectEnabled) { return; }
       var el = this.el;
       var object3D = el.object3D;
       var camera = el.sceneEl.camera;
       var cameraPortalOrientation;
       var distance;
       var textEl = this.textEl;
+
+      if (!this.data.visualAspectEnabled) { return; }
+
       // Update matrices
       object3D.updateMatrixWorld();
       camera.parent.updateMatrixWorld();
@@ -189,20 +192,19 @@ module.exports.Component = registerComponent('link', {
       elWorldPosition.setFromMatrixPosition(object3D.matrixWorld);
       cameraWorldPosition.setFromMatrixPosition(camera.matrixWorld);
       distance = elWorldPosition.distanceTo(cameraWorldPosition);
-      // Store original orientation to be restored when the portal
-      // stops facing the camera
+
+      // Store original orientation to be restored when the portal stops facing the camera.
       this.previousQuaternion = this.previousQuaternion || quaternion.clone();
 
-      // If the portal is far away from the user the portal faces the camera
       if (distance > 20) {
+        // If the portal is far away from the user, face portal to camera.
         object3D.lookAt(cameraWorldPosition);
-      } else { // When the portal is close to the user (camera)
+      } else {
+        // When portal is close to the user/camera.
         cameraPortalOrientation = this.calculateCameraPortalOrientation();
-        // If the user gets very close to the portal it is replaced
-        // by a holed sphere where she can peek inside
+        // If user gets very close to portal, replace with holed sphere they can peek in.
         if (distance < 0.5) {
-          // Configure text size and sphere orientation depending
-          // the side the user approaches the portal
+          // Configure text size and sphere orientation depending side user approaches portal.
           if (this.semiSphereEl.getAttribute('visible') === true) { return; }
           textEl.setAttribute('text', 'width', 1.5);
           if (cameraPortalOrientation <= 0.0) {
@@ -218,7 +220,7 @@ module.exports.Component = registerComponent('link', {
           this.semiSphereEl.setAttribute('visible', true);
           this.peekCameraPortalOrientation = cameraPortalOrientation;
         } else {
-          // Calculate wich side the camera is approaching the camera (back / front)
+          // Calculate wich side the camera is approaching the camera (back / front).
           // Adjust text orientation based on camera position.
           if (cameraPortalOrientation <= 0.0) {
             textEl.setAttribute('rotation', '0 180 0');
@@ -246,8 +248,12 @@ module.exports.Component = registerComponent('link', {
     if (hiddenEls.length > 0) { return; }
     el.sceneEl.object3D.traverse(function (object) {
       if (object && object.el && object.el.hasAttribute('link-controls')) { return; }
-      if (!object.el || object === el.sceneEl.object3D || object.el === el || object.el === self.sphereEl ||
-        object.el === el.sceneEl.cameraEl || object.el.getAttribute('visible') === false || object.el === self.textEl || object.el === self.semiSphereEl) { return; }
+      if (!object.el || object === el.sceneEl.object3D || object.el === el ||
+          object.el === self.sphereEl || object.el === el.sceneEl.cameraEl ||
+          object.el.getAttribute('visible') === false || object.el === self.textEl ||
+          object.el === self.semiSphereEl) {
+        return;
+      }
       object.el.setAttribute('visible', false);
       hiddenEls.push(object.el);
     });
@@ -259,8 +265,8 @@ module.exports.Component = registerComponent('link', {
   },
 
   /**
-   *  Calculate if the camera / user faces the front or back face of the portal
-   *  @returns {number} > 0 if the camera faces the front of the portal < 0 if it faces the back.
+   * Calculate whether the camera faces the front or back face of the portal.
+   * @returns {number} > 0 if camera faces front of portal, < 0 if it faces back of portal.
    */
   calculateCameraPortalOrientation: (function () {
     var mat4 = new THREE.Matrix4();
@@ -272,33 +278,32 @@ module.exports.Component = registerComponent('link', {
       var el = this.el;
       var camera = el.sceneEl.camera;
 
-      // Reset tmp variables
+      // Reset tmp variables.
       cameraPosition.set(0, 0, 0);
       portalNormal.set(0, 0, 1);
       portalPosition.set(0, 0, 0);
 
-      // Apply portal orientation to the normal
+      // Apply portal orientation to the normal.
       el.object3D.matrixWorld.extractRotation(mat4);
       portalNormal.applyMatrix4(mat4);
 
-      // Calculate portal world position
+      // Calculate portal world position.
       el.object3D.updateMatrixWorld();
       el.object3D.localToWorld(portalPosition);
 
-      // Calculate camera world position
+      // Calculate camera world position.
       camera.parent.parent.updateMatrixWorld();
       camera.parent.updateMatrixWorld();
       camera.updateMatrixWorld();
       camera.localToWorld(cameraPosition);
 
-      // Calculate vector from portal to camera
+      // Calculate vector from portal to camera.
       // (portal) -------> (camera)
       cameraPosition.sub(portalPosition).normalize();
       portalNormal.normalize();
 
-      // The side where the camera (user) approaches the portal
-      // is given by the sign of the dot product of the portal normal
-      // and the portal to camera vectors.
+      // Side where camera approaches portal is given by sign of dot product of portal normal
+      // and portal to camera vectors.
       return Math.sign(portalNormal.dot(cameraPosition));
     };
   })(),
@@ -311,10 +316,10 @@ module.exports.Component = registerComponent('link', {
 /* eslint-disable */
 registerShader('portal', {
   schema: {
-    pano: { type: 'map', is: 'uniform' },
-    borderEnabled: { default: 1.0, type: 'int', is: 'uniform' },
-    strokeColor: { default: 'white', type: 'color', is: 'uniform' },
-    innerColor: { default: 'red', type: 'color', is: 'uniform' }
+    borderEnabled: {default: 1.0, type: 'int', is: 'uniform'},
+    backgroundColor: {default: 'red', type: 'color', is: 'uniform'},
+    pano: {type: 'map', is: 'uniform'},
+    strokeColor: {default: 'white', type: 'color', is: 'uniform'}
   },
 
   vertexShader: [
@@ -335,7 +340,7 @@ registerShader('portal', {
     '#define RECIPROCAL_PI2 0.15915494',
     'uniform sampler2D pano;',
     'uniform vec3 strokeColor;',
-    'uniform vec3 innerColor;',
+    'uniform vec3 backgroundColor;',
     'uniform float borderEnabled;',
     'varying float vDistanceToCenter;',
     'varying float vDistance;',
@@ -349,7 +354,7 @@ registerShader('portal', {
     'if (vDistanceToCenter > borderThickness && borderEnabled == 1.0) {',
     'gl_FragColor = vec4(strokeColor, 1.0);',
     '} else {',
-    'gl_FragColor = mix(texture2D(pano, sampleUV), vec4(innerColor, 1.0), clamp(pow((vDistance / 15.0), 2.0), 0.0, 1.0));',
+    'gl_FragColor = mix(texture2D(pano, sampleUV), vec4(backgroundColor, 1.0), clamp(pow((vDistance / 15.0), 2.0), 0.0, 1.0));',
     '}',
     '}'
   ].join('\n')


### PR DESCRIPTION
**Description:**
Fixes #2930 + adds customisable title color prop

**Changes proposed:**
- Adds prop to change link portal **background** color (rather than the hardcoded red)
- Adds prop to change link **title** color
- Refactors link declaration schema to be accordingly specific: borderColor, innerColor and titleColor
- Updates docs accordingly
