### PR TITLE
have camera call enter VR handler if scene already entered VR with displayactivate

### DIFF
--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -39,6 +39,9 @@ module.exports.Component = registerComponent('camera', {
     this.onExitVR = bind(this.onExitVR, this);
     sceneEl.addEventListener('enter-vr', this.onEnterVR);
     sceneEl.addEventListener('exit-vr', this.onExitVR);
+
+    // Call enter VR handler if the scene has entered VR before the event listeners attached.
+    if (sceneEl.is('vr-mode')) { this.onEnterVR(); }
   },
 
   /**
@@ -131,7 +134,9 @@ module.exports.Component = registerComponent('camera', {
     // Remove the offset if there is positional tracking when entering VR.
     // Necessary for fullscreen mode with no headset.
     // Checking this.hasPositionalTracking to make the value injectable for unit tests.
-    hasPositionalTracking = this.hasPositionalTracking !== undefined ? this.hasPositionalTracking : checkHasPositionalTracking();
+    hasPositionalTracking = this.hasPositionalTracking !== undefined
+      ? this.hasPositionalTracking
+      : checkHasPositionalTracking();
 
     if (!userHeightOffset || !hasPositionalTracking) { return; }
 

--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -8,12 +8,13 @@ window.debug = true;
 navigator.getVRDisplays = function () {
   var resolvePromise = Promise.resolve();
   var mockVRDisplay = {
-    requestPresent: resolvePromise,
+    cancelAnimationFrame: function (h) { return window.cancelAnimationFrame(1); },
+    capabilities: {},
     exitPresent: resolvePromise,
-    submitFrame: function () { return; },
     getPose: function () { return { orientation: null, position: null }; },
     requestAnimationFrame: function () { return 1; },
-    cancelAnimationFrame: function (h) { return window.cancelAnimationFrame(1); }
+    requestPresent: resolvePromise,
+    submitFrame: function () { return; }
   };
   return Promise.resolve([mockVRDisplay]);
 };


### PR DESCRIPTION
**Description:**

Fixes issue with camera starting too high (offset not removed) when refreshing page or navigating.

The scene was entering VR before the camera had a chance to attach its event listeners. Perhaps, this affects other components in the future too, maybe we should emit the event later?

Related, we had an issue filed to initialize the camera before any other components.

**Changes proposed:**
- have camera call enter VR handler if scene already entered VR with displayactivate
