### PR TITLE
Update WebVRPolyfill to 0.10.3 to fix Chrome devicemotion regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "style-attr": "^1.0.2",
     "three": "github:supermedium/three.js#r90fixPoseAndRaycaster",
     "three-bmfont-text": "^2.1.0",
-    "webvr-polyfill": "^0.9.40"
+    "webvr-polyfill": "^0.10.3"
   },
   "devDependencies": {
     "browserify": "^13.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,13 @@
 // Check before the polyfill runs.
 window.hasNativeWebVRImplementation = !!window.navigator.getVRDisplays || !!window.navigator.getVRDevices;
 
-window.WebVRConfig = window.WebVRConfig || {
+// WebVR polyfill
+var WebVRPolyfill = require('webvr-polyfill');
+window.webvrpolyfill = new WebVRPolyfill({
   BUFFER_SCALE: 1,
   CARDBOARD_UI_DISABLED: true,
-  ROTATE_INSTRUCTIONS_DISABLED: true,
-  TOUCH_PANNER_DISABLED: true,
-  MOUSE_KEYBOARD_CONTROLS_DISABLED: true
-};
-
-// WebVR polyfill
-require('webvr-polyfill');
+  ROTATE_INSTRUCTIONS_DISABLED: true
+});
 
 var utils = require('./utils/');
 
@@ -83,7 +80,7 @@ require('./core/a-mixin');
 require('./extras/components/');
 require('./extras/primitives/');
 
-console.log('A-Frame Version: 0.8.1 (Date 2018-03-14, Commit #5ead860)');
+console.log('A-Frame Version: 0.8.1 (Date 2018-03-15, Commit #9941383)');
 console.log('three Version:', pkg.dependencies['three']);
 console.log('WebVR Polyfill Version:', pkg.dependencies['webvr-polyfill']);
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -1,6 +1,6 @@
 var vrDisplay;
 var polyfilledVRDisplay;
-var POLYFILL_VRDISPLAY_ID = 'Cardboard VRDisplay (webvr-polyfill)';
+var POLYFILL_VRDISPLAY_ID = 'Cardboard VRDisplay';
 
 if (navigator.getVRDisplays) {
   navigator.getVRDisplays().then(function (displays) {

--- a/tests/node/test.js
+++ b/tests/node/test.js
@@ -9,11 +9,15 @@ suite('node acceptance tests', function () {
   setup(function () {
     let _window = global.window = jsdom.jsdom().defaultView;
     global.navigator = _window.navigator;
+    global.document = _window.document;
+    global.screen = {};
   });
 
   teardown(function () {
     delete global.window;
     delete global.navigator;
+    delete global.document;
+    delete global.screen;
   });
 
   test('can run in node', function () {


### PR DESCRIPTION
**Description:**

This also handles Chrome changes in devicemotion in m65-m67. More information can be found in the [0.10.3](https://github.com/immersive-web/webvr-polyfill/releases/tag/v0.10.3) release notes of the issues, but as of now, this is necessary for A-Frame to work in current versions of Chrome.

I'd suggest checking out the [0.10.0](https://github.com/immersive-web/webvr-polyfill/releases/tag/v0.10.0) the release notes as well to confirm there hasn't been any feature changes that is necessary for A-Frame.

I believe this would fix https://github.com/aframevr/aframe/issues/3427

**Changes proposed:**

- Update webvr-polyfill from 0.9.40 to 0.10.3

**Tested**

Pixel
* Chrome Stable 65.0.3325.109 (with/without sensor)
* Chrome Beta 65.0.3325.144
* Chrome Canary 67.0.3370.0
* Firefox on Android 58.0.2
* Samsung Internet 6.4.10.5 (Chrome 56.0.2924.87)

iPhone 10.3.3
* Safari
* Chrome 65.0.3325.152
* Edge 41.11
* Firefox v10.6

iPhone X iOS 11.2.6
* Safari
* Chrome 65.0.3325.152