### PR TITLE
Update docs on stateadded/removed event detail

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -473,8 +473,8 @@ Below is what the event detail contains for each event:
 |                      | data      | Component data.                                    |
 | componentremoved     | name      | Name of component that was removed.                |
 |                      | id        | ID of component that was removed.                  |
-| stateadded           | state     | The state that was attached (string).              |
-| stateremoved         | state     | The state that was detached (string).              |
+| stateadded           | N/A       | The state that was attached (string).              |
+| stateremoved         | N/A       | The state that was detached (string).              |
 | schemachanged        | component | Name of component that had it's schema changed.    |
 
 #### Listening for Component Changes


### PR DESCRIPTION
**Description:** The detail for state events is now just the string containing the state name. Not sure if this is the best way to express that, but the current docs look like they're saying the state is in `event.detail.state` whereas it is instead in `event.detail`
