### PR TITLE
Audio file in guide should link to media on CDN

### DIFF
--- a/docs/guides/building-a-360-image-gallery.md
+++ b/docs/guides/building-a-360-image-gallery.md
@@ -34,7 +34,7 @@ This is the starting point for our scene:
 ```html
 <a-scene>
   <a-assets>
-    <audio id="click-sound" src="audio/click.ogg"></audio>
+    <audio id="click-sound" src="https://cdn.aframe.io/360-image-gallery-boilerplate/audio/click.ogg"></audio>
 
     <!-- Images. -->
     <img id="city" src="https://cdn.aframe.io/360-image-gallery-boilerplate/img/city.jpg">


### PR DESCRIPTION
**Description:**
In the *Building a 360° Image Gallery* Guide, the example for the "basic scene" has a path to an audio file that is relative. Trying to run this locally will not work unless the user finds the file, downloads it and copies it to the correct path. Not very friendly for first-time users.

**Changes proposed:**
- Use src URL for media on CDN, as per the Glitch example.
