### PR TITLE
Fix Touch pose (fixes #2965)

### DIFF
--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -76,7 +76,7 @@ registerComponent('laser-controls', {
 
     'oculus-touch-controls': {
       cursor: {downEvents: ['triggerdown'], upEvents: ['triggerup']},
-      raycaster: {origin: {x: 0.001, y: 0, z: 0.065}, direction: {x: 0, y: -0.8, z: -1}}
+      raycaster: {origin: {x: 0, y: 0, z: 0}}
     },
 
     'vive-controls': {

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -2,6 +2,7 @@ var bind = require('../utils/bind');
 var registerComponent = require('../core/component').registerComponent;
 var trackedControlsUtils = require('../utils/tracked-controls');
 var onButtonEvent = trackedControlsUtils.onButtonEvent;
+var THREE = require('../lib/three');
 
 var TOUCH_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/oculus/oculus-touch-controller-';
 var TOUCH_CONTROLLER_MODEL_OBJ_URL_L = TOUCH_CONTROLLER_MODEL_BASE_URL + 'left.obj';
@@ -11,7 +12,7 @@ var TOUCH_CONTROLLER_MODEL_OBJ_MTL_R = TOUCH_CONTROLLER_MODEL_BASE_URL + 'right.
 
 var GAMEPAD_ID_PREFIX = 'Oculus Touch';
 
-var PIVOT_OFFSET = {x: 0, y: -0.015, z: 0.04};
+var PIVOT_OFFSET = {x: 0, y: 0, z: 0};
 
 /**
  * Oculus Touch controls.
@@ -191,6 +192,18 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
     // Offset pivot point
     controllerObject3D.position = PIVOT_OFFSET;
+
+    // Fix issue #2965 for default Touch model, rotate it 45 degrees.
+    // But if it isn't the default Touch model, don't.
+    controllerObject3D.traverse(function (o3d) {
+      if (o3d instanceof THREE.Mesh) {
+        if (o3d.name.startsWith('body_oculus-touch-controller-')) {
+          o3d.parent.rotateX(45 * Math.PI / 180);
+          o3d.parent.translateY(0.02);
+          o3d.parent.translateZ(-0.03);
+        }
+      }
+    });
   },
 
   onAxisMoved: function (evt) {

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -12,8 +12,6 @@ var TOUCH_CONTROLLER_MODEL_OBJ_MTL_R = TOUCH_CONTROLLER_MODEL_BASE_URL + 'right.
 
 var GAMEPAD_ID_PREFIX = 'Oculus Touch';
 
-var PIVOT_OFFSET = {x: 0, y: 0, z: 0};
-
 /**
  * Oculus Touch controls.
  * Interface with Oculus Touch controllers and map Gamepad events to
@@ -190,17 +188,13 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     buttonMeshes.ybutton = controllerObject3D.getObjectByName('buttonY_oculus-touch-controller-left.001');
     buttonMeshes.bbutton = controllerObject3D.getObjectByName('buttonB_oculus-touch-controller-right.003');
 
-    // Offset pivot point
-    controllerObject3D.position = PIVOT_OFFSET;
-
-    // Fix issue #2965 for default Touch model, rotate it 45 degrees.
-    // But if it isn't the default Touch model, don't.
-    controllerObject3D.traverse(function (o3d) {
-      if (o3d instanceof THREE.Mesh) {
-        if (o3d.name.startsWith('body_oculus-touch-controller-')) {
-          o3d.parent.rotateX(45 * THREE.Math.DEG2RAD);
-          o3d.parent.translateY(0.02);
-          o3d.parent.translateZ(-0.03);
+    // For default Touch model, rotate it 45 degrees to match reality.
+    controllerObject3D.traverse(function (object3d) {
+      if (object3d instanceof THREE.Mesh) {
+        if (object3d.name.startsWith('body_oculus-touch-controller-')) {
+          object3d.parent.rotateX(45 * THREE.Math.DEG2RAD);
+          object3d.parent.translateY(0.02);
+          object3d.parent.translateZ(-0.03);
         }
       }
     });

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -198,7 +198,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     controllerObject3D.traverse(function (o3d) {
       if (o3d instanceof THREE.Mesh) {
         if (o3d.name.startsWith('body_oculus-touch-controller-')) {
-          o3d.parent.rotateX(45 * Math.PI / 180);
+          o3d.parent.rotateX(45 * THREE.Math.DEG2RAD);
           o3d.parent.translateY(0.02);
           o3d.parent.translateZ(-0.03);
         }

--- a/tests/components/laser-controls.test.js
+++ b/tests/components/laser-controls.test.js
@@ -43,8 +43,8 @@ suite('laser-controls', function () {
       el.emit('controllerconnected', {name: 'oculus-touch-controls'});
       setTimeout(() => {
         var raycaster = el.getAttribute('raycaster');
-        assert.notEqual(raycaster.origin.z, 0);
-        assert.notEqual(raycaster.direction.y, 0);
+        assert.equal(raycaster.origin.z, 0);
+        assert.equal(raycaster.direction.y, 0);
         done();
       });
     });


### PR DESCRIPTION
Modify oculus-touch-controls to accommodate current model and semi-recent browser / SDK behavioral changes in Touch controller pose.  See discussion in #2965.

Note that the model pose changes are made conditionally to the default Touch model only, and that the positional offset are not exactly perfect still, but IMO slightly better aligned with real-life than previous suggestions.
