### PR TITLE
Fix control transform components and rotationOffset

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -169,8 +169,13 @@ module.exports.Component = registerComponent('tracked-controls', {
       object3D.matrixAutoUpdate = false;
       object3D.matrix.compose(object3D.position, object3D.quaternion, object3D.scale);
       object3D.matrix.multiplyMatrices(standingMatrix, object3D.matrix);
-      object3D.matrixWorldNeedsUpdate = true;
+      object3D.matrix.decompose(object3D.position, object3D.quaternion, object3D.scale);
     }
+
+    object3D.rotateZ(this.data.rotationOffset * THREE.Math.DEG2RAD);
+
+    object3D.updateMatrix();
+    object3D.matrixWorldNeedsUpdate = true;
   },
 
   /**

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -152,19 +152,19 @@ module.exports.Component = registerComponent('tracked-controls', {
     // Compose pose from Gamepad.
     pose = controller.pose;
 
-    if (pose.position !== null) {
+    if (pose.position) {
       object3D.position.fromArray(pose.position);
     } else {
       // Controller not 6DOF, apply arm model.
       if (this.data.armModel) { this.applyArmModel(object3D.position); }
     }
 
-    if (pose.orientation !== null) {
+    if (pose.orientation) {
       object3D.quaternion.fromArray(pose.orientation);
     }
 
     // Apply transforms, if 6DOF and in VR.
-    if (vrDisplay && pose.position !== null) {
+    if (vrDisplay && pose.position) {
       standingMatrix = this.el.sceneEl.renderer.vr.getStandingMatrix();
       object3D.matrixAutoUpdate = false;
       object3D.matrix.compose(object3D.position, object3D.quaternion, object3D.scale);

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -164,7 +164,7 @@ module.exports.Component = registerComponent('tracked-controls', {
     }
 
     // Apply transforms, if 6DOF and in VR.
-    if (vrDisplay) {
+    if (vrDisplay && pose.position !== null) {
       standingMatrix = this.el.sceneEl.renderer.vr.getStandingMatrix();
       object3D.matrixAutoUpdate = false;
       object3D.matrix.compose(object3D.position, object3D.quaternion, object3D.scale);

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -140,6 +140,15 @@ suite('tracked-controls', function () {
       component.tick();
       assertVec3(el.getAttribute('position'), [2, 2.5, 0]);
     });
+
+    test('does not apply standing matrix transform for 3DoF', function () {
+      standingMatrix.makeTranslation(1, 0.5, -3);
+      controller.pose.position = null;
+      el.sceneEl.systems['tracked-controls'].vrDisplay = true;
+      component.tick();
+      // assert position after default camera position and arm model are applied
+      assertVec3CloseTo(el.getAttribute('position'), [0.28, 1.12, -0.32], 0.01);
+    });
   });
 
   suite('updatePose (rotation)', function () {
@@ -419,10 +428,18 @@ function assertMatrix4 (matrixA, matrixB) {
   assert.ok(matrixA.equals(matrixB), `\n${matrixA.elements}\n${matrixB.elements}`);
 }
 
+function assertVec3CloseTo (vec3, arr, delta) {
+  var debugOutput = `${[vec3.x, vec3.y, vec3.z]} is not close to ${arr}`;
+  assert.closeTo(vec3.x, arr[0], delta, debugOutput);
+  assert.closeTo(vec3.y, arr[1], delta, debugOutput);
+  assert.closeTo(vec3.z, arr[2], delta, debugOutput);
+}
+
 function assertVec3 (vec3, arr) {
-  assert.equal(vec3.x, arr[0]);
-  assert.equal(vec3.y, arr[1]);
-  assert.equal(vec3.z, arr[2]);
+  var debugOutput = `${[vec3.x, vec3.y, vec3.z]} does not equal ${arr}`;
+  assert.equal(vec3.x, arr[0], debugOutput);
+  assert.equal(vec3.y, arr[1], debugOutput);
+  assert.equal(vec3.z, arr[2], debugOutput);
 }
 
 function assertQuaternion (quaternion, arr) {


### PR DESCRIPTION
**Description:**
#3327 changed the way we calculate tracked controller pose:
- As a side effect, the code no longer updated the individual `position` and `quaternion` properties of the controller object. This prevents users and libraries (like `networked-aframe`) from reading those properties.
- It also removed use of `tracked-control`'s `rotationOffset` property, this lead to `hand-controls` with incorrectly rotated hand models when using the Oculus Rift and Touch, as evident in the tracked-controls example.
- Lastly, it regressed standing matrix application for 3DoF controls -- i.e. standing matrix should only be applied for 6DoF controls, since the controller position is controlled by the arm model, which bases it off the head position.

**Changes proposed:**
- Decompose the tracked object's matrix in to its individual components
- Reintroduce use of the `rotationOffset` property.
- Only apply the standing matrix if the controller is 6DoF
- Add tests to cover these changes.
