### PR TITLE
fix not emitting click event twice in a intersection

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -275,7 +275,11 @@ module.exports.Component = registerComponent('cursor', {
     }
 
     // Unset current intersection.
-    if (this.intersectedEl) { this.clearCurrentIntersection(); }
+    if (this.intersectedEl) {
+      this.clearCurrentIntersection();
+      // Already intersecting.
+      if (this.intersectedEl === intersectedEl) { return; }
+    }
 
     this.setIntersection(intersectedEl, intersection);
   },

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -275,11 +275,7 @@ module.exports.Component = registerComponent('cursor', {
     }
 
     // Unset current intersection.
-    if (this.intersectedEl) {
-      this.clearCurrentIntersection();
-      // Already intersecting.
-      if (this.intersectedEl === intersectedEl) { return; }
-    }
+    this.clearCurrentIntersection();
 
     this.setIntersection(intersectedEl, intersection);
   },
@@ -299,6 +295,10 @@ module.exports.Component = registerComponent('cursor', {
     var cursorEl = this.el;
     var data = this.data;
     var self = this;
+
+    // Already intersecting.
+    if (this.intersectedEl === intersectedEl) { return; }
+
     // Set new intersection.
     this.intersection = intersection;
     this.intersectedEl = intersectedEl;
@@ -323,6 +323,9 @@ module.exports.Component = registerComponent('cursor', {
     var index;
     var intersection;
     var intersections;
+
+    // Nothing to be cleared.
+    if (!this.intersectedEl) { return; }
 
     // No longer hovering (or fusing).
     this.intersectedEl.removeState(STATES.HOVERED);


### PR DESCRIPTION
If a intersection has already been processed in clearCurrentIntersection, it isn't necessary to process it any more.
