### PR TITLE
do not set `parentNode` -- it's a read-only property

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -241,7 +241,7 @@ var proto = Object.create(ANode.prototype, {
       var parentEl = this.parentEl;
       this.parentEl.remove(this);
       this.attachedToParent = false;
-      this.parentEl = this.parentNode = null;
+      this.parentEl = null;
       parentEl.emit('child-detached', {el: this});
     }
   },


### PR DESCRIPTION
we noticed this after getting errors when running babel on
a-frame (which we had to do since it now uses some features
that uglify does not support)

**Description:**

**Changes proposed:**
-
-
-
