### PR TITLE
[docs] example of getUrlParameter

### DIFF
--- a/docs/core/utils.md
+++ b/docs/core/utils.md
@@ -205,3 +205,18 @@ AFRAME.registerComponent('foo', {
   tick: function (t, dt) {}
 });
 ```
+
+
+## Web Utils
+
+### `AFRAME.utils.getUrlParameter ( name )` 
+
+Returns the value of a URL parameter as a string otherwise returns an empty string.
+
+
+```js
+// visiting the current page with ?testing=aframe
+var testing = AFRAME.utils.getUrlParameter ( "testing" );
+console.log(testing)
+// will return "aframe"
+```

--- a/docs/core/utils.md
+++ b/docs/core/utils.md
@@ -206,17 +206,14 @@ AFRAME.registerComponent('foo', {
 });
 ```
 
+## Miscellaneous
 
-## Web Utils
+### `AFRAME.utils.getUrlParameter (name)`
 
-### `AFRAME.utils.getUrlParameter ( name )` 
-
-Returns the value of a URL parameter as a string otherwise returns an empty string.
-
+Returns the value of a URL parameter as a string, otherwise returns an empty
+string.
 
 ```js
-// visiting the current page with ?testing=aframe
-var testing = AFRAME.utils.getUrlParameter ( "testing" );
-console.log(testing)
-// will return "aframe"
+AFRAME.utils.getUrlParameter('testing');
+// If visiting the current page with ?testing=aframe, this will log 'aframe'.
 ```


### PR DESCRIPTION
Somehow get getUrlParameter() isn't documented

**Description:**

**Changes proposed:**
-
-
-
