### PR TITLE
Oculus touch model position

### DIFF
--- a/docs/components/daydream-controls.md
+++ b/docs/components/daydream-controls.md
@@ -36,15 +36,17 @@ It can occassionally take a few seconds before the controller can be used.
 
 ## Value
 
-| Property             | Description                                        | Default |
-|----------------------|----------------------------------------------------|---------|
-| armModel             | Whether the arm model is used for positional data. | true    |
-| buttonColor          | Button colors when not pressed.                    | #000000 |
-| buttonTouchedColor   | Button colors when touched.                        | #777777 |
-| buttonHighlightColor | Button colors when pressed and active.             | #FFFFFF |
-| hand                 | Set hand that will be tracked (i.e., right, left). |         |
-| model                | Whether the Daydream controller model is loaded.   | true    |
-| rotationOffset       | Offset to apply to model rotation.                 | 0       |
+| Property             | Description                                        | Default              |
+|----------------------|----------------------------------------------------|----------------------|
+| armModel             | Whether the arm model is used for positional data. | true                 |
+| buttonColor          | Button colors when not pressed.                    | #000000              |
+| buttonTouchedColor   | Button colors when touched.                        | #777777              |
+| buttonHighlightColor | Button colors when pressed and active.             | #FFFFFF              |
+| hand                 | Set hand that will be tracked (i.e., right, left). |                      |
+| model                | Whether the Daydream controller model is loaded.   | true                 |
+| rotationOffset       | Offset to apply to model rotation.                 | 0                    |
+| orientationOffset    | Offset to apply to model orientation.              | x: 0, y: 0, z: 0     |
+
 
 ## Events
 

--- a/docs/components/daydream-controls.md
+++ b/docs/components/daydream-controls.md
@@ -44,7 +44,6 @@ It can occassionally take a few seconds before the controller can be used.
 | buttonHighlightColor | Button colors when pressed and active.             | #FFFFFF              |
 | hand                 | Set hand that will be tracked (i.e., right, left). |                      |
 | model                | Whether the Daydream controller model is loaded.   | true                 |
-| rotationOffset       | Offset to apply to model rotation.                 | 0                    |
 | orientationOffset    | Offset to apply to model orientation.              | x: 0, y: 0, z: 0     |
 
 

--- a/docs/components/gearvr-controls.md
+++ b/docs/components/gearvr-controls.md
@@ -27,15 +27,16 @@ and/or pressed buttons (trackpad, trigger).
 
 ## Value
 
-| Property             | Description                                        | Default |
-|----------------------|----------------------------------------------------|---------|
-| armModel             | Whether the arm model is used for positional data. | true    |
-| buttonColor          | Button colors when not pressed.                    | #000000 |
-| buttonTouchedColor   | Button colors when touched.                        | #777777 |
-| buttonHighlightColor | Button colors when pressed and active.             | #FFFFFF |
-| hand                 | The hand that will be tracked (e.g., right, left). |         |
-| model                | Whether the Gear controller model is loaded.       | true    |
-| rotationOffset       | Offset to apply to model rotation.                 | 0       |
+| Property             | Description                                        | Default              |
+|----------------------|----------------------------------------------------|----------------------|
+| armModel             | Whether the arm model is used for positional data. | true                 |
+| buttonColor          | Button colors when not pressed.                    | #000000              |
+| buttonTouchedColor   | Button colors when touched.                        | #777777              |
+| buttonHighlightColor | Button colors when pressed and active.             | #FFFFFF              |
+| hand                 | The hand that will be tracked (e.g., right, left). |                      |
+| model                | Whether the Gear controller model is loaded.       | true                 |
+| rotationOffset       | Offset to apply to model rotation.                 | 0                    |
+| orientationOffset    | Offset to apply to model orientation.              | x: 0, y: 0, z: 0     |
 
 ## Events
 

