### PR TITLE
[docs] Update camera position/offset documentation.

### DIFF
--- a/docs/components/camera.md
+++ b/docs/components/camera.md
@@ -13,23 +13,21 @@ to move and rotate the camera.
 
 ## Examples
 
-A camera situated at the average height of human eye level (1.6 meters).
-When used with controls that receive rotation or position (e.g. from a
-VR device) this position will be overridden.
+A camera should usually be positioned at the average height of human eye level (1.6 meters). When used with controls that receive rotation or position (e.g. from a VR device) this position will be overridden.
 
 ```html
-  <a-entity position="0 1.6 0" camera look-controls></a-entity>
+<a-entity camera look-controls position="0 1.6 0"></a-entity>
 ```
 
-When moving or rotating the camera relative to the scene, use a camera rig
-around the camera. By doing so, the camera's height offset can be updated
-by roomscale devices, while still allowing the tracked area to be
-moved independently around the scene.
+When moving or rotating the camera relative to the scene, use a camera rig.
+By doing so, the camera's height offset can be updated by roomscale devices,
+while still allowing the tracked area to be moved independently around the
+scene.
 
 ```html
-  <a-entity id="#rig" position="25 10 0">
-    <a-entity id="camera" position="0 1.6 0" camera look-controls></a-entity>
-  </a-entity>
+<a-entity id="#rig" position="25 10 0">
+  <a-entity id="camera" camera look-controls></a-entity>
+</a-entity>
 ```
 
 ## Properties

--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -19,7 +19,7 @@ The look-controls component is usually used alongside the [camera
 component](camera.md).
 
 ```html
-<a-entity camera look-controls></a-entity>
+<a-entity camera look-controls position="0 1.6 0"></a-entity>
 ```
 
 ## Properties

--- a/docs/components/wasd-controls.md
+++ b/docs/components/wasd-controls.md
@@ -15,7 +15,7 @@ component][components-camera].
 ## Example
 
 ```html
-<a-entity camera look-controls wasd-controls></a-entity>
+<a-entity camera look-controls wasd-controls position="0 1.6 0"></a-entity>
 ```
 
 ## Properties

--- a/docs/primitives/a-camera.md
+++ b/docs/primitives/a-camera.md
@@ -31,12 +31,22 @@ by modifying the camera entity's position and rotation.
 
 ## Manually Positioning the Camera
 
-To position the camera, set the position on a wrapper `<a-entity>`. Don't set
-the position directly on the camera primitive because controls will quickly
-override the set position:
+A camera is situated by default at the average height of human eye level (1.6
+meters). When used with controls that receive rotation or position (e.g. from a
+VR device) this position will be overridden.
 
 ```html
-<a-entity position="0 0 5">
-  <a-camera></a-camera>
+<!-- Place camera at ground level (will be overridden by VR devices) -->
+<a-camera position="0 0 0"></a-camera>
+```
+
+When moving or rotating the camera relative to the scene, use a camera rig.
+By doing so, the camera's height offset can be updated by roomscale devices,
+while still allowing the tracked area to be moved independently around the
+scene.
+
+```html
+<a-entity id="#rig" position="25 10 0">
+  <a-camera id="camera"></a-camera>
 </a-entity>
 ```

--- a/src/extras/primitives/primitives/a-camera.js
+++ b/src/extras/primitives/primitives/a-camera.js
@@ -4,7 +4,8 @@ registerPrimitive('a-camera', {
   defaultComponents: {
     'camera': {},
     'look-controls': {},
-    'wasd-controls': {}
+    'wasd-controls': {},
+    'position': {y: 1.6}
   },
 
   mappings: {


### PR DESCRIPTION
NOTE: This also sets the default height of `<a-camera/>` to 1.6m, matching pre-0.8.0 behavior.

Fixes #3462.