### PR TITLE
add raycaster.enabled property to toggle tick handler

### DIFF
--- a/docs/components/raycaster.md
+++ b/docs/components/raycaster.md
@@ -54,6 +54,7 @@ AFRAME.registerComponent('collider-check', {
 | --------            | -----------                                                                                                                                                        | ------------- |
 | autoRefresh         | Whether to automatically refresh raycaster's list of objects to test for intersection using mutation observers to detect added or removed entities and components. | true          |
 | direction           | Vector3 coordinate of which direction the ray should point from relative to the entity's origin.                                                                   | 0, 0, 0       |
+| enabled             | Whether raycaster is actively checking for intersections.                                                                                                          | true          |
 | far                 | Maximum distance under which resulting entities are returned. Cannot be lower then `near`.                                                                         | Infinity      |
 | interval            | Number of milliseconds to wait in between each intersection test. Lower number is better for faster updates. Higher number is better for performance.              | 100           |
 | near                | Minimum distance over which resuilting entities are returned. Cannot be lower than 0.                                                                              | 0             |

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -36,7 +36,9 @@ var OBSERVER_CONFIG = {
  */
 module.exports.Component = registerComponent('raycaster', {
   schema: {
+    autoRefresh: {default: true},
     direction: {type: 'vec3', default: {x: 0, y: 0, z: -1}},
+    enabled: {default: true},
     far: {default: 1000},
     interval: {default: 100},
     near: {default: 0},
@@ -44,8 +46,7 @@ module.exports.Component = registerComponent('raycaster', {
     origin: {type: 'vec3'},
     recursive: {default: true},
     showLine: {default: false},
-    useWorldCoordinates: {default: false},
-    autoRefresh: {default: true}
+    useWorldCoordinates: {default: false}
   },
 
   init: function () {
@@ -165,6 +166,8 @@ module.exports.Component = registerComponent('raycaster', {
       var prevCheckTime = this.prevCheckTime;
       var prevIntersectedEls = this.prevIntersectedEls;
       var rawIntersections;
+
+      if (!this.data.enabled) { return; }
 
       // Only check for intersection if interval time has passed.
       if (prevCheckTime && (time - prevCheckTime < data.interval)) { return; }


### PR DESCRIPTION
**Description:**

Sometimes want to switch between a collider and ray. Or only enable ray when needed (e.g., menu is present).

**Changes proposed:**
- raycaster.enabled
