### PR TITLE
Expanded commit hash for document-register-element dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "browserify-css": "^0.8.2",
     "debug": "ngokevin/debug#noTimestamp",
     "deep-assign": "^2.0.0",
-    "document-register-element": "dmarcos/document-register-element#8ccc532b7",
+    "document-register-element": "dmarcos/document-register-element#8ccc532b7f3744be954574caf3072a5fd260ca90",
     "envify": "^3.4.1",
     "load-bmfont": "^1.2.3",
     "object-assign": "^4.0.1",


### PR DESCRIPTION
**Description:**

Expanding the commit-ish to the full hash doesn't harm us (and is good practice anyway,) and by doing so it lets us far more easily resolve the dependency and actually be able to install the package under, for example, PNPM. 

See pnpm/pnpm#1127

**Changes proposed:**
- Expand the commit-ish for document-register-element to the full hash
