### PR TITLE
[cursor] Use recent intersection data from raycaster.

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -253,6 +253,7 @@ module.exports.Component = registerComponent('cursor', {
    * Handle intersection.
    */
   onIntersection: function (evt) {
+    var currentIntersection;
     var cursorEl = this.el;
     var index;
     var intersectedEl;
@@ -271,7 +272,7 @@ module.exports.Component = registerComponent('cursor', {
 
     // Ignore events further away than active intersection.
     if (this.intersectedEl) {
-      var currentIntersection = this.el.components.raycaster.getIntersection(this.intersectedEl);
+      currentIntersection = this.el.components.raycaster.getIntersection(this.intersectedEl);
       if (currentIntersection.distance <= intersection.distance) { return; }
     }
 
@@ -355,8 +356,9 @@ module.exports.Component = registerComponent('cursor', {
   twoWayEmit: function (evtName) {
     var el = this.el;
     var intersectedEl = this.intersectedEl;
-    var intersection = this.el.components.raycaster.getIntersection(intersectedEl);
+    var intersection;
 
+    intersection = this.el.components.raycaster.getIntersection(intersectedEl);
     this.eventDetail.intersectedEl = intersectedEl;
     this.eventDetail.intersection = intersection;
     el.emit(evtName, this.eventDetail);

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -274,16 +274,16 @@ module.exports.Component = registerComponent('raycaster', {
   },
 
   /**
-   * Returns the most recent intersection details for a given entity, if any.
-   * @param  {AEntity} el
+   * Return the most recent intersection details for a given entity, if any.
+   * @param {AEntity} el
    * @return {Object}
    */
   getIntersection: function (el) {
-    for (var i = 0; i < this.intersections.length; i++) {
-      var intersection = this.intersections[i];
-      if (intersection.object.el === el) {
-        return intersection;
-      }
+    var i;
+    var intersection;
+    for (i = 0; i < this.intersections.length; i++) {
+      intersection = this.intersections[i];
+      if (intersection.object.el === el) { return intersection; }
     }
     return null;
   },

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -274,6 +274,21 @@ module.exports.Component = registerComponent('raycaster', {
   },
 
   /**
+   * Returns the most recent intersection details for a given entity, if any.
+   * @param  {AEntity} el
+   * @return {Object}
+   */
+  getIntersection: function (el) {
+    for (var i = 0; i < this.intersections.length; i++) {
+      var intersection = this.intersections[i];
+      if (intersection.object.el === el) {
+        return intersection;
+      }
+    }
+    return null;
+  },
+
+  /**
    * Update origin and direction of raycaster using entity transforms and supplied origin or
    * direction offsets.
    */


### PR DESCRIPTION
* Pulls most recent intersection info from raycaster, removes `cursor.intersection` property.
* Remove redundant `updateMatrixWorld()` call.
* Ensure `clearCurrentIntersection()` does not select a new intersection entity if used in a context where another intersection is already known.

Fixes #3467, #3485, #3445.