### PR TITLE
use optionalTarget for raycaster.intersectObjects to save array (fixes #3437)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "present": "0.0.6",
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
-    "three": "github:dmarcos/three.js#r90fixPose",
+    "three": "github:supermedium/three.js#r90fixPoseAndRaycaster",
     "three-bmfont-text": "^2.1.0",
     "webvr-polyfill": "^0.9.40"
   },

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -57,6 +57,7 @@ module.exports.Component = registerComponent('raycaster', {
     this.objects = [];
     this.prevCheckTime = undefined;
     this.prevIntersectedEls = [];
+    this.rawIntersections = [];
     this.raycaster = new THREE.Raycaster();
     this.updateOriginDirection();
     this.setDirty = this.setDirty.bind(this);
@@ -189,7 +190,7 @@ module.exports.Component = registerComponent('raycaster', {
     var newIntersectedEls = this.newIntersectedEls;
     var newIntersections = this.newIntersections;
     var prevIntersectedEls = this.prevIntersectedEls;
-    var rawIntersections;
+    var rawIntersections = this.rawIntersections;
     var self = this;
 
     if (!this.data.enabled) { return; }
@@ -202,7 +203,8 @@ module.exports.Component = registerComponent('raycaster', {
 
     // Raycast.
     this.updateOriginDirection();
-    rawIntersections = this.raycaster.intersectObjects(this.objects, data.recursive);
+    rawIntersections.length = 0;
+    this.raycaster.intersectObjects(this.objects, data.recursive, rawIntersections);
 
     // Only keep intersections against objects that have a reference to an entity.
     intersections.length = 0;


### PR DESCRIPTION
**Description:**

My three.js PR was merged. Cherry-picked it on the current three.js branch.

Save array per tick (usually) per raycaster.

**Changes proposed:**
- Use optionalTarget for raycaster.intersectObjects.
