### PR TITLE
get rid of some string split operations

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -234,7 +234,7 @@ function extractDomain (url) {
   var domain = url.indexOf('://') > -1 ? url.split('/')[2] : url.split('/')[0];
 
   // Find and remove port number.
-  return domain.split(':')[0];
+  return domain.substring(0, domain.indexOf(':'));
 }
 
 /**

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -311,16 +311,22 @@ var proto = Object.create(ANode.prototype, {
   initComponent: {
     value: function (attrName, data, isDependency) {
       var component;
-      var componentInfo = attrName.split(MULTIPLE_COMPONENT_DELIMITER);
-      var componentId = componentInfo[1];
-      var componentName = componentInfo[0];
-      var isComponentDefined = checkComponentDefined(this, attrName) || data !== undefined;
+      var componentId;
+      var componentInfo;
+      var componentName;
+      var isComponentDefined;
+
+      componentInfo = utils.split(attrName, MULTIPLE_COMPONENT_DELIMITER);
+      componentId = componentInfo[1];
+      componentName = componentInfo[0];
 
       // Not a registered component.
       if (!COMPONENTS[componentName]) { return; }
 
       // Component is not a dependency and is undefined.
       // If a component is a dependency, then it is okay to have no data.
+      isComponentDefined = checkComponentDefined(this, attrName) ||
+                           data !== undefined;
       if (!isComponentDefined && !isDependency) { return; }
 
       // Component already initialized.
@@ -849,7 +855,7 @@ function mergeComponentData (attrValue, extraData) {
 
 function isComponent (componentName) {
   if (componentName.indexOf(MULTIPLE_COMPONENT_DELIMITER) !== -1) {
-    componentName = componentName.split(MULTIPLE_COMPONENT_DELIMITER)[0];
+    componentName = utils.split(componentName, MULTIPLE_COMPONENT_DELIMITER)[0];
   }
   if (!COMPONENTS[componentName]) { return false; }
   return true;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -322,3 +322,19 @@ module.exports.findAllScenes = function (el) {
 
 // Must be at bottom to avoid circular dependency.
 module.exports.srcLoader = require('./src-loader');
+
+/**
+ * String split with cached result.
+ */
+module.exports.split = (function () {
+  var splitCache = {};
+
+  return function (str, delimiter) {
+    if (!(delimiter in splitCache)) { splitCache[delimiter] = {}; }
+
+    if (str in splitCache[delimiter]) { return splitCache[delimiter][str]; }
+
+    splitCache[delimiter][str] = str.split(delimiter);
+    return splitCache[delimiter][str];
+  };
+})();


### PR DESCRIPTION
**Description:**

Copied a util over from #3305 

**Changes proposed:**
- Get rid of few string split operations, namely for `multiple` components

