### PR TITLE
Substantially optimize coordinates.parse

### DIFF
--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -43,7 +43,7 @@ function parse (value, defaultVec) {
 
   vec = {};
   COORDINATE_KEYS.forEach(function (key, i) {
-    if (coordinate[i] !== undefined) {
+    if (coordinate[i]) {
       vec[key] = parseFloat(coordinate[i], 10);
     } else {
       var defaultVal = defaultVec && defaultVec[key];

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -5,7 +5,7 @@ var extend = require('object-assign');
 var warn = debug('utils:coordinates:warn');
 
 // Order of coordinates parsed by coordinates.parse.
-var coordinateKeys = ['x', 'y', 'z', 'w'];
+var COORDINATE_KEYS = ['x', 'y', 'z', 'w'];
 
 // Coordinate string regex. Handles negative, positive, and decimals.
 var regex = /^\s*((-?\d*\.{0,1}\d+(e-?\d+)?)\s+){2,3}(-?\d*\.{0,1}\d+(e-?\d+)?)\s*$/;
@@ -42,17 +42,15 @@ function parse (value, defaultVec) {
   coordinate = value.trim().split(/\s+/g);
 
   vec = {};
-  for (var i = 0; i < coordinateKeys.length; i++) {
-    var key = coordinateKeys[i];
-    if (coordinate.length > i) {
+  COORDINATE_KEYS.forEach(function (key, i) {
+    if (coordinate[i] !== undefined) {
       vec[key] = parseFloat(coordinate[i], 10);
     } else {
       var defaultVal = defaultVec && defaultVec[key];
-      if (defaultVal !== undefined) {
-        vec[key] = parseIfString(defaultVal);
-      }
+      if (defaultVal === undefined) { return; }
+      vec[key] = parseIfString(defaultVal);
     }
-  }
+  });
   return vec;
 }
 module.exports.parse = parse;

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -34,7 +34,8 @@ function parse (value, defaultVec) {
     return typeof defaultVec === 'object' ? extend({}, defaultVec) : defaultVec;
   }
 
-  coordinate = value.trim().replace(/\s+/g, ' ').split(' ');
+  coordinate = value.trim().split(/\s+/g);
+
   vec = {};
   vec.x = coordinate[0] || defaultVec && defaultVec.x;
   vec.y = coordinate[1] || defaultVec && defaultVec.y;

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -42,7 +42,7 @@ function parse (value, defaultVec) {
   coordinate = value.trim().split(/\s+/g);
 
   vec = {};
-  for (var i = 0; i < 4; i++) {
+  for (var i = 0; i < coordinateKeys.length; i++) {
     var key = coordinateKeys[i];
     if (coordinate.length > i) {
       vec[key] = parseFloat(coordinate[i], 10);


### PR DESCRIPTION
`coordinates.parse` winds up accounting for a moderate amount of time if you do per-frame updates of attributes containing new string or object coordinates. (In our project, an example was a raycaster component which we updated with a new direction and origin each frame.) This change makes it between 2x and 10x faster in both the string-input and object-input cases in Firefox and Chrome (depending on input characteristics) while being more or less equally straightforward.

[Here's a JSPerf comparing the old and new versions](https://jsperf.com/a-frame-coordinates-parsing/8).

There's one edge case I'm worried about. In the old version, if you gave the input `{x: 1, y: "2", splatoon: "42", "whiz": "bang"}`, it would return `{x: 1, y: 2, splatoon: 42, whiz: NaN}`. That is, it would parse any string keys at all in the input, even ones that it didn't know anything about, and even ones that aren't floats. That behavior seems strange to me, it didn't seem documented anywhere, and no test was exercising it, but it's true. If that behavior is important, then let me know and I'll hack it back in.