### PR TITLE
fix cursor mouseenter/mouseleave issues on overlapping entities, do not grab new intersections after cleared in cursor component

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -59,7 +59,7 @@ module.exports.Component = registerComponent('cursor', {
     // Debounce.
     this.updateCanvasBounds = utils.debounce(function updateCanvasBounds () {
       self.canvasBounds = self.el.sceneEl.canvas.getBoundingClientRect();
-    }, 200);
+    }, 1000);
 
     this.eventDetail = {};
     this.intersectedEventDetail = {cursorEl: this.el};
@@ -285,7 +285,6 @@ module.exports.Component = registerComponent('cursor', {
    */
   onIntersectionCleared: function (evt) {
     var clearedEls = evt.detail.clearedEls;
-
     // Check if the current intersection has ended
     if (clearedEls.indexOf(this.intersectedEl) === -1) { return; }
     this.clearCurrentIntersection();
@@ -320,9 +319,6 @@ module.exports.Component = registerComponent('cursor', {
 
   clearCurrentIntersection: function () {
     var cursorEl = this.el;
-    var index;
-    var intersection;
-    var intersections;
 
     // Nothing to be cleared.
     if (!this.intersectedEl) { return; }
@@ -339,15 +335,6 @@ module.exports.Component = registerComponent('cursor', {
 
     // Clear fuseTimeout.
     clearTimeout(this.fuseTimeout);
-
-    // Set intersection to another raycasted element if any.
-    intersections = this.el.components.raycaster.intersections;
-    if (intersections.length === 0) { return; }
-    // exclude the cursor.
-    index = intersections[0].object.el === cursorEl ? 1 : 0;
-    intersection = intersections[index];
-    if (!intersection) { return; }
-    this.setIntersection(intersection.object.el, intersection);
   },
 
   /**

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -68,6 +68,7 @@ module.exports.Component = registerComponent('raycaster', {
 
     this.intersectedClearedDetail = {el: this.el};
     this.intersectionClearedDetail = {clearedEls: this.clearedIntersectedEls};
+    this.intersectionDetail = {};
   },
 
   /**
@@ -250,10 +251,9 @@ module.exports.Component = registerComponent('raycaster', {
 
     // Emit all intersections at once on raycasting entity.
     if (newIntersections.length) {
-      el.emit('raycaster-intersection', {
-        els: newIntersectedEls,
-        intersections: newIntersections
-      });
+      this.intersectionDetail.els = newIntersectedEls;
+      this.intersectionDetail.intersections = newIntersections;
+      el.emit('raycaster-intersection', this.intersectionDetail);
     }
 
     // Update line length.

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -355,21 +355,6 @@ suite('cursor', function () {
       assert.notOk(el.is('cursor-fusing'));
       assert.notOk(el.is('cursor-hovering'));
     });
-
-    test('sets another interesected element if any', function () {
-      var dummyEl = document.createElement('a-entity');
-      var dummyIntersection = {object: {el: dummyEl}};
-      component.intersection = intersection;
-      component.intersectedEl = intersectedEl;
-      el.addState('cursor-fusing');
-      el.addState('cursor-hovering');
-      el.components.raycaster.intersections = [dummyIntersection];
-      el.emit('raycaster-intersection-cleared', {clearedEls: [intersectedEl]});
-      assert.notOk(el.is('cursor-fusing'));
-      assert.ok(el.is('cursor-hovering'));
-      assert.equal(dummyEl, el.components.cursor.intersectedEl);
-      assert.equal(dummyIntersection, el.components.cursor.intersection);
-    });
   });
 
   suite('onMouseMove', function () {


### PR DESCRIPTION
**Description:**

There was some old code in cursor component lying around that when its intersected entity is cleared, it will look for the next one. 

This causes issues. It's better to just rely on the incoming raycaster-intersection/raycaster-intersection-cleared events rather than trying to manage intersections in cursor component.

**Changes proposed:**
- Don't set new intersection after intersection clear in cursor component.
- Reuse event detail in raycaster.
- Remove old vars.
