### PR TITLE
Add configurable loading screen.

### DIFF
--- a/docs/components/loader.md
+++ b/docs/components/loader.md
@@ -1,0 +1,33 @@
+---
+title: loader
+type: components
+layout: docs
+parent_section: components
+examples: []
+---
+
+The loader component configures the loading screen visual style.
+
+To configure the style of the loader title bar one can redefine `.a-loader-title` style. The example below sets the text color to red:
+
+```css
+ .a-loader-title {
+   color: red;
+ }
+```
+
+## Example
+
+The example below sets the background color to black and dots color to red.
+
+```html
+<a-scene loader="dotsColor: red; backgroundColor: black"></a-scene>
+```
+
+## Properties
+
+| Property        | Description                                               | Default Value |
+|-----------------|-----------------------------------------------------------|---------------|
+| dotsColor       | Loader dots color.                                        | white         |
+| backgroundColor | Loader background color.                                  | #24CAFF       |
+| enabled         | Enables / Disables the loading screen.                    | true          |

--- a/src/core/loadingScreen.js
+++ b/src/core/loadingScreen.js
@@ -1,0 +1,102 @@
+/* global THREE */
+var utils = require('../utils/');
+var styleParser = utils.styleParser;
+
+var sceneEl;
+var titleEl;
+var getSceneCanvasSize;
+
+var LOADER_TITLE_CLASS = 'a-loader-title';
+
+// It catches vrdisplayactivate early to ensure we can enter VR mode after the scene loads.
+window.addEventListener('vrdisplayactivate', function () {
+  var vrManager = sceneEl.renderer.vr;
+  var vrDisplay = utils.device.getVRDisplay();
+
+  vrManager.setDevice(vrDisplay);
+  vrManager.enabled = true;
+  if (!vrDisplay.isPresenting) {
+    return vrDisplay.requestPresent([{source: sceneEl.canvas}]).then(function () {}, function () {});
+  }
+});
+
+module.exports.setup = function setup (el, getCanvasSize) {
+  sceneEl = el;
+  getSceneCanvasSize = getCanvasSize;
+  var loaderAttribute = sceneEl.hasAttribute('loader') ? styleParser.parse(sceneEl.getAttribute('loader')) : undefined;
+  var dotsColor = loaderAttribute && loaderAttribute.dotsColor || 'white';
+  var backgroundColor = loaderAttribute && loaderAttribute.backgroundColor || '#24CAFF';
+  var loaderEnabled = loaderAttribute === undefined || loaderAttribute.enabled === true || loaderAttribute.enabled === undefined; // true default
+  var loaderScene;
+  var sphereGeometry;
+  var sphereMaterial;
+  var sphereMesh1;
+  var sphereMesh2;
+  var sphereMesh3;
+  var camera;
+  var clock;
+  var time;
+  var render;
+
+  if (!loaderEnabled) { return; }
+
+  // Setup Scene.
+  loaderScene = new THREE.Scene();
+  sphereGeometry = new THREE.SphereGeometry(0.20, 36, 18, 0, 2 * Math.PI, 0, Math.PI);
+  sphereMaterial = new THREE.MeshBasicMaterial({color: dotsColor});
+  sphereMesh1 = new THREE.Mesh(sphereGeometry, sphereMaterial);
+  sphereMesh2 = sphereMesh1.clone();
+  sphereMesh3 = sphereMesh1.clone();
+  camera = new THREE.PerspectiveCamera(80, window.innerWidth / window.innerHeight, 0.0005, 10000);
+  clock = new THREE.Clock();
+  time = 0;
+  render = function () {
+    sceneEl.renderer.render(loaderScene, camera);
+    time = clock.getElapsedTime() % 4;
+    sphereMesh1.visible = time >= 1;
+    sphereMesh2.visible = time >= 2;
+    sphereMesh3.visible = time >= 3;
+  };
+
+  loaderScene.background = new THREE.Color(backgroundColor);
+  loaderScene.add(camera);
+  sphereMesh1.position.set(-1, 0, -15);
+  sphereMesh2.position.set(0, 0, -15);
+  sphereMesh3.position.set(1, 0, -15);
+  camera.add(sphereMesh1);
+  camera.add(sphereMesh2);
+  camera.add(sphereMesh3);
+  setupTitle();
+
+  // Delay 200ms to avoid loader flashes.
+  setTimeout(function () {
+    if (sceneEl.hasLoaded) { return; }
+    resize(camera);
+    titleEl.style.display = 'block';
+    window.addEventListener('resize', function () { resize(camera); });
+    sceneEl.renderer.setAnimationLoop(render);
+  }, 200);
+};
+
+module.exports.remove = function remove () {
+  window.removeEventListener('resize', resize);
+  if (!titleEl) { return; }
+  // Hide title.
+  titleEl.style.display = 'none';
+};
+
+function resize (camera) {
+  var size = getSceneCanvasSize(sceneEl.canvas, false, sceneEl.maxCanvasSize, sceneEl.is('vr-mode'));
+  camera.aspect = size.width / size.height;
+  camera.updateProjectionMatrix();
+   // Notify renderer of size change.
+  sceneEl.renderer.setSize(size.width, size.height, false);
+}
+
+function setupTitle () {
+  titleEl = document.createElement('div');
+  titleEl.className = LOADER_TITLE_CLASS;
+  titleEl.innerHTML = document.title;
+  titleEl.style.display = 'none';
+  sceneEl.appendChild(titleEl);
+}

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -1,6 +1,7 @@
 /* global Promise, screen */
 var initMetaTags = require('./metaTags').inject;
 var initWakelock = require('./wakelock');
