### PR TITLE
[gltf-model] Add system to configure and enable Draco compression.

### DIFF
--- a/src/components/gltf-model.js
+++ b/src/components/gltf-model.js
@@ -10,8 +10,12 @@ module.exports.Component = registerComponent('gltf-model', {
   schema: {type: 'model'},
 
   init: function () {
+    var dracoLoader = this.system.getDRACOLoader();
     this.model = null;
     this.loader = new THREE.GLTFLoader();
+    if (dracoLoader) {
+      this.loader.setDRACOLoader(dracoLoader);
+    }
   },
 
   update: function () {

--- a/src/lib/three.js
+++ b/src/lib/three.js
@@ -19,6 +19,7 @@ if (THREE.Cache) {
 }
 
 // TODO: Eventually include these only if they are needed by a component.
+require('three/examples/js/loaders/DRACOLoader');  // THREE.DRACOLoader
 require('three/examples/js/loaders/GLTFLoader');  // THREE.GLTFLoader
 require('three/examples/js/loaders/OBJLoader');  // THREE.OBJLoader
 require('three/examples/js/loaders/MTLLoader');  // THREE.MTLLoader

--- a/src/systems/gltf-model.js
+++ b/src/systems/gltf-model.js
@@ -1,0 +1,26 @@
+var registerSystem = require('../core/system').registerSystem;
+var THREE = require('../lib/three');
+
+/**
+ * glTF model system.
+ *
+ * Configures glTF loading options. Models using glTF compression require that a Draco decoder be
+ * provided externally.
+ *
+ * @param {string} dracoDecoderPath - Base path from which to load Draco decoder library.
+ */
+module.exports.System = registerSystem('gltf-model', {
+  schema: {
+    dracoDecoderPath: {default: ''}
+  },
+
+  init: function () {
+    var path = this.data.dracoDecoderPath;
+    THREE.DRACOLoader.setDecoderPath(path);
+    this.dracoLoader = path ? new THREE.DRACOLoader() : null;
+  },
+
+  getDRACOLoader: function () {
+    return this.dracoLoader;
+  }
+});

--- a/src/systems/index.js
+++ b/src/systems/index.js
@@ -1,7 +1,7 @@
 require('./camera');
 require('./geometry');
+require('./gltf-model');
 require('./light');
 require('./material');
 require('./shadow');
 require('./tracked-controls');
-


### PR DESCRIPTION
Fixes #3640.

Adds a `gltf-model` system, through which compression (via Draco) can be enabled. `THREE.DRACOLoader` loads a WASM or JS decoder, choosing automatically based on browser capabilities. The decoders must be placed in a directory accessible to the application. Example:

```html
<a-scene stats gltf-model="dracoDecoderPath: /lib/decoder/;">
  <a-entity gltf-model="foo.glb" ></a-entity>
</a-scene>
```

If the change and the API look ok I'll update docs.