### PR TITLE
have getAttribute(visible) return object3D.visible directly (fixes #3278)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -723,6 +723,7 @@ var proto = Object.create(ANode.prototype, {
       if (attr === 'position') { return this.object3D.position; }
       if (attr === 'rotation') { return getRotation(this); }
       if (attr === 'scale') { return this.object3D.scale; }
+      if (attr === 'visible') { return this.object3D.visible; }
       component = this.components[attr];
       if (component) { return component.data; }
       return window.HTMLElement.prototype.getAttribute.call(this, attr);

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -944,6 +944,22 @@ suite('a-entity', function () {
       el.object3D.scale.set(1, 2, 3);
       assert.shallowDeepEqual(el.getAttribute('scale'), {x: 1, y: 2, z: 3});
     });
+
+    test('returns visible previously set with setAttribute', function () {
+      var el = this.el;
+      el.setAttribute('visible', false);
+      assert.equal(el.getAttribute('visible'), false);
+      el.setAttribute('visible', true);
+      assert.equal(el.getAttribute('visible'), true);
+    });
+
+    test('returns visible set by modifying the object3D visible', function () {
+      var el = this.el;
+      el.object3D.visible = false;
+      assert.equal(el.getAttribute('visible'), false);
+      el.object3D.visible = true;
+      assert.equal(el.getAttribute('visible'), true);
+    });
   });
 
   suite('removeAttribute', function () {


### PR DESCRIPTION
**Description:**

#3278 

Similar to the changes for position / rotation / scale, for a common operation on the base Object3D, modifying the visibility, allow directly modifying `object3D.visible` while having the changes reflected at the A-Frame level. This lets us skip the whole setAttribute code path and change into a simple boolean flip.

**Changes proposed:**
- have getAttribute(visible) return object3D.visible directly 
