### PR TITLE
[docs] Add a section about non-ascii characters to text component.

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -166,6 +166,29 @@ the SDF font, DejaVu:
 [fontexampleimage]: http://i.imgur.com/iWtXHm5.png
 ![Arial Black vs. Deja Vu][fontexampleimage]
 
+### Non-ASCII Characters
+
+To use non-ascii characters, you need to create your own custom font. The easiest way is to use [a web-based MSDF tool][msdf-bmfont-web]. Select your required character set and generate your own custom msdf font zip file.
+
+Once you download your custom msdf font zip file, extract it and rename `*.png` to `*-msdf.png`, then put both png and json files to your A-Frame directory.
+
+Lastly, you should specify the character set used in your HTML by using `<meta>` tag to avoid text to be garbled. If your text is garbled, it is not rendered.
+
+```html
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <script src="https://aframe.io/releases/0.8.2/aframe.min.js"></script>
+  </head>
+  <body>
+    <a-scene>
+      <a-sky color="lightblue"></a-sky>
+      <a-text value="ABCあいうえお日本語" font="custom-msdf.json" negate="false" scale="2 2 1" position="-2 2 -4"></a-text>
+    </a-scene>
+  </body>
+</html>
+```
+
 ## Sizing
 
 [position]: ./position.md


### PR DESCRIPTION
It is essential for non-English users like me to know how to use non-ASCII characters in A-Frame. I added a section about how to generate a custom msdf font to use non-ASCII characters. In my case, it is Japanese characters.