### PR TITLE
add cursor event listeners to canvas, not window

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -150,22 +150,25 @@ module.exports.Component = registerComponent('cursor', {
     });
     el.removeEventListener('raycaster-intersection', this.onIntersection);
     el.removeEventListener('raycaster-intersection-cleared', this.onIntersectionCleared);
-    window.removeEventListener('mousemove', this.onMouseMove);
-    window.removeEventListener('touchstart', this.onMouseMove);
-    window.removeEventListener('touchmove', this.onMouseMove);
-    window.removeEventListener('resize', this.updateCanvasBounds);
+    canvas.removeEventListener('mousemove', this.onMouseMove);
+    canvas.removeEventListener('touchstart', this.onMouseMove);
+    canvas.removeEventListener('touchmove', this.onMouseMove);
+    canvas.removeEventListener('resize', this.updateCanvasBounds);
   },
 
   updateMouseEventListeners: function () {
+    var canvas;
     var el = this.el;
-    window.removeEventListener('mousemove', this.onMouseMove);
-    window.removeEventListener('touchstart', this.onMouseMove);
-    window.removeEventListener('touchmove', this.onMouseMove);
+
+    canvas = el.sceneEl.canvas;
+    canvas.removeEventListener('mousemove', this.onMouseMove);
+    canvas.removeEventListener('touchstart', this.onMouseMove);
+    canvas.removeEventListener('touchmove', this.onMouseMove);
     el.setAttribute('raycaster', 'useWorldCoordinates', false);
     if (this.data.rayOrigin !== 'mouse') { return; }
-    window.addEventListener('mousemove', this.onMouseMove, false);
-    window.addEventListener('touchstart', this.onMouseMove, false);
-    window.addEventListener('touchmove', this.onMouseMove, false);
+    canvas.addEventListener('mousemove', this.onMouseMove, false);
+    canvas.addEventListener('touchstart', this.onMouseMove, false);
+    canvas.addEventListener('touchmove', this.onMouseMove, false);
     el.setAttribute('raycaster', 'useWorldCoordinates', true);
     this.updateCanvasBounds();
   },

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -363,7 +363,7 @@ suite('cursor', function () {
       event.clientX = 5;
       event.clientY = 5;
       el.setAttribute('cursor', 'rayOrigin', 'mouse');
-      window.dispatchEvent(event);
+      el.sceneEl.canvas.dispatchEvent(event);
       process.nextTick(function () {
         var raycaster = el.getAttribute('raycaster');
         assert.notEqual(raycaster.direction.x, 0);
@@ -375,7 +375,7 @@ suite('cursor', function () {
       var event = new CustomEvent('touchstart');
       event.touches = {item: function () { return {clientX: 5, clientY: 5}; }};
       el.setAttribute('cursor', 'rayOrigin', 'mouse');
-      window.dispatchEvent(event);
+      el.sceneEl.canvas.dispatchEvent(event);
       process.nextTick(function () {
         var raycaster = el.getAttribute('raycaster');
         assert.notEqual(raycaster.direction.x, 0);


### PR DESCRIPTION
**Description:**

Cursor only cares about actual touch events.

This fixes an issue where vive-controls touchstart bubbled up to window and cursor was receiving them.