--- a/docs/components/gearvr-controls.md
+++ b/docs/components/gearvr-controls.md
@@ -35,7 +35,6 @@ and/or pressed buttons (trackpad, trigger).
 | buttonHighlightColor | Button colors when pressed and active.             | #FFFFFF              |
 | hand                 | The hand that will be tracked (e.g., right, left). |                      |
 | model                | Whether the Gear controller model is loaded.       | true                 |
-| rotationOffset       | Offset to apply to model rotation.                 | 0                    |
 | orientationOffset    | Offset to apply to model orientation.              | x: 0, y: 0, z: 0     |
 
 ## Events

--- a/docs/components/oculus-touch-controls.md
+++ b/docs/components/oculus-touch-controls.md
@@ -27,6 +27,7 @@ mappings, events, and a Touch controller model.
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Touch controller model is loaded.      | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |
+| orientationOffset    | Offset to apply to model orientation.              | x: 0, y: 0, z: 0     |
 
 ## Events
 

--- a/docs/components/oculus-touch-controls.md
+++ b/docs/components/oculus-touch-controls.md
@@ -26,7 +26,6 @@ mappings, events, and a Touch controller model.
 |----------------------|----------------------------------------------------|----------------------|
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Touch controller model is loaded.      | true                 |
-| rotationOffset       | Offset to apply to model rotation.                 | 0                    |
 | orientationOffset    | Offset to apply to model orientation.              | x: 0, y: 0, z: 0     |
 
 ## Events

--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -41,7 +41,6 @@ so using idPrefix for Vive / OpenVR controllers is recommended.
 | controller        | Index of the controller in array returned by the Gamepad API.   | 0                          |
 | id                | Selects the controller from the Gamepad API using exact match.  |                            |
 | idPrefix          | Selects the controller from the Gamepad API using prefix match. |                            |
-| rotationOffset    | Offset to add to model rotation.                                | 0                          |
 | headElement       | Head element for arm model if needed (if not active camera).    |                            |
 | hand              | Which hand to use, if arm model is needed.  (left negates X)    | right                      |
 | orientationOffset | Offset to apply to model orientation.                           | x: 0, y: 0, z: 0     |

--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -44,6 +44,8 @@ so using idPrefix for Vive / OpenVR controllers is recommended.
 | rotationOffset    | Offset to add to model rotation.                                | 0                          |
 | headElement       | Head element for arm model if needed (if not active camera).    |                            |
 | hand              | Which hand to use, if arm model is needed.  (left negates X)    | right                      |
+| orientationOffset | Offset to apply to model orientation.                           | x: 0, y: 0, z: 0     |
+
 
 ## Events
 

--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -29,7 +29,6 @@ buttons (trigger, grip, menu, system) and trackpad.
 | buttonHighlightColor | Button colors when pressed and active.             | #22D1EE (light blue) |
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Vive controller model is loaded.       | true                 |
-| rotationOffset       | Offset to apply to model rotation.                 | 0                    |
 | orientationOffset    | Offset to apply to model orientation.              | x: 0, y: 0, z: 0     |
 
 ## Events

--- a/docs/components/vive-controls.md
+++ b/docs/components/vive-controls.md
@@ -30,6 +30,7 @@ buttons (trigger, grip, menu, system) and trackpad.
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | model                | Whether the Vive controller model is loaded.       | true                 |
 | rotationOffset       | Offset to apply to model rotation.                 | 0                    |
+| orientationOffset    | Offset to apply to model orientation.              | x: 0, y: 0, z: 0     |
 
 ## Events
 

