### PR TITLE
Fix erroneous canvas size on iOS devices

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -465,7 +465,7 @@ module.exports.AScene = registerElement('a-scene', {
         // except when in fullscreen mode.
         if (!camera || !canvas || (this.is('vr-mode') && (this.isMobile || isEffectPresenting))) { return; }
         // Update camera.
-        var setSize = function() {
+        var setSize = function () {
           size = getCanvasSize(canvas, embedded);
           camera.aspect = size.width / size.height;
           camera.updateProjectionMatrix();
@@ -479,8 +479,7 @@ module.exports.AScene = registerElement('a-scene', {
           // transition. Delay resizing for 100ms to allow the transition to
           // finish.
           setTimeout(setSize, 100);
-        }
-        else {
+        } else {
           // Most devices can update the size right away.
           setSize();
         }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -472,7 +472,7 @@ module.exports.AScene = registerElement('a-scene', {
           // Notify renderer of size change.
           self.renderer.setSize(size.width, size.height, false);
         };
-        if (self.isIOS) {
+        if (this.isIOS && !embedded) {
           // On iOS devices (at least as of iOS 11.1.1), particularly in Chrome
           // or home-screen-icon Safari, when the orientation is changed the
           // canvas size returned by getCanvasSize() is incorrect during the


### PR DESCRIPTION
This PR is related to issue #3230.

**Description:**
In iOS, orientation changes firing `AScene.resize` may erroneously set the canvas size, reducing the visible area by half:
![portrait](https://user-images.githubusercontent.com/2229853/32746853-93e734fe-c87c-11e7-9df9-6f8694b5b669.PNG)
![landscape](https://user-images.githubusercontent.com/2229853/32746854-93fb6a32-c87c-11e7-918b-5ffa4fa4aaa1.PNG)

This occurs only in non-embedded scenes because the values in `window.innerHeight` and `window.innerWidth` (used by `getCanvasSize()`) are incorrect mid-transition in some browsers. Affected (so far): iOS Chrome, and Safari when the page is launched full-screen via a home screen bookmark.

**Changes proposed:**
- Modify `AScene.resize` to institute a 100ms delay before resizing via `getCanvasSize()` for non-embedded scenes on iOS devices.
