### PR TITLE
added: depthTest and depthWrite properties to the Text component

### DIFF
--- a/src/components/text.js
+++ b/src/components/text.js
@@ -49,6 +49,8 @@ module.exports.Component = registerComponent('text', {
   schema: {
     align: {type: 'string', default: 'left', oneOf: ['left', 'right', 'center']},
     alphaTest: {default: 0.5},
+    depthTest: {default: true},
+    depthWrite: {default: true},
     // `anchor` defaults to center to match geometries.
     anchor: {default: 'center', oneOf: ['left', 'right', 'center', 'align']},
     baseline: {default: 'center', oneOf: ['top', 'center', 'bottom']},
@@ -432,6 +434,8 @@ function createShader (el, shaderName, data) {
  */
 function updateBaseMaterial (material, data) {
   material.side = data.side;
+  material.depthTest = data.depthTest;
+  material.depthWrite = data.depthWrite;
 }
 
 /**


### PR DESCRIPTION
**Description:**

This closes #2914. There is currently no way to control depth testing or depth writing with the Text component. This adds `depthTest` and `depthWrite` properties to the Text component, as per Materials.

Ideally it would be nice in the future if the Material component could be used with objects using custom shaders, such as Text. But in the (hopeful) meanwhile this adds `depthTest` and `depthWrite` properties to `Text` so you can also control that stuff, should you need to (because sometimes you want 3d positional text that's guaranteed not to clip geometry)

**Changes proposed:**
- `depthTest` and `depthWrite` properties are added to the Text component. These are forwarded to the custom material in `updateBaseMaterial()` (like `side`)
