### PR TITLE
fix cleared events not emitted in some cases

### DIFF
--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -219,7 +219,7 @@ module.exports.Component = registerComponent('raycaster', {
       // Emit intersection cleared on both entities per formerly intersected entity.
       clearedIntersectedEls.length = 0;
       for (i = 0; i < prevIntersectedEls.length; i++) {
-        if (intersectedEls.indexOf(prevIntersectedEls[i]) !== -1) { break; }
+        if (intersectedEls.indexOf(prevIntersectedEls[i]) !== -1) { continue; }
         prevIntersectedEls[i].emit('raycaster-intersected-cleared', {el: el});
         clearedIntersectedEls.push(prevIntersectedEls[i]);
       }


### PR DESCRIPTION
From the comment https://github.com/aframevr/aframe/commit/0b60c12bd48de67c5e82eb1c19159800a07f1ca1#commitcomment-24807425
we changed the `return` to a `break`, but it should really be a `continue`.

I tested with two overlapping cubes, and with the break, sometime I had a cube that stayed in a hover state and the ray wasn't on it. I couldn't reproduce the issue by replacing `break` with `continue`.

#3131 is maybe related to this?
