### PR TITLE
don't use getOrCreate mesh for geometry/material

### DIFF
--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -25,7 +25,8 @@ module.exports.Component = registerComponent('geometry', {
    */
   update: function (previousData) {
     var data = this.data;
-    var mesh = this.el.getOrCreateObject3D('mesh', THREE.Mesh);
+    var el = this.el;
+    var mesh;
     var system = this.system;
 
     // Dispose old geometry if we created one.
@@ -35,7 +36,17 @@ module.exports.Component = registerComponent('geometry', {
     }
 
     // Create new geometry.
-    this.geometry = mesh.geometry = system.getOrCreateGeometry(data);
+    this.geometry = system.getOrCreateGeometry(data);
+
+    // Set on mesh. If mesh does not exist, create it.
+    mesh = el.getObject3D('mesh');
+    if (mesh) {
+      mesh.geometry = this.geometry;
+    } else {
+      mesh = new THREE.Mesh();
+      mesh.geometry = this.geometry;
+      el.setObject3D('mesh', mesh);
+    }
   },
 
   /**

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -152,11 +152,24 @@ module.exports.Component = registerComponent('material', {
    * @returns {object} Material.
    */
   setMaterial: function (material) {
-    var mesh = this.el.getOrCreateObject3D('mesh', THREE.Mesh);
+    var el = this.el;
+    var mesh;
     var system = this.system;
+
     if (this.material) { disposeMaterial(this.material, system); }
-    this.material = mesh.material = material;
+
+    this.material = material;
     system.registerMaterial(material);
+
+    // Set on mesh. If mesh does not exist, create it.
+    mesh = el.getObject3D('mesh');
+    if (mesh) {
+      mesh.material = this.material;
+    } else {
+      mesh = new THREE.Mesh();
+      mesh.material = this.material;
+      el.setObject3D('mesh', mesh);
+    }
   }
 });
 

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -161,14 +161,16 @@ module.exports.Component = registerComponent('material', {
     this.material = material;
     system.registerMaterial(material);
 
-    // Set on mesh. If mesh does not exist, create it.
+    // Set on mesh. If mesh does not exist, wait for it.
     mesh = el.getObject3D('mesh');
     if (mesh) {
-      mesh.material = this.material;
+      mesh.material = material;
     } else {
-      mesh = new THREE.Mesh();
-      mesh.material = this.material;
-      el.setObject3D('mesh', mesh);
+      el.addEventListener('object3dset', function waitForMesh (evt) {
+        if (evt.detail.type !== 'mesh' || evt.target !== el) { return; }
+        el.getObject3D('mesh').material = material;
+        el.removeEventListener('object3dset', waitForMesh);
+      });
     }
   }
 });

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -11,9 +11,10 @@ suite('material', function () {
   setup(function (done) {
     el = entityFactory();
     this.sinon = sinon.sandbox.create();
+    el.setAttribute('geometry', '');
     el.setAttribute('material', 'shader: flat');
     if (el.hasLoaded) { done(); }
-    el.addEventListener('loaded', function () {
+    el.addEventListener('loaded', function (evt) {
       done();
     });
   });
@@ -196,6 +197,7 @@ suite('material', function () {
   suite('side', function () {
     test('can be set with initial material', function (done) {
       var el = entityFactory();
+      el.setAttribute('geometry', '');
       el.setAttribute('material', 'side: double');
       el.addEventListener('loaded', function () {
         assert.ok(el.getObject3D('mesh').material.side, THREE.DoubleSide);

--- a/tests/shaders/flat.test.js
+++ b/tests/shaders/flat.test.js
@@ -4,6 +4,7 @@ var entityFactory = require('../helpers').entityFactory;
 suite('flat material', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
+    el.setAttribute('geometry', '');
     el.setAttribute('material', 'shader: flat');
     if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {

--- a/tests/shaders/standard.test.js
+++ b/tests/shaders/standard.test.js
@@ -7,6 +7,7 @@ var VIDEO = 'base/tests/assets/test.mp4';
 suite('standard material', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
+    el.setAttribute('geometry', '');
     el.setAttribute('material', {shader: 'standard'});
     if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {

--- a/tests/systems/material.test.js
+++ b/tests/systems/material.test.js
@@ -21,6 +21,7 @@ suite('material system', function () {
       var el = this.el;
       var material;
       var system;
+      el.setAttribute('geometry', '');
       el.setAttribute('material', '');
       system = el.components.material.system;
       material = el.getObject3D('mesh').material;
@@ -32,6 +33,7 @@ suite('material system', function () {
       var oldMaterial;
       var newMaterial;
       var system;
+      el.setAttribute('geometry', '');
       el.setAttribute('material', 'shader: flat');
       oldMaterial = el.getObject3D('mesh').material;
       el.setAttribute('material', 'shader: standard');


### PR DESCRIPTION
**Description:**

@donmccurdy raised this in an issue before. I just ran into problems with it.

The `getOrCreateObject3D` makes listening on the `object3dset` event unreliable, since the `getOrCreateObject3D` will emit the `object3dset` event while the object has an **empty mesh**, before the geometry/material is properly set.

After this, I think we can deprecate `getOrCreateObject3D`.

**Changes proposed:**
- Only set the object3d *after* the material/geometry are set.
- Have material not set the Mesh, it depends on other components to provide mesh (e.g, geometry/model). Waits for object3dset event.
