### PR TITLE
Introduce postprocessing API

### DIFF
--- a/docs/core/effects.md
+++ b/docs/core/effects.md
@@ -1,0 +1,27 @@
+---
+title: Effects
+type: core
+layout: docs
+parent_section: core
+order: 5
+source_code: src/core/scene/effect.js
+examples: []
+---
+
+Effects are post processing special effects that are applied after the scene is renderered.
+All the built-in effects are designed to work in both 2D and VR modes.
+
+Effects are components applied to `<a-scene>` and there's a fixed order in wich the effects are applied regardless on when and how are applied to `<a-scene>`
+
+The effects available are bloom, vignette, tint, noise, gamma, film and are named with the prefix `effect-`
+
+<!--toc-->
+
+## Example
+
+```html
+<a-scene effect-bloom effect-sepia background="color: black">
+  <a-box color="white"></a-box>
+</a-scene>
+```
+

--- a/examples/test/effects/index.html
+++ b/examples/test/effects/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Laser Controls</title>
+    <meta name="description" content="Effects - A-Frame">
+    <script src="../../../dist/aframe-master.js"></script>
+  </head>
+  <body>
+    <a-scene effect-bloom effect-sepia background="color: black">
+      <a-box color="white" position="0 1.6 -2"></a-box>
+    </a-scene>
+  </body>
+</html>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -30,6 +30,7 @@ require('./windows-motion-controls');
 
 require('./scene/background');
 require('./scene/debug');
+require('./scene/effects');
 require('./scene/embedded');
 require('./scene/inspector');
 require('./scene/fog');

--- a/src/components/scene/effects/bloom.js
+++ b/src/components/scene/effects/bloom.js
@@ -1,0 +1,28 @@
+/* global THREE */
+var registerEffect = require('../../../core/effect').registerEffect;
+
+require('../../../../vendor/effects/CopyShader');
+require('../../../../vendor/effects/ShaderPass');
+require('../../../../vendor/effects/LuminosityHighPassShader');
+require('../../../../vendor/effects/UnrealBloomPass');
+
+registerEffect('bloom', {
+  schema: {
+    strength: {default: 1.5},
+    radius: {default: 0.4},
+    threshold: {default: 0.5}
+  },
+
+  initPass: function () {
+    this.pass = new THREE.UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 1.5, 0.4, 0.85);
+  },
+
+  update: function () {
+    var data = this.data;
+    var pass = this.pass;
+    if (!pass) { return; }
+    pass.strength = data.strength;
+    pass.radius = data.radius;
+    pass.threshold = data.threshold;
+  }
+});

--- a/src/components/scene/effects/index.js
+++ b/src/components/scene/effects/index.js
@@ -1,0 +1,3 @@
+require('./bloom');
+require('./sepia');
+

--- a/src/components/scene/effects/sepia.js
+++ b/src/components/scene/effects/sepia.js
@@ -1,0 +1,22 @@
+/* global THREE */
+var registerEffect = require('../../../core/effect').registerEffect;
+
+require('../../../../vendor/effects/ShaderPass');
+require('../../../../vendor/effects/SepiaShader');
+
+registerEffect('sepia', {
+  schema: {
+    amount: {default: 1.0}
+  },
+
+  initPass: function () {
+    this.pass = new THREE.ShaderPass(THREE.SepiaShader);
+    this.update();
+  },
+
+  update: function () {
+    if (!this.pass) { return; }
+    this.pass.uniforms.amount.value = this.data.amount;
+    this.pass.uniforms.needsUpdate = true;
+  }
+});

