### PR TITLE
[look-controls] Support Pointer Lock API.

### DIFF
--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -10,7 +10,7 @@ examples: []
 The look-controls component:
 
 - Rotates the entity when we rotate a VR head-mounted display (HMD).
-- Rotates the entity when we click-drag mouse.
+- Rotates the entity when we move the mouse.
 - Rotates the entity when we touch-drag the touchscreen.
 
 ## Example
@@ -24,13 +24,16 @@ component](camera.md).
 
 ## Properties
 
-| Property         | Description                                                      | Default Value |
-|------------------|------------------------------------------------------------------|---------------|
-| enabled          | Whether look controls are enabled.                               | true          |
-| hmdEnabled       | Whether to use VR headset pose in VR mode.                       | true          |
-| reverseMouseDrag | Whether to reverse mouse drag.                                   | false         |
-| touchEnabled     | Whether to use touch controls in magic window mode.              | true          |
-| userHeight | Height offset to add to the camera when *not* in VR mode so the camera is not on ground level. The default camera that A-Frame injects or the `<a-camera>` primitive sets this to 1.6 meters. But note the default camera component alone (`<a-entity camera>`) defaults this to 0. | 0             |
+[pointer-lock-api]: https://developer.mozilla.org/docs/Web/API/Pointer_Lock_API
+
+| Property           | Description                                                      | Default Value |
+|--------------------|------------------------------------------------------------------|---------------|
+| enabled            | Whether look controls are enabled.                               | true          |
+| hmdEnabled         | Whether to use VR headset pose in VR mode.                       | true          |
+| reverseMouseDrag   | Whether to reverse mouse drag.                                   | false         |
+| touchEnabled       | Whether to use touch controls in magic window mode.              | true          |
+| pointerLockEnabled | Whether to hide the cursor using the [Pointer Lock API][pointer-lock-api]. | true |
+| userHeight         | Height offset to add to the camera when *not* in VR mode so the camera is not on ground level. The default camera that A-Frame injects or the `<a-camera>` primitive sets this to 1.6 meters. But note the default camera component alone (`<a-entity camera>`) defaults this to 0. | 0 |
 
 ## Customizing look-controls
 

--- a/tests/components/look-controls.test.js
+++ b/tests/components/look-controls.test.js
@@ -60,6 +60,42 @@ suite('look-controls', function () {
       });
       window.dispatchEvent(new Event('mouseup'));
     });
+
+    test('requests pointer lock on mousedown', function (done) {
+      var canvasEl = this.sceneEl.canvas;
+
+      var requestPointerLock = this.sinon.spy(canvasEl, 'requestPointerLock');
+
+      process.nextTick(function () {
+        assert.ok(requestPointerLock.called);
+        document.body.classList.remove(GRABBING_CLASS);
+        done();
+      });
+
+      var event = new Event('mousedown');
+      event.button = 0;
+      canvasEl.dispatchEvent(event);
+    });
+
+    test('does not request pointer lock when option is disabled', function (done) {
+      var sceneEl = this.sceneEl;
+      var canvasEl = sceneEl.canvas;
+      var cameraEl = sceneEl.camera.el;
+
+      var requestPointerLock = this.sinon.spy(canvasEl, 'requestPointerLock');
+
+      cameraEl.setAttribute('look-controls', {pointerLockEnabled: false});
+
+      process.nextTick(function () {
+        assert.notOk(requestPointerLock.called);
+        document.body.classList.remove(GRABBING_CLASS);
+        done();
+      });
+
+      var event = new Event('mousedown');
+      event.button = 0;
+      canvasEl.dispatchEvent(event);
+    });
   });
 
   suite('saveCameraPose', function () {


### PR DESCRIPTION
Fixes #2625.

From the last comment:

> Yeah, I'm in favor of a Pointer Lock on by default. I shared some A-Frame stuff to people on desktop and the click-drag is not usable. For default desktop mode, I'd favor Pointer Lock/a-cursor versus Click-Drag/mouse-cursor (they conflict anyways).

... it sounds like we're leaning toward "on by default" rather than "on by default after entering fullscreen". If that's still correct and we want to merge this, I'll add the tests and docs.

/cc @ngokevin 