### PR TITLE
vr-mode-ui: click event stopped from propagation

### DIFF
--- a/src/components/scene/vr-mode-ui.js
+++ b/src/components/scene/vr-mode-ui.js
@@ -144,6 +144,7 @@ function createEnterVRButton (onClick) {
   wrapper.appendChild(vrButton);
   vrButton.addEventListener('click', function (evt) {
     onClick();
+    evt.stopPropagation();
   });
   return wrapper;
 }


### PR DESCRIPTION
The trigger on a Cardboard V2 causes a screen touch, so it's common to listen for an click on the scene element or window.  This changes prevents a tap on the a-enter-vr button from propagating to the scene and window, so the other listener doesn't have to disentangle an "enter vr" tap from the Cardboard button.
