### PR TITLE
Update webvr-polyfill to 0.10.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "style-attr": "^1.0.2",
     "three": "github:supermedium/three.js#r90fixPoseAndRaycaster",
     "three-bmfont-text": "^2.1.0",
-    "webvr-polyfill": "^0.10.4"
+    "webvr-polyfill": "^0.10.5"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
This fixes an issue from late December where objects close to the camera appear duplicated/out of focus (https://github.com/immersive-web/webvr-polyfill/issues/312)