### PR TITLE
Update <a-image> Fine tuning description

### DIFF
--- a/docs/primitives/a-image.md
+++ b/docs/primitives/a-image.md
@@ -44,8 +44,10 @@ The image primitive shows an image on a flat plane.
 
 ## Fine-Tuning
 
-Ensuring that the image is not distorted by stretching requires us to appropriately set the `width` and `height`.
+Ensuring that the image is not distorted by stretching requires us to appropriately set the `width` and `height` preserving the original aspect ratio of the image. This properties are set in meters, don't confuse with pixels.
+
+For example, a 2:1 image:
 
 ```html
-<a-image src="#logo" width="200" height="100"></a-image>
+<a-image src="#logo" width="3" height="1.5"></a-image>
 ```


### PR DESCRIPTION
**Description:**
<a-image>  Fine tuning description do not specify that units are still meters and the example uses large numbers, it's kind of confussing.
**Changes proposed:**
- Update the description for <a-image> Fine tuning section


