### PR TITLE
avoid constantly cloning and copying quaternion in link component

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -25,6 +25,7 @@ module.exports.Component = registerComponent('link', {
   init: function () {
     this.navigate = this.navigate.bind(this);
     this.previousQuaternion = undefined;
+    this.quaternionClone = new THREE.Quaternion();
     // Store hidden elements during peek mode so we can show them again later.
     this.hiddenEls = [];
     this.initVisualAspect();
@@ -193,10 +194,12 @@ module.exports.Component = registerComponent('link', {
       cameraWorldPosition.setFromMatrixPosition(camera.matrixWorld);
       distance = elWorldPosition.distanceTo(cameraWorldPosition);
 
-      // Store original orientation to be restored when the portal stops facing the camera.
-      this.previousQuaternion = this.previousQuaternion || quaternion.clone();
-
       if (distance > 20) {
+        // Store original orientation to be restored when the portal stops facing the camera.
+        if (!this.previousQuaternion) {
+          this.quaternionClone.copy(quaternion);
+          this.previousQuaternion = this.quaternionClone;
+        }
         // If the portal is far away from the user, face portal to camera.
         object3D.lookAt(cameraWorldPosition);
       } else {


### PR DESCRIPTION
**Description:**

avoid constantly cloning and copying quaternion when we are close to portal (<= 20)

**Changes proposed:**
- avoid quaternion.clone() on each tick by reusing a quaternionClone variable and doing instead a copy.
- If I well understood the code, object3D.quaternion is modified only by object3D.lookAt, so to avoid doing quaternionClone.copy and object3D.quaternion.copy on each tick when we are close to portal, simply do quaternionClone.copy before the object3D.lookAt