+var loadingScreen = require('../loadingScreen');
 var re = require('../a-register-element');
 var scenes = require('./scenes');
 var systems = require('../system').systems;
@@ -85,7 +86,6 @@ module.exports.AScene = registerElement('a-scene', {
     attachedCallback: {
       value: function () {
         var self = this;
-
         // Renderer initialization
         setupCanvas(this);
         this.setupRenderer();
@@ -551,6 +551,7 @@ module.exports.AScene = registerElement('a-scene', {
         this.addEventListener('camera-set-active', function () {
           renderer.vr.setPoseTarget(self.camera);
         });
+        loadingScreen.setup(this, getCanvasSize);
       },
       writable: window.debug
     },
@@ -580,6 +581,7 @@ module.exports.AScene = registerElement('a-scene', {
           if (sceneEl.renderer) {
             if (window.performance) { window.performance.mark('render-started'); }
             sceneEl.clock = new THREE.Clock();
+            loadingScreen.remove();
             sceneEl.render();
             sceneEl.renderStarted = true;
             sceneEl.emit('renderstart');

--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -264,3 +264,18 @@ a-scene audio {
   text-indent: -9999px;
   width: 50px;
 }
+
+.a-loader-title {
+  background-color: rgba(0, 0, 0, 0.6);
+  font-family: sans-serif, monospace;
+  text-align: center;
+  font-size: 20px;
+  height: 50px;
+  font-weight: 300;
+  line-height: 50px;
+  position: absolute;
+  right: 0px;
+  left: 0px;
+  top: 0px;
+  color: white;
+}

--- a/tests/core/loadingScreen.test.js
+++ b/tests/core/loadingScreen.test.js
@@ -1,0 +1,34 @@
+/* global assert, process, setup, suite, teardown, test */
+var AScene = require('core/scene/a-scene').AScene;
+var helpers = require('../helpers');
+
+helpers.getSkipCISuite()('loadingScreen', function () {
+  suite('setup', function () {
+    setup(function () {
+      AScene.prototype.setupRenderer.restore();
+    });
+
+    test('adds title element', function (done) {
+      var el = this.el = document.createElement('a-scene');
+      document.body.appendChild(el);
+      el.addEventListener('loaded', function () {
+        assert.ok(el.querySelector('.a-loader-title'));
+        done();
+      });
+    });
+
+    test('does not add title element if loadingScreen is disabled', function (done) {
+      var el = this.el = document.createElement('a-scene');
+      el.setAttribute('loader', 'enabled: false');
+      document.body.appendChild(el);
+      el.addEventListener('loaded', function () {
+        assert.notOk(el.querySelector('.a-loader-title'));
+        done();
+      });
+    });
+
+    teardown(function () {
+      document.body.removeChild(this.el);
+    });
+  });
+});


### PR DESCRIPTION
**Description:**

Loading screen to avoid blank screen while loading assets and scene render loop has not yet started. The loader animation doesn't require 60fps to mask main thread pauses.

The logic is a `pseudo-component` since it has to initialize and render while the assets load. 

The title of the page is displayed above the loading indicator.

The color of the dots, background and style of the title bar are configurable.

![loader](https://d3vv6lp55qjaqc.cloudfront.net/items/0M3q3m0W2Z3h3G17152y/Image%202018-09-05%20at%203.06.05%20AM.png?X-CloudApp-Visitor-Id=222920&v=51eab09b)
