### PR TITLE
Make camera system aware of mixins.

### DIFF
--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -100,11 +100,15 @@ module.exports.System = registerSystem('camera', {
     cameraEls = sceneEl.querySelectorAll('[camera]');
     for (i = 0; i < cameraEls.length; i++) {
       cameraEl = cameraEls[i];
-      if (newCameraEl === cameraEl) { continue; }
+      if (isMixin(cameraEl) || newCameraEl === cameraEl) { continue; }
       cameraEl.setAttribute('camera', 'active', false);
       cameraEl.pause();
     }
     sceneEl.emit('camera-set-active', {cameraEl: newCameraEl});
+
+    function isMixin (el) {
+      return el.tagName === 'A-MIXIN';
+    }
   }
 });
 

--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -100,15 +100,11 @@ module.exports.System = registerSystem('camera', {
     cameraEls = sceneEl.querySelectorAll('[camera]');
     for (i = 0; i < cameraEls.length; i++) {
       cameraEl = cameraEls[i];
-      if (isMixin(cameraEl) || newCameraEl === cameraEl) { continue; }
+      if (!cameraEl.isEntity || newCameraEl === cameraEl) { continue; }
       cameraEl.setAttribute('camera', 'active', false);
       cameraEl.pause();
     }
     sceneEl.emit('camera-set-active', {cameraEl: newCameraEl});
-
-    function isMixin (el) {
-      return el.tagName === 'A-MIXIN';
-    }
   }
 });
 


### PR DESCRIPTION
Fix #3090

Prevents the camera system from taking into account a-mixin elements when
handling the active camera.