### PR TITLE
Update webvr-polyfill to 0.10.4 for patch to Chrome m65

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "style-attr": "^1.0.2",
     "three": "github:supermedium/three.js#r90fixPoseAndRaycaster",
     "three-bmfont-text": "^2.1.0",
-    "webvr-polyfill": "^0.10.3"
+    "webvr-polyfill": "^0.10.4"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
**Description:**

Fixes an issue affecting only the Chrome m65 hotfix patch where rotation isn't working correctly when starting from a specific orientation (https://github.com/immersive-web/webvr-polyfill/issues/309) 

**Changes proposed:**
- Update webvr-polyfill from 0.10.3 to 0.10.4
-
-
