### PR TITLE
Cursor update: new raycaster API and touch handling for rayOrigin: mouse

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -171,38 +171,38 @@ module.exports.Component = registerComponent('cursor', {
   },
 
   onMouseMove: (function () {
+    var direction = new THREE.Vector3();
     var mouse = new THREE.Vector2();
     var origin = new THREE.Vector3();
-    var direction = new THREE.Vector3();
-    var rayCasterConfig = {
-      origin: origin,
-      direction: direction
-    };
+    var rayCasterConfig = {origin: origin, direction: direction};
+
     return function (evt) {
+      var bounds = this.canvasBounds;
       var camera = this.el.sceneEl.camera;
+      var left;
+      var point;
+      var top;
+
       camera.parent.updateMatrixWorld();
       camera.updateMatrixWorld();
 
       // Calculate mouse position based on the canvas element
-      var bounds = this.canvasBounds;
-      var point;
       if (evt.type === 'touchmove' || evt.type === 'touchstart') {
-        // just track the first touch for simplicity
+        // Track the first touch for simplicity.
         point = evt.touches.item(0);
       } else {
         point = evt;
       }
-      var left = point.clientX - bounds.left;
-      var top = point.clientY - bounds.top;
+
+      left = point.clientX - bounds.left;
+      top = point.clientY - bounds.top;
       mouse.x = (left / bounds.width) * 2 - 1;
       mouse.y = -(top / bounds.height) * 2 + 1;
 
       origin.setFromMatrixPosition(camera.matrixWorld);
       direction.set(mouse.x, mouse.y, 0.5).unproject(camera).sub(origin).normalize();
       this.el.setAttribute('raycaster', rayCasterConfig);
-      if (evt.type === 'touchstart' || evt.type === 'touchmove') {
-        evt.preventDefault();
-      }
+      if (evt.type === 'touchstart' || evt.type === 'touchmove') { evt.preventDefault(); }
     };
   })(),
 
@@ -212,7 +212,7 @@ module.exports.Component = registerComponent('cursor', {
   onCursorDown: function (evt) {
     this.twoWayEmit(EVENTS.MOUSEDOWN);
     this.cursorDownEl = this.intersectedEl;
-    evt.type === 'touchstart' && evt.preventDefault();
+    if (evt.type === 'touchstart') { evt.preventDefault(); }
   },
 
   /**
@@ -236,7 +236,7 @@ module.exports.Component = registerComponent('cursor', {
     }
 
     this.cursorDownEl = null;
-    evt.type === 'touchend' && evt.preventDefault();
+    if (evt.type === 'touchend') { evt.preventDefault(); }
   },
 
   /**

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -290,16 +290,12 @@ module.exports.Component = registerComponent('cursor', {
    * Handle intersection cleared.
    */
   onIntersectionCleared: function (evt) {
-    var cursorEl = this.el;
-    var intersectedEl = evt.detail.el;
+    var clearedEls = evt.detail.clearedEls;
 
-    // Ignore the cursor.
-    if (cursorEl === intersectedEl) { return; }
-
-    // Ignore if the event didn't occur on the current intersection.
-    if (intersectedEl !== this.intersectedEl) { return; }
-
-    this.clearCurrentIntersection();
+    // Check if the current intersection has ended
+    if (clearedEls.indexOf(this.intersectedEl) !== -1) {
+      this.clearCurrentIntersection();
+    }
   },
 
   clearCurrentIntersection: function () {

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -370,6 +370,7 @@ suite('cursor', function () {
         done();
       });
     });
+
     test('update raycaster based on touch coordinates', function (done) {
       var event = new CustomEvent('touchstart');
       event.touches = {item: function () { return {clientX: 5, clientY: 5}; }};

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -299,13 +299,13 @@ suite('cursor', function () {
 
   suite('onIntersectionCleared', function () {
     test('does not do anything if not intersecting', function () {
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
+      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
     });
 
     test('does not do anything if only the cursor is intersecting', function () {
       component.intersection = intersection;
       component.intersectedEl = intersectedEl;
-      el.emit('raycaster-intersection-cleared', {els: [el]});
+      el.emit('raycaster-intersection-cleared', {clearedEls: [el]});
       assert.ok(component.intersection);
       assert.ok(component.intersectedEl);
     });
@@ -313,7 +313,7 @@ suite('cursor', function () {
     test('unsets intersectedEl', function () {
       component.intersection = intersection;
       component.intersectedEl = intersectedEl;
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
+      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
       assert.notOk(component.intersection);
       assert.notOk(component.intersectedEl);
     });
@@ -322,7 +322,7 @@ suite('cursor', function () {
       component.intersection = intersection;
       component.intersectedEl = intersectedEl;
       intersectedEl.addState('cursor-hovered');
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
+      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
       assert.notOk(intersectedEl.is('cursor-hovered'));
     });
 
@@ -333,7 +333,7 @@ suite('cursor', function () {
         assert.equal(evt.detail.intersectedEl, intersectedEl);
         done();
       });
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
+      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
     });
 
     test('emits mouseleave event on intersectedEl', function (done) {
@@ -343,7 +343,7 @@ suite('cursor', function () {
         assert.equal(evt.detail.cursorEl, el);
         done();
       });
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
+      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
     });
 
     test('removes cursor-hovering and cursor-fusing states on cursor', function () {
@@ -351,67 +351,7 @@ suite('cursor', function () {
       component.intersectedEl = intersectedEl;
       el.addState('cursor-fusing');
       el.addState('cursor-hovering');
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
-      assert.notOk(el.is('cursor-fusing'));
-      assert.notOk(el.is('cursor-hovering'));
-    });
-  });
-
-  suite('onIntersectionCleared', function () {
-    test('does not do anything if not intersecting', function () {
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
-    });
-
-    test('does not do anything if only the cursor is intersecting', function () {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      el.emit('raycaster-intersection-cleared', {els: [el]});
-      assert.ok(component.intersection);
-      assert.ok(component.intersectedEl);
-    });
-
-    test('unsets intersectedEl', function () {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
-      assert.notOk(component.intersection);
-      assert.notOk(component.intersectedEl);
-    });
-
-    test('removes cursor-hovered state on intersectedEl', function () {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      intersectedEl.addState('cursor-hovered');
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
-      assert.notOk(intersectedEl.is('cursor-hovered'));
-    });
-
-    test('emits mouseleave event on el', function (done) {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      once(el, 'mouseleave', function (evt) {
-        assert.equal(evt.detail.intersectedEl, intersectedEl);
-        done();
-      });
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
-    });
-
-    test('emits mouseleave event on intersectedEl', function (done) {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      once(intersectedEl, 'mouseleave', function (evt) {
-        assert.equal(evt.detail.cursorEl, el);
-        done();
-      });
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
-    });
-
-    test('removes cursor-hovering and cursor-fusing states on cursor', function () {
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      el.addState('cursor-fusing');
-      el.addState('cursor-hovering');
-      el.emit('raycaster-intersection-cleared', {el: intersectedEl});
+      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
       assert.notOk(el.is('cursor-fusing'));
       assert.notOk(el.is('cursor-hovering'));
     });

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -430,6 +430,17 @@ suite('cursor', function () {
         done();
       });
     });
+    test('update raycaster based on touch coordinates', function (done) {
+      var event = new CustomEvent('touchstart');
+      event.touches = {item: function () { return {clientX: 5, clientY: 5}; }};
+      el.setAttribute('cursor', 'rayOrigin', 'mouse');
+      window.dispatchEvent(event);
+      process.nextTick(function () {
+        var raycaster = el.getAttribute('raycaster');
+        assert.notEqual(raycaster.direction.x, 0);
+        done();
+      });
+    });
   });
 
   suite('canvas events', function () {

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -93,7 +93,7 @@ suite('cursor', function () {
       once(el, 'mousedown', function () {
         done();
       });
-      component.onCursorDown();
+      component.onCursorDown({});
     });
 
     test('emits mousedown event on intersectedEl', function (done) {
@@ -102,14 +102,14 @@ suite('cursor', function () {
       once(intersectedEl, 'mousedown', function () {
         done();
       });
-      component.onCursorDown();
+      component.onCursorDown({});
     });
 
     test('sets cursorDownEl', function () {
       component.intersection = intersection;
       component.intersectedEl = intersectedEl;
       assert.notOk(component.cursorDownEl);
-      component.onCursorDown();
+      component.onCursorDown({});
       assert.equal(component.cursorDownEl, intersectedEl);
     });
   });


### PR DESCRIPTION
**Not yet complete - need advice**

**Description:** Improve handling of touch input for `rayOrigin: mouse` mode. Make necessary updates for compatibility with `raycaster` post #3126.

Fixes #3140 
Fixes #3114 

**Changes proposed:**

- Bind touch events to onMouseMove handler
- Alter handler to find coordinates in either MouseEvent or TouchEvent touch 0
- Update onIntersectionCleared to handle array of entities and `clearedEls` property name
- Cancel handled touch events so that mobile browsers do not emulate duplicate MouseEvents


**Problem:**

Adapting `cursor` to handle touch events was straightforward, but it didn't completely solve the problem. For a mouse click, we know the mouse position in advance, and the raycaster has had time to refresh. For a touch, however, we don't know the position until the `touchstart`. As the raycaster only refreshes intersections on an interval, it is outdated when `onCursorDown` checks the current intersection. The current effect is that, with each new touch, the `cursor` events/states will effect entities under the previous touch location, always lagging one touch behind. 

I see two potential solutions, and I'd like to know which the maintainers favor:

1. Set the touch event handling on a timeout equal to the current raycaster interval so that they are called after the next raycaster refresh
2. Modify `raycaster` component to allow on-demand refresh (i.e. move everything from `tick` after the interval check into a separate method)

Other concerns:

The current touch tracking is simplistic: starts on the first touch, ignores additional new touches, and ends when any touch ends (even if that first touch is still going). Two other options that could be implemented without major changes would be to keep track of that first touch in a state variable in order to not end until it ends or to update the ray location with every new touch but still end on the first `touchend`.