### PR TITLE
[deprecate] Entity.getOrCreateObject3D

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -204,6 +204,8 @@ var proto = Object.create(ANode.prototype, {
         object3D = new Constructor();
         this.setObject3D(type, object3D);
       }
+      warn('`getOrCreateObject3D` has been deprecated. Use `setObject3D()` ' +
+           'and `object3dset` event instead.');
       return object3D;
     }
   },

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -856,25 +856,6 @@ suite('a-entity', function () {
     });
   });
 
-  suite('getOrCreateObject3D', function () {
-    test('creates an object3D if the type does not exist', function () {
-      var el = this.el;
-      el.getOrCreateObject3D('mesh', THREE.Object3D);
-      assert.ok(el.getObject3D('mesh'));
-      assert.equal(el.getObject3D('mesh').constructor, THREE.Object3D);
-    });
-
-    test('returns existing object3D if it exists', function () {
-      var el = this.el;
-      var Constructor = function () {};
-      var dummy = {};
-      el.object3DMap['dummy'] = dummy;
-      el.getOrCreateObject3D('dummy', Constructor);
-      assert.ok(el.getObject3D('dummy'));
-      assert.equal(el.getObject3D('dummy'), dummy);
-    });
-  });
-
   suite('getAttribute', function () {
     test('returns full component data', function () {
       var componentData;


### PR DESCRIPTION
**Description:**

Move away from this as it creates empty stub meshes which are confusing and can mess things up. Geometry and material have been changed to not use these already ,which were the only cases in the core.

Use `setObject3D()` and `object3dset` event instead.

**Changes proposed:**
- deprecate getOrCreateObject3D