--- a/src/core/effect.js
+++ b/src/core/effect.js
@@ -1,0 +1,78 @@
+require('../../vendor/effects/EffectComposer');
+require('../../vendor/effects/RenderPass');
+
+var registerComponent = require('./component').registerComponent;
+var THREE = require('../lib/three');
+var warn = require('../utils/').debug('components:effect:warn');
+
+var lastEffectInitialized;
+
+var effectOrder = ['render', 'bloom', 'sepia'];
+var passes = {};
+
+var proto = {
+  schema: {},
+  init: function () {
+    var sceneEl = this.el;
+
+    if (!this.el.isScene) {
+      warn('Effect components can only be applied to <a-scene>');
+      return;
+    }
+
+    if (!sceneEl.camera) {
+      sceneEl.addEventListener('camera-set-active', this.init.bind(this));
+      return;
+    }
+    sceneEl.effectComposer || this.initEffectComposer();
+    this.initPass();
+    this.update();
+    lastEffectInitialized.renderToScreen = false;
+    this.pass.renderToScreen = true;
+    lastEffectInitialized = this.pass;
+    passes[this.effectName] = this.pass;
+    this.rebuild();
+  },
+
+  rebuild: function () {
+    var effectComposer = this.el.effectComposer;
+    effectComposer.passes = [];
+    effectOrder.forEach(function (effect) {
+      if (!passes[effect]) { return; }
+      effectComposer.addPass(passes[effect]);
+    });
+  },
+
+  remove: function () {
+    this.el.effectComposer.removePass(this.pass);
+    passes[this.effectName] = undefined;
+  },
+
+  initEffectComposer: function () {
+    var sceneEl = this.el;
+    var effectComposer = sceneEl.effectComposer = new THREE.EffectComposer(sceneEl.renderer);
+    var renderPass = new THREE.RenderPass(sceneEl.object3D, sceneEl.camera);
+    effectComposer.addPass(renderPass);
+    lastEffectInitialized = renderPass;
+    renderPass.renderToScreen = true;
+    passes.render = renderPass;
+    setTimeout(function () { effectComposer.resize(); }, 0);
+    return effectComposer;
+  }
+};
+
+/**
+ * Registers an effect to A-Frame.
+ *
+ * @param {string} name - Effect name.
+ * @param {object} definition - Effect property and methods.
+ */
+module.exports.registerEffect = function (name, definition) {
+  Object.keys(definition).forEach(function (key) {
+    proto[key] = definition[key];
+  });
+
+  proto.effectName = name;
+
+  registerComponent('effect-' + name, proto);
+};

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -630,14 +630,20 @@ module.exports.AScene = registerElement('a-scene', {
      */
     render: {
       value: function () {
-        this.delta = this.clock.getDelta() * 1000;
+        var effectComposer = this.effectComposer;
         var renderer = this.renderer;
+
+        this.delta = this.clock.getDelta() * 1000;
         this.time = this.clock.elapsedTime * 1000;
 
         if (this.isPlaying) { this.tick(this.time, this.delta); }
 
         renderer.setAnimationLoop(this.render);
-        renderer.render(this.object3D, this.camera, this.renderTarget);
+        if (effectComposer) {
+          effectComposer.render();
+        } else {
+          renderer.render(this.object3D, this.camera, this.renderTarget);
+        }
       },
       writable: true
     }

--- a/vendor/effects/CopyShader.js
+++ b/vendor/effects/CopyShader.js
@@ -1,0 +1,46 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ *
+ * Full-screen textured quad shader
+ */
+
+THREE.CopyShader = {
+
+  uniforms: {
+
+    "tDiffuse": { value: null },
+    "opacity":  { value: 1.0 }
+
+  },
+
+  vertexShader: [
+
+    "varying vec2 vUv;",
+
+    "void main() {",
+
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+
+    "}"
+
+  ].join( "\n" ),
+
+  fragmentShader: [
+
+    "uniform float opacity;",
+
+    "uniform sampler2D tDiffuse;",
+
+    "varying vec2 vUv;",
+
+    "void main() {",
+
+      "vec4 texel = texture2D( tDiffuse, vUv );",
+      "gl_FragColor = opacity * texel;",
+
+    "}"
+
+  ].join( "\n" )
+
+};

--- a/vendor/effects/EffectComposer.js
+++ b/vendor/effects/EffectComposer.js
@@ -1,0 +1,247 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ */
+
+THREE.EffectComposer = function ( renderer, renderTarget ) {
+
+  this.renderer = renderer;
+
+  window.addEventListener( 'vrdisplaypresentchange' , this.resize.bind(this) );
+  window.addEventListener( 'resize' , this.resize.bind(this) );
+
+  if ( renderTarget === undefined ) {
+
+    var parameters = {
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      format: THREE.RGBAFormat,
+      stencilBuffer: false
+    };
+
+    var size = renderer.getDrawingBufferSize();
+    renderTarget = new THREE.WebGLRenderTarget( size.width, size.height, parameters );
+    renderTarget.texture.name = 'EffectComposer.rt1';
+
+  }
+
+  this.renderTarget1 = renderTarget;
+  this.renderTarget2 = renderTarget.clone();
+  this.renderTarget2.texture.name = 'EffectComposer.rt2';
+
+  this.writeBuffer = this.renderTarget1;
+  this.readBuffer = this.renderTarget2;
+
+  this.passes = [];
+  this.maskActive = false;
+
+  // dependencies
+
+  if ( THREE.CopyShader === undefined ) {
+
+    console.error( 'THREE.EffectComposer relies on THREE.CopyShader' );
+
+  }
+
+  if ( THREE.ShaderPass === undefined ) {
+
+    console.error( 'THREE.EffectComposer relies on THREE.ShaderPass' );
+
+  }
+
+  this.copyPass = new THREE.ShaderPass( THREE.CopyShader );
+
+};
+
+Object.assign( THREE.EffectComposer.prototype, {
+
+  swapBuffers: function ( pass ) {
+
+    if ( pass.needsSwap ) {
+
+      if ( this.maskActive ) {
+
+        var context = this.renderer.context;
+
+        context.stencilFunc( context.NOTEQUAL, 1, 0xffffffff );
+
+        this.copyPass.render( this.renderer, this.writeBuffer, this.readBuffer, delta );
+
+        context.stencilFunc( context.EQUAL, 1, 0xffffffff );
+
+      }
+
+      var tmp = this.readBuffer;
+      this.readBuffer = this.writeBuffer;
+      this.writeBuffer = tmp;
+
+    }
+
+    if ( THREE.MaskPass !== undefined ) {
+
+      if ( pass instanceof THREE.MaskPass ) {
+
+        this.maskActive = true;
+
+      } else if ( pass instanceof THREE.ClearMaskPass ) {
+
+        this.maskActive = false;
+
+      }
+
+    }
+
+  },
+
+  addPass: function ( pass ) {
+
+    this.passes.push( pass );
+
+    var size = this.renderer.getDrawingBufferSize();
+    pass.setSize( size.width, size.height );
+
+  },
+
+  removePass: function ( pass ) {
+
+    var index = this.passes.indexOf(pass);
+
+    if ( index === -1 ) { return; }
+
+    this.passes.splice( this.passes.indexOf(pass), 1 );
+
+    this.passes[this.passes.length - 1].renderToScreen = true;
+
+    this.resize();
+
+  },
+
+  insertPass: function ( pass, index ) {
+
+    this.passes.splice( index, 0, pass );
+
+  },
+
+  render: function ( delta, starti ) {
+
+    var maskActive = this.maskActive;
+
+    var pass, i, il = this.passes.length;
+
+    var scope = this;
+
+    var currentOnAfterRender;
+
+    for ( i = starti || 0; i < il; i ++ ) {
+
+      pass = this.passes[ i ];
+      
+      if ( pass.enabled === false ) continue;
+
+      // If VR mode is enabled and rendering the whole scene is required.
+      // The pass renders the scene and and postprocessing is resumed before
+      // submitting the frame to the headset by using the onAfterRender callback.
+      if ( this.renderer.vr.enabled && pass.scene ) {
+
+        currentOnAfterRender = pass.scene.onAfterRender;
+
+        pass.scene.onAfterRender = function () {
+
+          // Disable stereo rendering when doing postprocessing
+          // on a render target.
+          scope.renderer.vr.enabled = false;
+
+          scope.render( delta, i + 1, maskActive );
+
+          // Renable vr mode.
+          scope.renderer.vr.enabled = true;
+        }
+
+        pass.render( this.renderer, this.writeBuffer, this.readBuffer, delta, maskActive );
+        
+        // Restore onAfterRender
+        pass.scene.onAfterRender = currentOnAfterRender;
+
+        this.swapBuffers( pass );
+
+        return;
+      }
+
+      pass.render( this.renderer, this.writeBuffer, this.readBuffer, delta, maskActive );
+
+      this.swapBuffers(pass);
+
+    }
+
+  },
+
+  reset: function ( renderTarget ) {
+
+    if ( renderTarget === undefined ) {
+
+      var size = this.renderer.getDrawingBufferSize();
+
+      renderTarget = this.renderTarget1.clone();
+      renderTarget.setSize( size.width, size.height );
+
+    }
+
+    this.renderTarget1.dispose();
+    this.renderTarget2.dispose();
+    this.renderTarget1 = renderTarget;
+    this.renderTarget2 = renderTarget.clone();
+
+    this.writeBuffer = this.renderTarget1;
+    this.readBuffer = this.renderTarget2;
+
+  },
+
+  setSize: function ( width, height ) {
+
+    this.renderTarget1.setSize( width, height );
+    this.renderTarget2.setSize( width, height );
+
+    for ( var i = 0; i < this.passes.length; i ++ ) {
+
+      this.passes[ i ].setSize( width, height );
+
+    }
+
+  },
+
+  resize: function ( ) {
+
+    var rendererSize = this.renderer.getDrawingBufferSize();
+    this.setSize( rendererSize.width, rendererSize.height );
+
+  }
+
+} );
+
+
+THREE.Pass = function () {
+
+  // if set to true, the pass is processed by the composer
+  this.enabled = true;
+
+  // if set to true, the pass indicates to swap read and write buffer after rendering
+  this.needsSwap = true;
+
+  // if set to true, the pass clears its buffer before rendering
+  this.clear = false;
+
+  // if set to true, the result of the pass is rendered to screen
+  this.renderToScreen = false;
+
+};
+
+Object.assign( THREE.Pass.prototype, {
+
+  setSize: function ( width, height ) {},
+
+  render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
+
+    console.error( 'THREE.Pass: .render() must be implemented in derived pass.' );
+
+  }
+
+} );

--- a/vendor/effects/LuminosityHighPassShader.js
+++ b/vendor/effects/LuminosityHighPassShader.js
@@ -1,0 +1,64 @@
+/**
+ * @author bhouston / http://clara.io/
+ *
+ * Luminosity
+ * http://en.wikipedia.org/wiki/Luminosity
+ */
+
+THREE.LuminosityHighPassShader = {
+
+  shaderID: "luminosityHighPass",
+
+  uniforms: {
+
+    "tDiffuse": { type: "t", value: null },
+    "luminosityThreshold": { type: "f", value: 1.0 },
+    "smoothWidth": { type: "f", value: 1.0 },
+    "defaultColor": { type: "c", value: new THREE.Color( 0x000000 ) },
+    "defaultOpacity":  { type: "f", value: 0.0 }
+
+  },
+
+  vertexShader: [
+
+    "varying vec2 vUv;",
+
+    "void main() {",
+
+      "vUv = uv;",
+
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+
+    "}"
+
+  ].join("\n"),
+
+  fragmentShader: [
+
+    "uniform sampler2D tDiffuse;",
+    "uniform vec3 defaultColor;",
+    "uniform float defaultOpacity;",
+    "uniform float luminosityThreshold;",
+    "uniform float smoothWidth;",
+
+    "varying vec2 vUv;",
+
+    "void main() {",
+
+      "vec4 texel = texture2D( tDiffuse, vUv );",
+
+      "vec3 luma = vec3( 0.299, 0.587, 0.114 );",
+
+      "float v = dot( texel.xyz, luma );",
+
+      "vec4 outputColor = vec4( defaultColor.rgb, defaultOpacity );",
+
+      "float alpha = smoothstep( luminosityThreshold, luminosityThreshold + smoothWidth, v );",
+
+      "gl_FragColor = mix( outputColor, texel, alpha );",
+
+    "}"
+
+  ].join("\n")
+
+};

--- a/vendor/effects/RenderPass.js
+++ b/vendor/effects/RenderPass.js
@@ -1,0 +1,63 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ */
+
+THREE.RenderPass = function ( scene, camera, overrideMaterial, clearColor, clearAlpha ) {
+
+  THREE.Pass.call( this );
+
+  this.scene = scene;
+  this.camera = camera;
+
+  this.overrideMaterial = overrideMaterial;
+
+  this.clearColor = clearColor;
+  this.clearAlpha = ( clearAlpha !== undefined ) ? clearAlpha : 0;
+
+  this.clear = true;
+  this.clearDepth = false;
+  this.needsSwap = false;
+
+};
+
+THREE.RenderPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ), {
+
+  constructor: THREE.RenderPass,
+
+  render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
+
+    var oldAutoClear = renderer.autoClear;
+    renderer.autoClear = false;
+
+    this.scene.overrideMaterial = this.overrideMaterial;
+
+    var oldClearColor, oldClearAlpha;
+
+    if ( this.clearColor ) {
+
+      oldClearColor = renderer.getClearColor().getHex();
+      oldClearAlpha = renderer.getClearAlpha();
+
+      renderer.setClearColor( this.clearColor, this.clearAlpha );
+
+    }
+
+    if ( this.clearDepth ) {
+
+      renderer.clearDepth();
+
+    }
+
+    renderer.render( this.scene, this.camera, this.renderToScreen ? null : readBuffer, this.clear );
+
+    if ( this.clearColor ) {
+
+      renderer.setClearColor( oldClearColor, oldClearAlpha );
+
+    }
+
+    this.scene.overrideMaterial = null;
+    renderer.autoClear = oldAutoClear;
+  }
+
+} );

