### PR TITLE
check that value is actually object in component build data

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -473,7 +473,7 @@ Component.prototype = {
       if (this.isSingleProperty) {
         if (skipTypeChecking === true) { return newData; }
         // If object-based, copy the value to not modify the original.
-        if (this.isObjectBased) {
+        if (isObject(newData)) {
           copyData(this.parsingAttrValue, newData);
           return parseProperty(this.parsingAttrValue, schema);
         }

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -250,6 +250,24 @@ suite('Component', function () {
         done();
       });
     });
+
+    test('copies data correctly for single-prop object-based with string input', done => {
+      registerComponent('test', {
+        schema: {
+          default: {},
+          parse: function (value) {
+            return value;
+          }
+        }
+      });
+
+      helpers.elFactory().then(el => {
+        el.setAttribute('test', 'foo');
+        el.setAttribute('test', 'bar');
+        assert.equal(el.components.test.data, 'bar');
+        done();
+      });
+    });
   });
 
   suite('updateProperties', function () {


### PR DESCRIPTION
**Description:**

`isObjectBased` only applies for the **output** of components. `buildData` should not necessarily assume that inputs are object-based even if the parse output is object-based.

- [x] tests

**Changes proposed:**
- Check that value is actually an object before attempting copy.
