### PR TITLE
Eliminate redundant work in raycaster component

### DIFF
--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -320,8 +320,7 @@ module.exports.Component = registerComponent('raycaster', {
         return;
       }
 
-      // Grab the position and rotation.
-      el.object3D.updateMatrixWorld();
+      // Grab the position and rotation. (As a side effect, this updates el.object3D.matrixWorld.)
       el.object3D.getWorldPosition(originVec3);
 
       // If non-zero origin, translate the origin into world space.


### PR DESCRIPTION
`THREE.Object3D.getWorldPosition` [already internally calls](https://github.com/mrdoob/three.js/blob/12e7e072a595dfba6374a36c76da308ec0a04cf4/src/core/Object3D.js#L446) `updateMatrixWorld` in order to always produce an up-to-date position, so we don't want to call it ourselves first -- that's just doing the work twice.