### PR TITLE
Explains gltf animations

### DIFF
--- a/docs/components/gltf-model.md
+++ b/docs/components/gltf-model.md
@@ -97,7 +97,7 @@ rendering.
 
 ## Using animations
 
-If you want to use the animations from your glTF model, you can use the [animation-mixer](https://github.com/donmccurdy/aframe-extras/tree/master/src/loaders#animation) component from [aframe-extras](https://github.com/donmccurdy/aframe-extras). By default the first animation is played in a loop. 
+If you want to use the animations from your glTF model, you can use the [animation-mixer](https://github.com/donmccurdy/aframe-extras/tree/master/src/loaders#animation) component from [aframe-extras](https://github.com/donmccurdy/aframe-extras). By default all animations are played in a loop. 
 
 ```html
 <a-entity gltf-model="#monster" animation-mixer></a-entity>

--- a/docs/components/gltf-model.md
+++ b/docs/components/gltf-model.md
@@ -95,6 +95,14 @@ rendering.
 <a-entity gltf-model="url(/path/to/tree.gltf)"></a-entity>
 ```
 
+## Using animations
+
+If you want to use the animations from your glTF model, you can use the [animation-mixer](https://github.com/donmccurdy/aframe-extras/tree/master/src/loaders#animation) component from [aframe-extras](https://github.com/donmccurdy/aframe-extras). By default the first animation is played in a loop. 
+
+```html
+<a-entity gltf-model="#monster" animation-mixer></a-entity>
+```
+
 ## More Resources
 
 [sketchfab]: https://sketchfab.com/models?features=downloadable&sort_by=-likeCount


### PR DESCRIPTION
Adds a short explainer and links to the animation-mixer component from aframe-extras to help people use animations in their glTF models

**Description:**

I was asked how to get animations for a glTF model to work and I was surprised to find that the documentation mentions nothing about that.

**Changes proposed:**
- Explain that animations are supported via the `animation-mixer` component
- link to aframe-extras docs for the `animation-mixer` component
