### PR TITLE
Fix iOS orientation change squeeze

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -120,7 +120,7 @@ module.exports.AScene = registerElement('a-scene', {
           // after an orientation change. The window size is correct if the operation
           // is postponed a few milliseconds.
           // self.resize can be called directly once the bug above is fixed.
-          if (this.isIOS) {
+          if (self.isIOS) {
             setTimeout(resize, 100);
           } else {
             resize();

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -709,7 +709,7 @@ function getMaxSize (maxSize, isVR) {
   var size;
   var pixelRatio = window.devicePixelRatio;
 
-  size = {height: window.innerHeight, width: window.innerWidth};
+  size = {height: document.body.offsetHeight, width: document.body.offsetWidth};
   if (!maxSize || isVR || (maxSize.width === -1 && maxSize.height === -1)) {
     return size;
   }


### PR DESCRIPTION
**Description:**

See https://github.com/aframevr/aframe/issues/3525

**Changes proposed:**
- Fix bug where `isiOS` is not checked on the right scope
- Use document body offset width and height instead of window inner width and height

