### PR TITLE
Add additional button tests for DayDream controls.

### DIFF
--- a/tests/components/daydream-controls.test.js
+++ b/tests/components/daydream-controls.test.js
@@ -126,14 +126,14 @@ suite('daydream-controls', function () {
       component.checkIfControllerPresent();
 
       // Install event handler listening for thumbstickmoved.
-      this.el.addEventListener('trackpadmoved', function (evt) {
+      el.addEventListener('trackpadmoved', function (evt) {
         assert.equal(evt.detail.x, 0.1);
         assert.equal(evt.detail.y, 0.2);
         done();
       });
 
       // Emit axismove.
-      this.el.emit('axismove', {axis: [0.1, 0.2], changed: [true, false]});
+      el.emit('axismove', {axis: [0.1, 0.2], changed: [true, false]});
     });
 
     test('does not emit trackpadmove on axismove with no changes', function (done) {
@@ -145,12 +145,12 @@ suite('daydream-controls', function () {
       component.checkIfControllerPresent();
 
       // Purposely fail.
-      this.el.addEventListener('trackpadmoved', function (evt) {
+      el.addEventListener('trackpadmoved', function (evt) {
         assert.fail('trackpadmoved should not fire if axes have not changed.');
       });
 
       // Emit axismove.
-      this.el.emit('axismove', {axis: [0.1, 0.2], changed: [false, false]});
+      el.emit('axismove', {axis: [0.1, 0.2], changed: [false, false]});
 
       setTimeout(() => { done(); });
     });
@@ -168,13 +168,13 @@ suite('daydream-controls', function () {
       const eventState = {value: 0.5, pressed: true, touched: true};
 
       // Install event handler listening for triggerchanged.
-      this.el.addEventListener('trackpadchanged', function (evt) {
+      el.addEventListener('trackpadchanged', function (evt) {
         assert.deepEqual(evt.detail, eventState);
         done();
       });
 
       // Emit buttonchanged for the trackpad button.
-      this.el.emit('buttonchanged', {id: 0, state: eventState});
+      el.emit('buttonchanged', {id: 0, state: eventState});
     });
 
     test('emits menuchanged on buttonchanged for button 1', function (done) {
@@ -188,13 +188,13 @@ suite('daydream-controls', function () {
       const eventState = {value: 0.5, pressed: true, touched: true};
 
       // Install event handler listening for triggerchanged.
-      this.el.addEventListener('menuchanged', function (evt) {
+      el.addEventListener('menuchanged', function (evt) {
         assert.deepEqual(evt.detail, eventState);
         done();
       });
 
       // Emit buttonchanged for the menu button.
-      this.el.emit('buttonchanged', {id: 1, state: eventState});
+      el.emit('buttonchanged', {id: 1, state: eventState});
     });
 
     test('emits systemanged on buttonchanged for button 2', function (done) {
@@ -208,13 +208,13 @@ suite('daydream-controls', function () {
       const eventState = {value: 0.5, pressed: true, touched: true};
 
       // Install event handler listening for triggerchanged.
-      this.el.addEventListener('systemchanged', function (evt) {
+      el.addEventListener('systemchanged', function (evt) {
         assert.deepEqual(evt.detail, eventState);
         done();
       });
 
       // Emit buttonchanged for the system button.
-      this.el.emit('buttonchanged', {id: 2, state: eventState});
+      el.emit('buttonchanged', {id: 2, state: eventState});
     });
   });
 

--- a/tests/components/daydream-controls.test.js
+++ b/tests/components/daydream-controls.test.js
@@ -129,7 +129,6 @@ suite('daydream-controls', function () {
       this.el.addEventListener('trackpadmoved', function (evt) {
         assert.equal(evt.detail.x, 0.1);
         assert.equal(evt.detail.y, 0.2);
-        assert.ok(evt.detail);
         done();
       });
 
@@ -137,7 +136,7 @@ suite('daydream-controls', function () {
       this.el.emit('axismove', {axis: [0.1, 0.2], changed: [true, false]});
     });
 
-    test(' does not emit trackpadmove on axismove with no changes', function (done) {
+    test('does not emit trackpadmove on axismove with no changes', function (done) {
       var el = this.el;
       var component = el.components['daydream-controls'];
 
@@ -147,7 +146,7 @@ suite('daydream-controls', function () {
 
       // Purposely fail.
       this.el.addEventListener('trackpadmoved', function (evt) {
-        assert.ok(false);
+        assert.fail('trackpadmoved should not fire if axes have not changed.');
       });
 
       // Emit axismove.
@@ -158,7 +157,7 @@ suite('daydream-controls', function () {
   });
 
   suite('buttonchanged', function () {
-    test('emits trackpadchanged on buttonchanged', function (done) {
+    test('emits trackpadchanged on buttonchanged for button 0', function (done) {
       var el = this.el;
       var component = el.components['daydream-controls'];
 
@@ -166,15 +165,56 @@ suite('daydream-controls', function () {
 
       component.checkIfControllerPresent();
 
+      const eventState = {value: 0.5, pressed: true, touched: true};
+
       // Install event handler listening for triggerchanged.
       this.el.addEventListener('trackpadchanged', function (evt) {
-        assert.ok(evt.detail);
+        assert.deepEqual(evt.detail, eventState);
         done();
       });
 
-      // Emit buttonchanged.
-      this.el.emit('buttonchanged',
-                   {id: 0, state: {value: 0.5, pressed: true, touched: true}});
+      // Emit buttonchanged for the trackpad button.
+      this.el.emit('buttonchanged', {id: 0, state: eventState});
+    });
+
+    test('emits menuchanged on buttonchanged for button 1', function (done) {
+      var el = this.el;
+      var component = el.components['daydream-controls'];
+
+      el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
+
+      component.checkIfControllerPresent();
+
+      const eventState = {value: 0.5, pressed: true, touched: true};
+
+      // Install event handler listening for triggerchanged.
+      this.el.addEventListener('menuchanged', function (evt) {
+        assert.deepEqual(evt.detail, eventState);
+        done();
+      });
+
+      // Emit buttonchanged for the menu button.
+      this.el.emit('buttonchanged', {id: 1, state: eventState});
+    });
+
+    test('emits systemanged on buttonchanged for button 2', function (done) {
+      var el = this.el;
+      var component = el.components['daydream-controls'];
+
+      el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
+
+      component.checkIfControllerPresent();
+
+      const eventState = {value: 0.5, pressed: true, touched: true};
+
+      // Install event handler listening for triggerchanged.
+      this.el.addEventListener('systemchanged', function (evt) {
+        assert.deepEqual(evt.detail, eventState);
+        done();
+      });
+
+      // Emit buttonchanged for the system button.
+      this.el.emit('buttonchanged', {id: 2, state: eventState});
     });
   });
 


### PR DESCRIPTION
The DayDream controls were missing menu and system button tests to make sure that they get remapped and reemitted properly given their remapped names.

Additionally was able to fix up the trackpadchanged to use the deep object check for event state and then copy this across the two new tests.

Found one test that had a leading space in the description, fixed and then changed one assert.ok -> assert.fail which is more appropriate given the context.