### PR TITLE
Fix material array handling in shadow component

### DIFF
--- a/src/components/shadow.js
+++ b/src/components/shadow.js
@@ -42,7 +42,7 @@ module.exports.Component = registerComponent('shadow', {
 
       // If scene has already rendered, materials must be updated.
       if (sceneEl.hasLoaded && node.material) {
-        var materials = node.material.materials || [node.material];
+        var materials = Array.isArray(node.material) ? node.material : [node.material];
         for (var i = 0; i < materials.length; i++) {
           materials[i].needsUpdate = true;
         }

--- a/tests/components/shadow.test.js
+++ b/tests/components/shadow.test.js
@@ -6,6 +6,7 @@ suite('shadow component', function () {
   var component;
   var el;
   var mesh;
+  var meshWithMaterialArray;
 
   setup(function (done) {
     el = entityFactory();
@@ -18,6 +19,11 @@ suite('shadow component', function () {
     mesh = new THREE.Mesh(
       new THREE.Sphere(2),
       new THREE.MeshBasicMaterial({color: 0xffff00})
+    );
+    meshWithMaterialArray = new THREE.Mesh(
+      new THREE.Sphere(2),
+      [new THREE.MeshBasicMaterial({color: 0xffff00}),
+        new THREE.MeshBasicMaterial({color: 0xffff00})]
     );
   });
 
@@ -43,16 +49,12 @@ suite('shadow component', function () {
     });
 
     test('sets needsUpdate on material array', function () {
-      var mesh2 = new THREE.Mesh(
-        new THREE.Sphere(2),
-        [new THREE.MeshBasicMaterial({color: 0xffff00}),
-          new THREE.MeshBasicMaterial({color: 0xffff00})]
-      );
-      el.object3D.add(mesh2);
-      mesh2.material[0].needsUpdate = false;
-      mesh2.material[1].needsUpdate = false;
+      el.object3D.add(meshWithMaterialArray);
+      meshWithMaterialArray.material[0].needsUpdate = false;
+      meshWithMaterialArray.material[1].needsUpdate = false;
       component.update();
-      assert.ok(mesh2.material[0].needsUpdate && mesh2.material[1].needsUpdate);
+      assert.ok(meshWithMaterialArray.material[0].needsUpdate &&
+        meshWithMaterialArray.material[1].needsUpdate);
     });
 
     test('refreshes after setObject3D', function () {

--- a/tests/components/shadow.test.js
+++ b/tests/components/shadow.test.js
@@ -35,11 +35,24 @@ suite('shadow component', function () {
       assert.notOk(mesh.receiveShadow);
     });
 
-    test('sets needsUpdate on materials', function () {
+    test('sets needsUpdate on material', function () {
       el.object3D.add(mesh);
       mesh.material.needsUpdate = false;
       component.update();
       assert.ok(mesh.material.needsUpdate);
+    });
+
+    test('sets needsUpdate on material array', function () {
+      var mesh2 = new THREE.Mesh(
+        new THREE.Sphere(2),
+        [new THREE.MeshBasicMaterial({color: 0xffff00}),
+          new THREE.MeshBasicMaterial({color: 0xffff00})]
+      );
+      el.object3D.add(mesh2);
+      mesh2.material[0].needsUpdate = false;
+      mesh2.material[1].needsUpdate = false;
+      component.update();
+      assert.ok(mesh2.material[0].needsUpdate && mesh2.material[1].needsUpdate);
     });
 
     test('refreshes after setObject3D', function () {


### PR DESCRIPTION
**Description:**

This PR fixes material array handling in shadow component.

In Three.js r89, `mesh.material` can be `THREE.*Material` or array of `THREE.*Material`. 

`THREE.MultiMaterial` is already deprecated, it's converted to material array.

So we should check if `mesh.material` is array instead.

Question: Is var name `meshWithMaterialArray` in the test too long?

**Changes proposed:**
- use `node.material` instead of `node.material.materials` for material array in shadow component.
