### PR TITLE
init pos/rot/scale/vis components first if defined (fixes #3516)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -9,6 +9,7 @@ var debug = utils.debug('core:a-entity:debug');
 var warn = utils.debug('core:a-entity:warn');
 
 var MULTIPLE_COMPONENT_DELIMITER = '__';
+var OBJECT3D_COMPONENTS = ['position', 'rotation', 'scale', 'visible'];
 
 /**
  * Entity is a container object that components are plugged into to comprise everything in
@@ -442,7 +443,15 @@ var proto = Object.create(ANode.prototype, {
       // Gather entity-defined components.
       for (i = 0; i < this.attributes.length; ++i) {
         name = this.attributes[i].name;
+        if (OBJECT3D_COMPONENTS.indexOf(name) !== -1) { continue; }
         if (isComponent(name)) { componentsToUpdate[name] = true; }
+      }
+
+      // object3D components first (position, rotation, scale, visible).
+      for (i = 0; i < OBJECT3D_COMPONENTS.length; i++) {
+        name = OBJECT3D_COMPONENTS[i];
+        if (!this.hasAttribute(name)) { continue; }
+        this.updateComponent(name, this.getDOMAttribute(name));
       }
 
       // Initialize or update rest of components.

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1260,6 +1260,7 @@ suite('a-entity', function () {
         done();
       });
     });
+
     test('nested calls do not leak components to children', function () {
       registerComponent('test', {
         init: function () {
@@ -1273,6 +1274,19 @@ suite('a-entity', function () {
       mixinFactory('addGeometry', {geometry: 'shape: sphere'});
       this.el.setAttribute('mixin', 'addTest');
       assert.notOk(this.child.components['test']);
+    });
+
+    test('initializes object3d components first', function (done) {
+      registerComponent('test', {
+        init: function () {
+          var object3D = this.el.object3D;
+          assert.equal(object3D.position.y, 5);
+          assert.equal(object3D.visible, false);
+          done();
+        }
+      });
+
+      this.el.innerHTML = '<a-entity class="test" test position="0 5 0" visible="false"></a-entity';
     });
   });
 


### PR DESCRIPTION
**Description:**

I want components to know the defined pos/rot/scale/visible without setting dependency. 

**Changes proposed:**
-
-
-
