### PR TITLE
Clone the properties that are object type into oldData so the update …

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -522,7 +522,16 @@ function cloneData (data) {
 */
 function extendProperties (dest, source, isSinglePropSchema) {
   if (isSinglePropSchema && (source === null || typeof source !== 'object')) { return source; }
-  return utils.extend(dest, source);
+  var copy = utils.extend(dest, source);
+  var keys = Object.keys(copy);
+  var key;
+  var i;
+  for (i = 0; i < keys.length; i++) {
+    key = keys[i];
+    if (!copy[key] || copy[key].constructor !== Object) { continue; }
+    copy[key] = utils.clone(copy[key]);
+  }
+  return copy;
 }
 
 /**

--- a/tests/components/line.test.js
+++ b/tests/components/line.test.js
@@ -69,6 +69,17 @@ suite('line', function () {
       assert.equal(positionArray[5], 9);
     });
 
+    test('set end but no start position', function () {
+      var end = {x: 4, y: 5, z: 6};
+      el.setAttribute('line', {end: end});
+      end.z = 9;
+      var updateSpy = this.sinon.spy(el.components.line, 'update');
+      el.setAttribute('line', {end: end});
+      var endPoint = el.getAttribute('line').end;
+      assert.equal(endPoint.z, 9);
+      assert.ok(updateSpy.called);
+    });
+
     test('modify color', function () {
       el.setAttribute('line', {color: '#f9a'});
 


### PR DESCRIPTION
…method is called when they change. We were holding a reference and the deepEqual test was passing and the update method was never called (fix #3403)

-
