### PR TITLE
don't bubble object3dset/remove events

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -170,7 +170,7 @@ var proto = Object.create(ANode.prototype, {
       // Add.
       this.object3D.add(obj);
       this.object3DMap[type] = obj;
-      this.emit('object3dset', {object: obj, type: type});
+      this.emit('object3dset', {object: obj, type: type}, false);
     }
   },
 
@@ -186,7 +186,7 @@ var proto = Object.create(ANode.prototype, {
       }
       this.object3D.remove(obj);
       delete this.object3DMap[type];
-      this.emit('object3dremove', {type: type});
+      this.emit('object3dremove', {type: type}, false);
     }
   },
 


### PR DESCRIPTION
**Description:**

I think there's potential for surprise if we're listening to an object3dset event, and accidentally catch an object3dset event from a child. One would have to know to check the event target, which is unlikely to remember.

**Changes proposed:**
- Don't bubble object3dset/remove events.

