### PR TITLE
fix canvas textures being created as video textures

### DIFF
--- a/examples/test/canvas-texture/components/canvas-updater.js
+++ b/examples/test/canvas-texture/components/canvas-updater.js
@@ -1,0 +1,14 @@
+/* global AFRAME */
+
+AFRAME.registerComponent('canvas-updater', {
+  dependencies: ['geometry', 'material'],
+
+  tick: function () {
+    var el = this.el;
+    var material;
+
+    material = el.getObject3D('mesh').material;
+    if (!material.map) { return; }
+    material.map.needsUpdate = true;
+  }
+});

--- a/examples/test/canvas-texture/index.html
+++ b/examples/test/canvas-texture/index.html
@@ -5,6 +5,7 @@
     <title>Canvas Texture</title>
     <meta name="description" content="Canvas Texture - A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
+    <script src="./components/canvas-updater.js"></script>
     <script src="./components/draw-canvas-rectangles.js"></script>
   </head>
   <body>
@@ -16,6 +17,7 @@
       <a-entity material="shader: flat; src: #helloWorldCanvas"
                 geometry="primitive: plane; width: 160; height: 90"
                 position="0 60 -250" rotation="0 35 0"
+                canvas-updater
                 draw-canvas-rectangles="#helloWorldCanvas">
       </a-entity>
     </a-scene>

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -99,10 +99,10 @@ module.exports.System = registerSystem('material', {
    * @param {function} cb - Callback to pass texture to.
    */
   loadCanvas: function (src, data, cb) {
-    // Hack readyState and HAVE_CURRENT_DATA on canvas to work with THREE.VideoTexture
-    src.readyState = 2;
-    src.HAVE_CURRENT_DATA = 2;
-    this.loadVideo(src, data, cb);
+    var texture;
+    texture = new THREE.CanvasTexture(src);
+    setTextureProperties(texture, data);
+    cb(texture);
   },
 
     /**

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -80,6 +80,19 @@ suite('material', function () {
       });
     });
 
+    test('can load canvas texture', function (done) {
+      var canvas = document.createElement('canvas');
+      canvas.setAttribute('id', 'canvas');
+      el.sceneEl.appendChild(canvas);
+      el.addEventListener('materialtextureloaded', function (evt) {
+        assert.equal(el.components.material.material.map.image, canvas);
+        done();
+      });
+      setTimeout(() => {
+        el.setAttribute('material', {src: '#canvas'});
+      });
+    });
+
     test('removes texture when src attribute removed', function (done) {
       var imageUrl = 'base/tests/assets/test.png';
       el.setAttribute('material', '');


### PR DESCRIPTION
**Description:**

https://stackoverflow.com/questions/50493717/how-to-get-aframe-to-only-upload-canvas-contents-to-texture-when-needed/50505535#50505535

Canvas textures was re-uploading to GPU every frame.

**Changes proposed:**
- Don't use VideoTexture for canvas...
