### PR TITLE
look-controls: in flat mode, allows camera z-rotation (by other control)

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -198,7 +198,6 @@ module.exports.Component = registerComponent('look-controls', {
     // On mobile, do camera rotation with touch events and sensors.
     el.object3D.rotation.x = hmdEuler.x + pitchObject.rotation.x;
     el.object3D.rotation.y = hmdEuler.y + yawObject.rotation.y;
-    el.object3D.rotation.z = 0;
   },
 
   /**


### PR DESCRIPTION
**Description:**
Removes the line where camera z-rotation is always forced to 0

**Changes proposed:**
In v0.7.x, look-controls allowed experiences with the feel of flying; specifically, banking into turns. (for example, https://elfland-glider.surge.sh/)  The current implementation sets camera z-rotation to 0 on every tick, making look-controls incompatible with such experiences.  As z-rotation is initially zeroed, that line is not necessary to keep z-rotation zero on non-banking experiences.

If an experience needs to alter the z-rotation, it must still implement that separately.
