### PR TITLE
Updated default event listener value

### DIFF
--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -66,7 +66,7 @@ We also provide a link primitive with a different syntax:
 | highlightedColor    | Border color when highlighted.                                                                                                               | '#24CAFF'     |
 | href                | Destination URL where the link points to.                                                                                                    | ''            |
 | image               | 360&deg; image used as scene preview in the portal. Can be a selector to an `<img>` element or a URL.                                        | ''            |
-| on                  | Event to listen to that triggers link traversal.                                                                                             | ''            |
+| on                  | Event to listen to that triggers link traversal.                                                                                             | 'click'        |
 | peekMode            | Whether the 360&deg; image is fully expanded for preview.                                                                                    | false         |
 | title               | Text displayed on the link. The `href` or page URL is used if not defined.                                                                   | ''            |
 | titleColor          | Color of the text displayed on the link.                                                                                                     | white         |


### PR DESCRIPTION
**Description:**
Updated docs to reflect the defaults of the component

**Changes proposed:**

The 'link' component defines the default value for the 'on' parameter to be 'click'
Updated the docs to reflect this.
```
schema: {
    backgroundColor: {default: 'red', type: 'color'},
    borderColor: {default: 'white', type: 'color'},
    highlighted: {default: false},
    highlightedColor: {default: '#24CAFF', type: 'color'},
    href: {default: ''},
    image: {type: 'asset'},
    on: {default: 'click'},
    peekMode: {default: false},
    title: {default: ''},
    titleColor: {default: 'white', type: 'color'},
    visualAspectEnabled: {default: true}
  },
```