### PR TITLE
set transforms using object3d vs setAttribute in look-controls

### DIFF
--- a/tests/components/look-controls.test.js
+++ b/tests/components/look-controls.test.js
@@ -81,7 +81,7 @@ suite('look-controls', function () {
       var lookControlsComponent = cameraEl.components['look-controls'];
       lookControlsComponent.hasPositionalTracking = false;
       sceneEl.emit('enter-vr');
-      assert.notOk(lookControlsComponent.savedPose);
+      assert.notOk(lookControlsComponent.hasSavedPose);
     });
   });
 


### PR DESCRIPTION
**Description:**

Porting some critical code to faster/cleaner object3D API for transform updates.

**Changes proposed:**
- Use 3js object3D API for transforms in look-controls for bit of speed.
- Don't need to re-allocate object `this.savedPose` every enter VR.
