### PR TITLE
[docs] Typo fix.

### DIFF
--- a/docs/components/raycaster.md
+++ b/docs/components/raycaster.md
@@ -41,7 +41,7 @@ AFRAME.registerComponent('collider-check', {
   dependencies: ['raycaster'],
 
   init: function () {
-    this.el.addEventListener('raycaster-intersected', function () {
+    this.el.addEventListener('raycaster-intersection', function () {
       console.log('Player hit something!');
     });
   }


### PR DESCRIPTION
**Description:**

In the example, event `raycaster-intersected` will not be triggered on the raycaster element or its parent element while event `raycaster-intersection` will according to the [docs for raycaster events](https://aframe.io/docs/0.8.0/components/raycaster.html#events) and my test with A-Frame v0.8.0.

Maybe this is a spelling mistake.

**Changes proposed:**
- Replace 'raycaster-intersected' with 'raycaster-intersection'.
