### PR TITLE
[docs] Typo fix.

### DIFF
--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -112,7 +112,7 @@ sky).
 ### Point
 
 Point lights, unlike directional lights, are omni-directional and affect
-materials depending on their position and distance. Point likes are like light
+materials depending on their position and distance. Point lights are like light
 bulb. The closer the light bulb gets to an object, the greater the object is
 lit.
 


### PR DESCRIPTION
**Description:**

Fix wrong spelling caused by mistake.

**Changes proposed:**

- 'Point likes are like light bulb.' => 'Point lights are like light bulb.'
