### PR TITLE
[text] Read URL of first texture page from JSON.

### DIFF
--- a/tests/components/text.test.js
+++ b/tests/components/text.test.js
@@ -11,7 +11,8 @@ suite('text', function () {
       return {
         default: '/base/tests/assets/test.fnt?foo',
         mozillavr: '/base/tests/assets/test.fnt?bar',
-        roboto: '/base/tests/assets/test.fnt?baz'
+        roboto: '/base/tests/assets/test.fnt?baz',
+        msdf: '/base/tests/assets/test.fnt?msdf'
       }[key];
     });
 
@@ -230,6 +231,28 @@ suite('text', function () {
         done();
       });
       el.setAttribute('text', {font: 'mozillavr', fontImage: '/base/tests/assets/test2.png'});
+    });
+
+    test('loads font with inferred font image', function (done) {
+      // `test.fnt` contains an absolute filepath, which should be ignored
+      // in favor of a page-relative texture URL.
+      el.addEventListener('textfontset', evt => {
+        component.currentFont.pages[0] = 'C:\\Windows\\Documents\\custom-texture.png';
+        assert.equal(component.getFontImageSrc(), '/base/tests/assets/test.png');
+        done();
+      });
+      el.setAttribute('text', 'font', '/base/tests/assets/test.fnt');
+    });
+
+    test('loads font with referenced font image', function (done) {
+      // `test.fnt` contains a local reference to the page texture, which
+      // should be loaded relative to the font's base path.
+      el.addEventListener('textfontset', evt => {
+        component.currentFont.pages[0] = 'custom-texture.png';
+        assert.equal(component.getFontImageSrc(), '/base/tests/assets/custom-texture.png');
+        done();
+      });
+      el.setAttribute('text', {font: 'msdf'});
     });
 
     test('uses up-to-date data once loaded', function (done) {


### PR DESCRIPTION
The JSON file in an MSDF font should contain the paths of any textures it relies on. Currently those are ignored (https://github.com/aframevr/aframe/pull/3643#discussion_r195370194) and we try to infer the path from the JSON file name. For fonts created with http://msdf-bmfont.donmccurdy.com/, the paths in the JSON are correct but inferred paths are not.

For some of the default fonts, it looks like the JSON contains absolute paths on disk, which clearly won't work — not sure what tool was used to create those, and whether it should be fixed? For now this PR looks for absolute non-HTTP(S) paths and ignores them.