### PR TITLE
Layout fix on undesired list style at aframe.io/docs

### DIFF
--- a/docs/introduction/visual-inspector-and-dev-tools.md
+++ b/docs/introduction/visual-inspector-and-dev-tools.md
@@ -189,13 +189,13 @@ and send it to us! Now we're unblocked from developing.
 and want to show it to someone. Take a recording and send it to them to debug.
 No need to give bug reproduction steps, it's all in the recording!
 
-[machinima]: https://github.com/wmurphyrd/aframe-machinima-testing/
-[William Murphy]: https://twitter.com/datatitian
-
 7. **Automated unit testing**: We can use recordings with unit testing
 frameworks such as Karma and Mocha to replay the recording and make assertions.
 For example, touch an box and check that it changes color. See [A-Frame
 Machinima Testing][machinima] by [William Murphy] for an example.
+
+[machinima]: https://github.com/wmurphyrd/aframe-machinima-testing/
+[William Murphy]: https://twitter.com/datatitian
 
 ### How to Record
 


### PR DESCRIPTION
**Description:**

Anchors defined inside an ordered list may split the list at [aframe.io/docs](https://aframe.io/docs/master/introduction/visual-inspector-and-dev-tools.html#use-cases), which is undesired, however it's totally fine in preview on GitHub.

Please see the snapshot below, where a "6" is followed by an “1”. :)

![0](https://user-images.githubusercontent.com/23452609/41588415-4361f0c8-73e4-11e8-8a85-876be1ae6c9b.png)


**Changes proposed:**
- Move the position of definition for url anchors.
- (Alternative) Inline the urls.
