### PR TITLE
add early deprecation warning for <a-animation>

### DIFF
--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -15,6 +15,9 @@ var EASING_FUNCTIONS = animationConstants.easingFunctions;
 var FILLS = animationConstants.fills;
 var REPEATS = animationConstants.repeats;
 var isCoordinates = coordinates.isCoordinates;
+var warn = utils.debug('core:a-animation:warn');
+
+var hasLoggedDeprecation = false;
 
 /**
  * Animation element that applies Tween animation to parent element (entity).
@@ -39,6 +42,12 @@ module.exports.AAnimation = registerElement('a-animation', {
         this.isRunning = false;
         this.partialSetAttribute = function () { /* no-op */ };
         this.tween = null;
+
+        if (!hasLoggedDeprecation) {
+          warn('<a-animation> has been deprecated and will be replaced by the animation ' +
+               'component: https://www.npmjs.com/package/aframe-animation-component');
+          hasLoggedDeprecation = true;
+        }
       }
     },
 


### PR DESCRIPTION
**Description:**

In 9.0.0+, will swap out for the [animation component](https://www.npmjs.com/package/aframe-animation-component) we're using ﻿﻿with more ergonomics, features (inc. [timeline](https://www.npmjs.com/package/aframe-animation-timeline-component)), perf (synchronous, animejs v2/3, ability to tween properties and skip setAttribute, or ability to tween like position.z), consistency, less verbose etc. Throwing an early warning for now.
