### PR TITLE
Added 'detachedCallback' when registering elements for zone.js compatibility

### DIFF
--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -81,7 +81,8 @@ function wrapANodeMethods (obj) {
   var ANodeMethods = [
     'attachedCallback',
     'attributeChangedCallback',
-    'createdCallback'
+    'createdCallback',
+    'detachedCallback'
   ];
   wrapMethods(newObj, ANodeMethods, obj, ANode.prototype);
   copyProperties(obj, newObj);
@@ -100,7 +101,8 @@ function wrapAEntityMethods (obj) {
   var ANodeMethods = [
     'attachedCallback',
     'attributeChangedCallback',
-    'createdCallback'
+    'createdCallback',
+    'detachedCallback'
   ];
   var AEntityMethods = [
     'attachedCallback',


### PR DESCRIPTION
**Description:**
There is an issue when using the  aframe library in Angular6+ projects. This is due to the fact that Angular's dependency, zone.js rewrites some of the document.* methods. In this scenario it is the document.registerElement that fails - missing 'detachedCallback' function. Zone.js requires all callback methods to be defined. 

**Changes proposed:**
- Add 'detachedCallback' to AEntity and ANode methods (empty, just for the compatibility)
