### PR TITLE
Detail how to enable Daydream controls support

### DIFF
--- a/docs/components/daydream-controls.md
+++ b/docs/components/daydream-controls.md
@@ -14,6 +14,13 @@ It wraps the [tracked-controls component][trackedcontrols] while adding button
 mappings, events, and a Daydream controller model that highlights the touched
 and/or pressed buttons (trackpad).
 
+As a first time set up, to use the Daydream controller on Chrome for Android
+enable both `WebVR` and `Gamepad Extensions` experiments in `chrome://flags`
+and relaunch the browser.
+
+Then, open your web app, enter VR mode and place the phone inside the headset.
+It can occassionally take a few seconds before the controller can be used.
+
 ## Example
 
 ```html


### PR DESCRIPTION
**Description:**
It took me a long time to realise that the Gamepad extensions had to be enabled in order to use the controller.

**Changes proposed:**
This is a documentation change. I hope it is clear enough.