### PR TITLE
optimize event emit (fixes #3294)

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
-/* global CustomEvent, location */
+/* global location */
+
 /* Centralized place to reference utilities since utils is exposed to the user. */
 var debug = require('./debug');
 var deepAssign = require('deep-assign');
@@ -104,22 +105,6 @@ module.exports.debounce = function (func, wait, immediate) {
     timeout = setTimeout(later, wait);
     if (callNow) func.apply(context, args);
   };
-};
-
-/**
- * Fires a custom DOM event.
- *
- * @param {Element} el Element on which to fire the event.
- * @param {String} name Name of the event.
- * @param {Object=} [data={bubbles: true, {detail: <el>}}]
- *   Data to pass as `customEventInit` to the event.
- */
-module.exports.fireEvent = function (el, name, data) {
-  data = data || {};
-  data.detail = data.detail || {};
-  data.detail.target = data.detail.target || el;
-  var evt = new CustomEvent(name, data);
-  el.dispatchEvent(evt);
 };
 
 /**

--- a/tests/components/vive-controls.test.js
+++ b/tests/components/vive-controls.test.js
@@ -160,7 +160,6 @@ suite('vive-controls', function () {
       controlsSystem.controllers = component.controllersWhenPresent;
       component.checkIfControllerPresent();
       el.addEventListener('triggerdown', function (evt) {
-        assert.ok(evt.detail);
         done();
       });
       el.emit('buttondown', {id: 1});
@@ -170,7 +169,6 @@ suite('vive-controls', function () {
       controlsSystem.controllers = component.controllersWhenPresent;
       component.checkIfControllerPresent();
       el.addEventListener('triggerup', function (evt) {
-        assert.ok(evt.detail);
         done();
       });
       el.emit('buttonup', {id: 1});

--- a/tests/core/a-node.test.js
+++ b/tests/core/a-node.test.js
@@ -18,10 +18,24 @@ suite('a-node', function () {
       var el = this.el;
       el.addEventListener('hadouken', function (event) {
         assert.equal(event.detail.power, 10);
-        assert.equal(event.detail.target, el);
+        assert.equal(event.target, el);
         done();
       });
       el.emit('hadouken', {power: 10});
+    });
+
+    test('does not leak detail between events', function (done) {
+      var el = this.el;
+      el.addEventListener('foo', function (evt) {
+        setTimeout(() => {
+          assert.equal(evt.detail.foo, 10);
+          assert.notOk('bar' in evt.detail);
+          done();
+        });
+      });
+
+      el.emit('foo', {foo: 10});
+      el.emit('bar', {bar: 20});
     });
 
     test('can emit event with extraData', function (done) {
@@ -29,7 +43,7 @@ suite('a-node', function () {
       el.addEventListener('hadouken', function (event) {
         assert.equal(event.cancelable, true);
         assert.equal(event.detail.power, 10);
-        assert.equal(event.detail.target, el);
+        assert.equal(event.target, el);
         done();
       });
       el.emit('hadouken', {power: 10}, true, {cancelable: true});


### PR DESCRIPTION
**Description:**

Emit was potentially creating object in three spots:

- `data = {bubbles: !!bubbles, detail: detail}`
- `data = data || {};`
- `data.detail = data.detail || {};`

This PR makes it to reuse the same object on each emit, **except** if `extraData` is provided, in which that customizes the event and we need a separate object.

There is no worry of cross-contamination. The `CustomEvent` data parameter will pass the object properties along to the event object, but the data parameter objects themselves aren't exposed.

I removed the indirection to the `utils.fireEvent` (unused, undocumented). It seems its purpose was to create objects if necessary which is no longer needed. It also added `detail.target` which is not needed because the browser natively has `event.target` and `event.currentTarget`. Also made it confusing when event detail objects are reused at application level, the `event.detail.target` was often incorrect in my experience through contamination.

**Changes proposed:**
- Get rid of object allocations in `.emit()` except in the case of `extraData`.
- Don't allocate empty object for `nodeready` event, just pass `undefined`.
