### PR TITLE
use trigger as well as trackpad press for cursor (mouse) events

### DIFF
--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -76,7 +76,7 @@ registerComponent('laser-controls', {
     },
 
     'oculus-go-controls': {
-      cursor: {downEvents: ['trackpaddown'], upEvents: ['trackpadup']},
+      cursor: {downEvents: ['trackpaddown', 'triggerdown'], upEvents: ['trackpadup', 'triggerup']},
       raycaster: {origin: {x: 0, y: 0.0005, z: 0}}
     },
 


### PR DESCRIPTION
Unlike gearvr-controls, oculus-go-controls was only mapping trackpad press to mouse up/down.  This is contrary to standard usage of the Go controller, which almost always uses the trigger for point-and-click tasks.  So I added triggerdown/triggerup, just like on GearVR.

**Description:**

**Changes proposed:**
-
-
-
