### PR TITLE
allow removal of mixed-in components (removeAttribute)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -388,12 +388,10 @@ var proto = Object.create(ANode.prototype, {
     value: function (name) {
       var component;
       var isDefault;
-      var isMixedIn;
 
       // Don't remove default or mixed-in components.
       isDefault = name in this.defaultComponents;
-      isMixedIn = isComponentMixedIn(name, this.mixinEls);
-      if (isDefault || isMixedIn) { return; }
+      if (isDefault) { return; }
 
       component = this.components[name];
       if (!component) { return; }
@@ -517,7 +515,7 @@ var proto = Object.create(ANode.prototype, {
 
       // Remove component.
       if (component && propertyName === undefined) {
-        this.setEntityAttribute(attr, undefined, null);
+        this.removeComponent(attr);
         // Do not remove the component from the DOM if default component.
         if (this.components[attr]) { return; }
       }

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -981,7 +981,7 @@ suite('a-entity', function () {
       assert.ok('position' in el.components);
     });
 
-    test('does not remove mixed-in component', function () {
+    test('can remove mixed-in component', function () {
       var el = this.el;
       var mixinId = 'geometry';
       mixinFactory(mixinId, {geometry: 'primitive: box'});
@@ -989,9 +989,9 @@ suite('a-entity', function () {
       el.setAttribute('geometry', 'primitive: sphere');
       assert.ok('geometry' in el.components);
       el.removeAttribute('geometry');
-      assert.notEqual(el.getAttribute('geometry'), null);
+      assert.equal(el.getAttribute('geometry'), null);
       // Geometry still exists since it is mixed in.
-      assert.ok('geometry' in el.components);
+      assert.notOk('geometry' in el.components);
     });
 
     test('resets a component property', function () {


### PR DESCRIPTION
**Description:**

Found out I wasn't able to remove a mixed-in component.

I had `<a-mixin id="foo" raycastable>` to start entities off with raycastable-ness. But later, I would toggle them, but it didn't take. Seems there was 2-year old logic to not allow removal of mixed-in components, which doesn't make sense anymore.

**Changes proposed:**
- Allow removal of mixed-in component.
- Use `removeComponent` versus the weird `setEntityAttribute(attr, undefined, null)`.

