### PR TITLE
removed the convertUpAxis line from the collada loader component

### DIFF
--- a/src/components/collada-model.js
+++ b/src/components/collada-model.js
@@ -7,7 +7,6 @@ module.exports.Component = registerComponent('collada-model', {
   init: function () {
     this.model = null;
     this.loader = new THREE.ColladaLoader();
-    this.loader.options.convertUpAxis = true;
   },
 
   update: function () {


### PR DESCRIPTION
this feature was deprecated in three.js/commit/a07f3f7037a5abd58b6335a6a4bd168b0e11393e

**Description:**
remove attempt to use deprecated three.js feature

**Changes proposed:**
- remove line 10 from `src/components/collada-model.js`

**Questions**
I was unclear on if I should commit the updated/built files? It's really only `src/components/collada-model.js` that changed.