### PR TITLE
Use forEach instead of for...of (fixes #3449)

### DIFF
--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -59,12 +59,12 @@ module.exports.registerElement = function (tagName, obj) {
   }
 
   // Give all functions their proper name.
-  for (var propName of Object.getOwnPropertyNames(newObj.prototype)) {
+  Object.getOwnPropertyNames(newObj.prototype).forEach(function (propName) {
     var propVal = newObj.prototype[propName];
     if (typeof propVal === 'function') {
       propVal.displayName = propName;
     }
-  }
+  });
 
   return document.registerElement(tagName, newObj);
 };


### PR DESCRIPTION
**Description:**
As described on #3449 if you want to build project which depends on aframe it fails because of ES6 syntax on `aframe-master.js:75038`. This code comes from `a-register-element.js:62`

**Changes proposed:**
I have changed for..of loop:
```javascript
for (var propName of Object.getOwnPropertyNames(newObj.prototype)){}
```
to forEach function call:
```javascript
Object.getOwnPropertyNames(newObj.prototype).forEach(function(propName){})
```
