### PR TITLE
Prevent component leakage in updateComponents

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -36,6 +36,7 @@ var proto = Object.create(ANode.prototype, {
       this.components = {};
       // To avoid double initializations and infinite loops.
       this.initializingComponents = {};
+      this.componentsToUpdate = {};
       this.isEntity = true;
       this.isPlaying = false;
       this.object3D = new THREE.Group();
@@ -421,55 +422,52 @@ var proto = Object.create(ANode.prototype, {
    *   from other sources (e.g., implemented by primitives).
    */
   updateComponents: {
-    value: (function () {
-      var componentsToUpdate = {};
+    value: function () {
+      var data;
+      var extraComponents;
+      var i;
+      var name;
+      var componentsToUpdate = this.componentsToUpdate;
 
-      return function () {
-        var data;
-        var extraComponents;
-        var i;
-        var name;
+      if (!this.hasLoaded) { return; }
 
-        if (!this.hasLoaded) { return; }
-
-        // Gather mixin-defined components.
-        for (i = 0; i < this.mixinEls.length; i++) {
-          for (name in this.mixinEls[i].componentCache) {
-            if (isComponent(name)) { componentsToUpdate[name] = true; }
-          }
-        }
-
-        // Gather from extra initial component data if defined (e.g., primitives).
-        if (this.getExtraComponents) {
-          extraComponents = this.getExtraComponents();
-          for (name in extraComponents) {
-            if (isComponent(name)) { componentsToUpdate[name] = true; }
-          }
-        }
-
-        // Gather entity-defined components.
-        for (i = 0; i < this.attributes.length; ++i) {
-          name = this.attributes[i].name;
+      // Gather mixin-defined components.
+      for (i = 0; i < this.mixinEls.length; i++) {
+        for (name in this.mixinEls[i].componentCache) {
           if (isComponent(name)) { componentsToUpdate[name] = true; }
         }
+      }
 
-        // Initialze or update default components first.
-        for (name in this.defaultComponents) {
-          data = mergeComponentData(this.getDOMAttribute(name),
-                                    extraComponents && extraComponents[name]);
-          this.updateComponent(name, data);
-          delete componentsToUpdate[name];
+      // Gather from extra initial component data if defined (e.g., primitives).
+      if (this.getExtraComponents) {
+        extraComponents = this.getExtraComponents();
+        for (name in extraComponents) {
+          if (isComponent(name)) { componentsToUpdate[name] = true; }
         }
+      }
 
-        // Initialize or update rest of components.
-        for (name in componentsToUpdate) {
-          data = mergeComponentData(this.getDOMAttribute(name),
-                                    extraComponents && extraComponents[name]);
-          this.updateComponent(name, data);
-          delete componentsToUpdate[name];
-        }
-      };
-    })(),
+      // Gather entity-defined components.
+      for (i = 0; i < this.attributes.length; ++i) {
+        name = this.attributes[i].name;
+        if (isComponent(name)) { componentsToUpdate[name] = true; }
+      }
+
+      // Initialze or update default components first.
+      for (name in this.defaultComponents) {
+        data = mergeComponentData(this.getDOMAttribute(name),
+                                  extraComponents && extraComponents[name]);
+        this.updateComponent(name, data);
+        delete componentsToUpdate[name];
+      }
+
+      // Initialize or update rest of components.
+      for (name in componentsToUpdate) {
+        data = mergeComponentData(this.getDOMAttribute(name),
+                                  extraComponents && extraComponents[name]);
+        this.updateComponent(name, data);
+        delete componentsToUpdate[name];
+      }
+    },
     writable: window.debug
   },
 

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1247,6 +1247,29 @@ suite('a-entity', function () {
     });
   });
 
+  suite('updateComponents', function () {
+    setup(function (done) {
+      this.child = this.el.appendChild(document.createElement('a-entity'));
+      this.child.addEventListener('loaded', function () {
+        done();
+      });
+    });
+    test('nested calls do not leak components to children', function () {
+      registerComponent('test', {
+        init: function () {
+          var children = this.el.getChildEntities();
+          if (children.length) {
+            children[0].setAttribute('mixin', 'addGeometry');
+          }
+        }
+      });
+      mixinFactory('addTest', {test: ''});
+      mixinFactory('addGeometry', {geometry: 'shape: sphere'});
+      this.el.setAttribute('mixin', 'addTest');
+      assert.notOk(this.child.components['test']);
+    });
+  });
+
   suite('applyMixin', function () {
     test('combines mixin and element components with a dynamic schema', function () {
       var el = this.el;


### PR DESCRIPTION
**Description:** Prevent an edge case wherein an entity could erroneously add its components to its child entities. Fix #3200 

**Changes proposed:**
- Move `componentsToUpdate` object from IIFE closure to instance variable

The diff is messy due to a change in indentation level for `updateComponents`. The actual changes to the method were 1) remove the IIFE and 2) declare a local componentsToUpdate variable that points to the instance variable
