### PR TITLE
Log errors during node initialization

### DIFF
--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -4,6 +4,7 @@ var isNode = require('./a-register-element').isNode;
 var utils = require('../utils/');
 
 var warn = utils.debug('core:a-node:warn');
+var error = utils.debug('core:a-node:error');
 
 var MIXIN_OBSERVER_CONFIG = {attributes: true};
 
@@ -128,6 +129,8 @@ module.exports = registerElement('a-node', {
           self.hasLoaded = true;
           if (cb) { cb(); }
           self.emit('loaded', undefined, false);
+        }).catch(function (err) {
+          error('Failure loading node: ', err);
         });
       },
       writable: true


### PR DESCRIPTION
Previously, this would just fail silently. This branch is running a lot of user code (i.e. component `init`) so it's frustrating not to get any console output if it fails.

An easy way to test is to open one of the examples and throw an error during `init`.