### PR TITLE
fixed: components+systems would misbehave with multiple scenes

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -36,7 +36,7 @@ var proto = Object.create(ANode.prototype, {
       this.components = {};
       // To avoid double initializations and infinite loops.
       this.initializingComponents = {};
-      this.deferredComponentUpdates = [];
+      this.queuedComponentUpdates = [];
       this.isEntity = true;
       this.isPlaying = false;
       this.object3D = new THREE.Group();
@@ -471,10 +471,10 @@ var proto = Object.create(ANode.prototype, {
         }
 
         // Perform any pending component updates.
-        for (i = 0; i < this.deferredComponentUpdates.length; ++i) {
-          this.updateComponent.apply(this, this.deferredComponentUpdates[i]);
+        for (i = 0; i < this.queuedComponentUpdates.length; ++i) {
+          this.updateComponent.apply(this, this.queuedComponentUpdates[i]);
         }
-        this.deferredComponentUpdates.length = 0;
+        this.queuedComponentUpdates.length = 0;
       };
     })(),
     writable: window.debug
@@ -493,7 +493,7 @@ var proto = Object.create(ANode.prototype, {
     value: function (attr, attrValue, clobber) {
       // If the entity has not initialised yet, queue this update for later
       if (!this.hasLoaded || !this.parentEl) {
-        this.deferredComponentUpdates.push([attr, attrValue, clobber]);
+        this.queuedComponentUpdates.push([attr, attrValue, clobber]);
         return;
       }
 

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -76,8 +76,6 @@ var proto = Object.create(ANode.prototype, {
 
       this.addToParent();
 
-      this.updateComponents();
-
       // Don't .load() scene on attachedCallback.
       if (this.isScene) { return; }
 
@@ -493,10 +491,12 @@ var proto = Object.create(ANode.prototype, {
    */
   updateComponent: {
     value: function (attr, attrValue, clobber) {
+      // If the entity has not initialised yet, queue this update for later
       if (!this.hasLoaded || !this.parentEl) {
         this.deferredComponentUpdates.push([attr, attrValue, clobber]);
         return;
       }
+
       var component = this.components[attr];
       var isDefault = attr in this.defaultComponents;
       if (component) {

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -85,6 +85,7 @@ module.exports = registerElement('a-node', {
 
     detachedCallback: {
       value: function () {
+        this.sceneEl = null;
         this.hasLoaded = false;
       }
     },

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -85,7 +85,6 @@ module.exports = registerElement('a-node', {
 
     detachedCallback: {
       value: function () {
-        this.sceneEl = null;
         this.hasLoaded = false;
       }
     },

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -1,7 +1,6 @@
 /* global Node */
 var schema = require('./schema');
 var scenes = require('./scene/scenes');
-var systems = require('./system');
 var utils = require('../utils/');
 
 var components = module.exports.components = {};  // Keep track of registered components.
@@ -468,13 +467,14 @@ module.exports.registerComponent = function (name, definition) {
                     'or two different components of the same name.');
   }
   NewComponent = function (el, attr, id) {
+    this.system = el.sceneEl.systems[name];
+
     Component.call(this, el, attr, id);
   };
 
   NewComponent.prototype = Object.create(Component.prototype, proto);
   NewComponent.prototype.name = name;
   NewComponent.prototype.constructor = NewComponent;
-  NewComponent.prototype.system = systems && systems.systems[name];
   NewComponent.prototype.play = wrapPlay(NewComponent.prototype.play);
   NewComponent.prototype.pause = wrapPause(NewComponent.prototype.pause);
 

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -1,4 +1,3 @@
-var components = require('./component');
 var schema = require('./schema');
 var utils = require('../utils/');
 
@@ -28,14 +27,9 @@ var systems = module.exports.systems = {};  // Keep track of registered systems.
  * @member {Element} sceneEl - Handle to the scene element where system applies to.
  */
 var System = module.exports.System = function (sceneEl) {
-  var component = components && components.components[this.name];
-
   // Set reference to scene.
   this.el = sceneEl;
   this.sceneEl = sceneEl;
-
-  // Set reference to matching component (if exists).
-  if (component) { component.Component.prototype.system = this; }
 
   // Process system configuration.
   this.buildData();


### PR DESCRIPTION
**Description:**

Currently, one of the barriers to supporting multiple scenes (see #916) on the same page is that components and systems do not interact correctly when multiple scenes exist.

Each scene contains its own systems, but the last scene to initialise always overwrites the global `Component.__proto__.system` property of its components. This means that systems and components for earlier scenes no longer function correctly (for instance lights don't attach themselves to their correct lights system, meaning default lighting isn't disabled).

This fixes that by initialising components _after_ they have been attached to the scene, and setting their `Component.system` instance property to the correct scene system. Any attempts to update component properties before this happens are queued and then processed after attachment and initialisation; However DOM updates still occur as expected, to ensure DOM manipulation and debug serialisation still all work as expected.

**Changes proposed:**
- `Component.__proto__.system` is now longer set by systems upon system initialisation
- Component initialisation now occurs as a result of the `load()` callback and `updateComponents()` once the entity has been attached to a scene
- Component initialisation sets its local `system` by accessing its local `el.sceneEl.systems`. This occurs immediately within the `Component` base ctor, before local construction and `init` occurs.
- Attempts to update the properties of components before initialisation occurs succeed successfully and update the DOM where expected. The actual component update, however, is queued and only executed once `updateComponents()` has been called on the attached parent entity.