### PR TITLE
name loadingscreen attribute name to loading-screen

### DIFF
--- a/docs/components/loading-screen.md
+++ b/docs/components/loading-screen.md
@@ -1,20 +1,23 @@
 ---
-title: loader
+title: loading-screen
 type: components
 layout: docs
 parent_section: components
 examples: []
 ---
 
-The loader component configures the loading screen visual style.
+The loading screen component configures the loading screen visual style.
 
-To configure the style of the loader title bar one can redefine `.a-loader-title` style. The example below sets the text color to red:
+To configure the style of the loader title bar one can redefine
+`.a-loader-title` style. The example below sets the text color to red:
 
 ```css
  .a-loader-title {
    color: red;
  }
 ```
+
+The title text is set to whatever is in `document.title` or `<title></title>`.
 
 ## Example
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -1,7 +1,7 @@
 /* global Promise, screen */
 var initMetaTags = require('./metaTags').inject;
 var initWakelock = require('./wakelock');
-var loadingScreen = require('../loadingScreen');
+var loadingScreen = require('./loadingScreen');
 var re = require('../a-register-element');
 var scenes = require('./scenes');
 var systems = require('../system').systems;

--- a/src/core/scene/loadingScreen.js
+++ b/src/core/scene/loadingScreen.js
@@ -1,11 +1,12 @@
 /* global THREE */
-var utils = require('../utils/');
+var utils = require('../../utils/');
 var styleParser = utils.styleParser;
 
 var sceneEl;
 var titleEl;
 var getSceneCanvasSize;
 
+var ATTR_NAME = 'loading-screen';
 var LOADER_TITLE_CLASS = 'a-loader-title';
 
 // It catches vrdisplayactivate early to ensure we can enter VR mode after the scene loads.
@@ -23,7 +24,7 @@ window.addEventListener('vrdisplayactivate', function () {
 module.exports.setup = function setup (el, getCanvasSize) {
   sceneEl = el;
   getSceneCanvasSize = getCanvasSize;
-  var loaderAttribute = sceneEl.hasAttribute('loader') ? styleParser.parse(sceneEl.getAttribute('loader')) : undefined;
+  var loaderAttribute = sceneEl.hasAttribute(ATTR_NAME) ? styleParser.parse(sceneEl.getAttribute(ATTR_NAME)) : undefined;
   var dotsColor = loaderAttribute && loaderAttribute.dotsColor || 'white';
   var backgroundColor = loaderAttribute && loaderAttribute.backgroundColor || '#24CAFF';
   var loaderEnabled = loaderAttribute === undefined || loaderAttribute.enabled === true || loaderAttribute.enabled === undefined; // true default

--- a/tests/core/loadingScreen.test.js
+++ b/tests/core/loadingScreen.test.js
@@ -19,7 +19,7 @@ helpers.getSkipCISuite()('loadingScreen', function () {
 
     test('does not add title element if loadingScreen is disabled', function (done) {
       var el = this.el = document.createElement('a-scene');
-      el.setAttribute('loader', 'enabled: false');
+      el.setAttribute('loading-screen', 'enabled: false');
       document.body.appendChild(el);
       el.addEventListener('loaded', function () {
         assert.notOk(el.querySelector('.a-loader-title'));


### PR DESCRIPTION
**Description:**

The component is currently `loader`, but it doesn't load anything, and clashes with three.js concept of Loaders.

**Changes proposed:**
- Rename to `loading-screen`.
- Document title.
