### PR TITLE
make the example 360 video page redirect to example Glitch

### DIFF
--- a/examples/boilerplate/360-video/index.html
+++ b/examples/boilerplate/360-video/index.html
@@ -1,20 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <title>360 Video</title>
-    <meta name="description" content="360 Video — A-Frame">
-    <script src="../../../dist/aframe-master.js"></script>
+    <meta http-equiv="refresh" content="0; https://aframe-360-video-native-hls-example.glitch.me">
   </head>
   <body>
-    <a-scene>
-      <a-assets>
-        <video id="video" autoplay loop crossorigin="anonymous">
-          <source src="https://ucarecdn.com/fadab25d-0b3a-45f7-8ef5-85318e92a261/"></source>
-        </video>
-      </a-assets>
-
-      <a-videosphere src="#video" rotation="0 180 0"></a-videosphere>
-    </a-scene>
+    <a href="https://aframe-360-video-native-hls-example.glitch.me">Redirecting... click to go directly</a>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -173,7 +173,7 @@
     <ul class="links">
       <li><a href="boilerplate/hello-world/">Hello World</a></li>
       <li><a href="boilerplate/panorama/">360&deg; Image</a></li>
-      <li><a href="boilerplate/360-video/">360&deg; Video</a></li>
+      <li><a href="https://aframe-360-video-native-hls-example.glitch.me/">360&deg; Video</a></li>
       <li><a href="boilerplate/3d-model/">3D Model (COLLADA)</a></li>
     </ul>
 


### PR DESCRIPTION
Per discussion on #2830, this PR replaces the previous example of 360 video in the repo to redirect to an example Glitch.  The example takes advantage of recently-merged #3176 to show how a video can be specified as HLS and MP4. 