### PR TITLE
add xOffset option to allow text padding

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -91,6 +91,7 @@ Inspector, and play with all the possible values to see the effects instantly!
 | width         | Width in meters.                                                                                                                                      | *derived from geometry if exists* |
 | wrapCount     | Number of characters before wrapping text (more or less).                                                                                             | 40                                |
 | wrapPixels    | Number of pixels before wrapping text.                                                                                                                | *derived from wrapCount*          |
+| xOffset       | X-offset to apply to add padding.                                                                                                                     | 0                                 |
 | zOffset       | Z-offset to apply to avoid Z-fighting if using with a geometry as a background.                                                                       | 0.001                             |
 
 [threetextusage]: https://github.com/Jam3/three-bmfont-text#usage

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -76,6 +76,8 @@ module.exports.Component = registerComponent('text', {
     wrapCount: {type: 'number', default: 40},
     // `wrapPixels` will wrap using bmfont pixel units (e.g., dejavu's is 32 pixels).
     wrapPixels: {type: 'number'},
+    // `xOffset` to add padding.
+    xOffset: {type: 'number', default: 0},
     // `yOffset` to adjust generated fonts from tools that may have incorrect metrics.
     yOffset: {type: 'number', default: 0},
     // `zOffset` will provide a small z offset to avoid z-fighting.
@@ -313,7 +315,7 @@ module.exports.Component = registerComponent('text', {
     }
 
     // Position and scale mesh to apply layout.
-    mesh.position.x = x * textScale;
+    mesh.position.x = x * textScale + data.xOffset;
     mesh.position.y = y * textScale;
     // Place text slightly in front to avoid Z-fighting.
     mesh.position.z = data.zOffset;


### PR DESCRIPTION
**Description:**

xOffset to allow for padding relative to the geometry plane behind it without having to separate them into two entities.,

**Changes proposed:**
- text.xOffset
