### PR TITLE
Fix controller reconnecting on Oculus Go / GearVR

### DIFF
--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -72,7 +72,6 @@ module.exports.Component = registerComponent('gearvr-controls', {
     el.addEventListener('model-loaded', this.onModelLoaded);
     el.addEventListener('axismove', this.onAxisMoved);
     this.controllerEventsActive = true;
-    this.addControllersUpdateListener();
   },
 
   removeEventListeners: function () {
@@ -85,7 +84,6 @@ module.exports.Component = registerComponent('gearvr-controls', {
     el.removeEventListener('model-loaded', this.onModelLoaded);
     el.removeEventListener('axismove', this.onAxisMoved);
     this.controllerEventsActive = false;
-    this.removeControllersUpdateListener();
   },
 
   checkIfControllerPresent: function () {

--- a/src/components/oculus-go-controls.js
+++ b/src/components/oculus-go-controls.js
@@ -70,7 +70,6 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     el.addEventListener('model-loaded', this.onModelLoaded);
     el.addEventListener('axismove', this.onAxisMoved);
     this.controllerEventsActive = true;
-    this.addControllersUpdateListener();
   },
 
   removeEventListeners: function () {
@@ -83,7 +82,6 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     el.removeEventListener('model-loaded', this.onModelLoaded);
     el.removeEventListener('axismove', this.onAxisMoved);
     this.controllerEventsActive = false;
-    this.removeControllersUpdateListener();
   },
 
   checkIfControllerPresent: function () {


### PR DESCRIPTION
**Description:**
This fixes controllers not being able to reconnect on Oculus Go and GearVR. The bug seems to just be due to a copy/paste error. This brings these 2 in line with the otehr controller components, keeping the `controllersupdated` event bound solong as the entity is playing. This is particularly important on Oculus Go as exiting VR causes the controller to disconnect (as far as the gamepad API is concenred) and the controller will reconnect when entering VR.

**Changes proposed:**
- Support disconnecting and reconnecting Oculus Go and GearVR controllers
