### PR TITLE
look-controls: in flat mode, allows camera z-rotation 

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -198,6 +198,7 @@ module.exports.Component = registerComponent('look-controls', {
     // On mobile, do camera rotation with touch events and sensors.
     el.object3D.rotation.x = hmdEuler.x + pitchObject.rotation.x;
     el.object3D.rotation.y = hmdEuler.y + yawObject.rotation.y;
+    el.object3D.rotation.z = hmdEuler.z;
   },
 
   /**


### PR DESCRIPTION
... from device orientation

##Description:
In flat mode, sets camera z-rotation from device orientation.

##Changes proposed:
In v0.7.x, in flat mode, look-controls allowed experiences with the feel of flying; specifically, banking into turns. (for example, https://elfland-glider.surge.sh/)  Also, tracking z-rotation kept the virtual horizon parallel with the real horizon.

This restores that functionality.
