### PR TITLE
remove two array allocations per deepEqual call (critical path)

### DIFF
--- a/src/utils/object-pool.js
+++ b/src/utils/object-pool.js
@@ -1,0 +1,78 @@
+/*
+  Adapted deePool by Kyle Simpson.
+  MIT License: http://getify.mit-license.org
+*/
+var EMPTY_SLOT = Object.freeze(Object.create(null));
+
+// Default object factory.
+function defaultObjectFactory () { return {}; }
+
+/**
+ * Create a new pool.
+ */
+module.exports.createPool = function createPool (objectFactory) {
+  var objPool = [];
+  var nextFreeSlot = null;  // Pool location to look for a free object to use.
+
+  objectFactory = objectFactory || defaultObjectFactory;
+
+  function use () {
+    var objToUse;
+    if (nextFreeSlot === null || nextFreeSlot === objPool.length) {
+      grow(objPool.length || 5);
+    }
+    objToUse = objPool[nextFreeSlot];
+    objPool[nextFreeSlot++] = EMPTY_SLOT;
+    clearObject(objToUse);
+    return objToUse;
+  }
+
+  function recycle (obj) {
+    if (!(obj instanceof Object)) { return; }
+    if (nextFreeSlot === null || nextFreeSlot === -1) {
+      objPool[objPool.length] = obj;
+      return;
+    }
+    objPool[--nextFreeSlot] = obj;
+  }
+
+  function grow (count) {
+    var currentLength;
+    var i;
+
+    count = count === undefined ? objPool.length : count;
+    if (count > 0 && nextFreeSlot == null) {
+      nextFreeSlot = 0;
+    }
+
+    if (count > 0) {
+      currentLength = objPool.length;
+      objPool.length += Number(count);
+      for (i = currentLength; i < objPool.length; i++) {
+        // Add new obj to pool.
+        objPool[i] = objectFactory();
+      }
+    }
+
+    return objPool.length;
+  }
+
+  function size () {
+    return objPool.length;
+  }
+
+  return {
+    grow: grow,
+    pool: objPool,
+    recycle: recycle,
+    size: size,
+    use: use
+  };
+};
+
+function clearObject (obj) {
+  var key;
+  if (!(obj.constructor === Object)) { return; }
+  for (key in obj) { obj[key] = undefined; }
+}
+module.exports.clearObject = clearObject;


### PR DESCRIPTION
**Description:**

From the browser performance tab, deepEqual was a large memory allocator. After this patch, deepEqual no longer even registers on the memory tab.

utils.deepEqual is called on every single component update. Saves two arrays per component update. For things like look-controls which updates pos/rot every frame, saves a lot.

**Changes proposed:**
- Don't use Object.keys in utils.deepEqual, use the same two arrays.
