### PR TITLE
Rollback package.json only including specific files

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,6 @@
   },
   "repository": "aframevr/aframe",
   "license": "MIT",
-  "files": [
-    "dist/*",
-    "docs/**/*"
-  ],
   "dependencies": {
     "@tweenjs/tween.js": "^16.8.0",
     "browserify-css": "^0.8.2",


### PR DESCRIPTION
**Description:**

I understand that @greggman 's motivation behind this commit is to make it faster to install A-Frame as dependency:
https://github.com/aframevr/aframe/commit/53f58fee02783e366ba8ecf3ec6a360f28c8a65a#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

However, I've been using A-Frame since day 1, and in all larger projects I've always included from source, ie. `require('aframe/src')` rather than  `require('aframe')`. Why? Because A-Frame is constantly evolving, and I often see the need to debug my way deep into A-Frame's code base to resolve issues both in my own code and in A-Frame's code base.

I also use some of A-Frame utilities and components independently of the A-Frame build, and again I do that by including the relevant file directly  from source.

After the change in the commit above, such things are no longer possible, and I can see that it already causes issues, so ie. this commit had to be made:
https://github.com/aframevr/aframe/commit/123102167dc4981c9ec24b36e47a0e8f746a0ecf#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

**Changes proposed:**
- Let's rollback this change, since there's harm in installing all the files, but there's a big problem for developers such as me if we don't install all the files.

