### PR TITLE
`//` is not a valid CSS comment

### DIFF
--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -47,7 +47,7 @@
   cursor: -webkit-grabbing;
 }
 
-// Class is removed when doing <a-scene embedded>.
+/* Class is removed when doing <a-scene embedded>. */
 a-scene.fullscreen .a-canvas {
   width: 100% !important;
   height: 100% !important;


### PR DESCRIPTION
**Description:**
Surprisingly (I often forget myself), `//` is not a valid CSS comment. When building A-Frame with webpack, it results in a bad selector in the minified CSS file and the next declaration can't be parsed by the browser. Here's the result unminified:
```css
// Class is removed when doing <a-scene embedded>. a-scene.fullscreen .a-canvas {
  width: 100%!important;
  height: 100%!important;
  top: 0!important;
  left: 0!important;
  right: 0!important;
  bottom: 0!important;
  z-index: 999999!important;
  position: fixed!important
}
```

**Changes proposed:**
- This patch replaces `//` by a `/* ... */` comment.