### PR TITLE
don't disable matrix autoupdate if no controller pose / vrdisplay

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -43,9 +43,6 @@ module.exports.Component = registerComponent('tracked-controls', {
     this.controllerEuler = new THREE.Euler();
 
     this.updateGamepad();
-
-    // The matrix is manipulate directly in the updatePose method.
-    this.el.object3D.matrixAutoUpdate = false;
   },
 
   tick: function (time, delta) {


### PR DESCRIPTION
**Description:**

Confused me a bit when I had tracked-controls on an entity (some components depending on tracked-controls axis), changing the controller entity position in 2D mode (for debug purposes) wasn't doing anything. I think the matrixAutoUpdate flip should happen only once a gamepad pose kicks in.

**Changes proposed:**
- tracked-controls don't disable matrix auto update on init
