### PR TITLE
Bug in 360 image gallery tutorial

### DIFF
--- a/docs/guides/building-a-360-image-gallery.md
+++ b/docs/guides/building-a-360-image-gallery.md
@@ -310,7 +310,7 @@ instances][multiple]:
 ```html
 <a-assets>
   <!-- ... -->
-  <script id="link" type="text/html">
+  <script id="plane" type="text/html">
     <a-entity class="link"
       geometry="primitive: plane; height: 1; width: 1"
       material="shader: flat; src: ${thumb}"


### PR DESCRIPTION
**Description:**
The id for the "plane" script (template) is incorrectly set to "link" in the example, which is confusing and also breaks the example.

**Changes proposed:**
- Use correct id in the example
