### PR TITLE
Add function to detect Oculus Go user-agent

### DIFF
--- a/docs/core/utils.md
+++ b/docs/core/utils.md
@@ -154,6 +154,10 @@ Checks if a VR headset is connected by looking for orientation data. Returns a `
 
 Checks if device is Gear VR. Returns a `boolean`.
 
+### `AFRAME.utils.device.isOculusGo ()`
+
+Checks if device is Oculus Go. Returns a `boolean`.
+
 ### `AFRAME.utils.device.isMobile ()`
 
 Checks if device is a smartphone. Returns a `boolean`.

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -65,6 +65,14 @@ function isGearVR () {
 }
 module.exports.isGearVR = isGearVR;
 
+/**
+ *  Detect Oculus Go device
+ */
+function isOculusGo() {
+  return /Pacific Build.+OculusBrowser.+SamsungBrowser.+Mobile VR/i.test(window.navigator.userAgent);
+}
+module.exports.isOculusGo = isOculusGo;
+
 function isR7 () {
   return /R7 Build/.test(window.navigator.userAgent);
 }


### PR DESCRIPTION
**Description:** function to detect Oculus Go user-agent as described on the official Oculus WebVR docs [here](https://developer.oculus.com/documentation/vrweb/latest/concepts/carmel-getting-started/
).

This function can be tested also in this codepen from the Oculus Browser: [CodePen Oculus Go](https://codepen.io/riccardogiorato/full/MXdxVd/)

**Changes proposed:**
- isOculusGo function to detect Oculus Go
