### PR TITLE
deprecate states, remove state mixin feature (fixes #2958)

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -151,23 +151,6 @@ console.log(entity.sceneEl === sceneEl);  // >> true.
 
 ## Methods
 
-### `addState (stateName)`
-
-`addState` will push a state onto the entity. This will emit the `stateadded`
-event, and we can check the state can for existence using `.is`:
-
-
-```js
-entity.addEventListener('stateadded', function (evt) {
-  if (evt.detail.state === 'selected') {
-    console.log('Entity now selected!');
-  }
-});
-
-entity.addState('selected');
-entity.is('selected');  // >> true
-```
-
 ### `emit (name, detail, bubbles)`
 
 [animation-begin]: ./animations.md#begin
@@ -438,25 +421,6 @@ AFRAME.registerComponent('example-light', {
     // object3DMap.light is now null.
   }
 });
-```
-
-### `removeState (stateName)`
-
-`removeState` will pop a state from the entity. This will emit the
-`stateremoved` event, and we can check the state its removal using `.is`:
-
-```js
-entity.addEventListener('stateremoved', function (evt) {
-  if (evt.detail.state === 'selected') {
-    console.log('Entity no longer selected.');
-  }
-});
-
-entity.addState('selected');
-entity.is('selected');  // >> true
-
-entity.removeState('selected');
-entity.is('selected');  // >> false
 ```
 
 ## Events

--- a/examples/showcase/tracked-controls/components/aabb-collider.js
+++ b/examples/showcase/tracked-controls/components/aabb-collider.js
@@ -58,12 +58,13 @@ AFRAME.registerComponent('aabb-collider', {
       collisions.forEach(handleHit);
       // No collisions.
       if (collisions.length === 0) { self.el.emit('hit', {el: null}); }
-      // Updated the state of the elements that are not intersected anymore.
+
       this.collisions.filter(function (el) {
         return collisions.indexOf(el) === -1;
-      }).forEach(function removeState (el) {
-        el.removeState(self.data.state);
+      }).forEach(function (el) {
+        el.emit('unhit');
       });
+
       // Store new collisions
       this.collisions = collisions;
 
@@ -90,7 +91,6 @@ AFRAME.registerComponent('aabb-collider', {
 
       function handleHit (hitEl) {
         hitEl.emit('hit');
-        hitEl.addState(self.data.state);
         self.el.emit('hit', {el: hitEl});
       }
 

--- a/examples/showcase/tracked-controls/components/grab.js
+++ b/examples/showcase/tracked-controls/components/grab.js
@@ -7,7 +7,6 @@
 */
 AFRAME.registerComponent('grab', {
   init: function () {
-    this.GRABBED_STATE = 'grabbed';
     // Bind event handlers
     this.onHit = this.onHit.bind(this);
     this.onGripOpen = this.onGripOpen.bind(this);
@@ -45,7 +44,7 @@ AFRAME.registerComponent('grab', {
     var hitEl = this.hitEl;
     this.grabbing = false;
     if (!hitEl) { return; }
-    hitEl.removeState(this.GRABBED_STATE);
+    hitEl.emit('ungrab');
     this.hitEl = undefined;
   },
 
@@ -55,7 +54,7 @@ AFRAME.registerComponent('grab', {
     // If the hand is not grabbing the element does not stick.
     // If we're already grabbing something you can't grab again.
     if (!hitEl || hitEl.is(this.GRABBED_STATE) || !this.grabbing || this.hitEl) { return; }
-    hitEl.addState(this.GRABBED_STATE);
+    hitEl.emit('grab');
     this.hitEl = hitEl;
   },
 

--- a/examples/showcase/tracked-controls/index.html
+++ b/examples/showcase/tracked-controls/index.html
@@ -6,20 +6,20 @@
     <meta name="description" content="Tracked Controls – A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
     <script src="components/aabb-collider.js"></script>
+    <script src="components/cube.js"></script>
     <script src="components/grab.js"></script>
     <script src="components/ground.js"></script>
+    <script src="https://unpkg.com/aframe-event-set-component@4.0.1/dist/aframe-event-set-component.min.js"></script>
     <script src="shaders/skyGradient.js"></script>
   </head>
   <body>
     <a-scene fog="color: #bc483e; near: 0; far: 65;">
       <a-assets>
         <a-mixin id="cube"
+                 event-set__grab="color: #FFE646"
+                 event-set__hit="color: #F2E646"
                  geometry="primitive: box; height: 0.30; width: 0.30; depth: 0.30"
                  material="color: #EF2D5E;"></a-mixin>
-        <a-mixin id="cube-collided"
-                 material="color: #F2E646;"></a-mixin>
-        <a-mixin id="cube-grabbed"
-                 material="color: #F2E646;"></a-mixin>
       </a-assets>
       <!-- Hands -->
       <a-entity hand-controls="left" aabb-collider="objects: .cube;" grab></a-entity>

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -13,12 +13,6 @@ var EVENTS = {
   MOUSEUP: 'mouseup'
 };
 
-var STATES = {
-  FUSING: 'cursor-fusing',
-  HOVERING: 'cursor-hovering',
-  HOVERED: 'cursor-hovered'
-};
-
 var CANVAS_EVENTS = {
   DOWN: ['mousedown', 'touchstart'],
   UP: ['mouseup', 'touchend']
@@ -83,11 +77,7 @@ module.exports.Component = registerComponent('cursor', {
   },
 
   remove: function () {
-    var el = this.el;
-    el.removeState(STATES.HOVERING);
-    el.removeState(STATES.FUSING);
     clearTimeout(this.fuseTimeout);
-    if (this.intersectedEl) { this.intersectedEl.removeState(STATES.HOVERED); }
     this.removeEventListeners();
   },
 
@@ -272,16 +262,12 @@ module.exports.Component = registerComponent('cursor', {
     this.intersectedEl = intersectedEl;
 
     // Hovering.
-    cursorEl.addState(STATES.HOVERING);
-    intersectedEl.addState(STATES.HOVERED);
     self.twoWayEmit(EVENTS.MOUSEENTER);
 
     // Begin fuse if necessary.
     if (data.fuseTimeout === 0 || !data.fuse) { return; }
-    cursorEl.addState(STATES.FUSING);
     this.twoWayEmit(EVENTS.FUSING);
     this.fuseTimeout = setTimeout(function fuse () {
-      cursorEl.removeState(STATES.FUSING);
       self.twoWayEmit(EVENTS.CLICK);
     }, data.fuseTimeout);
   },
@@ -299,12 +285,7 @@ module.exports.Component = registerComponent('cursor', {
   },
 
   clearCurrentIntersection: function () {
-    var cursorEl = this.el;
-
     // No longer hovering (or fusing).
-    this.intersectedEl.removeState(STATES.HOVERED);
-    cursorEl.removeState(STATES.HOVERING);
-    cursorEl.removeState(STATES.FUSING);
     this.twoWayEmit(EVENTS.MOUSELEAVE);
 
     // Unset intersected entity (after emitting the event).

--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -186,7 +186,7 @@ module.exports.Component = registerComponent('look-controls', {
       rotation.x = radToDeg(hmdEuler.x) + radToDeg(pitchObject.rotation.x);
       rotation.y = radToDeg(hmdEuler.y) + radToDeg(yawObject.rotation.y);
       rotation.z = radToDeg(hmdEuler.z);
-    } else if (!sceneEl.is('vr-mode') || isNullVector(hmdEuler) || !this.data.hmdEnabled) {
+    } else if (!sceneEl.hasAttribute('data-vr-mode') || isNullVector(hmdEuler) || !this.data.hmdEnabled) {
       // Mouse drag if WebVR not active (not connected, no incoming sensor data).
       currentRotation = this.el.getAttribute('rotation');
       this.calculateDeltaRotation();
@@ -234,7 +234,7 @@ module.exports.Component = registerComponent('look-controls', {
     var previousHMDPosition = this.previousHMDPosition;
     var sceneEl = this.el.sceneEl;
 
-    if (!sceneEl.is('vr-mode')) { return; }
+    if (!sceneEl.hasAttribute('data-vr-mode')) { return; }
 
     // Calculate change in position.
     currentHMDPosition = this.calculateHMDPosition();

--- a/src/components/scene/vr-mode-ui.js
+++ b/src/components/scene/vr-mode-ui.js
@@ -80,7 +80,7 @@ module.exports.Component = registerComponent('vr-mode-ui', {
   toggleEnterVRButtonIfNeeded: function () {
     var sceneEl = this.el;
     if (!this.enterVREl) { return; }
-    if (sceneEl.is('vr-mode')) {
+    if (sceneEl.hasAttribute('data-vr-mode')) {
       this.enterVREl.classList.add(HIDDEN_CLASS);
     } else {
       this.enterVREl.classList.remove(HIDDEN_CLASS);
@@ -91,7 +91,7 @@ module.exports.Component = registerComponent('vr-mode-ui', {
     var sceneEl = this.el;
     var orientationModalEl = this.orientationModalEl;
     if (!orientationModalEl || !sceneEl.isMobile) { return; }
-    if (!utils.device.isLandscape() && sceneEl.is('vr-mode')) {
+    if (!utils.device.isLandscape() && sceneEl.hasAttribute('data-vr-mode')) {
       // Show if in VR mode on portrait.
       orientationModalEl.classList.remove(HIDDEN_CLASS);
     } else {

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -763,6 +763,7 @@ var proto = Object.create(ANode.prototype, {
 
   addState: {
     value: function (state) {
+      warn('.addState is deprecated.');
       if (this.is(state)) { return; }
       this.states.push(state);
       this.emit('stateadded', {state: state});
@@ -772,6 +773,7 @@ var proto = Object.create(ANode.prototype, {
   removeState: {
     value: function (state) {
       var stateIndex = this.states.indexOf(state);
+      warn('.removeState is deprecated.');
       if (stateIndex === -1) { return; }
       this.states.splice(stateIndex, 1);
       this.emit('stateremoved', {state: state});
@@ -784,6 +786,7 @@ var proto = Object.create(ANode.prototype, {
    */
   is: {
     value: function (state) {
+      warn('.is is deprecated.');
       return this.states.indexOf(state) !== -1;
     }
   }

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -5,7 +5,6 @@ var THREE = require('../lib/three');
 var utils = require('../utils/');
 
 var AEntity;
-var bind = utils.bind;
 var debug = utils.debug('core:a-entity:debug');
 var warn = utils.debug('core:a-entity:warn');
 
@@ -128,62 +127,6 @@ var proto = Object.create(ANode.prototype, {
         return;
       }
       this.updateComponent(attrName, this.getDOMAttribute(attrName));
-    }
-  },
-
-  /**
-   * Add new mixin for each mixin with state suffix.
-   */
-  mapStateMixins: {
-    value: function (state, op) {
-      var mixins;
-      var mixinIds;
-      var i;
-
-      mixins = this.getAttribute('mixin');
-
-      if (!mixins) { return; }
-      mixinIds = mixins.split(' ');
-      for (i = 0; i < mixinIds.length; i++) {
-        op(mixinIds[i] + '-' + state);
-      }
-      this.updateComponents();
-    }
-  },
-
-  /**
-   * Handle update of mixin states (e.g., `box-hovered` where `box` is the mixin ID and
-   * `hovered` is the entity state.
-   */
-  updateStateMixins: {
-    value: function (newMixins, oldMixins) {
-      var diff;
-      var newMixinIds;
-      var oldMixinIds;
-      var i;
-      var j;
-      var stateMixinEls;
-
-      newMixinIds = newMixins.split(' ');
-      oldMixinIds = (oldMixins || '') ? oldMixins.split(' ') : [];
-
-      // List of mixins that might have been removed on update.
-      diff = oldMixinIds.filter(function (i) { return newMixinIds.indexOf(i) < 0; });
-
-      // Remove removed mixins.
-      for (i = 0; i < diff.length; i++) {
-        stateMixinEls = document.querySelectorAll('[id^=' + diff[i] + '-]');
-        for (j = 0; j < stateMixinEls.length; j++) {
-          this.unregisterMixin(stateMixinEls[j].id);
-        }
-      }
-
-      // Add new mixins.
-      for (i = 0; i < this.states.length; i++) {
-        for (j = 0; j < newMixinIds.length; j++) {
-          this.registerMixin(newMixinIds[j] + '-' + this.states[i]);
-        }
-      }
     }
   },
 
@@ -668,7 +611,6 @@ var proto = Object.create(ANode.prototype, {
     value: function (newMixins, oldMixins) {
       oldMixins = oldMixins || this.getAttribute('mixin');
       this.updateMixins(newMixins, oldMixins);
-      this.updateStateMixins(newMixins, oldMixins);
       this.updateComponents();
     }
   },
@@ -823,7 +765,6 @@ var proto = Object.create(ANode.prototype, {
     value: function (state) {
       if (this.is(state)) { return; }
       this.states.push(state);
-      this.mapStateMixins(state, bind(this.registerMixin, this));
       this.emit('stateadded', {state: state});
     }
   },
@@ -833,7 +774,6 @@ var proto = Object.create(ANode.prototype, {
       var stateIndex = this.states.indexOf(state);
       if (stateIndex === -1) { return; }
       this.states.splice(stateIndex, 1);
-      this.mapStateMixins(state, bind(this.unregisterMixin, this));
       this.emit('stateremoved', {state: state});
     }
   },

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -244,7 +244,7 @@ module.exports.AScene = registerElement('a-scene', {
         var effect = this.effect;
 
         // Don't enter VR if already in VR.
-        if (this.is('vr-mode')) { return Promise.resolve('Already in VR.'); }
+        if (this.hasAttribute('data-vr-mode')) { return Promise.resolve('Already in VR.'); }
 
         // Enter VR via WebVR API.
         if (!fromExternal && (this.checkHeadsetConnected() || this.isMobile)) {
@@ -256,7 +256,7 @@ module.exports.AScene = registerElement('a-scene', {
         return Promise.resolve();
 
         function enterVRSuccess () {
-          self.addState('vr-mode');
+          self.setAttribute('data-vr-mode', '');
           self.emit('enter-vr', {target: self});
 
           // Lock to landscape orientation on mobile.
@@ -298,7 +298,7 @@ module.exports.AScene = registerElement('a-scene', {
         var self = this;
 
         // Don't exit VR if not in VR.
-        if (!this.is('vr-mode')) { return Promise.resolve('Not in VR.'); }
+        if (!this.hasAttribute('data-vr-mode')) { return Promise.resolve('Not in VR.'); }
 
         exitFullscreen();
 
@@ -313,7 +313,7 @@ module.exports.AScene = registerElement('a-scene', {
         return Promise.resolve();
 
         function exitVRSuccess () {
-          self.removeState('vr-mode');
+          self.removeAttribute('data-vr-mode');
           // Lock to landscape orientation on mobile.
           if (self.isMobile && screen.orientation && screen.orientation.unlock) {
             screen.orientation.unlock();
@@ -454,7 +454,7 @@ module.exports.AScene = registerElement('a-scene', {
       value: function () {
         var camera = this.camera;
         var canvas = this.canvas;
-        var embedded = this.getAttribute('embedded') && !this.is('vr-mode');
+        var embedded = this.getAttribute('embedded') && !this.hasAttribute('data-vr-mode');
         var size;
         var isEffectPresenting = this.effect && this.effect.isPresenting;
         // Do not update renderer, if a camera or a canvas have not been injected.
@@ -462,7 +462,7 @@ module.exports.AScene = registerElement('a-scene', {
         // the getEyeParameters function of the WebVR API. These dimensions are independent of
         // the window size, therefore should not be overwritten with the window's width and height,
         // except when in fullscreen mode.
-        if (!camera || !canvas || (this.is('vr-mode') && (this.isMobile || isEffectPresenting))) { return; }
+        if (!camera || !canvas || (this.hasAttribute('data-vr-mode') && (this.isMobile || isEffectPresenting))) { return; }
         // Update camera.
         size = getCanvasSize(canvas, embedded);
         camera.aspect = size.width / size.height;

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -34,35 +34,6 @@ suite('cursor', function () {
   });
 
   suite('remove', function () {
-    test('removes hover state', function (done) {
-      el.emit('raycaster-intersection', {
-        intersections: [intersection],
-        els: [intersectedEl]
-      });
-      assert.ok(el.is('cursor-hovering'));
-      assert.ok(intersectedEl.is('cursor-hovered'));
-      el.removeAttribute('cursor');
-      process.nextTick(function () {
-        assert.notOk(el.is('cursor-hovering'));
-        assert.notOk(intersectedEl.is('cursor-hovered'));
-        done();
-      });
-    });
-
-    test('removes fuse state', function (done) {
-      el.setAttribute('cursor', 'fuse', true);
-      el.emit('raycaster-intersection', {
-        intersections: [intersection],
-        els: [intersectedEl]
-      });
-      assert.ok(el.is('cursor-fusing'));
-      el.removeAttribute('cursor');
-      process.nextTick(function () {
-        assert.notOk(el.is('cursor-fusing'));
-        done();
-      });
-    });
-
     test('removes intersection listener', function (done) {
       el.removeAttribute('cursor');
       process.nextTick(function () {
@@ -70,7 +41,7 @@ suite('cursor', function () {
           intersections: [intersection],
           els: [intersectedEl]
         });
-        assert.notOk(el.is('cursor-hovering'));
+        assert.notOk(el.components.intersectedEl);
         done();
       });
     });
@@ -161,7 +132,7 @@ suite('cursor', function () {
         intersections: [intersection],
         els: [el]
       });
-      assert.notOk(intersectedEl.is('cursor-hovered'));
+      assert.notOk(el.components.intersectedEl);
     });
 
     test('does not do anything if only the cursor is intersecting', function () {
@@ -169,15 +140,7 @@ suite('cursor', function () {
         intersections: [intersection],
         els: [el]
       });
-      assert.notOk(el.is('cursor-hovered'));
-    });
-
-    test('sets cursor-hovered state on intersectedEl', function () {
-      el.emit('raycaster-intersection', {
-        intersections: [intersection],
-        els: [intersectedEl]
-      });
-      assert.ok(intersectedEl.is('cursor-hovered'));
+      assert.notOk(el.components.intersectedEl);
     });
 
     test('emits mouseenter event on el', function (done) {
@@ -239,7 +202,6 @@ suite('cursor', function () {
         intersections: [intersection],
         els: [intersectedEl]
       });
-      assert.ok(el.is('cursor-hovering'));
     });
 
     test('emits a mouseleave event on the prevIntersectedEl', function (done) {
@@ -253,35 +215,6 @@ suite('cursor', function () {
       el.emit('raycaster-intersection', {
         intersections: [intersection],
         els: [intersectedEl]
-      });
-    });
-
-    test('does not set cursor-fusing state on cursor if not fuse', function () {
-      el.emit('raycaster-intersection', {
-        intersections: [intersection],
-        els: [intersectedEl]
-      });
-      assert.notOk(el.is('cursor-fusing'));
-    });
-
-    test('sets cursor-fusing state on cursor if fuse', function () {
-      el.setAttribute('cursor', 'fuse', true);
-      el.emit('raycaster-intersection', {
-        intersections: [intersection],
-        els: [intersectedEl]
-      });
-      assert.ok(el.is('cursor-fusing'));
-    });
-
-    test('removes fuse state and emits event on fuse click', function (done) {
-      el.setAttribute('cursor', {fuse: true, fuseTimeout: 1});
-      el.emit('raycaster-intersection', {
-        intersections: [intersection],
-        els: [intersectedEl]
-      });
-      once(el, 'click', function () {
-        assert.notOk(el.is('cursor-fusing'));
-        done();
       });
     });
 
@@ -316,44 +249,6 @@ suite('cursor', function () {
       el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
       assert.notOk(component.intersection);
       assert.notOk(component.intersectedEl);
-    });
-
-    test('removes cursor-hovered state on intersectedEl', function () {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      intersectedEl.addState('cursor-hovered');
-      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
-      assert.notOk(intersectedEl.is('cursor-hovered'));
-    });
-
-    test('emits mouseleave event on el', function (done) {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      once(el, 'mouseleave', function (evt) {
-        assert.equal(evt.detail.intersectedEl, intersectedEl);
-        done();
-      });
-      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
-    });
-
-    test('emits mouseleave event on intersectedEl', function (done) {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      once(intersectedEl, 'mouseleave', function (evt) {
-        assert.equal(evt.detail.cursorEl, el);
-        done();
-      });
-      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
-    });
-
-    test('removes cursor-hovering and cursor-fusing states on cursor', function () {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      el.addState('cursor-fusing');
-      el.addState('cursor-hovering');
-      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
-      assert.notOk(el.is('cursor-fusing'));
-      assert.notOk(el.is('cursor-hovering'));
     });
   });
 

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -211,62 +211,6 @@ suite('a-entity', function () {
     });
   });
 
-  suite('addState', function () {
-    test('adds state', function () {
-      var el = this.el;
-      el.states = [];
-      el.addState('happy');
-      assert.ok(el.states[0] === 'happy');
-    });
-
-    test('it does not add an existing state', function () {
-      var el = this.el;
-      el.states = ['happy'];
-      el.addState('happy');
-      assert.ok(el.states.length === 1);
-    });
-  });
-
-  suite('removeState', function () {
-    test('removes existing state', function () {
-      var el = this.el;
-      el.states = ['happy'];
-      el.removeState('happy');
-      assert.ok(el.states.length === 0);
-    });
-
-    test('removes non existing state', function () {
-      var el = this.el;
-      el.states = ['happy'];
-      el.removeState('sad');
-      assert.ok(el.states.length === 1);
-    });
-
-    test('removes existing state among multiple states', function () {
-      var el = this.el;
-      el.states = ['happy', 'excited'];
-      el.removeState('excited');
-      assert.equal(el.states.length, 1);
-      assert.ok(el.states[0] === 'happy');
-    });
-  });
-
-  suite('is', function () {
-    test('returns true if entity is in the given state', function () {
-      var el = this.el;
-      el.states = ['happy'];
-      el.is('happy');
-      assert.ok(el.is('happy'));
-    });
-
-    test('returns false if entity is not in the given state', function () {
-      var el = this.el;
-      el.states = ['happy'];
-      el.is('happy');
-      assert.ok(el.is('happy'));
-    });
-  });
-
   suite('setAttribute', function () {
     test('can set a component with a string', function () {
       var el = this.el;

--- a/tests/core/controls.test.js
+++ b/tests/core/controls.test.js
@@ -152,7 +152,7 @@ suite('rotation controls on camera with VRControls (integration unit test)', fun
 
   test('rotates camera around Y', function (done) {
     var el = this.el;
-    el.sceneEl.addState('vr-mode');
+    el.sceneEl.setAttribute('data-vr-mode', '');
     this.dolly.quaternion.setFromEuler(new THREE.Euler(0, PI, 0));
     el.sceneEl.tick();
     process.nextTick(function () {
@@ -166,7 +166,7 @@ suite('rotation controls on camera with VRControls (integration unit test)', fun
 
   test('rotates camera composing X and Y', function (done) {
     var el = this.el;
-    el.sceneEl.addState('vr-mode');
+    el.sceneEl.setAttribute('data-vr-mode', '');
     this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 4, PI, 0));
     el.sceneEl.tick();
     process.nextTick(function () {
@@ -180,7 +180,7 @@ suite('rotation controls on camera with VRControls (integration unit test)', fun
 
   test('rotates camera composing X and Y and Z', function (done) {
     var el = this.el;
-    el.sceneEl.addState('vr-mode');
+    el.sceneEl.setAttribute('data-vr-mode', '');
     this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 2, PI / 6, PI / 2));
     el.sceneEl.tick();
     process.nextTick(function () {
@@ -194,7 +194,7 @@ suite('rotation controls on camera with VRControls (integration unit test)', fun
 
   test('replaces previous rotation', function (done) {
     var el = this.el;
-    el.sceneEl.addState('vr-mode');
+    el.sceneEl.setAttribute('data-vr-mode', '');
     el.setAttribute('rotation', {x: -10000, y: -10000, z: -10000});
     this.dolly.quaternion.setFromEuler(new THREE.Euler(PI / 2, PI / 6, PI / 2));
     el.sceneEl.tick();
@@ -314,7 +314,7 @@ suite('rotation controls on camera with mouse drag (integration unit test)', fun
   test('does not rotate camera when dragging in VR with headset', function (done) {
     var el = this.el;
     this.dolly.quaternion.setFromEuler(new THREE.Euler(0, PI, 0));
-    el.sceneEl.addState('vr-mode');
+    el.sceneEl.setAttribute('data-vr-mode', '');
     el.sceneEl.canvas.dispatchEvent(new Event('mousedown'));
 
     process.nextTick(function afterMousedown () {
@@ -437,7 +437,7 @@ suite('position controls on camera with VRControls (integration unit test)', fun
     var sceneEl = el.sceneEl;
     var dolly = this.dolly;
 
-    sceneEl.addState('vr-mode');
+    sceneEl.setAttribute('data-vr-mode', '');
     el.components.camera.hasPositionalTracking = true;
     el.components.camera.removeHeightOffset();
 

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -80,7 +80,7 @@ suite('a-scene (without renderer)', function () {
       var sceneEl = this.el;
 
       sceneEl.addEventListener('enter-vr', function () {
-        assert.ok(sceneEl.is('vr-mode'));
+        assert.ok(sceneEl.hasAttribute('data-vr-mode'));
         done();
       });
 
@@ -92,10 +92,10 @@ suite('a-scene (without renderer)', function () {
     test('tells A-Frame about exiting VR if no longer presenting', function (done) {
       var event;
       var sceneEl = this.el;
-      sceneEl.addState('vr-mode');
+      sceneEl.setAttribute('data-vr-mode', '');
 
       sceneEl.addEventListener('exit-vr', function () {
-        assert.notOk(sceneEl.is('vr-mode'));
+        assert.notOk(sceneEl.hasAttribute('data-vr-mode'));
         done();
       });
 
@@ -120,7 +120,7 @@ suite('a-scene (without renderer)', function () {
     test('does not try to enter VR if already in VR', function (done) {
       var sceneEl = this.el;
       var requestSpy = this.requestSpy;
-      sceneEl.addState('vr-mode');
+      sceneEl.setAttribute('data-vr-mode', '');
       sceneEl.enterVR().then(function (val) {
         assert.equal(val, 'Already in VR.');
         assert.notOk(requestSpy.called);
@@ -170,7 +170,7 @@ suite('a-scene (without renderer)', function () {
     test('adds VR mode state', function (done) {
       var sceneEl = this.el;
       sceneEl.enterVR().then(function () {
-        assert.ok(sceneEl.is('vr-mode'));
+        assert.ok(sceneEl.hasAttribute('data-vr-mode'));
         done();
       });
     });
@@ -219,13 +219,13 @@ suite('a-scene (without renderer)', function () {
       sceneEl.effect = {exitPresent: function () { return Promise.resolve(); }};
       this.exitSpy = this.sinon.spy(sceneEl.effect, 'exitPresent');
 
-      sceneEl.addState('vr-mode');
+      sceneEl.setAttribute('data-vr-mode', '');
     });
 
     test('does not try to exit VR if not in VR', function (done) {
       var sceneEl = this.el;
       var exitSpy = this.exitSpy;
-      sceneEl.removeState('vr-mode');
+      sceneEl.removeAttribute('data-vr-mode');
       sceneEl.exitVR().then(function (val) {
         assert.equal(val, 'Not in VR.');
         assert.notOk(exitSpy.called);
@@ -275,7 +275,7 @@ suite('a-scene (without renderer)', function () {
     test('removes VR mode state', function (done) {
       var sceneEl = this.el;
       sceneEl.exitVR().then(function () {
-        assert.notOk(sceneEl.is('vr-mode'));
+        assert.notOk(sceneEl.hasAttribute('data-vr-mode'));
         done();
       });
     });
@@ -388,7 +388,7 @@ suite('a-scene (without renderer)', function () {
       sceneEl.effect = {
         isPresenting: false
       };
-      sceneEl.addState('vr-mode');
+      sceneEl.setAttribute('data-vr-mode', '');
 
       sceneEl.resize();
 
@@ -397,7 +397,7 @@ suite('a-scene (without renderer)', function () {
 
     test('does not resize renderer when in vr mode on mobile', function () {
       sceneEl.isMobile = true;
-      sceneEl.addState('vr-mode');
+      sceneEl.setAttribute('data-vr-mode', '');
 
       sceneEl.resize();
 
@@ -408,7 +408,7 @@ suite('a-scene (without renderer)', function () {
       sceneEl.effect = {
         isPresenting: true
       };
-      sceneEl.addState('vr-mode');
+      sceneEl.setAttribute('data-vr-mode', '');
 
       sceneEl.resize();
 


### PR DESCRIPTION
**Description:**

#2958 

The original intention was to add something similar to pseudo CSS selectors. But:

1. State mixins are a scattered / roundabout way of applying DOM data based on an event. The same can be accomplished more simply with events. I use [event-set](https://github.com/ngokevin/kframe/tree/master/components/event-set) and it's easy.
2. State mixins can be slow. Any time a state is added, the entity force refreshes all of its components despite data not having changed. This caused some unexpectedness for me when components were trying to get "updated" with the same data.
3. `.addState`/`.removeState`/`.is` can be done with classes or data attributes while being visible from the DOM.
4. Usage is low. The appearances outside A-Frame are mostly when people copied code from the original `tracked-controls` example. a-blast/a-painter/a-saturday-night does not use states.
5. Less maintenance. The cursor component had lots of states and had to be maintained alongside the events which accomplished the same thing.

**Changes proposed:**
- Remove state mixins auto-appliers.
- Deprecate states.