--- a/vendor/effects/SepiaShader.js
+++ b/vendor/effects/SepiaShader.js
@@ -1,0 +1,54 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ *
+ * Sepia tone shader
+ * based on glfx.js sepia shader
+ * https://github.com/evanw/glfx.js
+ */
+
+THREE.SepiaShader = {
+
+  uniforms: {
+
+    "tDiffuse": { value: null },
+    "amount":   { value: 1.0 }
+
+  },
+
+  vertexShader: [
+
+    "varying vec2 vUv;",
+
+    "void main() {",
+
+      "vUv = uv;",
+      "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+
+    "}"
+
+  ].join( "\n" ),
+
+  fragmentShader: [
+
+    "uniform float amount;",
+
+    "uniform sampler2D tDiffuse;",
+
+    "varying vec2 vUv;",
+
+    "void main() {",
+
+      "vec4 color = texture2D( tDiffuse, vUv );",
+      "vec3 c = color.rgb;",
+
+      "color.r = dot( c, vec3( 1.0 - 0.607 * amount, 0.769 * amount, 0.189 * amount ) );",
+      "color.g = dot( c, vec3( 0.349 * amount, 1.0 - 0.314 * amount, 0.168 * amount ) );",
+      "color.b = dot( c, vec3( 0.272 * amount, 0.534 * amount, 1.0 - 0.869 * amount ) );",
+
+      "gl_FragColor = vec4( min( vec3( 1.0 ), color.rgb ), color.a );",
+
+    "}"
+
+  ].join( "\n" )
+
+};

