### PR TITLE
Remove fromExternal flag from exitVR / enterVR. VRManager vr mode cannot be enabled / disabled with the flag present

### DIFF
--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -180,15 +180,6 @@ suite('a-scene (without renderer)', function () {
       });
     });
 
-    test('does not call requestPresent if flag passed', function (done) {
-      var sceneEl = this.el;
-      this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(true);
-      sceneEl.enterVR(true).then(function () {
-        assert.notOk(sceneEl.renderer.vr.enabled);
-        done();
-      });
-    });
-
     test('adds VR mode state', function (done) {
       var sceneEl = this.el;
       sceneEl.enterVR().then(function () {
@@ -281,16 +272,6 @@ suite('a-scene (without renderer)', function () {
       sceneEl.isMobile = false;
       this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(false);
       sceneEl.exitVR().then(function () {
-        assert.ok(sceneEl.renderer.vr.enabled);
-        done();
-      });
-    });
-
-    test('does not call exitPresent if flag passed', function (done) {
-      var sceneEl = this.el;
-      sceneEl.renderer.vr.enabled = true;
-      this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(true);
-      sceneEl.exitVR(true).then(function () {
         assert.ok(sceneEl.renderer.vr.enabled);
         done();
       });


### PR DESCRIPTION
@machenmusik Probably the `fromExternal` flag is no longer necessary. I cannot find a reason why we would still need it. Happy to reintroduce if still relevant.