### PR TITLE
Improve function names in debugger call stacks

### DIFF
--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -59,8 +59,8 @@ module.exports.registerElement = function (tagName, obj) {
   }
 
   // Give all functions their proper name.
-  for (const propName of Object.getOwnPropertyNames(newObj.prototype)) {
-    const propVal = newObj.prototype[propName];
+  for (var propName of Object.getOwnPropertyNames(newObj.prototype)) {
+    var propVal = newObj.prototype[propName];
     if (propVal && typeof propVal === 'function') {
       propVal.displayName = propName;
     }

--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -61,7 +61,7 @@ module.exports.registerElement = function (tagName, obj) {
   // Give all functions their proper name.
   for (var propName of Object.getOwnPropertyNames(newObj.prototype)) {
     var propVal = newObj.prototype[propName];
-    if (propVal && typeof propVal === 'function') {
+    if (typeof propVal === 'function') {
       propVal.displayName = propName;
     }
   }

--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -58,6 +58,14 @@ module.exports.registerElement = function (tagName, obj) {
     newObj = {prototype: Object.create(proto, newObj)};
   }
 
+  // Give all functions their proper name.
+  for (const propName of Object.getOwnPropertyNames(newObj.prototype)) {
+    const propVal = newObj.prototype[propName];
+    if (propVal && typeof propVal === 'function') {
+      propVal.displayName = propName;
+    }
+  }
+
   return document.registerElement(tagName, newObj);
 };
 

--- a/tests/core/a-register-element.test.js
+++ b/tests/core/a-register-element.test.js
@@ -66,7 +66,7 @@ suite('a-register-element', function () {
       document.body.appendChild(document.createElement('a-test-entity-2'));
     });
 
-    test.only('Names functions correctly', function (done) {
+    test('names functions correctly', function (done) {
       registerElement('a-test-entity-3', {
         prototype: Object.create(AEntity.prototype, {
           attachedCallback: {

--- a/tests/core/a-register-element.test.js
+++ b/tests/core/a-register-element.test.js
@@ -65,6 +65,20 @@ suite('a-register-element', function () {
       });
       document.body.appendChild(document.createElement('a-test-entity-2'));
     });
+
+    test.only('Names functions correctly', function (done) {
+      registerElement('a-test-entity-3', {
+        prototype: Object.create(AEntity.prototype, {
+          attachedCallback: {
+            value: function () {
+              assert.equal(this.attachedCallback.displayName, 'attachedCallback');
+              done();
+            }
+          }
+        })
+      });
+      document.body.appendChild(document.createElement('a-test-entity-3'));
+    });
   });
 
   suite('wrapMethods', function () {


### PR DESCRIPTION
**Description:**
Currently most functions in an A-Frame call stack are named "value" due to the way elements are defined and registered.
This change makes use of the [displayName](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName) property on functions to improve call stack readability.

Before:
![Debugger call stack with multiple functions named "value"](https://i.imgur.com/dMcjCXx.png)

After:
![Debugger call stack with properly named functions](https://i.imgur.com/IzFmOaD.png)

**Changes proposed:**
- Name functions on registered elements using the displayName property.