### PR TITLE
fix component update getting overriden by mixin due to not passing in the whole attrValue into buildData (fixes #3301)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -252,12 +252,14 @@ Component.prototype = {
     // Cache previously passed attribute to decide if we skip type checking.
     this.previousAttrValue = attrValue;
 
+    // Cache current attrValue for future updates. Updates `this.attrValue`.
     attrValue = this.parseAttrValueForCache(attrValue);
-    if (this.updateSchema) { this.updateSchema(this.buildData(attrValue, false, true)); }
-    this.data = this.buildData(attrValue, clobber, false, skipTypeChecking);
-
-    // Cache current attrValue for future updates.
     this.updateCachedAttrValue(attrValue, clobber);
+
+    if (this.updateSchema) {
+      this.updateSchema(this.buildData(this.attrValue, false, true));
+    }
+    this.data = this.buildData(this.attrValue, clobber, false, skipTypeChecking);
 
     if (!this.initialized) {
       // Component is being already initialized.


### PR DESCRIPTION
#3301 

**Description:**

Only the update value from setAttribute was being passed into buildData. Actually, we should take the combined value from setAttribute with the current attrValue cache, and pass that into buildData.

**Changes proposed:**
- Run the `updateCachedAttrValue` before `buildData`, and use the total `this.attrValue` into `buildData`.
