### PR TITLE
changes gear-vr controls to use trigger, as opposed to touchpad

### DIFF
--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -70,7 +70,7 @@ registerComponent('laser-controls', {
     },
 
     'gearvr-controls': {
-      cursor: {downEvents: ['trackpaddown'], upEvents: ['trackpadup']},
+      cursor: {downEvents: ['triggerdown'], upEvents: ['triggerup']},
       raycaster: {origin: {x: 0, y: 0.0005, z: 0}}
     },
 


### PR DESCRIPTION
**Description:**
laser-controls should use trigger for GearVR. See https://github.com/aframevr/aframe/issues/3519

**Changes proposed:**
- change gear-vr up and down events to be triggerup/triggerdown
