### PR TITLE
allow double underscores in component id

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -309,8 +309,10 @@ var proto = Object.create(ANode.prototype, {
       var isComponentDefined;
 
       componentInfo = utils.split(attrName, MULTIPLE_COMPONENT_DELIMITER);
-      componentId = componentInfo[1];
       componentName = componentInfo[0];
+      componentId = componentInfo.length > 2
+        ? componentInfo.slice(1).join('__')
+        : componentInfo[1];
 
       // Not a registered component.
       if (!COMPONENTS[componentName]) { return; }

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -547,6 +547,12 @@ suite('Component', function () {
       }, Error);
       assert.notOk('my__component' in components);
     });
+
+    test('can have underscore in component id', function () {
+      AFRAME.registerComponent('test', {multiple: true});
+      el.setAttribute('test__foo__bar', '');
+      assert.equal(el.components['test__foo__bar'].id, 'foo__bar');
+    });
   });
 
   suite('schema', function () {


### PR DESCRIPTION
**Description:**

Second pair of underscores should just be part of the component ID.