### PR TITLE
Force raycasting in onCursorDown

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -162,12 +162,10 @@ module.exports.Component = registerComponent('cursor', {
 
     canvas = el.sceneEl.canvas;
     canvas.removeEventListener('mousemove', this.onMouseMove);
-    canvas.removeEventListener('touchstart', this.onMouseMove);
     canvas.removeEventListener('touchmove', this.onMouseMove);
     el.setAttribute('raycaster', 'useWorldCoordinates', false);
     if (this.data.rayOrigin !== 'mouse') { return; }
     canvas.addEventListener('mousemove', this.onMouseMove, false);
-    canvas.addEventListener('touchstart', this.onMouseMove, false);
     canvas.addEventListener('touchmove', this.onMouseMove, false);
     el.setAttribute('raycaster', 'useWorldCoordinates', true);
     this.updateCanvasBounds();
@@ -205,7 +203,7 @@ module.exports.Component = registerComponent('cursor', {
       origin.setFromMatrixPosition(camera.matrixWorld);
       direction.set(mouse.x, mouse.y, 0.5).unproject(camera).sub(origin).normalize();
       this.el.setAttribute('raycaster', rayCasterConfig);
-      if (evt.type === 'touchstart' || evt.type === 'touchmove') { evt.preventDefault(); }
+      if (evt.type === 'touchmove') { evt.preventDefault(); }
     };
   })(),
 
@@ -213,6 +211,11 @@ module.exports.Component = registerComponent('cursor', {
    * Trigger mousedown and keep track of the mousedowned entity.
    */
   onCursorDown: function (evt) {
+    if (this.data.rayOrigin === 'mouse') {
+      // Raycast at new coordinates
+      this.onMouseMove(evt);
+      this.el.components.raycaster.checkIntersections();
+    }
     this.twoWayEmit(EVENTS.MOUSEDOWN);
     this.cursorDownEl = this.intersectedEl;
     if (evt.type === 'touchstart') { evt.preventDefault(); }

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -155,10 +155,21 @@ module.exports.Component = registerComponent('raycaster', {
   /**
    * Check for intersections and cleared intersections on an interval.
    */
-  tick: (function () {
+  tick: function (time) {
+    var data = this.data;
+    var prevCheckTime = this.prevCheckTime;
+
+    // Only check for intersection if interval time has passed.
+    if (prevCheckTime && (time - prevCheckTime < data.interval)) { return; }
+    // Update check time.
+    this.prevCheckTime = time;
+    this.checkIntersections();
+  },
+  /* Raycast for intersections and emit events for current and cleared inersections */
+  checkIntersections: (function () {
     var intersections = [];
 
-    return function (time) {
+    return function () {
       var clearedIntersectedEls = this.clearedIntersectedEls;
       var el = this.el;
       var data = this.data;
@@ -166,16 +177,10 @@ module.exports.Component = registerComponent('raycaster', {
       var intersectedEls = this.intersectedEls;
       var intersection;
       var lineLength;
-      var prevCheckTime = this.prevCheckTime;
       var prevIntersectedEls = this.prevIntersectedEls;
       var rawIntersections;
 
       if (!this.data.enabled) { return; }
-
-      // Only check for intersection if interval time has passed.
-      if (prevCheckTime && (time - prevCheckTime < data.interval)) { return; }
-      // Update check time.
-      this.prevCheckTime = time;
 
       // Refresh the object whitelist if needed.
       if (this.dirty) { this.refreshObjects(); }

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -382,6 +382,25 @@ suite('cursor', function () {
         done();
       });
     });
+    test('casts ray at current touch location', function (done) {
+      var event = new CustomEvent('touchstart');
+      var target = el.sceneEl.appendChild(document.createElement('a-entity'));
+      var mouseDownSpy = this.sinon.spy();
+      el.addEventListener('mousedown', mouseDownSpy);
+      el.setAttribute('cursor', 'rayOrigin', 'mouse');
+      target.setAttribute('geometry', '');
+      target.setAttribute('position', '0 0 -5');
+      target.addEventListener('loaded', function () {
+        target.object3D.updateMatrixWorld();
+        el.components.raycaster.refreshObjects();
+        el.components.raycaster.tick();
+        assert.strictEqual(component.intersectedEl, target);
+        event.touches = {item: function () { return {clientX: 5, clientY: 5}; }};
+        el.sceneEl.canvas.dispatchEvent(event);
+        assert.isFalse(mouseDownSpy.calledWithMatch({detail: {intersectedEl: target}}));
+        done();
+      });
+    });
   });
 
   suite('canvas events', function () {


### PR DESCRIPTION
**Description:** Get intersections based on the current touch/mouse location for `onCursorDown`. Continuation of #3143 to fully resolve #3114 

**Changes proposed:**

- Make on-demand intersection checks possible in `raycaster` by splitting the logic out of the throttled `tick` handler and into its own method
- Force raycaster intersection check in `onCursorDown` event
- Remove `touchstart` listener for `onMouseMove` and call it from within `onCursorDown` instead so that position is updated regardless of listener registration order