### PR TITLE
Make `a-animation` triggered by state change

### DIFF
--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -301,14 +301,14 @@ module.exports.AAnimation = registerElement('a-animation', {
 
     onStateAdded: {
       value: function (evt) {
-        if (evt.detail.state === this.data.begin) { this.start(); }
+        if (evt.detail === this.data.begin) { this.start(); }
       },
       writable: true
     },
 
     onStateRemoved: {
       value: function (evt) {
-        if (evt.detail.state === this.data.begin) { this.stop(); }
+        if (evt.detail === this.data.begin) { this.stop(); }
       },
       writable: true
     },


### PR DESCRIPTION
This comes from #3436.

`a-animation` had checked `evt.detail.state` when `state` was changed, though `evt.detail.state` was always `undefined`.
So, `a-animation` isn't triggered by any state change.
I changed this to check `evt.detail` instead of `evt.detail.state`.
