### PR TITLE
add logarithmicDepthBuffer option

### DIFF
--- a/src/components/scene/renderer.js
+++ b/src/components/scene/renderer.js
@@ -13,6 +13,7 @@ var warn = debug('components:renderer:warn');
 module.exports.Component = register('renderer', {
   schema: {
     antialias: {default: 'auto', oneOf: ['true', 'false', 'auto']},
+    logarithmicDepthBuffer: {default: 'auto', oneOf: ['true', 'false', 'auto']},
     maxCanvasWidth: {default: 1920},
     maxCanvasHeight: {default: 1920},
     gammaOutput: {default: false},
@@ -41,6 +42,10 @@ module.exports.Component = register('renderer', {
 
     if (sceneEl.time > 0 && data.antialias !== prevData.antialias) {
       warn('Property "antialias" cannot be changed after scene initialization');
+    }
+
+    if (sceneEl.time > 0 && data.logarithmicDepthBuffer !== prevData.logarithmicDepthBuffer) {
+      warn('Property "logarithmicDepthBuffer" cannot be changed after scene initialization');
     }
 
     if (data.sortObjects !== prevData.sortObjects) {

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -515,7 +515,7 @@ module.exports.AScene = registerElement('a-scene', {
         var rendererAttrString;
         var rendererConfig;
 
-        rendererConfig = {alpha: true, antialias: !isMobile, canvas: this.canvas};
+        rendererConfig = {alpha: true, antialias: !isMobile, canvas: this.canvas, logarithmicDepthBuffer: false};
         if (this.hasAttribute('antialias')) {
           rendererConfig.antialias = this.getAttribute('antialias') === 'true';
         }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -520,6 +520,10 @@ module.exports.AScene = registerElement('a-scene', {
           rendererConfig.antialias = this.getAttribute('antialias') === 'true';
         }
 
+        if (this.hasAttribute('logarithmicDepthBuffer')) {
+          rendererConfig.logarithmicDepthBuffer = this.getAttribute('logarithmicDepthBuffer') === 'true';
+        }
+
         this.maxCanvasSize = {height: 1920, width: 1920};
 
         if (this.hasAttribute('renderer')) {


### PR DESCRIPTION
**Description:**
I have ran into an issue while experimenting with AR.js (https://github.com/jeromeetienne/AR.js/issues/146) that required me to enable [logarithmicDepthBuffer](https://threejs.org/examples/?q=log#webgl_camera_logarithmicdepthbuffer). AFrame does not include this option, so I thought that I would include it myself. 

**Changes proposed:**
- added logarithmicDepthBuffer option to the scene as an attribute.
- added logarithmicDepthBuffer option to renderer component (not able to modify after scene initialization)
