### PR TITLE
Include source files in the installed A-Frame package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "license": "MIT",
   "files": [
     "dist/*",
-    "docs/**/*"
+    "docs/**/*",
+    "src/**/*"
   ],
   "dependencies": {
     "@tweenjs/tween.js": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "files": [
     "dist/*",
     "docs/**/*",
-    "src/**/*"
+    "src/**/*",
+    "vendor/**/*"
   ],
   "dependencies": {
     "@tweenjs/tween.js": "^16.8.0",


### PR DESCRIPTION
Include source files in the installed A-Frame package to allow developers to reference individual files and debug easier.

See discussion on https://github.com/aframevr/aframe/pull/3712