### PR TITLE
Fix NaN for faces & vertices on stats panel

### DIFF
--- a/vendor/rStats.extras.js
+++ b/vendor/rStats.extras.js
@@ -122,9 +122,6 @@ window.threeStats = function ( renderer ) {
         },
         'renderer.info.render.points': {
             caption: 'Points'
-        },
-        'renderer.info.render.vertices': {
-            caption: 'Vertices'
         }
     };
 
@@ -133,7 +130,7 @@ window.threeStats = function ( renderer ) {
         values: [ 'renderer.info.memory.geometries', 'renderer.info.programs', 'renderer.info.memory.textures' ]
     }, {
         caption: 'Three.js - Render',
-        values: [ 'renderer.info.render.calls', 'renderer.info.render.triangles', 'renderer.info.render.points', 'renderer.info.render.vertices' ]
+        values: [ 'renderer.info.render.calls', 'renderer.info.render.triangles', 'renderer.info.render.points' ]
     } ];
 
     var _fractions = [];
@@ -146,7 +143,6 @@ window.threeStats = function ( renderer ) {
         _rS( 'renderer.info.render.calls' ).set( renderer.info.render.calls );
         _rS( 'renderer.info.render.triangles' ).set( renderer.info.render.triangles );
         _rS( 'renderer.info.render.points' ).set( renderer.info.render.points );
-        _rS( 'renderer.info.render.vertices' ).set( renderer.info.render.triangles / 3 );
 
     }
 

--- a/vendor/rStats.extras.js
+++ b/vendor/rStats.extras.js
@@ -116,8 +116,8 @@ window.threeStats = function ( renderer ) {
         'renderer.info.render.calls': {
             caption: 'Calls'
         },
-        'renderer.info.render.faces': {
-            caption: 'Faces',
+        'renderer.info.render.triangles': {
+            caption: 'Triangles',
             over: 1000
         },
         'renderer.info.render.points': {
@@ -133,7 +133,7 @@ window.threeStats = function ( renderer ) {
         values: [ 'renderer.info.memory.geometries', 'renderer.info.programs', 'renderer.info.memory.textures' ]
     }, {
         caption: 'Three.js - Render',
-        values: [ 'renderer.info.render.calls', 'renderer.info.render.faces', 'renderer.info.render.points', 'renderer.info.render.vertices' ]
+        values: [ 'renderer.info.render.calls', 'renderer.info.render.triangles', 'renderer.info.render.points', 'renderer.info.render.vertices' ]
     } ];
 
     var _fractions = [];
@@ -144,9 +144,9 @@ window.threeStats = function ( renderer ) {
         _rS( 'renderer.info.programs' ).set( renderer.info.programs.length );
         _rS( 'renderer.info.memory.textures' ).set( renderer.info.memory.textures );
         _rS( 'renderer.info.render.calls' ).set( renderer.info.render.calls );
-        _rS( 'renderer.info.render.faces' ).set( renderer.info.render.faces );
+        _rS( 'renderer.info.render.triangles' ).set( renderer.info.render.triangles );
         _rS( 'renderer.info.render.points' ).set( renderer.info.render.points );
-        _rS( 'renderer.info.render.vertices' ).set( renderer.info.render.vertices );
+        _rS( 'renderer.info.render.vertices' ).set( renderer.info.render.triangles / 3 );
 
     }
 


### PR DESCRIPTION
**Description:**
https://github.com/aframevr/aframe/issues/3573
Matching the name change in three.js to fix a NaN error in the stats panel

Not sure why the vertices stopped working also, as I couldn't find the change that broke this – are vertices shared? If so the calculation for vertices will be incorrect.

EDIT: Ignore my stupid mistake with the vertex calculation!
