### PR TITLE
Fix broken markdown table

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -102,7 +102,7 @@ The implementation is based on [mattdesl's three-bmfont-text][three-bmfont-text]
 ## Events
 
 | Event Name  | Description                                  |
-|--- --- --- -|--- --- --- --- --- --- --- --- --- --- --- --|
+|-------------|----------------------------------------------|
 | textfontset | Emitted when the font source has been loaded |
 
 ## Fonts


### PR DESCRIPTION
The Events table in the documentation for the `text` component was broken