### PR TITLE
add support for setting the encoding of the main map

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -30,7 +30,8 @@ module.exports.Component = registerComponent('material', {
     side: {default: 'front', oneOf: ['front', 'back', 'double']},
     transparent: {default: false},
     vertexColors: {type: 'string', default: 'none', oneOf: ['face', 'vertex']},
-    visible: {default: true}
+    visible: {default: true},
+    encoding: {type: 'string', oneOf: ['sRGB', 'Linear']}
   },
 
   init: function () {

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -346,6 +346,16 @@ function setTextureProperties (texture, data) {
   if (offset.x !== 0 || offset.y !== 0) {
     texture.offset.set(offset.x, offset.y);
   }
+
+  if( data.encoding) {
+    let newEncoding = THREE[ data.encoding] || THREE[ data.encoding + "Encoding"];
+    if(newEncoding === undefined) {
+      error("Unrecognized encoding: " +  data.encoding);
+    }
+    else {
+      texture.encoding = newEncoding;
+    }
+  }
 }
 
 /**

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -39,7 +39,7 @@ module.exports.updateMapMaterialFromData = function (materialName, dataName, sha
     // Load texture for the new material src.
     // (And check if we should still use it once available in callback.)
     el.sceneEl.systems.material.loadTexture(src,
-      {src: src, repeat: data.repeat, offset: data.offset, npot: data.npot},
+      {src: src, repeat: data.repeat, offset: data.offset, npot: data.npot, encoding: data.encoding},
       checkSetMap);
   }
 


### PR DESCRIPTION
**Description:**
Allow specifying the encoding of the main map on the material. This is important for correct linear/gamma settings.

Looks like:
` <a-entity id="sky" 
            geometry="primitive:sphere; radius:30; phiLength:360; phiStart:0; thetaLength:180" 
            material="src:#skymap; encoding:sRGB"
            rotation="30 0 0">
`
 
**Changes proposed:**
I don't think this change is merge able as-is. But I wanted to get this out there to see if there was interest in doing something similar, or if there are plans to solve this some other way.
