### PR TITLE
set pose target when active camera is set

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -248,6 +248,10 @@ module.exports.AScene = registerElement('a-scene', {
         if (this.is('vr-mode')) { return Promise.resolve('Already in VR.'); }
         // Enter VR via WebVR API.
         if (!fromExternal && (this.checkHeadsetConnected() || this.isMobile)) {
+          if (!this.camera) {
+            // Attempted to enter VR before the camera was initialized. Aborting silently.
+            return Promise.resolve();
+          }
           vrDisplay = utils.device.getVRDisplay();
           vrManager.setDevice(vrDisplay);
           vrManager.enabled = true;

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -251,17 +251,6 @@ module.exports.AScene = registerElement('a-scene', {
           vrDisplay = utils.device.getVRDisplay();
           vrManager.setDevice(vrDisplay);
           vrManager.enabled = true;
-
-          if (this.camera) {
-            vrManager.setPoseTarget(this.camera.el.object3D);
-          }
-          // If the camera was not available, we skip setPoseTarget.
-          // We expect it to be set as a result of the camera-set-active event at a later point
-          // (usually shortly after entering VR).
-          this.addEventListener('camera-set-active', function () {
-            vrManager.setPoseTarget(self.camera.el.object3D);
-          });
-
           return vrDisplay.requestPresent([{source: this.canvas}])
                           .then(enterVRSuccess, enterVRFailure);
         }
@@ -494,6 +483,7 @@ module.exports.AScene = registerElement('a-scene', {
 
     setupRenderer: {
       value: function () {
+        var self = this;
         var renderer;
         renderer = this.renderer = new THREE.WebGLRenderer({
           canvas: this.canvas,
@@ -502,6 +492,11 @@ module.exports.AScene = registerElement('a-scene', {
         });
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
+        // We expect camera-set-active to be triggered at least once in the life of an a-frame app. Usually soon after
+        // it is initialized.
+        this.addEventListener('camera-set-active', function () {
+          renderer.vr.setPoseTarget(self.camera.el.object3D);
+        });
       },
       writable: window.debug
     },


### PR DESCRIPTION
**Description:**

The `vrdisplayactivate` event can sometimes cause A-Frame to enter VR prematurely. This PR delays `setPoseTarget` until the camera is available.

This may be difficult to repro. It usually occurs in development scenarios, when you're refreshing an app frequently. I've been able to so relatively often with these steps:

1. `git checkout v0.8.0`
1. `npx serve` (use a simple web server instead of `npm start`)
1. visit http://localhost:5000/examples/showcase/anime-UI/
1. make sure your cache is fresh
1. do not leave dev tools open (it causes timing delays)
1. add the example to your bookmark bar
1. enter vr with the button
1. click the bookmark button until it fails

In the failure cases, after you click on the bookmark button, you'll notice that the example fails to enter VR with `vrdisplayactivate` and an error appears in the console `TypeError: this.camera is undefined`. As a side effect, when you click on the "enter vr" button after you've reached this state, the `poseTarget` is uninitialized and you start seeing culling issues.

In the success cases, after you click on the bookmark button, the app re-enters VR with `vrdisplayactivate`.


**Changes proposed:**
- If `vrdisplayactivate` fires before the camera is initialized, delay `setPoseTarget` until the camera is available.