### PR TITLE
emit event for geometry set

### DIFF
--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -36,6 +36,8 @@ module.exports.Component = registerComponent('geometry', {
 
     // Create new geometry.
     this.geometry = mesh.geometry = system.getOrCreateGeometry(data);
+
+    this.el.emit('geometryset', null, false);
   },
 
   /**


### PR DESCRIPTION
**Description:**

Got a use case when I need to know when a new geometry is set so I can do stuff like reapply UVs or vertex colors.

**Changes proposed:**
- `geometryset` event, does not bubble, no event detail needed.
