### PR TITLE
allow multiple raycaster per entity

### DIFF
--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -47,6 +47,8 @@ module.exports.Component = registerComponent('raycaster', {
     useWorldCoordinates: {default: false}
   },
 
+  multiple: true,
+
   init: function () {
     this.clearedIntersectedEls = [];
     this.unitLineEndVec3 = new THREE.Vector3();


### PR DESCRIPTION
**Description:**

I have a controller that wants two raycasters for different purposes (different `objects`, toggled `enabled` in different circumstances, one auto-refresh / one not auto-refresh). At the moment, I do not need to discern which raycaster is emitting the events, I can discern at application level.

**Changes proposed:**
- raycaster `multiple`
