### PR TITLE
Laser controls cleanup

### DIFF
--- a/docs/components/laser-controls.md
+++ b/docs/components/laser-controls.md
@@ -56,9 +56,10 @@ to the distance to the intersection point.
 
 ## Properties
 
-| Properties | Description        |
-|------------|--------------------|
-| hand       | `left` or `right`. |
+| Properties | Description                                         | Default |
+|------------|-----------------------------------------------------|---------|
+| hand       | `left` or `right` when two controllers are present. | `right` |
+| model      | Whether the default controller models are loaded.   | `true`  |
 
 ## Customizing the Raycaster
 

--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -4,19 +4,21 @@ var bind = utils.bind;
 
 registerComponent('laser-controls', {
   schema: {
-    hand: {default: 'right'}
+    hand: {default: 'right'},
+    model: {default: true}
   },
 
   init: function () {
     var data = this.data;
     var el = this.el;
+    var controllerConfig = {hand: data.hand, model: data.model};
 
     // Set all controller models.
-    el.setAttribute('daydream-controls', {hand: data.hand});
-    el.setAttribute('gearvr-controls', {hand: data.hand});
-    el.setAttribute('oculus-touch-controls', {hand: data.hand});
-    el.setAttribute('vive-controls', {hand: data.hand});
-    el.setAttribute('windows-motion-controls', {hand: data.hand});
+    el.setAttribute('daydream-controls', controllerConfig);
+    el.setAttribute('gearvr-controls', controllerConfig);
+    el.setAttribute('oculus-touch-controls', controllerConfig);
+    el.setAttribute('vive-controls', controllerConfig);
+    el.setAttribute('windows-motion-controls', controllerConfig);
 
     // Bind methods
     this.createRay = bind(this.createRay, this);

--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -1,5 +1,6 @@
 var registerComponent = require('../core/component').registerComponent;
 var utils = require('../utils/');
+var bind = utils.bind;
 
 registerComponent('laser-controls', {
   schema: {
@@ -7,10 +8,8 @@ registerComponent('laser-controls', {
   },
 
   init: function () {
-    var config = this.config;
     var data = this.data;
     var el = this.el;
-    var self = this;
 
     // Set all controller models.
     el.setAttribute('daydream-controls', {hand: data.hand});
@@ -19,51 +18,60 @@ registerComponent('laser-controls', {
     el.setAttribute('vive-controls', {hand: data.hand});
     el.setAttribute('windows-motion-controls', {hand: data.hand});
 
+    // Bind methods
+    this.createRay = bind(this.createRay, this);
+    this.hideRay = bind(this.hideRay, this);
+    this.setModelReady = bind(this.setModelReady, this);
+
     // Wait for controller to connect, or have a valid pointing pose, before creating ray
-    el.addEventListener('controllerconnected', createRay);
-    el.addEventListener('controllerdisconnected', hideRay);
-    el.addEventListener('controllermodelready', function (evt) {
-      createRay(evt);
-      self.modelReady = true;
-    });
-
-    function createRay (evt) {
-      var controllerConfig = config[evt.detail.name];
-
-      if (!controllerConfig) { return; }
-
-      // Show the line unless a particular config opts to hide it, until a controllermodelready
-      // event comes through.
-      var raycasterConfig = utils.extend({
-        showLine: true
-      }, controllerConfig.raycaster || {});
-
-      // The controllermodelready event contains a rayOrigin that takes into account
-      // offsets specific to the loaded model.
-      if (evt.detail.rayOrigin) {
-        raycasterConfig.origin = evt.detail.rayOrigin.origin;
-        raycasterConfig.direction = evt.detail.rayOrigin.direction;
-        raycasterConfig.showLine = true;
-      }
-
-      // Only apply a default raycaster if it does not yet exist. This prevents it overwriting
-      // config applied from a controllermodelready event.
-      if (evt.detail.rayOrigin || !self.modelReady) {
-        el.setAttribute('raycaster', raycasterConfig);
-      } else {
-        el.setAttribute('raycaster', 'showLine', true);
-      }
-
-      el.setAttribute('cursor', utils.extend({
-        fuse: false
-      }, controllerConfig.cursor));
-    }
-
-    function hideRay () {
-      el.setAttribute('raycaster', 'showLine', false);
-    }
+    el.addEventListener('controllerconnected', this.createRay);
+    el.addEventListener('controllerdisconnected', this.hideRay);
+    el.addEventListener('controllermodelready', this.createRay);
+    el.addEventListener('controllermodelready', this.setModelReady);
   },
+  remove: function () {
+    this.el.removeEventListener('controllerconnected', this.createRay);
+    this.el.removeEventListener('controllerdisconnected', this.hideRay);
+    this.el.removeEventListener('controllermodelready', this.createRay);
+    this.el.removeEventListener('controllermodelready', this.setModelReady);
+  },
+  createRay: function (evt) {
+    var controllerConfig = this.config[evt.detail.name];
 
+    if (!controllerConfig) { return; }
+
+    // Show the line unless a particular config opts to hide it, until a controllermodelready
+    // event comes through.
+    var raycasterConfig = utils.extend({
+      showLine: true
+    }, controllerConfig.raycaster || {});
+
+    // The controllermodelready event contains a rayOrigin that takes into account
+    // offsets specific to the loaded model.
+    if (evt.detail.rayOrigin) {
+      raycasterConfig.origin = evt.detail.rayOrigin.origin;
+      raycasterConfig.direction = evt.detail.rayOrigin.direction;
+      raycasterConfig.showLine = true;
+    }
+
+    // Only apply a default raycaster if it does not yet exist. This prevents it overwriting
+    // config applied from a controllermodelready event.
+    if (evt.detail.rayOrigin || !this.modelReady) {
+      this.el.setAttribute('raycaster', raycasterConfig);
+    } else {
+      this.el.setAttribute('raycaster', 'showLine', true);
+    }
+
+    this.el.setAttribute('cursor', utils.extend({
+      fuse: false
+    }, controllerConfig.cursor));
+  },
+  hideRay: function () {
+    this.el.setAttribute('raycaster', 'showLine', false);
+  },
+  setModelReady: function () {
+    this.modelReady = true;
+  },
   config: {
     'daydream-controls': {
       cursor: {downEvents: ['trackpaddown'], upEvents: ['trackpadup']}

--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -23,19 +23,17 @@ registerComponent('laser-controls', {
     // Bind methods
     this.createRay = bind(this.createRay, this);
     this.hideRay = bind(this.hideRay, this);
-    this.setModelReady = bind(this.setModelReady, this);
+    this.onModelReady = bind(this.onModelReady, this);
 
     // Wait for controller to connect, or have a valid pointing pose, before creating ray
     el.addEventListener('controllerconnected', this.createRay);
     el.addEventListener('controllerdisconnected', this.hideRay);
-    el.addEventListener('controllermodelready', this.createRay);
-    el.addEventListener('controllermodelready', this.setModelReady);
+    el.addEventListener('controllermodelready', this.onModelReady);
   },
   remove: function () {
     this.el.removeEventListener('controllerconnected', this.createRay);
     this.el.removeEventListener('controllerdisconnected', this.hideRay);
-    this.el.removeEventListener('controllermodelready', this.createRay);
-    this.el.removeEventListener('controllermodelready', this.setModelReady);
+    this.el.removeEventListener('controllermodelready', this.onModelReady);
   },
   createRay: function (evt) {
     var controllerConfig = this.config[evt.detail.name];
@@ -71,7 +69,8 @@ registerComponent('laser-controls', {
   hideRay: function () {
     this.el.setAttribute('raycaster', 'showLine', false);
   },
-  setModelReady: function () {
+  onModelReady: function (evt) {
+    this.createRay(evt);
     this.modelReady = true;
   },
   config: {

--- a/tests/components/laser-controls.test.js
+++ b/tests/components/laser-controls.test.js
@@ -65,6 +65,15 @@ suite('laser-controls', function () {
         done();
       });
     });
+
+    test('passes model property to controllers', function () {
+      el.setAttribute('laser-controls', {model: false});
+      assert.isFalse(el.getAttribute('daydream-controls').model);
+      assert.isFalse(el.getAttribute('gearvr-controls').model);
+      assert.isFalse(el.getAttribute('oculus-touch-controls').model);
+      assert.isFalse(el.getAttribute('vive-controls').model);
+      assert.isFalse(el.getAttribute('windows-motion-controls').model);
+    });
   });
   suite('remove', function () {
     test('removes event handlers when removed', function () {

--- a/tests/components/laser-controls.test.js
+++ b/tests/components/laser-controls.test.js
@@ -66,4 +66,19 @@ suite('laser-controls', function () {
       });
     });
   });
+  suite('remove', function () {
+    test('removes event handlers when removed', function () {
+      el.removeAttribute('line');
+      el.removeAttribute('raycaster');
+      el.removeAttribute('laser-controls');
+      assert.isNotOk(el.getAttribute('line'));
+      assert.isNotOk(el.getAttribute('raycaster'));
+      el.emit('controllerconnected');
+      el.emit('controllermodelready');
+      assert.isNotOk(el.getAttribute('line'));
+      assert.isNotOk(el.getAttribute('raycaster'));
+      el.emit('controllerdisconnected');
+      assert.isNotOk(el.getAttribute('raycaster'));
+    });
+  });
 });

--- a/tests/components/laser-controls.test.js
+++ b/tests/components/laser-controls.test.js
@@ -65,16 +65,8 @@ suite('laser-controls', function () {
         done();
       });
     });
-
-    test('passes model property to controllers', function () {
-      el.setAttribute('laser-controls', {model: false});
-      assert.isFalse(el.getAttribute('daydream-controls').model);
-      assert.isFalse(el.getAttribute('gearvr-controls').model);
-      assert.isFalse(el.getAttribute('oculus-touch-controls').model);
-      assert.isFalse(el.getAttribute('vive-controls').model);
-      assert.isFalse(el.getAttribute('windows-motion-controls').model);
-    });
   });
+
   suite('remove', function () {
     test('removes event handlers when removed', function () {
       el.removeAttribute('line');
@@ -89,5 +81,25 @@ suite('laser-controls', function () {
       el.emit('controllerdisconnected');
       assert.isNotOk(el.getAttribute('raycaster'));
     });
+  });
+});
+suite('init with model:false', function () {
+  var el;
+
+  setup(function (done) {
+    el = entityFactory();
+    el.addEventListener('componentinitialized', function (evt) {
+      if (evt.detail.name !== 'laser-controls') { return; }
+      done();
+    });
+    el.setAttribute('laser-controls', 'model: false');
+  });
+
+  test('passes model property to controllers', function () {
+    assert.isFalse(el.getAttribute('daydream-controls').model);
+    assert.isFalse(el.getAttribute('gearvr-controls').model);
+    assert.isFalse(el.getAttribute('oculus-touch-controls').model);
+    assert.isFalse(el.getAttribute('vive-controls').model);
+    assert.isFalse(el.getAttribute('windows-motion-controls').model);
   });
 });


### PR DESCRIPTION
**Description:** Improve the cleanup of `laser-controls` on removal and allow an option to not load controller models. I'm suggesting this to improve my `progressive-controls` component, which uses `laser-controls` for pointing mode. I have an issue where the raycaster from laser-controls cannot be disabled for touch mode because it is added back on event triggers even if laser-controls is removed. I have also had a feature request for the model property from a user.

**Changes proposed:**

- When `laser-controls` is removed, also remove registered event listeners
- To accomplish the above, move helper functions from within `init` into component methods
- Add a `model` schema property that propagates to controller components