--- a/vendor/effects/ShaderPass.js
+++ b/vendor/effects/ShaderPass.js
@@ -1,0 +1,67 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ */
+
+THREE.ShaderPass = function ( shader, textureID ) {
+
+  THREE.Pass.call( this );
+
+  this.textureID = ( textureID !== undefined ) ? textureID : "tDiffuse";
+
+  if ( shader instanceof THREE.ShaderMaterial ) {
+
+    this.uniforms = shader.uniforms;
+
+    this.material = shader;
+
+  } else if ( shader ) {
+
+    this.uniforms = THREE.UniformsUtils.clone( shader.uniforms );
+
+    this.material = new THREE.ShaderMaterial( {
+
+      defines: Object.assign( {}, shader.defines ),
+      uniforms: this.uniforms,
+      vertexShader: shader.vertexShader,
+      fragmentShader: shader.fragmentShader
+
+    } );
+
+  }
+
+  this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+  this.scene = new THREE.Scene();
+
+  this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
+  this.quad.frustumCulled = false; // Avoid getting clipped
+  this.scene.add( this.quad );
+
+};
+
+THREE.ShaderPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ), {
+
+  constructor: THREE.ShaderPass,
+
+  render: function( renderer, writeBuffer, readBuffer, delta, maskActive ) {
+
+    if ( this.uniforms[ this.textureID ] ) {
+
+      this.uniforms[ this.textureID ].value = readBuffer.texture;
+
+    }
+
+    this.quad.material = this.material;
+
+    if ( this.renderToScreen ) {
+
+      renderer.render( this.scene, this.camera );
+
+    } else {
+
+      renderer.render( this.scene, this.camera, writeBuffer, this.clear );
+
+    }
+
+  }
+
+} );

