### PR TITLE
tidy up loose ends from #3423 (fixes #3447 and #3483)

### DIFF
--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -9,7 +9,7 @@ var GEARVR_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/samsun
 var GEARVR_CONTROLLER_MODEL_OBJ_URL = GEARVR_CONTROLLER_MODEL_BASE_URL + 'gear_vr_controller.obj';
 var GEARVR_CONTROLLER_MODEL_OBJ_MTL = GEARVR_CONTROLLER_MODEL_BASE_URL + 'gear_vr_controller.mtl';
 
-var GAMEPAD_ID_PREFIX = 'Gear VR|GearVR|Oculus Go';
+var GAMEPAD_ID_PREFIX = '((Gear VR)|(Oculus Go))';
 
 /**
  * Gear VR controls.

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -88,19 +88,15 @@ function findMatchingController (controllers, filterIdExact, filterIdPrefix, fil
   var i;
   var matchingControllerOccurence = 0;
   var targetControllerMatch = filterControllerIndex || 0;
-  var filterIdPrefixes;
+  var filterIdRegex;
   if (filterIdPrefix && filterIdPrefix.indexOf('|') >= 0) {
-    filterIdPrefixes = filterIdPrefix.split('|');
+    filterIdRegex = new RegExp('^' + filterIdPrefix);
   }
   for (i = 0; i < controllers.length; i++) {
     controller = controllers[i];
     // Determine if the controller ID matches our criteria
-    if (filterIdPrefixes) {
-      var matches = false;
-      for (var prefix in filterIdPrefixes) {
-        if (prefix && controller.id.indexOf(prefix) === -1) { matches = true; }
-      }
-      if (!matches) { continue; }
+    if (filterIdRegex) {
+      if (!filterIdRegex.test(controller.id)) { continue; }
     } else
     if (filterIdPrefix && controller.id.indexOf(filterIdPrefix) === -1) { continue; }
     if (!filterIdPrefix && controller.id !== filterIdExact) { continue; }


### PR DESCRIPTION
as discussed in #3423, 
use RegExp and update multi-prefix syntax; remove GearVR
(might be best to merge *after* the Oculus Browser fix is deployed next Tuesday)