### PR TITLE
Add null pointer check in cursor component

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -278,7 +278,7 @@ module.exports.Component = registerComponent('cursor', {
     // Ignore events further away than active intersection.
     if (this.intersectedEl) {
       currentIntersection = this.el.components.raycaster.getIntersection(this.intersectedEl);
-      if (currentIntersection.distance <= intersection.distance) { return; }
+      if (currentIntersection && currentIntersection.distance <= intersection.distance) { return; }
     }
 
     // Unset current intersection.


### PR DESCRIPTION
**Description:**

For some reason, after I added some sprites to my VR scene, I've started getting a lot errors from the cursor component about `currentIntersection` being null. Not sure if it's related to sprites per se, and this patch is more of symptom treatment than getting to the bottom of the problem. But when calling a function - in this case `raycaster.getIntersection` - that very explicitly can return null, there should also be a check before trying to use the returned variable IMO.

**Changes proposed:**

Added check to see if a current intersection is returned from the raycaster before doing the distance check to avoid null reference error.