--- a/docs/introduction/interactions-and-controllers.md
+++ b/docs/introduction/interactions-and-controllers.md
@@ -461,10 +461,11 @@ AFRAME.registerComponent('custom-controls', {
   },
 
   update: function () {
+    var hand = this.data.hand;
     var controlConfiguration = {
-      hand: this.data.hand,
+      hand: hand,
       model: false,
-      rotationOffset: hand === 'left' ? 90 : -90
+      orientationOffset: {x: 0, y: 0, z: hand === 'left' ? 90 : -90}
     };
 
     // Build on top of controller components.

--- a/src/components/daydream-controls.js
+++ b/src/components/daydream-controls.js
@@ -24,7 +24,6 @@ module.exports.Component = registerComponent('daydream-controls', {
     buttonTouchedColor: {type: 'color', default: '#777777'},
     buttonHighlightColor: {type: 'color', default: '#FFFFFF'},
     model: {default: true},
-    rotationOffset: {default: 0},
     orientationOffset: {type: 'vec3'},
     armModel: {default: true}
   },
@@ -109,7 +108,6 @@ module.exports.Component = registerComponent('daydream-controls', {
       armModel: data.armModel,
       hand: data.hand,
       idPrefix: GAMEPAD_ID_PREFIX,
-      rotationOffset: data.rotationOffset,
       orientationOffset: data.orientationOffset
     });
     if (!this.data.model) { return; }

--- a/src/components/daydream-controls.js
+++ b/src/components/daydream-controls.js
@@ -25,6 +25,7 @@ module.exports.Component = registerComponent('daydream-controls', {
     buttonHighlightColor: {type: 'color', default: '#FFFFFF'},
     model: {default: true},
     rotationOffset: {default: 0},
+    orientationOffset: {type: 'vec3'},
     armModel: {default: true}
   },
 
@@ -108,7 +109,8 @@ module.exports.Component = registerComponent('daydream-controls', {
       armModel: data.armModel,
       hand: data.hand,
       idPrefix: GAMEPAD_ID_PREFIX,
-      rotationOffset: data.rotationOffset
+      rotationOffset: data.rotationOffset,
+      orientationOffset: data.orientationOffset
     });
     if (!this.data.model) { return; }
     this.el.setAttribute('obj-model', {

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -25,6 +25,7 @@ module.exports.Component = registerComponent('gearvr-controls', {
     buttonHighlightColor: {type: 'color', default: '#FFFFFF'},
     model: {default: true},
     rotationOffset: {default: 0},
+    orientationOffset: {type: 'vec3'},
     armModel: {default: true}
   },
 
@@ -109,7 +110,8 @@ module.exports.Component = registerComponent('gearvr-controls', {
     el.setAttribute('tracked-controls', {
       armModel: data.armModel,
       idPrefix: GAMEPAD_ID_PREFIX,
-      rotationOffset: data.rotationOffset
+      rotationOffset: data.rotationOffset,
+      orientationOffset: data.orientationOffset
     });
     if (!this.data.model) { return; }
     this.el.setAttribute('obj-model', {

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -24,7 +24,6 @@ module.exports.Component = registerComponent('gearvr-controls', {
     buttonTouchedColor: {type: 'color', default: '#777777'},
     buttonHighlightColor: {type: 'color', default: '#FFFFFF'},
     model: {default: true},
-    rotationOffset: {default: 0},
     orientationOffset: {type: 'vec3'},
     armModel: {default: true}
   },
@@ -110,7 +109,6 @@ module.exports.Component = registerComponent('gearvr-controls', {
     el.setAttribute('tracked-controls', {
       armModel: data.armModel,
       idPrefix: GAMEPAD_ID_PREFIX,
-      rotationOffset: data.rotationOffset,
       orientationOffset: data.orientationOffset
     });
     if (!this.data.model) { return; }

--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -170,7 +170,7 @@ module.exports.Component = registerComponent('hand-controls', {
     controlConfiguration = {
       hand: hand,
       model: false,
-      rotationOffset: hand === 'left' ? 90 : -90
+      orientationOffset: {x: 0, y: 0, z: hand === 'left' ? 90 : -90}
     };
 
     // Set model.

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -31,7 +31,6 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     buttonTouchColor: {type: 'color', default: '#8AB'},
     buttonHighlightColor: {type: 'color', default: '#2DF'},  // Light blue.
     model: {default: true},
-    rotationOffset: {default: 0},
     orientationOffset: {type: 'vec3', default: {x: 43, y: 0, z: 0}}
   },
 
@@ -134,11 +133,9 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   injectTrackedControls: function () {
     var data = this.data;
-    var offset = data.hand === 'right' ? -90 : 90;
     this.el.setAttribute('tracked-controls', {
       id: data.hand === 'right' ? 'Oculus Touch (Right)' : 'Oculus Touch (Left)',
       controller: 0,
-      rotationOffset: data.rotationOffset !== -999 ? data.rotationOffset : offset,
       orientationOffset: data.orientationOffset
     });
     this.updateControllerModel();

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -25,7 +25,6 @@ module.exports.Component = registerComponent('tracked-controls', {
     id: {type: 'string', default: ''},
     hand: {type: 'string', default: ''},
     idPrefix: {type: 'string', default: ''},
-    rotationOffset: {default: 0},
     orientationOffset: {type: 'vec3'},
     // Arm model parameters when not 6DoF.
     armModel: {default: true},
@@ -180,13 +179,9 @@ module.exports.Component = registerComponent('tracked-controls', {
       object3D.matrix.decompose(object3D.position, object3D.quaternion, object3D.scale);
     }
 
-    if (data.rotationOffset !== 0) {
-      object3D.rotateZ(data.rotationOffset * THREE.Math.DEG2RAD);
-    } else {
-      object3D.rotateX(this.data.orientationOffset.x * THREE.Math.DEG2RAD);
-      object3D.rotateY(this.data.orientationOffset.y * THREE.Math.DEG2RAD);
-      object3D.rotateZ(this.data.orientationOffset.z * THREE.Math.DEG2RAD);
-    }
+    object3D.rotateX(this.data.orientationOffset.x * THREE.Math.DEG2RAD);
+    object3D.rotateY(this.data.orientationOffset.y * THREE.Math.DEG2RAD);
+    object3D.rotateZ(this.data.orientationOffset.z * THREE.Math.DEG2RAD);
 
     object3D.updateMatrix();
     object3D.matrixWorldNeedsUpdate = true;

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -26,6 +26,7 @@ module.exports.Component = registerComponent('tracked-controls', {
     hand: {type: 'string', default: ''},
     idPrefix: {type: 'string', default: ''},
     rotationOffset: {default: 0},
+    orientationOffset: {type: 'vec3'},
     // Arm model parameters when not 6DoF.
     armModel: {default: true},
     headElement: {type: 'selector'}
@@ -148,6 +149,7 @@ module.exports.Component = registerComponent('tracked-controls', {
    */
   updatePose: function () {
     var controller = this.controller;
+    var data = this.data;
     var object3D = this.el.object3D;
     var pose;
     var vrDisplay = this.system.vrDisplay;
@@ -162,7 +164,7 @@ module.exports.Component = registerComponent('tracked-controls', {
       object3D.position.fromArray(pose.position);
     } else {
       // Controller not 6DOF, apply arm model.
-      if (this.data.armModel) { this.applyArmModel(object3D.position); }
+      if (data.armModel) { this.applyArmModel(object3D.position); }
     }
 
     if (pose.orientation) {
@@ -178,7 +180,13 @@ module.exports.Component = registerComponent('tracked-controls', {
       object3D.matrix.decompose(object3D.position, object3D.quaternion, object3D.scale);
     }
 
-    object3D.rotateZ(this.data.rotationOffset * THREE.Math.DEG2RAD);
+    if (data.rotationOffset !== 0) {
+      object3D.rotateZ(data.rotationOffset * THREE.Math.DEG2RAD);
+    } else {
+      object3D.rotateX(this.data.orientationOffset.x * THREE.Math.DEG2RAD);
+      object3D.rotateY(this.data.orientationOffset.y * THREE.Math.DEG2RAD);
+      object3D.rotateZ(this.data.orientationOffset.z * THREE.Math.DEG2RAD);
+    }
 
     object3D.updateMatrix();
     object3D.matrixWorldNeedsUpdate = true;

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -24,7 +24,8 @@ module.exports.Component = registerComponent('vive-controls', {
     buttonColor: {type: 'color', default: '#FAFAFA'},  // Off-white.
     buttonHighlightColor: {type: 'color', default: '#22D1EE'},  // Light blue.
     model: {default: true},
-    rotationOffset: {default: 0}
+    rotationOffset: {default: 0},
+    orientationOffset: {type: 'vec3'}
   },
 
   /**
@@ -121,7 +122,8 @@ module.exports.Component = registerComponent('vive-controls', {
       idPrefix: GAMEPAD_ID_PREFIX,
       // Hand IDs: 0 = right, 1 = left, 2 = anything else.
       controller: data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2,
-      rotationOffset: data.rotationOffset
+      rotationOffset: data.rotationOffset,
+      orientationOffset: data.orientationOffset
     });
 
     // Load model.

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -24,7 +24,6 @@ module.exports.Component = registerComponent('vive-controls', {
     buttonColor: {type: 'color', default: '#FAFAFA'},  // Off-white.
     buttonHighlightColor: {type: 'color', default: '#22D1EE'},  // Light blue.
     model: {default: true},
-    rotationOffset: {default: 0},
     orientationOffset: {type: 'vec3'}
   },
 
@@ -122,7 +121,6 @@ module.exports.Component = registerComponent('vive-controls', {
       idPrefix: GAMEPAD_ID_PREFIX,
       // Hand IDs: 0 = right, 1 = left, 2 = anything else.
       controller: data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2,
-      rotationOffset: data.rotationOffset,
       orientationOffset: data.orientationOffset
     });
 

--- a/tests/components/laser-controls.test.js
+++ b/tests/components/laser-controls.test.js
@@ -40,11 +40,11 @@ suite('laser-controls', function () {
     });
 
     test('configures raycaster for oculus-touch-controls', function (done) {
-      el.emit('controllerconnected', {name: 'oculus-touch-controls'});
+      el.emit('controllerconnected', {name: 'gearvr-controls'});
       setTimeout(() => {
         var raycaster = el.getAttribute('raycaster');
-        assert.equal(raycaster.origin.z, 0);
-        assert.equal(raycaster.direction.y, 0);
+        assert.equal(raycaster.origin.x, 0);
+        assert.equal(raycaster.origin.y, 0.0005);
         done();
       });
     });

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -185,11 +185,14 @@ suite('tracked-controls', function () {
       assertQuaternion(el.object3D.quaternion, controller.pose.orientation);
     });
 
-    test('applies rotation Z-offset', function () {
-      el.setAttribute('tracked-controls', 'rotationOffset', 10);
+    test('applies orientation offset', function () {
+      el.setAttribute('tracked-controls', 'orientationOffset', {x: 3, y: 4, z: 5});
       component.tick();
-      assertVec3(el.getAttribute('rotation'), [0, 0, 10]);
-      assertMatrix4(el.object3D.matrix, new THREE.Matrix4().makeRotationZ(10 * THREE.Math.DEG2RAD));
+      var rotation = el.getAttribute('rotation');
+      rotation.x = Math.round(rotation.x);
+      rotation.y = Math.round(rotation.y);
+      rotation.z = Math.round(rotation.z);
+      assertVec3(rotation, [3, 4, 5]);
     });
   });
 
@@ -526,10 +529,6 @@ suite('tracked-controls', function () {
     });
   });
 });
-
-function assertMatrix4 (matrixA, matrixB) {
-  assert.ok(matrixA.equals(matrixB), `\n${matrixA.elements}\n${matrixB.elements}`);
-}
 
 function assertVec3CloseTo (vec3, arr, delta) {
   var debugOutput = `${[vec3.x, vec3.y, vec3.z]} is not close to ${arr}`;


### PR DESCRIPTION
The position offset was not applied correctly for the oculus touch model. The orientation did not match the real world position of the controller. Introduced a `orientationOffset` attribute to be able to match any controller model with real world orientation. rotationOffset should be deprecated but I left it for backwards compatiblity. We can remove in 0.9.0