### PR TITLE
Changed GearVR device to not be mobile

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -45,6 +45,9 @@ var isMobile = (function () {
     if (isIOS() || isTablet() || isR7()) {
       _isMobile = true;
     }
+    if (isGearVR()) {
+      _isMobile = false;
+    }
   })(window.navigator.userAgent || window.navigator.vendor || window.opera);
 
   return function () { return _isMobile; };


### PR DESCRIPTION
**Description:**
As mentioned [here](https://github.com/aframevr/aframe/issues/1346#issuecomment-340851877) the Samsung Internet VR Browser does not correctly display aframe, instead showing the game through two eyeholes. This pull request was intended to fix that but instead it simply shows the aframe game on a screen (like a watching it on a cinema screen). So this is an improvement but not a fix.

**Changes proposed:**
- Make _isMobile false if on gearvr.
- See [this](https://github.com/aframevr/aframe/issues/1346#issuecomment-340861743) comment made by @dbradleyfl
