### PR TITLE
mixin composition + string split cache util (fixes #3270)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -600,8 +600,9 @@ var proto = Object.create(ANode.prototype, {
         return;
       }
       if (attr === 'mixin') {
+        // Ignore if `<a-node>` code is just updating computed mixin in the DOM.
+        if (newVal === this.computedMixinStr) { return; }
         this.mixinUpdate(newVal, oldVal);
-        return;
       }
     }
   },
@@ -641,8 +642,8 @@ var proto = Object.create(ANode.prototype, {
 
       // Not a component. Normal set attribute.
       if (!COMPONENTS[componentName]) {
-        ANode.prototype.setAttribute.call(this, attrName, arg1);
         if (attrName === 'mixin') { this.mixinUpdate(arg1); }
+        ANode.prototype.setAttribute.call(this, attrName, arg1);
         return;
       }
 

--- a/src/core/a-mixin.js
+++ b/src/core/a-mixin.js
@@ -1,6 +1,7 @@
 var ANode = require('./a-node');
 var registerElement = require('./a-register-element').registerElement;
 var components = require('./component').components;
+var utils = require('../utils');
 
 var MULTIPLE_COMPONENT_DELIMITER = '__';
 
@@ -14,6 +15,7 @@ module.exports = registerElement('a-mixin', {
       value: function () {
         this.componentCache = {};
         this.id = this.getAttribute('id');
+        this.isMixin = true;
       }
     },
 
@@ -37,8 +39,8 @@ module.exports = registerElement('a-mixin', {
      */
     setAttribute: {
       value: function (attr, value) {
-        this.cacheAttribute(attr, value);
         window.HTMLElement.prototype.setAttribute.call(this, attr, value);
+        this.cacheAttribute(attr, value);
       }
     },
 
@@ -47,8 +49,12 @@ module.exports = registerElement('a-mixin', {
      */
     cacheAttribute: {
       value: function (attr, value) {
-        var componentName = attr.split(MULTIPLE_COMPONENT_DELIMITER)[0];
-        var component = components[componentName];
+        var component;
+        var componentName;
+
+        // Get component data.
+        componentName = utils.split(attr, MULTIPLE_COMPONENT_DELIMITER)[0];
+        component = components[componentName];
         if (!component) { return; }
         if (value === undefined) {
           value = window.HTMLElement.prototype.getAttribute.call(this, attr);
@@ -89,15 +95,17 @@ module.exports = registerElement('a-mixin', {
      */
     updateEntities: {
       value: function () {
+        var entity;
+        var entities;
+        var i;
+
         if (!this.sceneEl) { return; }
-        var entities = this.sceneEl.querySelectorAll('[mixin~=' + this.id + ']');
-        for (var i = 0; i < entities.length; i++) {
-          var entity = entities[i];
+
+        entities = this.sceneEl.querySelectorAll('[mixin~=' + this.id + ']');
+        for (i = 0; i < entities.length; i++) {
+          entity = entities[i];
           if (!entity.hasLoaded) { continue; }
-          entity.registerMixin(this.id);
-          Object.keys(this.componentCache).forEach(function updateComponent (componentName) {
-            entity.updateComponent(componentName);
-          });
+          entity.mixinUpdate(this.id);
         }
       }
     }

--- a/src/core/a-mixin.js
+++ b/src/core/a-mixin.js
@@ -104,7 +104,7 @@ module.exports = registerElement('a-mixin', {
         entities = this.sceneEl.querySelectorAll('[mixin~=' + this.id + ']');
         for (i = 0; i < entities.length; i++) {
           entity = entities[i];
-          if (!entity.hasLoaded) { continue; }
+          if (!entity.hasLoaded || entity.isMixin) { continue; }
           entity.mixinUpdate(this.id);
         }
       }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -322,3 +322,19 @@ module.exports.findAllScenes = function (el) {
 
 // Must be at bottom to avoid circular dependency.
 module.exports.srcLoader = require('./src-loader');
+
+/**
+ * String split with cached result.
+ */
+module.exports.split = (function () {
+  var splitCache = {};
+
+  return function (str, delimiter) {
+    if (!(delimiter in splitCache)) { splitCache[delimiter] = {}; }
+
+    if (str in splitCache[delimiter]) { return splitCache[delimiter][str]; }
+
+    splitCache[delimiter][str] = str.split(delimiter);
+    return splitCache[delimiter][str];
+  };
+})();

--- a/tests/core/a-mixin.test.js
+++ b/tests/core/a-mixin.test.js
@@ -2,25 +2,27 @@
 var helpers = require('../helpers');
 
 suite('a-mixin', function () {
+  var assetsEl;
+  var el;
+
   setup(function (done) {
-    var el = this.el = helpers.entityFactory();
+    el = helpers.entityFactory();
     var self = this;
 
     el.addEventListener('loaded', function () {
       var sceneEl = self.sceneEl = el.sceneEl;
-      self.assetsEl = sceneEl.querySelector('a-assets');
+      assetsEl = sceneEl.querySelector('a-assets');
       done();
     });
   });
 
   test('applies to already loaded entity', function (done) {
-    var el = this.el;
     var mixinEl = document.createElement('a-mixin');
     el.setAttribute('mixin', 'ring');
 
     mixinEl.setAttribute('id', 'ring');
     mixinEl.setAttribute('geometry', 'primitive: ring');
-    this.assetsEl.appendChild(mixinEl);
+    assetsEl.appendChild(mixinEl);
 
     mixinEl.addEventListener('loaded', function () {
       assert.equal(el.getAttribute('geometry').primitive, 'ring');
@@ -33,19 +35,131 @@ suite('a-mixin', function () {
   });
 
   test('applies to already loaded entity with component', function (done) {
-    var el = this.el;
     var mixinEl = document.createElement('a-mixin');
     el.setAttribute('mixin', 'ring');
     el.setAttribute('geometry', 'buffer: false');
     mixinEl.setAttribute('id', 'ring');
     mixinEl.setAttribute('geometry', 'primitive: ring');
-    this.assetsEl.appendChild(mixinEl);
+    assetsEl.appendChild(mixinEl);
 
     mixinEl.addEventListener('loaded', function () {
       var geometry = el.getAttribute('geometry');
       assert.equal(geometry.buffer, false);
       assert.equal(geometry.primitive, 'ring');
       done();
+    });
+  });
+
+  suite('mixin composition', function () {
+    test('allows mixin to define mixin post-attach', () => {
+      var mixinEl1;
+      var mixinEl2;
+
+      el.setAttribute('mixin', 'bar');
+
+      mixinEl1 = document.createElement('a-mixin');
+      mixinEl1.setAttribute('id', 'foo');
+      assetsEl.appendChild(mixinEl1);
+
+      mixinEl2 = document.createElement('a-mixin');
+      mixinEl2.setAttribute('id', 'bar');
+      mixinEl2.setAttribute('mixin', 'foo');
+      mixinEl2.setAttribute('geometry', 'primitive: sphere');
+      assetsEl.appendChild(mixinEl2);
+
+      assert.equal(el.mixinEls.length, 2);
+      assert.equal(el.getAttribute('mixin'), 'foo bar');
+      assert.ok(el.mixinEls.indexOf(mixinEl1) !== -1);
+      assert.ok(el.mixinEls.indexOf(mixinEl2) !== -1);
+      assert.equal(el.getAttribute('geometry').primitive, 'sphere');
+    });
+
+    test('allows mixin to define mixin pre-attach', () => {
+      var mixinEl1;
+      var mixinEl2;
+
+      mixinEl1 = document.createElement('a-mixin');
+      mixinEl1.setAttribute('id', 'foo');
+      assetsEl.appendChild(mixinEl1);
+
+      mixinEl2 = document.createElement('a-mixin');
+      mixinEl2.setAttribute('id', 'bar');
+      mixinEl2.setAttribute('mixin', 'foo');
+      mixinEl2.setAttribute('geometry', 'primitive: sphere');
+      assetsEl.appendChild(mixinEl2);
+
+      el.setAttribute('mixin', 'bar');
+
+      assert.equal(el.mixinEls.length, 2);
+      assert.equal(el.getAttribute('mixin'), 'foo bar');
+      assert.ok(el.mixinEls.indexOf(mixinEl1) !== -1);
+      assert.ok(el.mixinEls.indexOf(mixinEl2) !== -1);
+      assert.equal(el.getAttribute('geometry').primitive, 'sphere');
+    });
+
+    test('compositing mixin components override composited mixin components', () => {
+      var mixinEl1;
+      var mixinEl2;
+
+      el.setAttribute('mixin', 'bar');
+
+      mixinEl1 = document.createElement('a-mixin');
+      mixinEl1.setAttribute('id', 'foo');
+      mixinEl1.setAttribute('geometry', 'primitive: torus');
+      mixinEl1.setAttribute('material', 'color: blue');
+      assetsEl.appendChild(mixinEl1);
+
+      mixinEl2 = document.createElement('a-mixin');
+      mixinEl2.setAttribute('id', 'bar');
+      mixinEl2.setAttribute('mixin', 'foo');
+      mixinEl2.setAttribute('geometry', 'primitive: sphere');
+      assetsEl.appendChild(mixinEl2);
+
+      assert.equal(el.mixinEls.length, 2);
+      assert.ok(el.mixinEls.indexOf(mixinEl1) !== -1);
+      assert.ok(el.mixinEls.indexOf(mixinEl2) !== -1);
+
+      assert.equal(el.getAttribute('geometry').primitive, 'sphere');
+      assert.equal(el.getAttribute('material').color, 'blue');
+    });
+
+    test('composites multiple levels of nested mixins', () => {
+      var mixinEl1;
+      var mixinEl2;
+      var mixinEl3;
+      var mixinEl4;
+      var mixinEl5;
+
+      mixinEl1 = document.createElement('a-mixin');
+      mixinEl1.setAttribute('id', 'foo');
+      mixinEl1.setAttribute('mixin', 'bar');
+      assetsEl.appendChild(mixinEl1);
+
+      mixinEl2 = document.createElement('a-mixin');
+      mixinEl2.setAttribute('id', 'bar');
+      mixinEl2.setAttribute('mixin', 'qaz qux');
+      assetsEl.appendChild(mixinEl2);
+
+      mixinEl3 = document.createElement('a-mixin');
+      mixinEl3.setAttribute('id', 'qaz');
+      assetsEl.appendChild(mixinEl3);
+
+      mixinEl4 = document.createElement('a-mixin');
+      mixinEl4.setAttribute('id', 'qux');
+      assetsEl.appendChild(mixinEl4);
+
+      mixinEl5 = document.createElement('a-mixin');
+      mixinEl5.setAttribute('id', 'baz');
+      assetsEl.appendChild(mixinEl5);
+
+      el.setAttribute('mixin', 'baz foo');
+
+      assert.equal(el.getAttribute('mixin'), 'baz qaz qux bar foo');
+      assert.equal(el.mixinEls[0], mixinEl5);
+      assert.equal(el.mixinEls[1], mixinEl3);
+      assert.equal(el.mixinEls[2], mixinEl4);
+      assert.equal(el.mixinEls[3], mixinEl2);
+      assert.equal(el.mixinEls[4], mixinEl1);
     });
   });
 });

--- a/tests/core/a-mixin.test.js
+++ b/tests/core/a-mixin.test.js
@@ -51,7 +51,7 @@ suite('a-mixin', function () {
   });
 
   suite('mixin composition', function () {
-    test('allows mixin to define mixin post-attach', () => {
+    test('allows mixin to define mixin post-attach', done => {
       var mixinEl1;
       var mixinEl2;
 
@@ -61,20 +61,25 @@ suite('a-mixin', function () {
       mixinEl1.setAttribute('id', 'foo');
       assetsEl.appendChild(mixinEl1);
 
-      mixinEl2 = document.createElement('a-mixin');
-      mixinEl2.setAttribute('id', 'bar');
-      mixinEl2.setAttribute('mixin', 'foo');
-      mixinEl2.setAttribute('geometry', 'primitive: sphere');
-      assetsEl.appendChild(mixinEl2);
+      setTimeout(() => {
+        mixinEl2 = document.createElement('a-mixin');
+        mixinEl2.setAttribute('id', 'bar');
+        mixinEl2.setAttribute('mixin', 'foo');
+        mixinEl2.setAttribute('geometry', 'primitive: sphere');
+        assetsEl.appendChild(mixinEl2);
 
-      assert.equal(el.mixinEls.length, 2);
-      assert.equal(el.getAttribute('mixin'), 'foo bar');
-      assert.ok(el.mixinEls.indexOf(mixinEl1) !== -1);
-      assert.ok(el.mixinEls.indexOf(mixinEl2) !== -1);
-      assert.equal(el.getAttribute('geometry').primitive, 'sphere');
+        setTimeout(() => {
+          assert.equal(el.mixinEls.length, 2);
+          assert.equal(el.getAttribute('mixin'), 'foo bar');
+          assert.ok(el.mixinEls.indexOf(mixinEl1) !== -1);
+          assert.ok(el.mixinEls.indexOf(mixinEl2) !== -1);
+          assert.equal(el.getAttribute('geometry').primitive, 'sphere');
+          done();
+        });
+      });
     });
 
-    test('allows mixin to define mixin pre-attach', () => {
+    test('allows mixin to define mixin pre-attach', done => {
       var mixinEl1;
       var mixinEl2;
 
@@ -82,22 +87,29 @@ suite('a-mixin', function () {
       mixinEl1.setAttribute('id', 'foo');
       assetsEl.appendChild(mixinEl1);
 
-      mixinEl2 = document.createElement('a-mixin');
-      mixinEl2.setAttribute('id', 'bar');
-      mixinEl2.setAttribute('mixin', 'foo');
-      mixinEl2.setAttribute('geometry', 'primitive: sphere');
-      assetsEl.appendChild(mixinEl2);
+      setTimeout(() => {
+        mixinEl2 = document.createElement('a-mixin');
+        mixinEl2.setAttribute('id', 'bar');
+        mixinEl2.setAttribute('mixin', 'foo');
+        mixinEl2.setAttribute('geometry', 'primitive: sphere');
+        assetsEl.appendChild(mixinEl2);
 
-      el.setAttribute('mixin', 'bar');
+        setTimeout(() => {
+          el.setAttribute('mixin', 'bar');
 
-      assert.equal(el.mixinEls.length, 2);
-      assert.equal(el.getAttribute('mixin'), 'foo bar');
-      assert.ok(el.mixinEls.indexOf(mixinEl1) !== -1);
-      assert.ok(el.mixinEls.indexOf(mixinEl2) !== -1);
-      assert.equal(el.getAttribute('geometry').primitive, 'sphere');
+          setTimeout(() => {
+            assert.equal(el.mixinEls.length, 2);
+            assert.equal(el.getAttribute('mixin'), 'foo bar');
+            assert.ok(el.mixinEls.indexOf(mixinEl1) !== -1);
+            assert.ok(el.mixinEls.indexOf(mixinEl2) !== -1);
+            assert.equal(el.getAttribute('geometry').primitive, 'sphere');
+            done();
+          });
+        });
+      });
     });
 
-    test('compositing mixin components override composited mixin components', () => {
+    test('compositing mixin components override composited mixin components', done => {
       var mixinEl1;
       var mixinEl2;
 
@@ -109,21 +121,26 @@ suite('a-mixin', function () {
       mixinEl1.setAttribute('material', 'color: blue');
       assetsEl.appendChild(mixinEl1);
 
-      mixinEl2 = document.createElement('a-mixin');
-      mixinEl2.setAttribute('id', 'bar');
-      mixinEl2.setAttribute('mixin', 'foo');
-      mixinEl2.setAttribute('geometry', 'primitive: sphere');
-      assetsEl.appendChild(mixinEl2);
+      setTimeout(() => {
+        mixinEl2 = document.createElement('a-mixin');
+        mixinEl2.setAttribute('id', 'bar');
+        mixinEl2.setAttribute('mixin', 'foo');
+        mixinEl2.setAttribute('geometry', 'primitive: sphere');
+        assetsEl.appendChild(mixinEl2);
 
-      assert.equal(el.mixinEls.length, 2);
-      assert.ok(el.mixinEls.indexOf(mixinEl1) !== -1);
-      assert.ok(el.mixinEls.indexOf(mixinEl2) !== -1);
+        setTimeout(() => {
+          assert.equal(el.mixinEls.length, 2);
+          assert.ok(el.mixinEls.indexOf(mixinEl1) !== -1);
+          assert.ok(el.mixinEls.indexOf(mixinEl2) !== -1);
 
-      assert.equal(el.getAttribute('geometry').primitive, 'sphere');
-      assert.equal(el.getAttribute('material').color, 'blue');
+          assert.equal(el.getAttribute('geometry').primitive, 'sphere');
+          assert.equal(el.getAttribute('material').color, 'blue');
+          done();
+        });
+      });
     });
 
-    test('composites multiple levels of nested mixins', () => {
+    test('composites multiple levels of nested mixins', done => {
       var mixinEl1;
       var mixinEl2;
       var mixinEl3;
@@ -135,31 +152,44 @@ suite('a-mixin', function () {
       mixinEl1.setAttribute('mixin', 'bar');
       assetsEl.appendChild(mixinEl1);
 
-      mixinEl2 = document.createElement('a-mixin');
-      mixinEl2.setAttribute('id', 'bar');
-      mixinEl2.setAttribute('mixin', 'qaz qux');
-      assetsEl.appendChild(mixinEl2);
+      setTimeout(() => {
+        mixinEl2 = document.createElement('a-mixin');
+        mixinEl2.setAttribute('id', 'bar');
+        mixinEl2.setAttribute('mixin', 'qaz qux');
+        assetsEl.appendChild(mixinEl2);
 
-      mixinEl3 = document.createElement('a-mixin');
-      mixinEl3.setAttribute('id', 'qaz');
-      assetsEl.appendChild(mixinEl3);
+        setTimeout(() => {
+          mixinEl3 = document.createElement('a-mixin');
+          mixinEl3.setAttribute('id', 'qaz');
+          assetsEl.appendChild(mixinEl3);
 
-      mixinEl4 = document.createElement('a-mixin');
-      mixinEl4.setAttribute('id', 'qux');
-      assetsEl.appendChild(mixinEl4);
+          setTimeout(() => {
+            mixinEl4 = document.createElement('a-mixin');
+            mixinEl4.setAttribute('id', 'qux');
+            assetsEl.appendChild(mixinEl4);
 
-      mixinEl5 = document.createElement('a-mixin');
-      mixinEl5.setAttribute('id', 'baz');
-      assetsEl.appendChild(mixinEl5);
+            setTimeout(() => {
+              mixinEl5 = document.createElement('a-mixin');
+              mixinEl5.setAttribute('id', 'baz');
+              assetsEl.appendChild(mixinEl5);
 
-      el.setAttribute('mixin', 'baz foo');
+              setTimeout(() => {
+                el.setAttribute('mixin', 'baz foo');
 
-      assert.equal(el.getAttribute('mixin'), 'baz qaz qux bar foo');
-      assert.equal(el.mixinEls[0], mixinEl5);
-      assert.equal(el.mixinEls[1], mixinEl3);
-      assert.equal(el.mixinEls[2], mixinEl4);
-      assert.equal(el.mixinEls[3], mixinEl2);
-      assert.equal(el.mixinEls[4], mixinEl1);
+                setTimeout(() => {
+                  assert.equal(el.getAttribute('mixin'), 'baz qaz qux bar foo');
+                  assert.equal(el.mixinEls[0], mixinEl5);
+                  assert.equal(el.mixinEls[1], mixinEl3);
+                  assert.equal(el.mixinEls[2], mixinEl4);
+                  assert.equal(el.mixinEls[3], mixinEl2);
+                  assert.equal(el.mixinEls[4], mixinEl1);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
**Description:**

Allow for mixin composition to build "classes" out of multiple mixins.

```
<a-mixin id="font" text="font: myfont.json"></a-mixin>
<a-mixin id="red" text="color: red"></a-mixin>

<a-mixin id="redText" mixin="red font"></a-mixin>

<a-entity mixin="redText someMixin">
// This will turn into `<a-entity mixin="red font redFont someMixin">`

```

**Changes proposed:**
- Allow for mixin composition.
- String split util (used by mixin) which caches string split operations to save memory.

