### PR TITLE
[breaking] remove raycaster-intersected garbage in favor of fetching getIntersection manually

### DIFF
--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -75,6 +75,8 @@ module.exports.Component = registerComponent('raycaster', {
     this.otherLineEndVec3 = new THREE.Vector3();
     this.lineData = {end: this.lineEndVec3};
 
+    this.getIntersection = this.getIntersection.bind(this);
+    this.intersectedDetail = {el: this.el, getIntersection: this.getIntersection};
     this.intersectedClearedDetail = {el: this.el};
     this.intersectionClearedDetail = {clearedEls: this.clearedIntersectedEls};
     this.intersectionDetail = {};
@@ -254,10 +256,7 @@ module.exports.Component = registerComponent('raycaster', {
 
     // Emit intersected on intersected entity per intersected entity.
     for (i = 0; i < newIntersectedEls.length; i++) {
-      newIntersectedEls[i].emit(EVENTS.INTERSECT, {
-        el: el,
-        intersection: newIntersections[i]
-      });
+      newIntersectedEls[i].emit(EVENTS.INTERSECT, this.intersectedDetail);
     }
 
     // Emit all intersections at once on raycasting entity.

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -194,7 +194,10 @@ suite('raycaster', function () {
     });
 
     test('can catch basic intersection', function (done) {
-      targetEl.addEventListener('raycaster-intersected', function () { done(); });
+      targetEl.addEventListener('raycaster-intersected', function (evt) {
+        assert.ok(evt.detail.getIntersection(targetEl));
+        done();
+      });
       component.tick();
     });
 


### PR DESCRIPTION
**Description:**

The intersection in the event detail requires object creation. Pass a function instead. The intersection data is only used in certain and more involved cases and calling a function to get the intersection data is easy.

Can update docs if looks good.

**Changes proposed:**
- Instead of emit an object per intersection on tick, reuse the event detail, and offer `getIntersection` method to fetch intersection data.