### PR TITLE
clear raycaster intersections when disabled (fixes #3593)

### DIFF
--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -283,6 +283,20 @@ suite('raycaster', function () {
       });
       component.tick();
     });
+
+    test('clears intersections when disabled', function (done) {
+      targetEl.addEventListener('raycaster-intersected', function () {
+        targetEl.addEventListener('raycaster-intersected-cleared', function () {
+          done();
+        });
+        assert.equal(component.intersectedEls.length, 2);
+        assert.equal(component.clearedIntersectedEls.length, 0);
+        el.setAttribute('raycaster', 'enabled', false);
+        assert.equal(component.intersectedEls.length, 0);
+        assert.equal(component.clearedIntersectedEls.length, 2);
+      });
+      component.tick();
+    });
   });
 
   suite('non-recursive raycaster', function () {


### PR DESCRIPTION
**Description:**

Fix an issue where entities would not get `mouseleave`d when raycaster was disabled.

**Changes proposed:**
- When toggling raycaster to disabled, clear its intersections.
- Use event constants to define in one place now that they are used in multiple methods.
