### PR TITLE
apply rotation component, if present, in look-controls

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -187,13 +187,27 @@ module.exports.Component = registerComponent('look-controls', {
     var pitchObject = this.pitchObject;
     var yawObject = this.yawObject;
     var sceneEl = this.el.sceneEl;
+    var q = this.hmdQuaternion;
 
     // In VR mode, THREE is in charge of updating the camera rotation.
     if (sceneEl.is('vr-mode') && sceneEl.checkHeadsetConnected()) { return; }
 
     // Calculate polyfilled HMD quaternion.
     this.polyfillControls.update();
-    hmdEuler.setFromQuaternion(this.polyfillObject.quaternion, 'YXZ');
+
+    // If rotation component exists, get its values and apply them.
+    var rotationComponent = el.components.rotation;
+    if (rotationComponent) {
+      hmdEuler.set(
+        THREE.Math.DEG2RAD * rotationComponent.data.x,
+        THREE.Math.DEG2RAD * rotationComponent.data.y,
+        THREE.Math.DEG2RAD * rotationComponent.data.z, 'YXZ');
+      q.setFromEuler(hmdEuler);
+      q.multiply(this.polyfillObject.quaternion);
+      hmdEuler.setFromQuaternion(q, 'YXZ');
+    } else {
+      hmdEuler.setFromQuaternion(this.polyfillObject.quaternion, 'YXZ');
+    }
 
     // On mobile, do camera rotation with touch events and sensors.
     el.object3D.rotation.x = hmdEuler.x + pitchObject.rotation.x;


### PR DESCRIPTION
Per discussion on Slack:

In version 0.8.x, `look-controls` was changed to ignore the `rotation` component and directly override `object3d.rotation` -- which appears to have broken some use cases.

This PR modifies `updateOrientation()` in `look-controls` to also take into account the value of the `rotation` component, if present.