### PR TITLE
simplify text shaders and prevent ugly alpha issues when text is small/far away in front of element with alpha (fixes #3557)

### DIFF
--- a/src/shaders/msdf.js
+++ b/src/shaders/msdf.js
@@ -33,44 +33,32 @@ module.exports.Shader = registerShader('msdf', {
     '#endif',
 
     'precision highp float;',
-    // FIXME: Experimentally determined constants.
-    '#define BIG_ENOUGH 0.001',
-    '#define MODIFIED_ALPHATEST (0.02 * isBigEnough / BIG_ENOUGH)',
-    '#define ALL_SMOOTH 0.4',
-    '#define ALL_ROUGH 0.02',
-    '#define DISCARD_ALPHA (alphaTest / (2.2 - 1.2 * ratio))',
+    'uniform bool negate;',
+    'uniform float alphaTest;',
+    'uniform float opacity;',
     'uniform sampler2D map;',
     'uniform vec3 color;',
-    'uniform float opacity;',
-    'uniform float alphaTest;',
-    'uniform bool negate;',
     'varying vec2 vUV;',
 
     'float median(float r, float g, float b) {',
     '  return max(min(r, g), min(max(r, g), b));',
     '}',
+
+    // FIXME: Experimentally determined constants.
+    '#define BIG_ENOUGH 0.001',
+    '#define MODIFIED_ALPHATEST (0.02 * isBigEnough / BIG_ENOUGH)',
+
     'void main() {',
     '  vec3 sample = texture2D(map, vUV).rgb;',
-    '  if (negate) {',
-    '    sample = 1.0 - sample;',
-    '  }',
+    '  if (negate) { sample = 1.0 - sample; }',
+
     '  float sigDist = median(sample.r, sample.g, sample.b) - 0.5;',
-    '  float alpha = clamp(sigDist/fwidth(sigDist) + 0.5, 0.0, 1.0);',
+    '  float alpha = clamp(sigDist / fwidth(sigDist) + 0.5, 0.0, 1.0);',
     '  float dscale = 0.353505;',
     '  vec2 duv = dscale * (dFdx(vUV) + dFdy(vUV));',
     '  float isBigEnough = max(abs(duv.x), abs(duv.y));',
-    // When texel is too small, blend raw alpha value rather than supersampling.
-    // FIXME: Experimentally determined constant.
-    '  if (isBigEnough > BIG_ENOUGH) {',
-    '    float ratio = BIG_ENOUGH / isBigEnough;',
-    '    alpha = ratio * alpha + (1.0 - ratio) * (sigDist + 0.5);',
-    '  }',
-    // When texel is big enough, do standard alpha test.
-    // FIXME: Experimentally determined constant.
-    // Looks much better if we *don't* do this, but do we get Z fighting?
-    '  if (isBigEnough <= BIG_ENOUGH && alpha < alphaTest) { discard; return; }',
-    // Else, do modified alpha test.
-    // FIXME: Experimentally determined constant.
+
+    '  // Do modified alpha test.',
     '  if (alpha < alphaTest * MODIFIED_ALPHATEST) { discard; return; }',
     '  gl_FragColor = vec4(color.xyz, alpha * opacity);',
     '}'

--- a/src/shaders/sdf.js
+++ b/src/shaders/sdf.js
@@ -32,76 +32,73 @@ module.exports.Shader = registerShader('sdf', {
     '#endif',
 
     'precision highp float;',
-    // FIXME: experimentally determined constants
+    'uniform float alphaTest;',
+    'uniform float opacity;',
+    'uniform sampler2D map;',
+    'uniform vec3 color;',
+    'varying vec2 vUV;',
+
+    '#ifdef GL_OES_standard_derivatives',
+    '  float contour(float width, float value) {',
+    '    return smoothstep(0.5 - value, 0.5 + value, width);',
+    '  }',
+    '#else',
+    '  float aastep(float value, float afwidth) {',
+    '    return smoothstep(0.5 - afwidth, 0.5 + afwidth, value);',
+    '  }',
+    '#endif',
+
+    // FIXME: Experimentally determined constants.
     '#define BIG_ENOUGH 0.001',
     '#define MODIFIED_ALPHATEST (0.02 * isBigEnough / BIG_ENOUGH)',
     '#define ALL_SMOOTH 0.4',
     '#define ALL_ROUGH 0.02',
     '#define DISCARD_ALPHA (alphaTest / (2.2 - 1.2 * ratio))',
-    'uniform sampler2D map;',
-    'uniform vec3 color;',
-    'uniform float opacity;',
-    'uniform float alphaTest;',
-    'varying vec2 vUV;',
-    '#ifdef GL_OES_standard_derivatives',
-    'float contour(float width, float value) {',
-    '  return smoothstep(0.5 - value, 0.5 + value, width);',
-    '}',
-    '#else',
-    'float aastep(float value, float afwidth) {',
-    '  return smoothstep(0.5 - afwidth, 0.5 + afwidth, value);',
-    '}',
-    '#endif',
+
     'void main() {',
-    '#ifdef GL_OES_standard_derivatives',
-    // when we have derivatives and can get texel size etc., that allows supersampling etc.
-    '  vec2 uv = vUV;',
-    '  vec4 texColor = texture2D(map, uv);',
-    '  float dist = texColor.a;',
-    '  float width = fwidth(dist);',
-    '  float alpha = contour(dist, width);',
-    '  float dscale = 0.353505;',
-    '  vec2 duv = dscale * (dFdx(uv) + dFdy(uv));',
-    '  float isBigEnough = max(abs(duv.x), abs(duv.y));',
-    // when texel is too small, blend raw alpha value rather than supersampling etc.
-    // FIXME: experimentally determined constant
-    '  if (isBigEnough > BIG_ENOUGH) {',
-    '    float ratio = BIG_ENOUGH / isBigEnough;',
-    '    alpha = ratio * alpha + (1.0 - ratio) * dist;',
-    '  }',
-    // otherwise do weighted supersampling
-    // FIXME: why this weighting?
-    '  else if (isBigEnough <= BIG_ENOUGH) {',
-    '    vec4 box = vec4 (uv - duv, uv + duv);',
-    '    alpha = (alpha + 0.5 * (',
-    '      contour(texture2D(map, box.xy).a, width)',
-    '      + contour(texture2D(map, box.zw).a, width)',
-    '      + contour(texture2D(map, box.xw).a, width)',
-    '      + contour(texture2D(map, box.zy).a, width)',
-    '    )) / 3.0;',
-    '  }',
-    // when texel is big enough, do standard alpha test
-    // FIXME: experimentally determined constant
-    // looks much better if we DON'T do this, but do we get Z fighting etc.?
-    '  if (isBigEnough <= BIG_ENOUGH && alpha < alphaTest) { discard; return; }',
-    // else do modified alpha test
-    // FIXME: experimentally determined constant
-    '  if (alpha < alphaTest * MODIFIED_ALPHATEST) { discard; return; }',
-    '#else',
-    '  vec4 texColor = texture2D(map, vUV);',
-    '  float value = texColor.a;',
-    // when we don't have derivatives, use approximations
-    // FIXME: if we understood font pixel dimensions, this could probably be improved
-    '  float afwidth = (1.0 / 32.0) * (1.4142135623730951 / (2.0 * gl_FragCoord.w));',
-    '  float alpha = aastep(value, afwidth);',
-    // use gl_FragCoord.w to guess when we should blend
-    // FIXME: if we understood font pixel dimensions, this could probably be improved
-    '  float ratio = (gl_FragCoord.w >= ALL_SMOOTH) ? 1.0 : (gl_FragCoord.w < ALL_ROUGH) ? 0.0 : (gl_FragCoord.w - ALL_ROUGH) / (ALL_SMOOTH - ALL_ROUGH);',
-    '  if (alpha < alphaTest) { if (ratio >= 1.0) { discard; return; } alpha = 0.0; }',
-    '  alpha = alpha * ratio + (1.0 - ratio) * value;',
-    '  if (ratio < 1.0)',
-    '    if (alpha <= DISCARD_ALPHA) { discard; return; }',
-    '#endif',
+       // When we have derivatives and can get texel size for supersampling.
+    '  #ifdef GL_OES_standard_derivatives',
+    '    vec2 uv = vUV;',
+    '    vec4 texColor = texture2D(map, uv);',
+    '    float dist = texColor.a;',
+    '    float width = fwidth(dist);',
+    '    float alpha = contour(dist, width);',
+    '    float dscale = 0.353505;',
+
+    '    vec2 duv = dscale * (dFdx(uv) + dFdy(uv));',
+    '    float isBigEnough = max(abs(duv.x), abs(duv.y));',
+
+         // Otherwise do weighted supersampling.
+         // FIXME: why this weighting?
+    '    if (isBigEnough <= BIG_ENOUGH) {',
+    '      vec4 box = vec4 (uv - duv, uv + duv);',
+    '      alpha = (alpha + 0.5 * (',
+    '        contour(texture2D(map, box.xy).a, width)',
+    '        + contour(texture2D(map, box.zw).a, width)',
+    '        + contour(texture2D(map, box.xw).a, width)',
+    '        + contour(texture2D(map, box.zy).a, width)',
+    '      )) / 3.0;',
+    '    }',
+
+         // Do modified alpha test.
+    '    if (alpha < alphaTest * MODIFIED_ALPHATEST) { discard; return; }',
+
+    '  #else',
+         // When we don't have derivatives, use approximations.
+    '    vec4 texColor = texture2D(map, vUV);',
+    '    float value = texColor.a;',
+         // FIXME: if we understood font pixel dimensions, this could probably be improved
+    '    float afwidth = (1.0 / 32.0) * (1.4142135623730951 / (2.0 * gl_FragCoord.w));',
+    '    float alpha = aastep(value, afwidth);',
+
+         // Use gl_FragCoord.w to guess when we should blend.
+         // FIXME: If we understood font pixel dimensions, this could probably be improved.
+    '    float ratio = (gl_FragCoord.w >= ALL_SMOOTH) ? 1.0 : (gl_FragCoord.w < ALL_ROUGH) ? 0.0 : (gl_FragCoord.w - ALL_ROUGH) / (ALL_SMOOTH - ALL_ROUGH);',
+    '    if (alpha < alphaTest) { if (ratio >= 1.0) { discard; return; } alpha = 0.0; }',
+    '    alpha = alpha * ratio + (1.0 - ratio) * value;',
+    '    if (ratio < 1.0 && alpha <= DISCARD_ALPHA) { discard; return; }',
+    '  #endif',
+
     '  gl_FragColor = vec4(color, opacity * alpha);',
     '}'
   ].join('\n')


### PR DESCRIPTION

**Description:**

All of the fiddling with the alpha didn't really help and made things look worse when blending with other entities with alpha, and at distance.

Text example looks unchanged, but in certain conditions the text degrades badly. Can see it below, but it often manifests worse:

## Before

<img width="742" alt="screen shot 2018-09-13 at 3 25 59 pm" src="https://user-images.githubusercontent.com/674727/45519483-1619b500-b76a-11e8-9cd0-e0e7bd68213f.png">

## After

<img width="808" alt="screen shot 2018-09-13 at 3 25 33 pm" src="https://user-images.githubusercontent.com/674727/45519482-1619b500-b76a-11e8-9fbd-a48409d30f60.png">


**Changes proposed:**

- Remove alpha modifications that were done based on experiment / guess & checks.
- Remove the logic `when texel is too small, blend raw alpha value rather than supersampling`
- Remove the logic `when texel is big enough, do standard alpha test`
- Less shader branching!