### PR TITLE
Fix shadow component "sets needsUpdate on material" test

### DIFF
--- a/tests/components/shadow.test.js
+++ b/tests/components/shadow.test.js
@@ -37,6 +37,7 @@ suite('shadow component', function () {
 
     test('sets needsUpdate on materials', function () {
       el.object3D.add(mesh);
+      mesh.material.needsUpdate = false;
       component.update();
       assert.ok(mesh.material.needsUpdate);
     });


### PR DESCRIPTION
**Description:**

The default value of `THREE.Material.needsUpdate` is `true`. (It's set to `false` in `renderer.render()`)

Then  we need to set `false` to `material.needsUpdate` before `component.update()` call in shadow component's "sets needsUpdate on material" test to check if `.needsUpdate` is set to `true` in the component.

**Changes proposed:**
- sets `false` to `mesh.material.needsUpdate` before `component.update()` call in the "sets needsUpdate on material" test