### PR TITLE
Resolve interference between multiple raycaster lines in a scene

### DIFF
--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -64,6 +64,9 @@ module.exports.Component = registerComponent('raycaster', {
     this.observer = new MutationObserver(this.setDirty);
     this.dirty = true;
     this.intersectionClearedDetail = {clearedEls: this.clearedIntersectedEls};
+    this.lineEndVec3 = new THREE.Vector3();
+    this.otherLineEndVec3 = new THREE.Vector3();
+    this.lineData = {end: this.lineEndVec3};
   },
 
   /**
@@ -295,30 +298,24 @@ module.exports.Component = registerComponent('raycaster', {
    * @param {number} length - Length of line. Pass in to shorten the line to the intersection
    *   point. If not provided, length will default to the max length, `raycaster.far`.
    */
-  drawLine: (function (length) {
-    var lineEndVec3 = new THREE.Vector3();
-    var otherLineEndVec3 = new THREE.Vector3();
-    var lineData = {end: lineEndVec3};
+  drawLine: function (length) {
+    var data = this.data;
+    var el = this.el;
+    // We switch each time the vector so the line update is triggered
+    // and to avoid unnecessary vector clone.
+    var endVec3 = this.lineData.end === this.lineEndVec3 ? this.otherLineEndVec3 : this.lineEndVec3;
 
-    return function (length) {
-      var data = this.data;
-      var el = this.el;
-      // We switch each time the vector so the line update is triggered
-      // and to avoid unnecessary vector clone.
-      var endVec3 = lineData.end === lineEndVec3 ? otherLineEndVec3 : lineEndVec3;
+    // Treat Infinity as 1000m for the line.
+    if (length === undefined) {
+      length = data.far === Infinity ? 1000 : data.far;
+    }
 
-      // Treat Infinity as 1000m for the line.
-      if (length === undefined) {
-        length = data.far === Infinity ? 1000 : data.far;
-      }
-
-      // Update the length of the line if given. `unitLineEndVec3` is the direction
-      // given by data.direction, then we apply a scalar to give it a length.
-      lineData.start = data.origin;
-      lineData.end = endVec3.copy(this.unitLineEndVec3).multiplyScalar(length);
-      el.setAttribute('line', lineData);
-    };
-  })()
+    // Update the length of the line if given. `unitLineEndVec3` is the direction
+    // given by data.direction, then we apply a scalar to give it a length.
+    this.lineData.start = data.origin;
+    this.lineData.end = endVec3.copy(this.unitLineEndVec3).multiplyScalar(length);
+    el.setAttribute('line', this.lineData);
+  }
 });
 
 /**

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -435,12 +435,65 @@ suite('raycaster', function () {
         component.tick();
         line = el.getAttribute('line');
         assert.equal(new THREE.Vector3().copy(line.start).sub(line.end).length(), 24.5);
-
         box.parentNode.removeChild(box);
         setTimeout(() => {
           component.tick();
           line = el.getAttribute('line');
           assert.equal(new THREE.Vector3().copy(line.start).sub(line.end).length(), 1000);
+          done();
+        });
+      });
+    });
+
+    test('truncates line length with two raycasters', function (done) {
+      var box;
+      var rayEl2;
+      var line;
+      var lineArray;
+      var lineStart = new THREE.Vector3();
+      var lineEnd = new THREE.Vector3();
+
+      el.setAttribute('raycaster', {direction: '0 0 -1', origin: '0 0 0', objects: '#target'});
+      lineArray = el.components.line.geometry.attributes.position.array;
+
+      rayEl2 = document.createElement('a-entity');
+      rayEl2.setAttribute('raycaster', {
+        direction: '0 -1 -1',
+        origin: '0 0 0',
+        showLine: true,
+        objects: '#target'
+      });
+      sceneEl.appendChild(rayEl2);
+
+      line = el.getAttribute('line');
+      assert.equal(new THREE.Vector3().copy(line.start).sub(line.end).length(), 1000);
+      lineEnd.fromArray(lineArray, 3);
+      assert.equal(lineStart.fromArray(lineArray).sub(lineEnd).length(), 1000);
+
+      box = document.createElement('a-entity');
+      box.id = 'target';
+      box.setAttribute('geometry', {primitive: 'box', width: 1, height: 1, depth: 1});
+      box.setAttribute('position', '0 0 -25');
+      sceneEl.appendChild(box);
+
+      box.addEventListener('loaded', function () {
+        el.sceneEl.object3D.updateMatrixWorld();
+        component.refreshObjects();
+        component.tick();
+        rayEl2.components.raycaster.tick();
+        rayEl2.components.raycaster.tick();
+        // ensure component and geometry are unaffected by other raycaster
+        line = el.getAttribute('line');
+        assert.equal(new THREE.Vector3().copy(line.start).sub(line.end).length(), 24.5);
+        lineEnd.fromArray(lineArray, 3);
+        assert.equal(lineStart.fromArray(lineArray).sub(lineEnd).length(), 24.5);
+        box.parentNode.removeChild(box);
+        setTimeout(() => {
+          component.tick();
+          line = el.getAttribute('line');
+          assert.equal(new THREE.Vector3().copy(line.start).sub(line.end).length(), 1000);
+          lineEnd.fromArray(lineArray, 3);
+          assert.equal(lineStart.fromArray(lineArray).sub(lineEnd).length(), 1000);
           done();
         });
       });


### PR DESCRIPTION
**Description:** Fix #3170, wherein shared objects between raycaster instances (from the .`drawLine` IIFE closure) prevented lines from being shortened on collision.

**Changes proposed:**

- Change `lineData` to be an instance object to resolve an issue where calls to `.setAttribute('line')` would not trigger `line.update`
- Change `lineEndVec3`/`otherLineEndVec3` to be instance variables to resolve an issue where `.getAttribute('line')` would report start/end values that did not reflect the underlying geometry vertices
