### PR TITLE
look-controls no longer manage the camera pose in VR mode (fix #3315 #3118 #3051 #2487)

### DIFF
--- a/docs/components/camera.md
+++ b/docs/components/camera.md
@@ -16,7 +16,7 @@ to move and rotate the camera.
 A camera situated at the average height of human eye level (1.6 meters).
 
 ```html
-<a-entity camera="userHeight: 1.6" look-controls></a-entity>
+  <a-entity position="0 1.6 0" camera look-controls></a-entity>
 ```
 
 ## Properties
@@ -36,21 +36,13 @@ A camera situated at the average height of human eye level (1.6 meters).
 If a camera is not specified, A-Frame will inject a default camera:
 
 ```html
-<a-entity camera="active: true; userHeight: 1.6" look-controls wasd-controls position="0 0 0" data-aframe-default-camera></a-entity>
+<a-entity camera="active: true" look-controls wasd-controls position="0 0 0" data-aframe-default-camera></a-entity>
 ```
 
 If a camera is specified (e.g., our own `<a-camera>` or `<a-entity camera>`),
 then the default camera will not be added.
 
 ## VR Behavior
-
-When not in VR mode, `userHeight` translates the camera up to approximate
-average height of human eye level. The injected camera has this set to 1.6
-(meters). When entering VR, this height offset is *removed* such that we used
-absolute position returned from the VR headset. The offset is convenient for
-experiences that work both in and out of VR, as well as making experiences look
-decent from a desktop screen as opposed to clipping the ground if the headset
-was resting on the ground.
 
 When exiting VR, the camera will restore its rotation to its rotation *before*
 it entered VR. This is so when we exit VR, the rotation of the camera is back

--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -26,14 +26,13 @@ component](camera.md).
 
 [pointer-lock-api]: https://developer.mozilla.org/docs/Web/API/Pointer_Lock_API
 
-| Property           | Description                                                      | Default Value |
-|--------------------|------------------------------------------------------------------|---------------|
-| enabled            | Whether look controls are enabled.                               | true          |
-| hmdEnabled         | Whether to use VR headset pose in VR mode.                       | true          |
-| reverseMouseDrag   | Whether to reverse mouse drag.                                   | false         |
-| touchEnabled       | Whether to use touch controls in magic window mode.              | true          |
+| Property         | Description                                                      | Default Value |
+|------------------|------------------------------------------------------------------|---------------|
+| enabled          | Whether look controls are enabled.                               | true          |
+| hmdEnabled       | Whether to use VR headset pose in VR mode.                       | true          |
+| reverseMouseDrag | Whether to reverse mouse drag.                                   | false         |
+| touchEnabled     | Whether to use touch controls in magic window mode.              | true          |
 | pointerLockEnabled | Whether to hide the cursor using the [Pointer Lock API][pointer-lock-api]. | true |
-| userHeight         | Height offset to add to the camera when *not* in VR mode so the camera is not on ground level. The default camera that A-Frame injects or the `<a-camera>` primitive sets this to 1.6 meters. But note the default camera component alone (`<a-entity camera>`) defaults this to 0. | 0 |
 
 ## Customizing look-controls
 
@@ -52,8 +51,7 @@ be left maintaining a wide array of flags.
 
 The component lives within a Browserify/Webpack context so you'll need to
 replace the `require` statements with A-Frame globals (e.g.,
-`AFRAME.registerComponent`, `window.THREE`,
-`AFRAME.constants.DEFAULT_CAMERA_HEIGHT`), and get rid of the `module.exports`.
+`AFRAME.registerComponent`, `window.THREE`), and get rid of the `module.exports`.
 
 ## Caveats
 

--- a/docs/primitives/a-camera.md
+++ b/docs/primitives/a-camera.md
@@ -9,11 +9,6 @@ source_code: src/extras/primitives/primitives/a-camera.js
 The camera primitive determines what the user sees. We can change the viewport
 by modifying the camera entity's position and rotation.
 
