### PR TITLE
Document that component data is readonly

### DIFF
--- a/docs/core/component.md
+++ b/docs/core/component.md
@@ -12,7 +12,7 @@ examples: []
 [entity]: ./entity.md
 [multiple]: #multiple
 [three]: http://threejs.org/
-[setAttribute]: ../introduction/javascript-events-dom-apis.md#updating-a-component-with-setattribute-
+[setAttribute]: ../introduction/javascript-events-dom-apis.md#updating-a-component-with-setattribute
 
 In the [entity-component-system pattern][ecs], a component is a reusable and
 modular chunk of data that we plug into an entity to add appearance, behavior,

--- a/docs/core/component.md
+++ b/docs/core/component.md
@@ -12,6 +12,7 @@ examples: []
 [entity]: ./entity.md
 [multiple]: #multiple
 [three]: http://threejs.org/
+[setAttribute]: ../introduction/javascript-events-dom-apis.md#updating-a-component-with-setattribute-
 
 In the [entity-component-system pattern][ecs], a component is a reusable and
 modular chunk of data that we plug into an entity to add appearance, behavior,
@@ -246,7 +247,7 @@ Within the methods, we have access to the component prototype via `this`:
 
 | Property        | Description                                                                                                                                                                                                                                         |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| this.data       | Parsed component properties computed from the schema default values, mixins, and the entity's attributes. <br/>__Note:__ The data property should be considered readonly. If a component wants to update its own data, it should use *setAttribute*.|
+| this.data       | Parsed component properties computed from the schema default values, mixins, and the entity's attributes. <br/>__Important:__ Do not modify the data attribute directly. It is updated internally by A-Frame. To modify a component, use [setAttribute][setAttribute].|
 | this.el         | Reference to the [entity][entity] as an HTML element.                                                                                                                                                                                               |
 | this.el.sceneEl | Reference to the [scene][scene] as an HTML element.                                                                                                                                                                                                 |
 | this.id         | If the component can have [multiple instances][multiple], the ID of the individual instance of the component (e.g., `foo` from `sound__foo`).                                                                                                       |

--- a/docs/core/component.md
+++ b/docs/core/component.md
@@ -244,12 +244,12 @@ the data to modify the entity. The handlers will usually interact with the
 
 Within the methods, we have access to the component prototype via `this`:
 
-| Property        | Description                                                                                                                                   |
-|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| this.data       | Parsed component properties computed from the schema default values, mixins, and the entity's attributes.                                     |
-| this.el         | Reference to the [entity][entity] as an HTML element.                                                                                         |
-| this.el.sceneEl | Reference to the [scene][scene] as an HTML element.                                                                                           |
-| this.id         | If the component can have [multiple instances][multiple], the ID of the individual instance of the component (e.g., `foo` from `sound__foo`). |
+| Property        | Description                                                                                                                                                                                                                                         |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| this.data       | Parsed component properties computed from the schema default values, mixins, and the entity's attributes. <br/>__Note:__ The data property should be considered readonly. If a component wants to update its own data, it should use *setAttribute*.|
+| this.el         | Reference to the [entity][entity] as an HTML element.                                                                                                                                                                                               |
+| this.el.sceneEl | Reference to the [scene][scene] as an HTML element.                                                                                                                                                                                                 |
+| this.id         | If the component can have [multiple instances][multiple], the ID of the individual instance of the component (e.g., `foo` from `sound__foo`).                                                                                                       |
 
 ### `.init ()`
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "karma-mocha-reporter": "^2.1.0",
     "karma-sinon-chai": "1.2.4",
     "lolex": "^1.5.1",
-    "markserv": "sukima/markserv#feature/fix-broken-websoketio-link",
+    "markserv": "github:sukima/markserv#feature/fix-broken-websoketio-link",
     "minifyify": "^7.3.3",
     "mocha": "^3.0.2",
     "mozilla-download": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "karma-mocha-reporter": "^2.1.0",
     "karma-sinon-chai": "1.2.4",
     "lolex": "^1.5.1",
-    "markserv": "0.0.20",
+    "markserv": "sukima/markserv#feature/fix-broken-websoketio-link",
     "minifyify": "^7.3.3",
     "mocha": "^3.0.2",
     "mozilla-download": "^1.1.1",


### PR DESCRIPTION
**Description:**
It's not obvious that component data is meant to be readonly. This can lead to confusion if a developer modifies data directly and it is later clobbered by a-frame.

**Changes proposed:**
- Add a note to the docs to clarify that component data is readonly and that `setAttribute` should be used instead.
