### PR TITLE
Fix for consistent firing of buttonup/down/touchstart/end/buttonchanged

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -51,7 +51,9 @@ module.exports.Component = registerComponent('tracked-controls', {
   tick: function (time, delta) {
     var mesh = this.el.getObject3D('mesh');
     // Update mesh animations.
-    if (mesh && mesh.update) { mesh.update(delta / 1000); }
+    if (mesh && mesh.update) {
+      mesh.update(delta / 1000);
+    }
     this.updateGamepad();
     this.updatePose();
     this.updateButtons();
@@ -87,6 +89,12 @@ module.exports.Component = registerComponent('tracked-controls', {
     this.controller = controller;
   },
 
+  /**
+   * Applies an artificial arm model to simulate elbow to wrist positioning
+   * based on the orientation of the controller.
+   *
+   * @param {object} controllerPosition - Existing vector to update with controller position.
+   */
   applyArmModel: function (controllerPosition) {
     // Use controllerPosition and deltaControllerPosition to avoid creating variables.
     var controller = this.controller;
@@ -156,7 +164,9 @@ module.exports.Component = registerComponent('tracked-controls', {
       object3D.position.fromArray(pose.position);
     } else {
       // Controller not 6DOF, apply arm model.
-      if (this.data.armModel) { this.applyArmModel(object3D.position); }
+      if (this.data.armModel) {
+        this.applyArmModel(object3D.position);
+      }
     }
 
     if (pose.orientation) {
@@ -210,8 +220,8 @@ module.exports.Component = registerComponent('tracked-controls', {
    * @returns {boolean} Whether button has changed in any way.
    */
   handleButton: function (id, buttonState) {
-    var changed = this.handlePress(id, buttonState) ||
-                  this.handleTouch(id, buttonState) ||
+    var changed = this.handlePress(id, buttonState) |
+                  this.handleTouch(id, buttonState) |
                   this.handleValue(id, buttonState);
     if (!changed) { return false; }
     this.el.emit('buttonchanged', {id: id, state: buttonState});

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -164,9 +164,7 @@ module.exports.Component = registerComponent('tracked-controls', {
       object3D.position.fromArray(pose.position);
     } else {
       // Controller not 6DOF, apply arm model.
-      if (this.data.armModel) {
-        this.applyArmModel(object3D.position);
-      }
+      if (this.data.armModel) { this.applyArmModel(object3D.position); }
     }
 
     if (pose.orientation) {

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -51,9 +51,7 @@ module.exports.Component = registerComponent('tracked-controls', {
   tick: function (time, delta) {
     var mesh = this.el.getObject3D('mesh');
     // Update mesh animations.
-    if (mesh && mesh.update) {
-      mesh.update(delta / 1000);
-    }
+    if (mesh && mesh.update) { mesh.update(delta / 1000); }
     this.updateGamepad();
     this.updatePose();
     this.updateButtons();

--- a/tests/components/gearvr-controls.test.js
+++ b/tests/components/gearvr-controls.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test */
+/* global assert, process, setup, sinon, suite, test */
 var entityFactory = require('../helpers').entityFactory;
 
 suite('gearvr-controls', function () {
@@ -27,8 +27,8 @@ suite('gearvr-controls', function () {
     test('returns not present if no controllers on first on first call', function () {
       var el = this.el;
       var component = el.components['gearvr-controls'];
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
 
       el.sceneEl.systems['tracked-controls'].controllers = [];
 
@@ -36,17 +36,17 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.notCalled(injectTrackedControlsSpy);
-      this.sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
       assert.strictEqual(component.controllerPresent, false);
     });
 
     test('does not remove event listeners if no controllers', function () {
       var el = this.el;
       var component = el.components['gearvr-controls'];
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
 
       el.sceneEl.systems['tracked-controls'].controllers = [];
 
@@ -55,18 +55,18 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.notCalled(injectTrackedControlsSpy);
-      this.sinon.assert.notCalled(addEventListenersSpy);
-      this.sinon.assert.notCalled(removeEventListenersSpy);
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.notCalled(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, false);
     });
 
     test('attaches events if controller is newly present', function () {
       var el = this.el;
       var component = el.components['gearvr-controls'];
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
 
       el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
 
@@ -74,18 +74,18 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.calledOnce(injectTrackedControlsSpy);
-      this.sinon.assert.calledOnce(addEventListenersSpy);
-      this.sinon.assert.notCalled(removeEventListenersSpy);
+      sinon.assert.calledOnce(injectTrackedControlsSpy);
+      sinon.assert.calledOnce(addEventListenersSpy);
+      sinon.assert.notCalled(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, true);
     });
 
     test('does not inject/attach events again if controller already present', function () {
       var el = this.el;
       var component = el.components['gearvr-controls'];
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
 
       el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
 
@@ -94,18 +94,18 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.notCalled(injectTrackedControlsSpy);
-      this.sinon.assert.notCalled(addEventListenersSpy);
-      this.sinon.assert.notCalled(removeEventListenersSpy);
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.notCalled(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, true);
     });
 
     test('removes event listeners if controller disappears', function () {
       var el = this.el;
       var component = el.components['gearvr-controls'];
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
 
       el.sceneEl.systems['tracked-controls'].controllers = [];
 
@@ -114,9 +114,9 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.notCalled(injectTrackedControlsSpy);
-      this.sinon.assert.notCalled(addEventListenersSpy);
-      this.sinon.assert.calledOnce(removeEventListenersSpy);
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.calledOnce(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, false);
     });
   });
@@ -212,11 +212,11 @@ suite('gearvr-controls', function () {
       el.setAttribute('gearvr-controls', 'armModel', false);
       makePresent(el);
       var trackedControls = el.components['tracked-controls'];
-      var applyArmModelSpy = this.sinon.spy(trackedControls, 'applyArmModel');
+      var applyArmModelSpy = sinon.spy(trackedControls, 'applyArmModel');
       trackedControls.tick();
 
       // Verify that the function which applies arm model is not called when disabled.
-      this.sinon.assert.notCalled(applyArmModelSpy);
+      sinon.assert.notCalled(applyArmModelSpy);
 
       // Additionally verify that no other offets have been applied.
       assert.strictEqual(el.object3D.position.x, 0);
@@ -229,11 +229,11 @@ suite('gearvr-controls', function () {
       el.setAttribute('gearvr-controls', 'armModel', true);
       makePresent(el);
       var trackedControls = el.components['tracked-controls'];
-      var applyArmModelSpy = this.sinon.spy(trackedControls, 'applyArmModel');
+      var applyArmModelSpy = sinon.spy(trackedControls, 'applyArmModel');
       trackedControls.tick();
 
       // Verify that the function which applies arm model is called.
-      this.sinon.assert.calledOnce(applyArmModelSpy);
+      sinon.assert.calledOnce(applyArmModelSpy);
     });
 
     test('verifies armModel position is applied for the right hand', function () {

--- a/tests/components/gearvr-controls.test.js
+++ b/tests/components/gearvr-controls.test.js
@@ -36,9 +36,9 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.notOk(addEventListenersSpy.called);
-      assert.ok(component.controllerPresent === false);
+      this.sinon.assert.notCalled(injectTrackedControlsSpy);
+      this.sinon.assert.notCalled(addEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, false);
     });
 
     test('does not remove event listeners if no controllers', function () {
@@ -55,10 +55,10 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.notOk(addEventListenersSpy.called);
-      assert.notOk(removeEventListenersSpy.called);
-      assert.ok(component.controllerPresent === false);
+      this.sinon.assert.notCalled(injectTrackedControlsSpy);
+      this.sinon.assert.notCalled(addEventListenersSpy);
+      this.sinon.assert.notCalled(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, false);
     });
 
     test('attaches events if controller is newly present', function () {
@@ -74,10 +74,10 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.ok(injectTrackedControlsSpy.called);
-      assert.ok(addEventListenersSpy.called);
-      assert.notOk(removeEventListenersSpy.called);
-      assert.ok(component.controllerPresent);
+      this.sinon.assert.calledOnce(injectTrackedControlsSpy);
+      this.sinon.assert.calledOnce(addEventListenersSpy);
+      this.sinon.assert.notCalled(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, true);
     });
 
     test('does not inject/attach events again if controller already present', function () {
@@ -94,10 +94,10 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.notOk(addEventListenersSpy.called);
-      assert.notOk(removeEventListenersSpy.called);
-      assert.ok(component.controllerPresent);
+      this.sinon.assert.notCalled(injectTrackedControlsSpy);
+      this.sinon.assert.notCalled(addEventListenersSpy);
+      this.sinon.assert.notCalled(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, true);
     });
 
     test('removes event listeners if controller disappears', function () {
@@ -114,10 +114,10 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.notOk(addEventListenersSpy.called);
-      assert.ok(removeEventListenersSpy.called);
-      assert.notOk(component.controllerPresent);
+      this.sinon.assert.notCalled(injectTrackedControlsSpy);
+      this.sinon.assert.notCalled(addEventListenersSpy);
+      this.sinon.assert.calledOnce(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, false);
     });
   });
 
@@ -130,14 +130,16 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
+      // Configure the event state for which we'll use the axis state for verification.
+      const eventState = {axis: [0.1, 0.2], changed: [true, false]};
+
       el.addEventListener('trackpadmoved', function (evt) {
-        assert.equal(evt.detail.x, 0.1);
-        assert.equal(evt.detail.y, 0.2);
-        assert.ok(evt.detail);
+        assert.equal(evt.detail.x, eventState.axis[0]);
+        assert.equal(evt.detail.y, eventState.axis[1]);
         done();
       });
 
-      el.emit('axismove', {axis: [0.1, 0.2], changed: [true, false]});
+      el.emit('axismove', eventState);
     });
 
     test('does not emit trackpadmoved on axismove with no changes', function (done) {
@@ -149,8 +151,8 @@ suite('gearvr-controls', function () {
       component.checkIfControllerPresent();
 
       // Fail purposely.
-      el.addEventListener('thumbstickmoved', function (evt) {
-        assert.ok(false);
+      el.addEventListener('trackpadmoved', function (evt) {
+        assert.fail('trackpadmoved was called when there was no change.');
       });
 
       el.emit('axismove', {axis: [0.1, 0.2], changed: [false, false]});
@@ -159,23 +161,26 @@ suite('gearvr-controls', function () {
   });
 
   suite('buttonchanged', function () {
-    test('if we get buttonchanged, emit trackpadchanged', function (done) {
+    test('if we get buttonchanged for button 0, emit trackpadchanged', function (done) {
       var el = this.el;
       var component = el.components['gearvr-controls'];
 
       el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
 
       component.checkIfControllerPresent();
+
+      // Configure the expected event state and use it to fire the event.
+      const eventState = {value: 0.5, pressed: true, touched: true};
 
       el.addEventListener('trackpadchanged', function (evt) {
-        assert.ok(evt.detail);
+        assert.deepEqual(evt.detail, eventState);
         done();
       });
 
-      el.emit('buttonchanged', {id: 0, state: {value: 0.5, pressed: true, touched: true}});
+      el.emit('buttonchanged', {id: 0, state: eventState});
     });
 
-    test('if we get buttonchanged, emit triggerchanged', function (done) {
+    test('if we get buttonchanged for button 1, emit triggerchanged', function (done) {
       var el = this.el;
       var component = el.components['gearvr-controls'];
 
@@ -183,12 +188,15 @@ suite('gearvr-controls', function () {
 
       component.checkIfControllerPresent();
 
+      // Configure the expected event state and use it to fire the event.
+      const eventState = {value: 0.5, pressed: true, touched: true};
+
       el.addEventListener('triggerchanged', function (evt) {
-        assert.ok(evt.detail);
+        assert.deepEqual(evt.detail, eventState);
         done();
       });
 
-      el.emit('buttonchanged', {id: 1, state: {value: 0.5, pressed: true, touched: true}});
+      el.emit('buttonchanged', {id: 1, state: eventState});
     });
   });
 
@@ -206,7 +214,14 @@ suite('gearvr-controls', function () {
       var trackedControls = el.components['tracked-controls'];
       var applyArmModelSpy = this.sinon.spy(trackedControls, 'applyArmModel');
       trackedControls.tick();
-      assert.notOk(applyArmModelSpy.called);
+
+      // Verify that the function which applies arm model is not called when disabled.
+      this.sinon.assert.notCalled(applyArmModelSpy);
+
+      // Additionally verify that no other offets have been applied.
+      assert.strictEqual(el.object3D.position.x, 0);
+      assert.strictEqual(el.object3D.position.y, 0);
+      assert.strictEqual(el.object3D.position.z, 0);
     });
 
     test('applies armModel if armModel enabled', function () {
@@ -216,7 +231,29 @@ suite('gearvr-controls', function () {
       var trackedControls = el.components['tracked-controls'];
       var applyArmModelSpy = this.sinon.spy(trackedControls, 'applyArmModel');
       trackedControls.tick();
-      assert.ok(applyArmModelSpy.called);
+
+      // Verify that the function which applies arm model is called.
+      this.sinon.assert.calledOnce(applyArmModelSpy);
+    });
+
+    test('verifies armModel position is applied for the right hand', function () {
+      var el = this.el;
+      el.setAttribute('gearvr-controls', 'armModel', true);
+      makePresent(el);
+      var trackedControls = el.components['tracked-controls'];
+      trackedControls.tick();
+      assert.ok(el.object3D.position.x > 0);
+    });
+
+    test('verifies armModel position is applied for the left hand', function () {
+      var el = this.el;
+      el.setAttribute('gearvr-controls', 'armModel', true);
+      el.setAttribute('gearvr-controls', 'hand', 'left');
+      el.components['gearvr-controls'].controllersWhenPresent[0].hand = 'left';
+      makePresent(el);
+      var trackedControls = el.components['tracked-controls'];
+      trackedControls.tick();
+      assert.ok(el.object3D.position.x < 0);
     });
   });
 });

--- a/tests/components/oculus-touch-controls.test.js
+++ b/tests/components/oculus-touch-controls.test.js
@@ -28,9 +28,9 @@ suite('oculus-touch-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.notOk(addEventListenersSpy.called);
-      assert.ok(removeEventListenersSpy.called);
+      this.sinon.assert.notCalled(injectTrackedControlsSpy);
+      this.sinon.assert.notCalled(addEventListenersSpy);
+      this.sinon.assert.calledOnce(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, false);
     });
 
@@ -44,9 +44,9 @@ suite('oculus-touch-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.notOk(addEventListenersSpy.called);
-      assert.notOk(removeEventListenersSpy.called);
+      this.sinon.assert.notCalled(injectTrackedControlsSpy);
+      this.sinon.assert.notCalled(addEventListenersSpy);
+      this.sinon.assert.notCalled(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, false);
     });
 
@@ -63,10 +63,10 @@ suite('oculus-touch-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.ok(injectTrackedControlsSpy.called, 'Inject');
-      assert.ok(addEventListenersSpy.called, 'Add');
-      assert.notOk(removeEventListenersSpy.called, 'Remove');
-      assert.ok(component.controllerPresent);
+      this.sinon.assert.calledOnce(injectTrackedControlsSpy);
+      this.sinon.assert.calledOnce(addEventListenersSpy);
+      this.sinon.assert.notCalled(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, true);
     });
 
     test('does not add/remove event listeners if presence does not change', function () {
@@ -83,10 +83,10 @@ suite('oculus-touch-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.notOk(addEventListenersSpy.called);
-      assert.notOk(removeEventListenersSpy.called);
-      assert.ok(component.controllerPresent);
+      this.sinon.assert.notCalled(injectTrackedControlsSpy);
+      this.sinon.assert.notCalled(addEventListenersSpy);
+      this.sinon.assert.notCalled(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, true);
     });
 
     test('removes event listeners if controller disappears', function () {
@@ -99,9 +99,9 @@ suite('oculus-touch-controls', function () {
 
       component.checkIfControllerPresent();
 
-      assert.notOk(injectTrackedControlsSpy.called);
-      assert.notOk(addEventListenersSpy.called);
-      assert.notOk(component.controllerPresent);
+      this.sinon.assert.notCalled(injectTrackedControlsSpy);
+      this.sinon.assert.notCalled(addEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, false);
     });
   });
 
@@ -110,15 +110,16 @@ suite('oculus-touch-controls', function () {
       el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
       // Do the check.
       component.checkIfControllerPresent();
+      // Set up the event details.
+      const eventDetails = {axis: [0.1, 0.2], changed: [true, false]};
       // Install event handler listening for thumbstickmoved.
       this.el.addEventListener('thumbstickmoved', function (evt) {
-        assert.equal(evt.detail.x, 0.1);
-        assert.equal(evt.detail.y, 0.2);
-        assert.ok(evt.detail);
+        assert.equal(evt.detail.x, eventDetails.axis[0]);
+        assert.equal(evt.detail.y, eventDetails.axis[1]);
         done();
       });
       // Emit axismove.
-      this.el.emit('axismove', {axis: [0.1, 0.2], changed: [true, false]});
+      this.el.emit('axismove', eventDetails);
     });
 
     test('does not emit thumbstickmoved if axismove has no changes', function (done) {
@@ -127,7 +128,7 @@ suite('oculus-touch-controls', function () {
       component.checkIfControllerPresent();
       // Fail purposely.
       this.el.addEventListener('thumbstickmoved', function (evt) {
-        assert.notOk(evt.detail);
+        assert.fail('thumbstickmoved should not be called');
       });
       // Emit axismove with no changes.
       this.el.emit('axismove', {axis: [0.1, 0.2], changed: [false, false]});
@@ -140,13 +141,15 @@ suite('oculus-touch-controls', function () {
       el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
       // Do the check.
       component.checkIfControllerPresent();
+      // Prepare the event details
+      const eventState = {value: 0.5, pressed: true, touched: true};
       // Install event handler listening for triggerchanged.
       el.addEventListener('triggerchanged', function (evt) {
-        assert.ok(evt.detail);
+        assert.deepEqual(evt.detail, eventState);
         done();
       });
       // Emit buttonchanged.
-      el.emit('buttonchanged', {id: 1, state: {value: 0.5, pressed: true, touched: true}});
+      el.emit('buttonchanged', {id: 1, state: eventState});
     });
   });
 });

--- a/tests/components/oculus-touch-controls.test.js
+++ b/tests/components/oculus-touch-controls.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test */
+/* global assert, process, setup, sinon, suite, test */
 var entityFactory = require('../helpers').entityFactory;
 
 suite('oculus-touch-controls', function () {
@@ -19,41 +19,41 @@ suite('oculus-touch-controls', function () {
 
   suite('checkIfControllerPresent', function () {
     test('removes event listeners if controllers not present', function () {
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
 
       // Mock has not been checked previously.
       delete component.controllerPresent;
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.notCalled(injectTrackedControlsSpy);
-      this.sinon.assert.notCalled(addEventListenersSpy);
-      this.sinon.assert.calledOnce(removeEventListenersSpy);
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.calledOnce(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, false);
     });
 
     test('does not call removeEventListeners multiple times', function () {
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
 
       // Mock that it's been checked previously.
       component.controllerPresent = false;
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.notCalled(injectTrackedControlsSpy);
-      this.sinon.assert.notCalled(addEventListenersSpy);
-      this.sinon.assert.notCalled(removeEventListenersSpy);
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.notCalled(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, false);
     });
 
     test('attach events if controller is newly present', function () {
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
 
       // Mock isControllerPresent to return true.
       el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
@@ -63,16 +63,16 @@ suite('oculus-touch-controls', function () {
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.calledOnce(injectTrackedControlsSpy);
-      this.sinon.assert.calledOnce(addEventListenersSpy);
-      this.sinon.assert.notCalled(removeEventListenersSpy);
+      sinon.assert.calledOnce(injectTrackedControlsSpy);
+      sinon.assert.calledOnce(addEventListenersSpy);
+      sinon.assert.notCalled(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, true);
     });
 
     test('does not add/remove event listeners if presence does not change', function () {
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
-      var removeEventListenersSpy = this.sinon.spy(component, 'removeEventListeners');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
 
       // Mock isControllerPresent to return true.
       el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
@@ -83,15 +83,15 @@ suite('oculus-touch-controls', function () {
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.notCalled(injectTrackedControlsSpy);
-      this.sinon.assert.notCalled(addEventListenersSpy);
-      this.sinon.assert.notCalled(removeEventListenersSpy);
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.notCalled(removeEventListenersSpy);
       assert.strictEqual(component.controllerPresent, true);
     });
 
     test('removes event listeners if controller disappears', function () {
-      var addEventListenersSpy = this.sinon.spy(component, 'addEventListeners');
-      var injectTrackedControlsSpy = this.sinon.spy(component, 'injectTrackedControls');
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
 
       // Mock that it's was currently present.
       component.controllerEventsActive = true;
@@ -99,8 +99,8 @@ suite('oculus-touch-controls', function () {
 
       component.checkIfControllerPresent();
 
-      this.sinon.assert.notCalled(injectTrackedControlsSpy);
-      this.sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
       assert.strictEqual(component.controllerPresent, false);
     });
   });

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -580,7 +580,7 @@ function toQuaternion (x, y, z) {
  */
 function assertButtonEvent (eventCall, eventName, eventId, eventState) {
   assert.equal(eventCall.args[0], eventName);
-  assert.deepEqual(eventCall.args[1].id, eventId);
+  assert.equal(eventCall.args[1].id, eventId);
   assert.deepEqual(eventCall.args[1].state, eventState);
 }
 

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -88,8 +88,8 @@ suite('tracked-controls', function () {
 
   suite('tick', function () {
     test('updates pose and buttons even if mesh is not defined', function () {
-      var updateButtonsSpy = this.sinon.spy(component, 'updateButtons');
-      var updatePoseSpy = this.sinon.spy(component, 'updatePose');
+      var updateButtonsSpy = sinon.spy(component, 'updateButtons');
+      var updatePoseSpy = sinon.spy(component, 'updatePose');
       assert.notOk(el.getObject3D('mesh'));
       component.tick();
       sinon.assert.calledOnce(updatePoseSpy);
@@ -195,14 +195,14 @@ suite('tracked-controls', function () {
 
   suite('handleAxes', function () {
     test('does not emit on initial state', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       component.tick();
       assert.notOk(component.handleAxes());
       sinon.assert.notCalled(emitSpy);
     });
 
     test('emits axismove on first touch', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.axes = [0.5, 0.5, 0.5];
       assert.deepEqual(component.axis, [0, 0, 0]);
       component.tick();
@@ -217,7 +217,7 @@ suite('tracked-controls', function () {
       component.tick();
       assert.deepEqual(component.axis, [0.5, 0.5, 0.5]);
 
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.axes = [1, 1, 1];
       component.tick();
       const emitCall = emitSpy.getCalls()[0];
@@ -231,7 +231,7 @@ suite('tracked-controls', function () {
       component.tick();
       assert.deepEqual(component.axis, [0.5, 0.5, 0.5]);
 
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.axes = [1, 0.5, 0.5];
       component.tick();
       const emitCall = emitSpy.getCalls()[0];
@@ -243,13 +243,13 @@ suite('tracked-controls', function () {
 
   suite('handleButton', function () {
     test('does not emit if button not pressed', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       component.tick();
       sinon.assert.notCalled(emitSpy);
     });
 
     test('emits buttonchanged if button pressed', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].pressed = true;
       component.tick();
 
@@ -261,7 +261,7 @@ suite('tracked-controls', function () {
     });
 
     test('emits buttonchanged if button touched', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].touched = true;
       component.tick();
 
@@ -273,7 +273,7 @@ suite('tracked-controls', function () {
     });
 
     test('emits buttonchanged if value changed', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].value = 0.5;
       component.tick();
 
@@ -285,7 +285,7 @@ suite('tracked-controls', function () {
     });
 
     test('emits independent streams for buttondown, touchstart and buttonchanged', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].pressed = true;
       controller.buttons[0].touched = true;
       component.tick();
@@ -310,7 +310,7 @@ suite('tracked-controls', function () {
     });
 
     test('emits independent streams for buttonup, touchend and buttonchanged', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       component.buttonStates[0] = {pressed: true, touched: true, value: 1};
       controller.buttons[0].pressed = false;
       controller.buttons[0].touched = false;
@@ -335,7 +335,7 @@ suite('tracked-controls', function () {
 
     test('emits correct event stream for spaced out interaction.', function () {
       // First round, verify we only see a touchstart and buttonchanged
-      let emitSpy = this.sinon.spy(el, 'emit');
+      let emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].touched = true;
       component.tick();
 
@@ -343,7 +343,7 @@ suite('tracked-controls', function () {
       emitSpy.restore();
 
       // Second round, verify we only see a buttondown and buttonchanged since pressed state isn't changing.
-      emitSpy = this.sinon.spy(el, 'emit');
+      emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].pressed = true;
       component.tick();
 
@@ -351,7 +351,7 @@ suite('tracked-controls', function () {
       emitSpy.restore();
 
       // Third round, verify we only see a buttonup and button changed when we release the button.
-      emitSpy = this.sinon.spy(el, 'emit');
+      emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].pressed = false;
       component.tick();
 
@@ -359,7 +359,7 @@ suite('tracked-controls', function () {
       emitSpy.restore();
 
       // Fourth round, verify we only see a touchend and button changed when we lift our touch.
-      emitSpy = this.sinon.spy(el, 'emit');
+      emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].touched = false;
       component.tick();
 
@@ -369,7 +369,7 @@ suite('tracked-controls', function () {
 
     test('emits correct event states on a fast click', function () {
       // First round, verify we see all activation events
-      let emitSpy = this.sinon.spy(el, 'emit');
+      let emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].pressed = true;
       controller.buttons[0].touched = true;
       controller.buttons[0].value = 1;
@@ -379,7 +379,7 @@ suite('tracked-controls', function () {
       emitSpy.restore();
 
       // Second round, verify we see all deactivation events
-      emitSpy = this.sinon.spy(el, 'emit');
+      emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].pressed = false;
       controller.buttons[0].touched = false;
       controller.buttons[0].value = 0;
@@ -389,7 +389,7 @@ suite('tracked-controls', function () {
       emitSpy.restore();
 
       // Finally verify there are no events backed up because of bad carryover state.
-      emitSpy = this.sinon.spy(el, 'emit');
+      emitSpy = sinon.spy(el, 'emit');
       component.tick();
       sinon.assert.notCalled(emitSpy);
     });
@@ -397,14 +397,14 @@ suite('tracked-controls', function () {
 
   suite('handlePress', function () {
     test('does not emit anything if button not pressed', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       component.tick();
       sinon.assert.notCalled(emitSpy);
       assert.notOk(component.handlePress(0, {pressed: false, touched: false, value: 0}));
     });
 
     test('emits buttondown if button pressed', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].pressed = true;
       component.tick();
 
@@ -416,7 +416,7 @@ suite('tracked-controls', function () {
     });
 
     test('emits buttonup if button released', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       component.buttonStates[1] = {pressed: true, touched: false, value: 1};
       controller.buttons[1].pressed = false;
       controller.buttons[1].value = 0;
@@ -430,7 +430,7 @@ suite('tracked-controls', function () {
     });
 
     test('does not emit buttonup if button pressed', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].pressed = true;
       component.tick();
       const emitUpCalls = emitSpy.getCalls().filter(
@@ -439,7 +439,7 @@ suite('tracked-controls', function () {
     });
 
     test('does not emit buttondown if button released', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       component.buttonStates[1] = {pressed: true, touched: false, value: 1};
       controller.buttons[1].pressed = false;
       controller.buttons[1].value = 0;
@@ -453,14 +453,14 @@ suite('tracked-controls', function () {
 
   suite('handleTouch', function () {
     test('does not do anything if button not touched', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       component.tick();
       sinon.assert.notCalled(emitSpy);
       assert.notOk(component.handleTouch(0, {pressed: false, touched: false, value: 0}));
     });
 
     test('emits touchstart if button touched', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       controller.buttons[0].touched = true;
       component.tick();
 
@@ -472,7 +472,7 @@ suite('tracked-controls', function () {
     });
 
     test('emits touchend if button no longer touched', function () {
-      const emitSpy = this.sinon.spy(el, 'emit');
+      const emitSpy = sinon.spy(el, 'emit');
       component.buttonStates[1] = {pressed: false, touched: true, value: 1};
       controller.buttons[1].touched = false;
       controller.buttons[1].value = 0;
@@ -508,14 +508,14 @@ suite('tracked-controls', function () {
     });
 
     test('if armModel false, do not apply', function () {
-      var applyArmModelSpy = this.sinon.spy(component, 'applyArmModel');
+      var applyArmModelSpy = sinon.spy(component, 'applyArmModel');
       component.data.armModel = false;
       component.tick();
       sinon.assert.notCalled(applyArmModelSpy);
     });
 
     test('if armModel true, apply', function () {
-      var applyArmModelSpy = this.sinon.spy(component, 'applyArmModel');
+      var applyArmModelSpy = sinon.spy(component, 'applyArmModel');
       component.data.armModel = true;
       component.tick();
       sinon.assert.calledOnce(applyArmModelSpy);


### PR DESCRIPTION
This change delinks these event streams so that they can fire independenty of one another. I've also added a sufficiently complete number of tests for the new behaior to make sure all events that should be firing are, looking for negative events (ensuring some events don't fire when they should not) and that the values all come through as expected.

As part of the fix I've supplied some helpers that are now consistently used in tracked-controls.test.js for verifying individual events and streams of events in a more concise way to avoid duplicating a lot of code.

I've also made consistent the use of sinon's spy asserts, which were previously using the ".called" property which reaches into the abstraction further than it should. This also allows us to upgrade certain spy verification's to look for a specific number of calls (calledOnce) which is an overall improvement.

This change cascaded into the oculus-touch-controls.test.js and gearvr-controls.test.js as well. For the oculus-touch-controls, this is mostly assert fixups, but also does some additional deep object verification.

For the gearvr-controls.test.js this included some bug fixes (using wrong event names) when I was trying to make the test fail and could not, only to realize it wasn't sniffing for the right event names. This is in preparation for creation of the oculus-go-controls component and test suite.

**Description:**

**Changes proposed:**
-
-
-