-[userheight]: ../components/camera.md#vr-behavior
-
-Note that by default, the camera origin will be at `0 1.6 0` in desktop mode
-and `0 0 0` in VR mode. Read about the [`camera.userHeight` property][userheight].
-
 ## Example
 
 ```html
@@ -31,7 +26,6 @@ and `0 0 0` in VR mode. Read about the [`camera.userHeight` property][userheight
 | fov                   | camera.fov                     | 80            |
 | look-controls-enabled | look-controls.enabled          | true          |
 | near                  | camera.near                    | 0.5           |
-| user-height           | camera.userHeight              | 1.6           |
 | reverse-mouse-drag    | look-controls.reverseMouseDrag | false         |
 | wasd-controls-enabled | wasd-controls.enabled          | true          |
 

--- a/examples/animation/aframe-logo/index.html
+++ b/examples/animation/aframe-logo/index.html
@@ -17,8 +17,7 @@
         <a-animation attribute="position" from="0 5 0" to="0 0 0" dur="4000"
                      easing="ease-out"></a-animation>
         <a-entity position="0 880 1290" rotation="-34 0 0">
-          <a-camera id="camera" near="1000" far="4000" fov="2.2" user-height="0"
-                    wasd-controls-enabled="false" look-controls-enabled="false"></a-camera>
+          <a-camera id="camera" near="1000" far="4000" fov="2.2" wasd-controls-enabled="false" look-controls-enabled="false"></a-camera>
         </a-entity>  
       </a-entity>
 

--- a/examples/animation/generic-logo/index.html
+++ b/examples/animation/generic-logo/index.html
@@ -14,7 +14,7 @@
       </a-assets>
 
       <a-entity>
-        <a-camera fov="80" near="0.1" wasd-controls-enabled="false" user-height="0"></a-camera>
+        <a-camera fov="80" near="0.1" wasd-controls-enabled="false"></a-camera>
       </a-entity>
 
       <!-- A generic logo made of animated elements -->

--- a/examples/animation/pivots/index.html
+++ b/examples/animation/pivots/index.html
@@ -18,7 +18,7 @@
       </a-assets>
 
       <a-entity position="0 0 8">
-        <a-camera user-height="0"></a-camera>
+        <a-camera></a-camera>
       </a-entity>
 
       <!-- 1 -->

--- a/examples/showcase/anime-UI/index.html
+++ b/examples/showcase/anime-UI/index.html
@@ -31,7 +31,7 @@
       </a-assets>
 
       <a-entity position="1.75 0 1.2" rotation="0 28 0">
-        <a-camera near="0.1" user-height="0"></a-camera>
+        <a-camera near="0.1"></a-camera>
       </a-entity>
 
       <a-entity position="0 0 -3">

--- a/examples/showcase/link-traversal/js/components/ground.js
+++ b/examples/showcase/link-traversal/js/components/ground.js
@@ -15,7 +15,7 @@ AFRAME.registerComponent('ground', {
           value.geometry.computeFaceNormals();
           value.geometry.computeVertexNormals();
           value.receiveShadow = true;
-          value.material.shading = THREE.FlatShading;
+          value.material.flatShading = THREE.FlatShading;
         }
       });
       self.el.setObject3D('ground', obj);

--- a/examples/showcase/tracked-controls/components/grab.js
+++ b/examples/showcase/tracked-controls/components/grab.js
@@ -12,37 +12,33 @@ AFRAME.registerComponent('grab', {
     this.onHit = this.onHit.bind(this);
     this.onGripOpen = this.onGripOpen.bind(this);
     this.onGripClose = this.onGripClose.bind(this);
+    this.currentPosition = new THREE.Vector3();
   },
 
   play: function () {
     var el = this.el;
     el.addEventListener('hit', this.onHit);
-    el.addEventListener('gripclose', this.onGripClose);
-    el.addEventListener('gripopen', this.onGripOpen);
-    el.addEventListener('thumbup', this.onGripClose);
-    el.addEventListener('thumbdown', this.onGripOpen);
-    el.addEventListener('pointup', this.onGripClose);
-    el.addEventListener('pointdown', this.onGripOpen);
+    el.addEventListener('buttondown', this.onGripClose);
+    el.addEventListener('buttonup', this.onGripOpen);
   },
 
   pause: function () {
     var el = this.el;
     el.removeEventListener('hit', this.onHit);
-    el.removeEventListener('gripclose', this.onGripClose);
-    el.removeEventListener('gripopen', this.onGripOpen);
-    el.removeEventListener('thumbup', this.onGripClose);
-    el.removeEventListener('thumbdown', this.onGripOpen);
-    el.removeEventListener('pointup', this.onGripClose);
-    el.removeEventListener('pointdown', this.onGripOpen);
+    el.addEventListener('buttondown', this.onGripClose);
+    el.addEventListener('buttonup', this.onGripOpen);
   },
 
   onGripClose: function (evt) {
+    if (this.grabbing) { return; }
     this.grabbing = true;
+    this.pressedButtonId = evt.detail.id;
     delete this.previousPosition;
   },
 
   onGripOpen: function (evt) {
     var hitEl = this.hitEl;
+    if (this.pressedButtonId !== evt.detail.id) { return; }
     this.grabbing = false;
     if (!hitEl) { return; }
     hitEl.removeState(this.GRABBED_STATE);
@@ -74,7 +70,9 @@ AFRAME.registerComponent('grab', {
   },
 
   updateDelta: function () {
-    var currentPosition = this.el.getAttribute('position');
+    var currentPosition = this.currentPosition;
+    this.el.object3D.updateMatrixWorld();
+    currentPosition.setFromMatrixPosition(this.el.object3D.matrixWorld);
     if (!this.previousPosition) {
       this.previousPosition = new THREE.Vector3();
       this.previousPosition.copy(currentPosition);

--- a/examples/showcase/tracked-controls/components/ground.js
+++ b/examples/showcase/tracked-controls/components/ground.js
@@ -14,7 +14,7 @@ AFRAME.registerComponent('ground', {
     objectLoader.load(MODEL_URL, function (obj) {
       obj.children.forEach(function (value) {
         value.receiveShadow = true;
-        value.material.shading = THREE.FlatShading;
+        value.material.flatShading = THREE.FlatShading;
       });
       object3D.add(obj);
     });

--- a/examples/showcase/tracked-controls/index.html
+++ b/examples/showcase/tracked-controls/index.html
@@ -27,10 +27,6 @@
                  material="color: #EF2D5E;"></a-mixin>
       </a-assets>
 
-      <!-- Hands -->
-      <a-entity hand-controls="left" aabb-collider="objects: .cube;" grab></a-entity>
-      <a-entity hand-controls="right" aabb-collider="objects: .cube;" grab></a-entity>
-
       <!-- A-Frame cubes -->
       <a-entity position="0 0 -0.5">
         <a-entity class="cube" mixin="cube" position="0.30 1.65 0"></a-entity>
@@ -62,8 +58,10 @@
          <a-entity light="type: point; color: #f4f4f4; intensity: 0.6; distance: 0" position="-8 10 -18"></a-entity>
          <a-entity light="type: ambient; color: #f4f4f4; intensity: 0.4;" position="-8 10 -18"></a-entity>
       </a-entity>
-      <a-camera></a-camera>
-
+      <!-- Hands -->
+      <a-entity hand-controls="left" aabb-collider="objects: .cube;" grab></a-entity>
+      <a-entity hand-controls="right" aabb-collider="objects: .cube;" grab></a-entity>
+      <a-entity position="0 1.6 2" camera look-controls wasd-controls></a-entity>
     </a-scene>
   </body>
 </html>

--- a/examples/test/animation/index.html
+++ b/examples/test/animation/index.html
@@ -18,7 +18,7 @@
       </a-assets>
 
       <a-entity position="0 0 6">
-        <a-camera wasd-controls-enabled="false" user-height="0"></a-camera>
+        <a-camera wasd-controls-enabled="false"></a-camera>
       </a-entity>
 
       <a-entity rotation="0 0 0" position="0 0 -5">

--- a/examples/test/cylinders/index.html
+++ b/examples/test/cylinders/index.html
@@ -14,7 +14,7 @@
       </a-assets>
 
       <a-entity position="0 0 8">
-        <a-camera user-height="0"></a-camera>
+        <a-camera></a-camera>
       </a-entity>
 
       <a-entity mixin="cylinder" position="-10 0 0" rotation="45 0 -45"

--- a/examples/test/laser-controls/index.html
+++ b/examples/test/laser-controls/index.html
@@ -49,6 +49,8 @@
     </script>
 
     <a-scene background="color: #212" antialias="true">
+       
+      <a-entity position="0 3.2 0" camera look-controls wasd-controls></a-entity>
       <a-entity id="leftHand" laser-controls="hand: left" raycaster="objects: [mixin='box']"></a-entity>
       <a-entity id="rightHand" laser-controls="hand: right" raycaster="objects: [mixin='box']" line="color: #118A7E"></a-entity>
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "present": "0.0.6",
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
-    "three": "0.89.0",
+    "three": "github:dmarcos/three.js#r89fix",
     "three-bmfont-text": "^2.1.0",
     "webvr-polyfill": "^0.9.40"
   },

--- a/src/extras/primitives/primitives/a-camera.js
+++ b/src/extras/primitives/primitives/a-camera.js
@@ -1,12 +1,9 @@
-var DEFAULT_CAMERA_HEIGHT = require('../../../constants/').DEFAULT_CAMERA_HEIGHT;
 var registerPrimitive = require('../primitives').registerPrimitive;
 
 registerPrimitive('a-camera', {
   defaultComponents: {
     'camera': {},
-    'look-controls': {
-      userHeight: DEFAULT_CAMERA_HEIGHT
-    },
+    'look-controls': {},
     'wasd-controls': {}
   },
 
@@ -18,7 +15,6 @@ registerPrimitive('a-camera', {
     near: 'camera.near',
     'wasd-controls-enabled': 'wasd-controls.enabled',
     'reverse-mouse-drag': 'look-controls.reverseMouseDrag',
-    'user-height': 'look-controls.userHeight',
     zoom: 'camera.zoom'
   }
 });

--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -5,6 +5,7 @@
   position: fixed;
   right: 0;
   top: 0;
+  --caca: 0;
 }
 
 /* Applied to the body element */

--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -26,6 +26,7 @@ module.exports.System = registerSystem('camera', {
   setupDefaultCamera: function () {
     var sceneEl = this.sceneEl;
     var defaultCameraEl;
+    var cameraRigEl;
 
     // Camera already defined or the one defined it is an spectator one.
     if (sceneEl.camera && !sceneEl.camera.el.getAttribute('camera').spectator) {
@@ -33,15 +34,23 @@ module.exports.System = registerSystem('camera', {
       return;
     }
 
+    // Set up camera rig.
+    cameraRigEl = document.createElement('a-entity');
+    cameraRigEl.setAttribute('position', {
+      x: 0,
+      y: constants.DEFAULT_CAMERA_HEIGHT,
+      z: 0
+    });
+
     // Set up default camera.
     defaultCameraEl = document.createElement('a-entity');
-    defaultCameraEl.setAttribute('position', '0 0 0');
-    defaultCameraEl.setAttribute(DEFAULT_CAMERA_ATTR, '');
     defaultCameraEl.setAttribute('camera', {active: true});
     defaultCameraEl.setAttribute('wasd-controls', '');
-    defaultCameraEl.setAttribute('look-controls', {userHeight: constants.DEFAULT_CAMERA_HEIGHT});
+    defaultCameraEl.setAttribute('look-controls', '');
     defaultCameraEl.setAttribute(constants.AFRAME_INJECTED, '');
-    sceneEl.appendChild(defaultCameraEl);
+    cameraRigEl.setAttribute(DEFAULT_CAMERA_ATTR, '');
+    cameraRigEl.appendChild(defaultCameraEl);
+    sceneEl.appendChild(cameraRigEl);
     sceneEl.addEventListener('enter-vr', this.removeDefaultOffset);
     sceneEl.addEventListener('exit-vr', this.addDefaultOffset);
     sceneEl.emit('camera-ready', {cameraEl: defaultCameraEl});

--- a/tests/components/daydream-controls.test.js
+++ b/tests/components/daydream-controls.test.js
@@ -15,6 +15,7 @@ suite('daydream-controls', function () {
         buttons: [{value: 0, pressed: false, touched: false}],
         pose: {orientation: [1, 0, 0, 0], position: null}
       }];
+      el.parentEl.renderer.vr.getStandingMatrix = function () {};
       done();
     });
   });

--- a/tests/components/gearvr-controls.test.js
+++ b/tests/components/gearvr-controls.test.js
@@ -18,6 +18,7 @@ suite('gearvr-controls', function () {
         ],
         pose: {orientation: [1, 0, 0, 0], position: null}
       }];
+      el.parentEl.renderer.vr.getStandingMatrix = function () {};
       done();
     });
   });

--- a/tests/components/look-controls.test.js
+++ b/tests/components/look-controls.test.js
@@ -7,17 +7,8 @@ suite('look-controls', function () {
   setup(function (done) {
     var el = this.sceneEl = document.createElement('a-scene');
     document.body.appendChild(el);
-    el.addEventListener('loaded', function () {
+    el.addEventListener('camera-ready', function () {
       done();
-    });
-  });
-
-  suite('update', function () {
-    test('can update userHeight', function () {
-      var cameraEl = this.sceneEl.camera.el;
-      assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 1.6, z: 0});
-      cameraEl.setAttribute('look-controls', 'userHeight', 2.5);
-      assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 2.5, z: 0});
     });
   });
 
@@ -118,33 +109,6 @@ suite('look-controls', function () {
       lookControlsComponent.hasPositionalTracking = false;
       sceneEl.emit('enter-vr');
       assert.notOk(lookControlsComponent.savedPose);
-    });
-  });
-
-  suite('addHeightOffset', function () {
-    test('adds userHeight offset', function () {
-      var cameraEl = this.sceneEl.camera.el;
-      assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 1.6, z: 0});
-    });
-  });
-
-  suite('removeCameraPose (enter VR)', function () {
-    test('removes the default offset w/ positional tracking', function () {
-      var sceneEl = this.sceneEl;
-      var cameraEl = sceneEl.camera.el;
-      cameraEl.components['look-controls'].hasPositionalTracking = true;
-      assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 1.6, z: 0});
-      sceneEl.emit('enter-vr');
-      assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 0, z: 0});
-    });
-
-    test('does not remove the default offset w/o positional tracking', function () {
-      var sceneEl = this.sceneEl;
-      var cameraEl = sceneEl.camera.el;
-      cameraEl.components['look-controls'].hasPositionalTracking = false;
-      assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 1.6, z: 0});
-      sceneEl.emit('enter-vr');
-      assert.shallowDeepEqual(cameraEl.getAttribute('position'), {x: 0, y: 1.6, z: 0});
     });
   });
 

--- a/tests/core/controls.test.js
+++ b/tests/core/controls.test.js
@@ -433,7 +433,6 @@ suite('position controls on camera with VRControls (integration unit test)', fun
 
     sceneEl.addState('vr-mode');
     cameraEl.components['look-controls'].hasPositionalTracking = true;
-    cameraEl.components['look-controls'].removeHeightOffset();
     this.position = [-1, 2, 3];
     el.sceneEl.render();
     var position = cameraEl.getAttribute('position');

--- a/tests/extras/primitives/primitives/a-camera.test.js
+++ b/tests/extras/primitives/primitives/a-camera.test.js
@@ -18,16 +18,4 @@ suite('a-camera', function () {
       done();
     });
   });
-
-  suite('user-height', function () {
-    test('updates height offset when DOM user-height attribute changes', function (done) {
-      var camera = this.camera;
-      assert.shallowDeepEqual(camera.getAttribute('position'), {x: 0, y: 1.6, z: 0});
-      camera.setAttribute('user-height', '0.5');
-      process.nextTick(function () {
-        assert.shallowDeepEqual(camera.getAttribute('position'), {x: 0, y: 0.5, z: 0});
-        done();
-      });
-    });
-  });
 });


### PR DESCRIPTION
Instead VRManager from THREE does update the pose applying always `standing` coordinates so a user height is always present in the pose: defaulting to 1.6 in the case of 3DOF headsets.