--- a/vendor/effects/UnrealBloomPass.js
+++ b/vendor/effects/UnrealBloomPass.js
@@ -1,0 +1,381 @@
+/**
+ * @author spidersharma / http://eduperiment.com/
+ * 
+ * Inspired from Unreal Engine
+ * https://docs.unrealengine.com/latest/INT/Engine/Rendering/PostProcessEffects/Bloom/
+ */
+THREE.UnrealBloomPass = function ( resolution, strength, radius, threshold ) {
+
+  THREE.Pass.call( this );
+
+  this.strength = ( strength !== undefined ) ? strength : 1;
+  this.radius = radius;
+  this.threshold = threshold;
+  this.resolution = ( resolution !== undefined ) ? new THREE.Vector2( resolution.x, resolution.y ) : new THREE.Vector2( 256, 256 );
+
+  // render targets
+  var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat };
+  this.renderTargetsHorizontal = [];
+  this.renderTargetsVertical = [];
+  this.nMips = 5;
+  var resx = Math.round( this.resolution.x / 2 );
+  var resy = Math.round( this.resolution.y / 2 );
+
+  this.renderTargetBright = new THREE.WebGLRenderTarget( resx, resy, pars );
+  this.renderTargetBright.texture.name = "UnrealBloomPass.bright";
+  this.renderTargetBright.texture.generateMipmaps = false;
+
+  for ( var i = 0; i < this.nMips; i ++ ) {
+
+    var renderTarget = new THREE.WebGLRenderTarget( resx, resy, pars );
+
+    renderTarget.texture.name = "UnrealBloomPass.h" + i;
+    renderTarget.texture.generateMipmaps = false;
+
+    this.renderTargetsHorizontal.push( renderTarget );
+
+    var renderTarget = new THREE.WebGLRenderTarget( resx, resy, pars );
+
+    renderTarget.texture.name = "UnrealBloomPass.v" + i;
+    renderTarget.texture.generateMipmaps = false;
+
+    this.renderTargetsVertical.push( renderTarget );
+
+    resx = Math.round( resx / 2 );
+
+    resy = Math.round( resy / 2 );
+
+  }
+
+  // luminosity high pass material
+
+  if ( THREE.LuminosityHighPassShader === undefined )
+    console.error( "THREE.UnrealBloomPass relies on THREE.LuminosityHighPassShader" );
+
+  var highPassShader = THREE.LuminosityHighPassShader;
+  this.highPassUniforms = THREE.UniformsUtils.clone( highPassShader.uniforms );
+
+  this.highPassUniforms[ "luminosityThreshold" ].value = threshold;
+  this.highPassUniforms[ "smoothWidth" ].value = 0.01;
+
+  this.materialHighPassFilter = new THREE.ShaderMaterial( {
+    uniforms: this.highPassUniforms,
+    vertexShader: highPassShader.vertexShader,
+    fragmentShader: highPassShader.fragmentShader,
+    defines: {}
+  } );
+
+  // Gaussian Blur Materials
+  this.separableBlurMaterials = [];
+  var kernelSizeArray = [ 3, 5, 7, 9, 11 ];
+  var resx = Math.round( this.resolution.x / 2 );
+  var resy = Math.round( this.resolution.y / 2 );
+
+  for ( var i = 0; i < this.nMips; i ++ ) {
+
+    this.separableBlurMaterials.push( this.getSeperableBlurMaterial( kernelSizeArray[ i ] ) );
+
+    this.separableBlurMaterials[ i ].uniforms[ "texSize" ].value = new THREE.Vector2( resx, resy );
+
+    resx = Math.round( resx / 2 );
+
+    resy = Math.round( resy / 2 );
+
+  }
+
+  // Composite material
+  this.compositeMaterial = this.getCompositeMaterial( this.nMips );
+  this.compositeMaterial.uniforms[ "blurTexture1" ].value = this.renderTargetsVertical[ 0 ].texture;
+  this.compositeMaterial.uniforms[ "blurTexture2" ].value = this.renderTargetsVertical[ 1 ].texture;
+  this.compositeMaterial.uniforms[ "blurTexture3" ].value = this.renderTargetsVertical[ 2 ].texture;
+  this.compositeMaterial.uniforms[ "blurTexture4" ].value = this.renderTargetsVertical[ 3 ].texture;
+  this.compositeMaterial.uniforms[ "blurTexture5" ].value = this.renderTargetsVertical[ 4 ].texture;
+  this.compositeMaterial.uniforms[ "bloomStrength" ].value = strength;
+  this.compositeMaterial.uniforms[ "bloomRadius" ].value = 0.1;
+  this.compositeMaterial.needsUpdate = true;
+
+  var bloomFactors = [ 1.0, 0.8, 0.6, 0.4, 0.2 ];
+  this.compositeMaterial.uniforms[ "bloomFactors" ].value = bloomFactors;
+  this.bloomTintColors = [ new THREE.Vector3( 1, 1, 1 ), new THREE.Vector3( 1, 1, 1 ), new THREE.Vector3( 1, 1, 1 ),
+               new THREE.Vector3( 1, 1, 1 ), new THREE.Vector3( 1, 1, 1 ) ];
+  this.compositeMaterial.uniforms[ "bloomTintColors" ].value = this.bloomTintColors;
+
+  // copy material
+  if ( THREE.CopyShader === undefined ) {
+
+    console.error( "THREE.BloomPass relies on THREE.CopyShader" );
+
+  }
+
+  var copyShader = THREE.CopyShader;
+
+  this.copyUniforms = THREE.UniformsUtils.clone( copyShader.uniforms );
+  this.copyUniforms[ "opacity" ].value = 1.0;
+
+  this.materialCopy = new THREE.ShaderMaterial( {
+    uniforms: this.copyUniforms,
+    vertexShader: copyShader.vertexShader,
+    fragmentShader: copyShader.fragmentShader,
+    blending: THREE.AdditiveBlending,
+    depthTest: false,
+    depthWrite: false,
+    transparent: true
+  } );
+
+  this.enabled = true;
+  this.needsSwap = false;
+
+  this.oldClearColor = new THREE.Color();
+  this.oldClearAlpha = 1;
+
+  this.camera = new THREE.OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
+  this.scene = new THREE.Scene();
+
+  this.basic = new THREE.MeshBasicMaterial();
+
+  this.quad = new THREE.Mesh( new THREE.PlaneBufferGeometry( 2, 2 ), null );
+  this.quad.frustumCulled = false; // Avoid getting clipped
+  this.scene.add( this.quad );
+
+};
+
+THREE.UnrealBloomPass.prototype = Object.assign( Object.create( THREE.Pass.prototype ), {
+
+  constructor: THREE.UnrealBloomPass,
+
+  dispose: function () {
+
+    for ( var i = 0; i < this.renderTargetsHorizontal.length; i ++ ) {
+
+      this.renderTargetsHorizontal[ i ].dispose();
+
+    }
+
+    for ( var i = 0; i < this.renderTargetsVertical.length; i ++ ) {
+
+      this.renderTargetsVertical[ i ].dispose();
+
+    }
+
+    this.renderTargetBright.dispose();
+
+  },
+
+  setSize: function ( width, height ) {
+
+    var resx = Math.round( width / 2 );
+    var resy = Math.round( height / 2 );
+
+    this.renderTargetBright.setSize( resx, resy );
+
+    for ( var i = 0; i < this.nMips; i ++ ) {
+
+      this.renderTargetsHorizontal[ i ].setSize( resx, resy );
+      this.renderTargetsVertical[ i ].setSize( resx, resy );
+
+      this.separableBlurMaterials[ i ].uniforms[ "texSize" ].value = new THREE.Vector2( resx, resy );
+
+      resx = Math.round( resx / 2 );
+      resy = Math.round( resy / 2 );
+
+    }
+
+  },
+
+  render: function ( renderer, writeBuffer, readBuffer, delta, maskActive ) {
+
+    this.oldClearColor.copy( renderer.getClearColor() );
+    this.oldClearAlpha = renderer.getClearAlpha();
+    var oldAutoClear = renderer.autoClear;
+    renderer.autoClear = false;
+
+    renderer.setClearColor( new THREE.Color( 0, 0, 0 ), 0 );
+
+    if ( maskActive ) renderer.context.disable( renderer.context.STENCIL_TEST );
+
+    // Render input to screen
+
+    if ( this.renderToScreen ) {
+
+      this.quad.material = this.basic;
+      this.basic.map = readBuffer.texture;
+
+      renderer.render( this.scene, this.camera, undefined, true );
+
+    }
+
+    // 1. Extract Bright Areas
+
+    this.highPassUniforms[ "tDiffuse" ].value = readBuffer.texture;
+    this.highPassUniforms[ "luminosityThreshold" ].value = this.threshold;
+    this.quad.material = this.materialHighPassFilter;
+
+    renderer.render( this.scene, this.camera, this.renderTargetBright, true );
+
+    // 2. Blur All the mips progressively
+
+    var inputRenderTarget = this.renderTargetBright;
+
+    for ( var i = 0; i < this.nMips; i ++ ) {
+
+      this.quad.material = this.separableBlurMaterials[ i ];
+
+      this.separableBlurMaterials[ i ].uniforms[ "colorTexture" ].value = inputRenderTarget.texture;
+      this.separableBlurMaterials[ i ].uniforms[ "direction" ].value = THREE.UnrealBloomPass.BlurDirectionX;
+      renderer.render( this.scene, this.camera, this.renderTargetsHorizontal[ i ], true );
+
+      this.separableBlurMaterials[ i ].uniforms[ "colorTexture" ].value = this.renderTargetsHorizontal[ i ].texture;
+      this.separableBlurMaterials[ i ].uniforms[ "direction" ].value = THREE.UnrealBloomPass.BlurDirectionY;
+      renderer.render( this.scene, this.camera, this.renderTargetsVertical[ i ], true );
+
+      inputRenderTarget = this.renderTargetsVertical[ i ];
+
+    }
+
+    // Composite All the mips
+
+    this.quad.material = this.compositeMaterial;
+    this.compositeMaterial.uniforms[ "bloomStrength" ].value = this.strength;
+    this.compositeMaterial.uniforms[ "bloomRadius" ].value = this.radius;
+    this.compositeMaterial.uniforms[ "bloomTintColors" ].value = this.bloomTintColors;
+
+    renderer.render( this.scene, this.camera, this.renderTargetsHorizontal[ 0 ], true );
+
+    // Blend it additively over the input texture
+
+    this.quad.material = this.materialCopy;
+    this.copyUniforms[ "tDiffuse" ].value = this.renderTargetsHorizontal[ 0 ].texture;
+
+    if ( maskActive ) renderer.context.enable( renderer.context.STENCIL_TEST );
+
+
+    if ( this.renderToScreen ) {
+
+      renderer.render( this.scene, this.camera, undefined, false );
+
+    } else {
+
+      renderer.render( this.scene, this.camera, readBuffer, false );
+
+    }
+
+    // Restore renderer settings
+
+    renderer.setClearColor( this.oldClearColor, this.oldClearAlpha );
+    renderer.autoClear = oldAutoClear;
+
+  },
+
+  getSeperableBlurMaterial: function ( kernelRadius ) {
+
+    return new THREE.ShaderMaterial( {
+
+      defines: {
+        "KERNEL_RADIUS": kernelRadius,
+        "SIGMA": kernelRadius
+      },
+
+      uniforms: {
+        "colorTexture": { value: null },
+        "texSize": { value: new THREE.Vector2( 0.5, 0.5 ) },
+        "direction": { value: new THREE.Vector2( 0.5, 0.5 ) }
+      },
+
+      vertexShader:
+        "varying vec2 vUv;\n\
+        void main() {\n\
+          vUv = uv;\n\
+          gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
+        }",
+
+      fragmentShader:
+        "#include <common>\
+        varying vec2 vUv;\n\
+        uniform sampler2D colorTexture;\n\
+        uniform vec2 texSize;\
+        uniform vec2 direction;\
+        \
+        float gaussianPdf(in float x, in float sigma) {\
+          return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;\
+        }\
+        void main() {\n\
+          vec2 invSize = 1.0 / texSize;\
+          float fSigma = float(SIGMA);\
+          float weightSum = gaussianPdf(0.0, fSigma);\
+          vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;\
+          for( int i = 1; i < KERNEL_RADIUS; i ++ ) {\
+            float x = float(i);\
+            float w = gaussianPdf(x, fSigma);\
+            vec2 uvOffset = direction * invSize * x;\
+            vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;\
+            vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;\
+            diffuseSum += (sample1 + sample2) * w;\
+            weightSum += 2.0 * w;\
+          }\
+          gl_FragColor = vec4(diffuseSum/weightSum, 1.0);\n\
+        }"
+    } );
+
+  },
+
+  getCompositeMaterial: function ( nMips ) {
+
+    return new THREE.ShaderMaterial( {
+
+      defines: {
+        "NUM_MIPS": nMips
+      },
+
+      uniforms: {
+        "blurTexture1": { value: null },
+        "blurTexture2": { value: null },
+        "blurTexture3": { value: null },
+        "blurTexture4": { value: null },
+        "blurTexture5": { value: null },
+        "dirtTexture": { value: null },
+        "bloomStrength": { value: 1.0 },
+        "bloomFactors": { value: null },
+        "bloomTintColors": { value: null },
+        "bloomRadius": { value: 0.0 }
+      },
+
+      vertexShader:
+        "varying vec2 vUv;\n\
+        void main() {\n\
+          vUv = uv;\n\
+          gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
+        }",
+
+      fragmentShader:
+        "varying vec2 vUv;\
+        uniform sampler2D blurTexture1;\
+        uniform sampler2D blurTexture2;\
+        uniform sampler2D blurTexture3;\
+        uniform sampler2D blurTexture4;\
+        uniform sampler2D blurTexture5;\
+        uniform sampler2D dirtTexture;\
+        uniform float bloomStrength;\
+        uniform float bloomRadius;\
+        uniform float bloomFactors[NUM_MIPS];\
+        uniform vec3 bloomTintColors[NUM_MIPS];\
+        \
+        float lerpBloomFactor(const in float factor) { \
+          float mirrorFactor = 1.2 - factor;\
+          return mix(factor, mirrorFactor, bloomRadius);\
+        }\
+        \
+        void main() {\
+          gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) + \
+                           lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) + \
+                           lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) + \
+                           lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) + \
+                           lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );\
+        }"
+    } );
+
+  }
+
+} );
+
+THREE.UnrealBloomPass.BlurDirectionX = new THREE.Vector2( 1.0, 0.0 );
+THREE.UnrealBloomPass.BlurDirectionY = new THREE.Vector2( 0.0, 1.0 );


### PR DESCRIPTION
This is a proposal for a built-in post-processing API. Setting up post-processing in a comprehensive manner that works well in 2D and VR modes is not trivial to do. It requires tight integration with the render loop. A built-in effects API will help raise the visual quality of the content and will make very easy for everybody to experiment with the different effects while ensuring good performance. At first we would not have a public API for user defined effects since many are not suitable for stereo rendering. By providing the effects we can control how and what order are applied to guarantee consistent results and FPS. Once we settle on an API we can consider open it up. 

The API is built by defining `effect-` prefixed scene level components for each effect. The order they are applied is fixed and independent on how and when they are defined. e.g:

````html
  <a-scene effect-bloom="strength: 1.6" effect-sepia background="color: black">
      <a-box color="white" position="0 1.6 -2"></a-box>
  </a-scene>
```` 
This PR just contains a bloom and sepia effects but I will expand before merge. I would love to hear what effects people want to see first.

![bloom](https://d3vv6lp55qjaqc.cloudfront.net/items/140k132K2b0s1F3N3R1P/Image%202018-06-14%20at%208.57.28%20PM.png?X-CloudApp-Visitor-Id=222920&v=62ce6cbb)