### PR TITLE
Adds backToFront param to pool.requestEntity(), to help w/ transparency

### DIFF
--- a/src/components/scene/pool.js
+++ b/src/components/scene/pool.js
@@ -67,8 +67,11 @@ module.exports.Component = registerComponent('pool', {
 
   /**
    * Used to request one of the available entities of the pool
+   * @param backToFront pass falsy if objects retrieved from the pool will generally be placed *nearer* the camera than
+   * older objects, such as bullets from the player's gun.  Pass truthy if they'll be *farther*, such as clouds the
+   * player is flying through.  @See https://aframe.io/docs/0.7.0/components/material.html#transparency-issues
    */
-  requestEntity: function () {
+  requestEntity: function (backToFront) {
     var el;
     if (this.availableEls.length === 0) {
       if (this.data.dynamic === false) {
@@ -80,7 +83,11 @@ module.exports.Component = registerComponent('pool', {
       }
       this.createEntity();
     }
-    el = this.availableEls.shift();
+    if (backToFront) {
+      el = this.availableEls.pop();
+    } else {
+      el = this.availableEls.shift();
+    }
     this.usedEls.push(el);
     el.setAttribute('visible', true);
     return el;


### PR DESCRIPTION
**Description:**
See https://aframe.io/docs/0.7.0/components/material.html#transparency-issues for context.

See https://glitch.com/edit/#!/trail-cause for an example of transparency issues.

One cannot use HTML to re-order pool objects, so this adds a backToFront param to pool.requestEntity(). If true, the available object created *last* is returned.  This is useful when each entity pulled from the pool is placed *farther* from the camera than previous entity, as when the player is flying through clouds.

For an example of use, see https://github.com/DougReeder/elfland-glider/tree/master/ginnungagap/index.html#L41

If it would work better as a parameter when creating the pool, I can rework this.

**Changes proposed:**
-
-
-


I agree to license my contributions under the MIT License.