### PR TITLE
Material blending

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -72,6 +72,7 @@ depending on the material type applied.
 | transparent  | Whether material is transparent. Transparent entities are rendered after non-transparent entities.                                                | false         |
 | vertexColors | Whether to use vertex or face colors to shade the material. Can be one of `none`, `vertex`, or `face`.                                            | none          |
 | visible      | Whether material is visible. Raycasters will ignore invisible materials.                                                                          | true          |
+| blending     | The blending mode for the material's RGB and Alpha sent to the WebGLRenderer. Can be one of `none`, `normal`, `additive`, `subtractive` or `multiply`.  | normal          |
 
 ## Events
 

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -30,7 +30,8 @@ module.exports.Component = registerComponent('material', {
     side: {default: 'front', oneOf: ['front', 'back', 'double']},
     transparent: {default: false},
     vertexColors: {type: 'string', default: 'none', oneOf: ['face', 'vertex']},
-    visible: {default: true}
+    visible: {default: true},
+    blending: {default: 'normal', oneOf: ['none', 'normal', 'additive', 'subtractive', 'multiply']}
   },
 
   init: function () {
@@ -121,6 +122,7 @@ module.exports.Component = registerComponent('material', {
     material.transparent = data.transparent !== false || data.opacity < 1.0;
     material.vertexColors = parseVertexColors(data.vertexColors);
     material.visible = data.visible;
+    material.blending = parseBlending(data.blending);
 
     // Check if material needs update.
     if (Object.keys(oldData).length &&
@@ -210,6 +212,33 @@ function parseVertexColors (coloring) {
     }
     default: {
       return THREE.NoColors;
+    }
+  }
+}
+
+/**
+ * Return a three.js constant determining blending
+ *
+ * @param {string} [blending=normal]
+ * - `none`, additive`, `subtractive`,`multiply` or `normal`.
+ * @returns {number}
+ */
+function parseBlending (blending) {
+  switch (blending) {
+    case 'none': {
+      return THREE.NoBlending;
+    }
+    case 'additive': {
+      return THREE.AdditiveBlending;
+    }
+    case 'subtractive': {
+      return THREE.SubtractiveBlending;
+    }
+    case 'multiply': {
+      return THREE.MultiplyBlending;
+    }
+    default: {
+      return THREE.NormalBlending;
     }
   }
 }

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -308,4 +308,31 @@ suite('material', function () {
     el.setAttribute('material', 'visible: false');
     assert.notOk(el.getObject3D('mesh').material.visible);
   });
+
+  suite('blending', function () {
+    test('defaults to normal', function () {
+      assert.equal(el.getAttribute('material').blending, 'normal');
+      assert.equal(el.components.material.material.blending, THREE.NormalBlending);
+    });
+
+    test('can set to no blending', function () {
+      el.setAttribute('material', 'blending', 'none');
+      assert.equal(el.components.material.material.blending, THREE.NoBlending);
+    });
+
+    test('can set to additive', function () {
+      el.setAttribute('material', 'blending', 'additive');
+      assert.equal(el.components.material.material.blending, THREE.AdditiveBlending);
+    });
+
+    test('can set to subtractibv', function () {
+      el.setAttribute('material', 'blending', 'subtractive');
+      assert.equal(el.components.material.material.blending, THREE.SubtractiveBlending);
+    });
+
+    test('can set to multiply', function () {
+      el.setAttribute('material', 'blending', 'multiply');
+      assert.equal(el.components.material.material.blending, THREE.MultiplyBlending);
+    });
+  });
 });


### PR DESCRIPTION
**Description:**
Add `blending` property to Aframe Material component
https://github.com/aframevr/aframe/issues/3502

**Changes proposed:**
- Add blending prop to Material component
- Add test

====

I think I've done this right. There's one thing I didn't understand though. If anyone could clarify it would help my understanding of the code.

As i understand it these lines are checking if certain props change, and if they do, we set `needsUpdate` to true
https://github.com/aframevr/aframe/blob/master/src/components/material.js#L127

As explained in the threejs docs this is only needed for certain properties: (https://github.com/mrdoob/three.js/blob/25f4534a5609f55a9d13cff47b1e535b4b109659/docs/manual/introduction/How-to-update-things.html#L175)
 and blending is not one of these.

My question is that I noticed (when writing the tests) that `material.needsUpdate` was true after setting the material.blending attribute. Why is this? I thought it would only be true if we manually set it when we want to trigger a re-render in webGL because e.g. vertex-colors changed.

Thanks