### PR TITLE
allow radians for rotation, make rotation multi-prop

### DIFF
--- a/src/components/rotation.js
+++ b/src/components/rotation.js
@@ -1,16 +1,39 @@
 var degToRad = require('../lib/three').Math.degToRad;
 var registerComponent = require('../core/component').registerComponent;
+var utils = require('../utils/');
+
+var defaultRotation = {x: 0, y: 0, z: 0};
+
+var UNIT_DEGREES = 'degrees';
+var UNIT_RADIANS = 'radians';
 
 module.exports.Component = registerComponent('rotation', {
-  schema: {type: 'vec3'},
+  schema: {
+    unit: {default: UNIT_DEGREES, oneOf: [UNIT_DEGREES, UNIT_RADIANS]},
+    x: {type: 'number'},
+    y: {type: 'number'},
+    z: {type: 'number'},
+    parse: function (val) {
+      if (val.constructor === Object) { return val; }
+      return utils.coordinates.parse(val, defaultRotation);
+    },
+    stringify: function (val) {
+      return utils.coordinates.stringify(val);
+    }
+  },
 
   /**
-   * Updates object3D rotation.
+   * Update object3D rotation.
    */
   update: function () {
     var data = this.data;
     var object3D = this.el.object3D;
-    object3D.rotation.set(degToRad(data.x), degToRad(data.y), degToRad(data.z));
+
+    if (data.unit === UNIT_DEGREES) {
+      object3D.rotation.set(degToRad(data.x), degToRad(data.y), degToRad(data.z));
+    } else {
+      object3D.rotation.set(data.x, data.y, data.z);
+    }
     object3D.rotation.order = 'YXZ';
   }
 });

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -123,6 +123,10 @@ Component.prototype = {
   parse: function (value, silent) {
     var schema = this.schema;
     if (isSingleProp(schema)) { return parseProperty(value, schema); }
+
+    // Multi-property component with custom parser.
+    if (schema.parse) { return schema.parse(value); }
+
     return parseProperties(styleParser.parse(value), schema, true, this.name, silent);
   },
 
@@ -139,6 +143,10 @@ Component.prototype = {
     var schema = this.schema;
     if (typeof data === 'string') { return data; }
     if (isSingleProp(schema)) { return stringifyProperty(data, schema); }
+
+    // Multi-property component with custom stringifier.
+    if (schema.stringify) { return schema.stringify(data); }
+
     data = stringifyProperties(data, schema);
     return styleParser.stringify(data);
   },
@@ -189,6 +197,9 @@ Component.prototype = {
        */
       if (typeof parsedValue === 'string') { parsedValue = value; }
     } else {
+      // Multi-property component with custom parser.
+      if (this.schema.parse) { return this.schema.parse(value); }
+
       // Parse using the style parser to avoid double parsing of individual properties.
       parsedValue = styleParser.parse(value);
     }


### PR DESCRIPTION
**Description:**

Most 3D math stuff is done in radians. Allowing radians allows applications that use radians to not have to convert to degrees only for A-Frame to convert back to radians. Makes it easy to do things like `.setAttribute('rotation', object3D.rotation)`.

Made rotation multi-prop to support `unit` property. Will later also move scale and position to be multi-prop to allow easier updating of single axis of these components.

**Changes proposed:**
- Radians prop type.
- Multi-prop rotation component.
