### PR TITLE
Bump three.js to r93

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "present": "0.0.6",
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
-    "three": "0.92.0",
+    "three": "0.93.0",
     "three-bmfont-text": "^2.1.0",
     "webvr-polyfill": "^0.10.5"
   },

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -154,13 +154,13 @@ module.exports.Component = registerComponent('screenshot', {
       // Use ortho camera.
       camera = this.camera;
       // Copy position and rotation of scene camera into the ortho one.
-      camera.position.copy(el.camera.getWorldPosition());
-      camera.rotation.copy(el.camera.getWorldRotation());
+      el.camera.getWorldPosition(camera.position);
+      el.camera.getWorldRotation(camera.rotation);
       // Create cube camera and copy position from scene camera.
       cubeCamera = new THREE.CubeCamera(el.camera.near, el.camera.far,
                                         Math.min(this.cubeMapSize, 2048));
-      cubeCamera.position.copy(el.camera.getWorldPosition());
-      cubeCamera.rotation.copy(el.camera.getWorldRotation());
+      el.camera.getWorldPosition(cubeCamera.position);
+      el.camera.getWorldRotation(cubeCamera.rotation);
       // Render scene with cube camera.
       cubeCamera.updateCubeMap(el.renderer, el.object3D);
       this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -640,7 +640,7 @@ module.exports.AScene = registerElement('a-scene', {
 
         if (this.isPlaying) { this.tick(this.time, this.delta); }
 
-        renderer.animate(this.render);
+        renderer.setAnimationLoop(this.render);
         renderer.render(this.object3D, this.camera, this.renderTarget);
       },
       writable: true

--- a/src/geometries/triangle.js
+++ b/src/geometries/triangle.js
@@ -26,7 +26,7 @@ registerGeometry('triangle', {
     triangle.a.set(data.vertexA.x, data.vertexA.y, data.vertexA.z);
     triangle.b.set(data.vertexB.x, data.vertexB.y, data.vertexB.z);
     triangle.c.set(data.vertexC.x, data.vertexC.y, data.vertexC.z);
-    normal = triangle.normal();
+    normal = triangle.getNormal(new THREE.Vector3());
 
     // Rotate the 3D triangle to be parallel to XY plane.
     quaternion.setFromUnitVectors(normal, rotateVector);

--- a/tests/components/light.test.js
+++ b/tests/components/light.test.js
@@ -1,5 +1,6 @@
 /* global assert, process, setup, suite, test */
 var entityFactory = require('../helpers').entityFactory;
+var THREE = require('index').THREE;
 
 suite('light', function () {
   setup(function (done) {
@@ -157,9 +158,10 @@ suite('light', function () {
       lightEl.setAttribute('light', 'type', 'spot');
       light = lightEl.getObject3D('light');
 
-      assert.equal(lightEl.object3D.position.x, light.getWorldPosition().x);
-      assert.equal(lightEl.object3D.position.y, light.getWorldPosition().y);
-      assert.equal(lightEl.object3D.position.z, light.getWorldPosition().z);
+      var pos = light.getWorldPosition(new THREE.Vector3());
+      assert.equal(lightEl.object3D.position.x, pos.x);
+      assert.equal(lightEl.object3D.position.y, pos.y);
+      assert.equal(lightEl.object3D.position.z, pos.z);
     });
 
     test('directional light object3d position is at light element position', function () {
@@ -169,9 +171,10 @@ suite('light', function () {
       lightEl.setAttribute('light', 'type', 'directional');
       light = lightEl.getObject3D('light');
 
-      assert.equal(lightEl.object3D.position.x, light.getWorldPosition().x);
-      assert.equal(lightEl.object3D.position.y, light.getWorldPosition().y);
-      assert.equal(lightEl.object3D.position.z, light.getWorldPosition().z);
+      var pos = light.getWorldPosition(new THREE.Vector3());
+      assert.equal(lightEl.object3D.position.x, pos.x);
+      assert.equal(lightEl.object3D.position.y, pos.y);
+      assert.equal(lightEl.object3D.position.z, pos.z);
     });
 
     // point light doesn't have the bug
@@ -182,9 +185,10 @@ suite('light', function () {
       lightEl.setAttribute('light', 'type', 'point');
       light = lightEl.getObject3D('light');
 
-      assert.equal(lightEl.object3D.position.x, light.getWorldPosition().x);
-      assert.equal(lightEl.object3D.position.y, light.getWorldPosition().y);
-      assert.equal(lightEl.object3D.position.z, light.getWorldPosition().z);
+      var pos = light.getWorldPosition(new THREE.Vector3());
+      assert.equal(lightEl.object3D.position.x, pos.x);
+      assert.equal(lightEl.object3D.position.y, pos.y);
+      assert.equal(lightEl.object3D.position.z, pos.z);
     });
 
     // ambient light doesn't have the bug
@@ -195,9 +199,10 @@ suite('light', function () {
       lightEl.setAttribute('light', 'type', 'ambient');
       light = lightEl.getObject3D('light');
 
-      assert.equal(lightEl.object3D.position.x, light.getWorldPosition().x);
-      assert.equal(lightEl.object3D.position.y, light.getWorldPosition().y);
-      assert.equal(lightEl.object3D.position.z, light.getWorldPosition().z);
+      var pos = light.getWorldPosition(new THREE.Vector3());
+      assert.equal(lightEl.object3D.position.x, pos.x);
+      assert.equal(lightEl.object3D.position.y, pos.y);
+      assert.equal(lightEl.object3D.position.z, pos.z);
     });
 
     test('hemisphere light object3d position is at light element position', function () {
@@ -207,9 +212,10 @@ suite('light', function () {
       lightEl.setAttribute('light', 'type', 'hemisphere');
       light = lightEl.getObject3D('light');
 
-      assert.equal(lightEl.object3D.position.x, light.getWorldPosition().x);
-      assert.equal(lightEl.object3D.position.y, light.getWorldPosition().y);
-      assert.equal(lightEl.object3D.position.z, light.getWorldPosition().z);
+      var pos = light.getWorldPosition(new THREE.Vector3());
+      assert.equal(lightEl.object3D.position.x, pos.x);
+      assert.equal(lightEl.object3D.position.y, pos.y);
+      assert.equal(lightEl.object3D.position.z, pos.z);
     });
   });
 


### PR DESCRIPTION
https://github.com/mrdoob/three.js/wiki/Migration-Guide#r92--r93
https://github.com/mrdoob/three.js/milestone/6?closed=1

`npm test` passes, and I ran all tests and examples in localhost:9000/examples on Ubuntu Firefox, without VR, and fixed a few simple warnings that flew out related to recent three.js API deprecations. Everything looks good at a glance.

It would probably be nice to test VR.

(Actually, the "Generic Logo" example doesn't work for me. But it doesn't seem related -- it also doesn't work for me on the [live site](https://aframe.io/aframe/examples/animation/generic-logo/). Tried Firefox and Chrome both.)