### PR TITLE
Update a-video.md

### DIFF
--- a/docs/primitives/a-video.md
+++ b/docs/primitives/a-video.md
@@ -48,11 +48,8 @@ iOS has a lot of restrictions on playing videos in the browser. To play an inlin
 
 - Set the `<meta name="apple-mobile-web-app-capable" content="yes">` meta tag. A-Frame will will inject this if missing.
 - Set the `webkit-playsinline` and `playsinline` attribute to the video element. A-Frame will add this to all videos if missing).
-- Pin the webpage to the iOS homescreen.
 
-Inline video support on iOS 10 may change this. On certain Android devices or
-browsers, we must:
+Since iOS 11, iOS has required user interaction to trigger video playback. This is also true on a number of Android device and
+browser combinations.
 
-[android-touch-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=178297
 
-- Require user interaction to trigger the video (such as a click or tap event). See [Chromium Bug 178297][android-touch-bug].


### PR DESCRIPTION
The caveats at the bottom of the page are no longer accurate. Specifically, the video can work in the browser when not on the home screen (line removed); and since iOS 11,  user interaction is required to play video. 

**Description:**

**Changes proposed:**
-
-
-
