### PR TITLE
Fix clipAction loop method in hand controls.

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -319,7 +319,7 @@ module.exports.Component = registerComponent('hand-controls', {
     // Grab clip action.
     toAction = mesh.mixer.clipAction(gesture);
     toAction.clampWhenFinished = true;
-    toAction.loop = THREE.PingPong;
+    toAction.loop = THREE.LoopRepeat;
     toAction.repetitions = 0;
     toAction.timeScale = reverse ? -1 : 1;
     toAction.weight = 1;


### PR DESCRIPTION
`THREE.PingPong` is not a defined constant. `THREE.LoopPingPong` is, but does not exhibit the desired behaviour. `THREE.LoopRepeat` seems to be correct.