### PR TITLE
Update docs and remove old deprecation warnings

### DIFF
--- a/docs/primitives/a-cursor.md
+++ b/docs/primitives/a-cursor.md
@@ -29,6 +29,8 @@ Read the [cursor component documentation](../components/cursor.md) for detailed 
 
 | Attribute    | Component Mapping  | Default Value |
 |--------------|--------------------|---------------|
+| far          | raycaster.far      | 1000          |
 | fuse         | cursor.fuse        | false         |
 | fuse-timeout | cursor.fuseTimeout | 1500          |
-| max-distance | cursor.maxDistance | 1000          |
+| interval     | raycaster.interval | 100           |
+| objects      | raycaster.objects  | 100           |

--- a/src/extras/primitives/primitives/a-camera.js
+++ b/src/extras/primitives/primitives/a-camera.js
@@ -20,14 +20,5 @@ registerPrimitive('a-camera', {
     'reverse-mouse-drag': 'look-controls.reverseMouseDrag',
     'user-height': 'camera.userHeight',
     zoom: 'camera.zoom'
-  },
-
-  deprecatedMappings: {
-    'cursor-color': 'a-camera[cursor-color] has been removed. Use a-cursor[color] instead.',
-    'cursor-maxdistance': 'a-camera[cursor-maxdistance] has been removed. Use a-cursor[max-distance] instead.',
-    'cursor-offset': 'a-camera[cursor-offset] has been removed. Use a-cursor[position] instead.',
-    'cursor-opacity': 'a-camera[cursor-offset] has been removed. Use a-cursor[opacity] instead.',
-    'cursor-scale': 'a-camera[cursor-scale] has been removed. Use a-cursor[scale] instead.',
-    'cursor-visible': 'a-camera[cursor-visible] has been removed. Use a-cursor[visible] instead.'
   }
 });


### PR DESCRIPTION
**Description:**

**Changes proposed:**
Update a-cursor schema docs and remove deprecatedMappings
from camera component which were removed since 0.2.0 and
recommended usage of a-cursor[max-distance] was removed since 0.3.0