### PR TITLE
reduce garbage in axismove in tracked-controls

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -34,7 +34,10 @@ module.exports.Component = registerComponent('tracked-controls', {
   init: function () {
     this.axis = [0, 0, 0];
     this.buttonStates = {};
+    this.changedAxes = [];
     this.targetControllerNumber = this.data.controller;
+
+    this.axisMoveEventDetail = {axis: this.axis, changed: this.changedAxes};
 
     this.dolly = new THREE.Object3D();
     this.controllerEuler = new THREE.Euler();
@@ -258,17 +261,21 @@ module.exports.Component = registerComponent('tracked-controls', {
     var controllerAxes = this.controller.axes;
     var i;
     var previousAxis = this.axis;
-    var changedAxes = [];
+    var changedAxes = this.changedAxes;
 
     // Check if axis changed.
+    this.changedAxes.length = 0;
     for (i = 0; i < controllerAxes.length; ++i) {
       changedAxes.push(previousAxis[i] !== controllerAxes[i]);
       if (changedAxes[i]) { changed = true; }
     }
     if (!changed) { return false; }
 
-    this.axis = controllerAxes.slice();
-    this.el.emit('axismove', {axis: this.axis, changed: changedAxes});
+    this.axis.length = 0;
+    for (i = 0; i < controllerAxes.length; i++) {
+      this.axis.push(controllerAxes[i]);
+    }
+    this.el.emit('axismove', this.axisMoveEventDetail);
     return true;
   },
 

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -214,8 +214,6 @@ suite('tracked-controls', function () {
       assert.deepEqual(component.axis, [0, 0, 0]);
       component.tick();
       assert.deepEqual(component.axis, [0.5, 0.5, 0.5]);
-      assert.notOk(component.handleAxes());
-      sinon.assert.calledTwice(emitSpy);
       assert.equal(emitSpy.getCalls()[1].args[0], 'axismove');
       assert.deepEqual(emitSpy.getCalls()[1].args[1].axis, [0.5, 0.5, 0.5]);
       assert.deepEqual(emitSpy.getCalls()[1].args[1].changed, [true, true, true]);


### PR DESCRIPTION
**Description:**

**Changes proposed:**
- Remove array creation from `.slice()`.
- Remove array creation from `changedAxes`.
- Remove object creation on event detail.
