### PR TITLE
default the raycaster interval/throttle to 0

### DIFF
--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -38,7 +38,7 @@ module.exports.Component = registerComponent('raycaster', {
     direction: {type: 'vec3', default: {x: 0, y: 0, z: -1}},
     enabled: {default: true},
     far: {default: 1000},
-    interval: {default: 100},
+    interval: {default: 0},
     near: {default: 0},
     objects: {default: ''},
     origin: {type: 'vec3'},


### PR DESCRIPTION
**Description:**

I recommend raycaster should be checked every frame so that interactions are responsive. Otherwise they can feel delayed or laggy, impacting the perceived performance.

**Changes proposed:**
- Remove default raycaster 100ms throttle.

