### PR TITLE
fix data from dom not parsed if skipTypeChecking (fixes #3150)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -156,15 +156,16 @@ Component.prototype = {
     if (value === undefined) { return; }
 
     // Merge new data with previous `attrValue` if updating and not clobbering.
-    if (!isSinglePropSchema && !clobber && this.attrValue) {
-      for (property in this.attrValue) {
-        if (!(property in attrValue)) {
-          attrValue[property] = this.attrValue[property];
-        }
+    if (!isSinglePropSchema && !clobber) {
+      this.attrValue = this.attrValue ? cloneData(this.attrValue) : {};
+      for (property in attrValue) {
+        this.attrValue[property] = attrValue[property];
       }
+      return;
     }
 
-    this.attrValue = extendProperties({}, attrValue, isSinglePropSchema);
+    // If single-prop schema or clobber.
+    this.attrValue = attrValue;
   },
 
   /**
@@ -217,6 +218,7 @@ Component.prototype = {
   updateProperties: function (attrValue, clobber) {
     var el = this.el;
     var isSinglePropSchema;
+    var key;
     var skipTypeChecking;
     var oldData = this.oldData;
 
@@ -228,9 +230,25 @@ Component.prototype = {
     }
 
     isSinglePropSchema = isSingleProp(this.schema);
+
     // Disable type checking if the passed attribute is an object and has not changed.
     skipTypeChecking = attrValue !== null && typeof this.previousAttrValue === 'object' &&
                        attrValue === this.previousAttrValue;
+    if (skipTypeChecking) {
+      for (key in this.attrValue) {
+        if (!(key in attrValue)) {
+          skipTypeChecking = false;
+          break;
+        }
+      }
+      for (key in attrValue) {
+        if (!(key in this.attrValue)) {
+          skipTypeChecking = false;
+          break;
+        }
+      }
+    }
+
     // Cache previously passed attribute to decide if we skip type checking.
     this.previousAttrValue = attrValue;
 


### PR DESCRIPTION
**Description:**

**Changes proposed:**
- Only skip type checking if there is not extra data coming from DOM that needs parsing.
- Simplify and fix attrValue update mutating the object used for setAttribute.
