### PR TITLE
Fix bug in raycaster example

### DIFF
--- a/examples/test/raycaster/simple.html
+++ b/examples/test/raycaster/simple.html
@@ -13,14 +13,14 @@
   AFRAME.registerComponent('raycast-blab', {
     init: function () {
       this.el.addEventListener('raycaster-intersected', function (evt) {
-        var el = evt.detail.target;
+        var el = evt.target;
 	// May get two intersection events per tick; same element, different faces.
         console.log('raycaster-intersected ' + el.outerHTML);
         el.setAttribute('material', 'color', '#7f7');
       });
 
       this.el.addEventListener('raycaster-intersected-cleared', function (evt) {
-        var el = evt.detail.target;
+        var el = evt.target;
 	// May get two intersection events per tick; same element, different faces.
         console.log('raycaster-intersected-cleared ' + el.outerHTML);
         el.setAttribute('material', 'color', '#f77');


### PR DESCRIPTION
It seems to me like this was always broken, and that it meant to get the top-level `target` on the event. After the fix, the example seems to correctly change the color of the big box that is the raycaster target when it is intersected, as I presume it was meant to. Tested on Firefox and Chrome.