### PR TITLE
keyboard-shortcuts adds and removes event listeners in play/pause

### DIFF
--- a/src/components/scene/keyboard-shortcuts.js
+++ b/src/components/scene/keyboard-shortcuts.js
@@ -11,7 +11,7 @@ module.exports.Component = registerComponent('keyboard-shortcuts', {
     var self = this;
     var scene = this.el;
 
-    this.listener = window.addEventListener('keyup', function (event) {
+    this.listener = function (event) {
       if (!shouldCaptureKeyEvent(event)) { return; }
       if (self.enterVREnabled && event.keyCode === 70) {  // f.
         scene.enterVR();
@@ -19,7 +19,7 @@ module.exports.Component = registerComponent('keyboard-shortcuts', {
       if (self.enterVREnabled && event.keyCode === 27) {  // escape.
         scene.exitVR();
       }
-    }, false);
+    };
   },
 
   update: function (oldData) {
@@ -27,7 +27,11 @@ module.exports.Component = registerComponent('keyboard-shortcuts', {
     this.enterVREnabled = data.enterVR;
   },
 
-  remove: function () {
+  play: function () {
+    window.addEventListener('keyup', this.listener, false);
+  },
+
+  pause: function () {
     window.removeEventListener('keyup', this.listener);
   }
 });

--- a/src/components/scene/keyboard-shortcuts.js
+++ b/src/components/scene/keyboard-shortcuts.js
@@ -1,3 +1,4 @@
+var bind = require('../../utils/bind');
 var registerComponent = require('../../core/component').registerComponent;
 var shouldCaptureKeyEvent = require('../../utils/').shouldCaptureKeyEvent;
 
@@ -8,18 +9,7 @@ module.exports.Component = registerComponent('keyboard-shortcuts', {
   },
 
   init: function () {
-    var self = this;
-    var scene = this.el;
-
-    this.listener = function (event) {
-      if (!shouldCaptureKeyEvent(event)) { return; }
-      if (self.enterVREnabled && event.keyCode === 70) {  // f.
-        scene.enterVR();
-      }
-      if (self.enterVREnabled && event.keyCode === 27) {  // escape.
-        scene.exitVR();
-      }
-    };
+    this.onKeyup = bind(this.onKeyup, this);
   },
 
   update: function (oldData) {
@@ -28,10 +18,21 @@ module.exports.Component = registerComponent('keyboard-shortcuts', {
   },
 
   play: function () {
-    window.addEventListener('keyup', this.listener, false);
+    window.addEventListener('keyup', this.onKeyup, false);
   },
 
   pause: function () {
-    window.removeEventListener('keyup', this.listener);
+    window.removeEventListener('keyup', this.onKeyup);
+  },
+
+  onKeyup: function (evt) {
+    var scene = this.el;
+    if (!shouldCaptureKeyEvent(evt)) { return; }
+    if (this.enterVREnabled && evt.keyCode === 70) {  // f.
+      scene.enterVR();
+    }
+    if (this.enterVREnabled && evt.keyCode === 27) {  // escape.
+      scene.exitVR();
+    }
   }
 });


### PR DESCRIPTION
Changes keyboard-shortcuts so event listener for key presses is attached in 'play' and removed in 'pause'. 
Linked to https://github.com/aframevr/aframe-inspector/pull/530 - we dont want the 'f' key to enter vr mode while the inspector is open and this component is paused.
