### PR TITLE
fix black texture issue with a-sky and a-videosphere components with three r89

### DIFF
--- a/src/extras/primitives/primitives/a-sky.js
+++ b/src/extras/primitives/primitives/a-sky.js
@@ -14,6 +14,7 @@ registerPrimitive('a-sky', utils.extendDeep({}, getMeshMixin(), {
     material: {
       color: '#FFF',
       shader: 'flat',
+      side: 'back',
       npot: true
     },
     scale: '-1 1 1'

--- a/src/extras/primitives/primitives/a-videosphere.js
+++ b/src/extras/primitives/primitives/a-videosphere.js
@@ -13,6 +13,7 @@ registerPrimitive('a-videosphere', utils.extendDeep({}, getMeshMixin(), {
     material: {
       color: '#FFF',
       shader: 'flat',
+      side: 'back',
       npot: true
     },
     scale: '-1 1 1'


### PR DESCRIPTION
Fix black texture issue with a-sky and a-videosphere components with three r89 because of the changes https://github.com/mrdoob/three.js/pull/12787

scale needs to stay -1 1 1 otherwise texture is flipped.

no-change needed for a-curvedimage

This fixes https://github.com/aframevr/aframe/issues/3288