### PR TITLE
Fix IIFE typo in Best Practices code sample

### DIFF
--- a/docs/introduction/best-practices.md
+++ b/docs/introduction/best-practices.md
@@ -150,8 +150,8 @@ AFRAME.registerComponent('foo', {
     return function () {
       helperVector.copy(this.el.object3D.position);
       helperQuaternion.copy(this.el.object3D.quaternion);
-    })();
-  }
+    };
+  })()
 });
 ```
 


### PR DESCRIPTION
**Description:**
The IIFE in the example code is supposed to be the outer function, not the inner function.
**Changes proposed:**
- Fixed the typo
