### PR TITLE
a-image transparent is by default true

### DIFF
--- a/docs/primitives/a-image.md
+++ b/docs/primitives/a-image.md
@@ -39,7 +39,7 @@ The image primitive shows an image on a flat plane.
 | shader          | material.shader         | flat          |
 | side            | material.side           | front         |
 | src             | material.src            | None          |
-| transparent     | material.transparent    | false         |
+| transparent     | material.transparent    | true          |
 | width           | geometry.width          | 1             |
 
 ## Fine-Tuning


### PR DESCRIPTION
**Description:**
According the source code this value is by default true. Is the documentation at fault or the code?

**Changes proposed:**
- Edit the documentation to correctly show the default value
-
-
