### PR TITLE
[collada-model] Deprecate 'collada-model'.

### DIFF
--- a/docs/components/collada-model.md
+++ b/docs/components/collada-model.md
@@ -9,6 +9,12 @@ examples: []
 
 The collada-model component loads a 3D model using a [COLLADA][wiki-collada] (.DAE) file.
 
+> **DEPRECATED**: The `collada-model` component is deprecated. Consider
+converting models with [COLLADA2GLTF][collada2gltf] and using `gltf-model`
+instead.
+
+[collada2gltf]: https://github.com/KhronosGroup/COLLADA2glTF
+
 ## Example
 
 We can load a COLLADA model by pointing to an asset that specifies the `src` to a COLLADA file.

--- a/docs/primitives/a-collada-model.md
+++ b/docs/primitives/a-collada-model.md
@@ -9,6 +9,12 @@ source_code: src/extras/primitives/primitives/a-collada-model.js
 The COLLADA model primitive displays a 3D COLLADA model created from a 3D
 modeling program or downloaded from the web.
 
+> **DEPRECATED**: The `collada-model` component is deprecated. Consider
+converting models with [COLLADA2GLTF][collada2gltf] and using `gltf-model`
+instead.
+
+[collada2gltf]: https://github.com/KhronosGroup/COLLADA2glTF
+
 ## Example
 
 ```html

--- a/src/components/collada-model.js
+++ b/src/components/collada-model.js
@@ -1,5 +1,8 @@
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
+var debug = require('../utils/debug');
+
+var warn = debug('components:collada-model:warn');
 
 module.exports.Component = registerComponent('collada-model', {
   schema: {type: 'asset'},
@@ -7,6 +10,7 @@ module.exports.Component = registerComponent('collada-model', {
   init: function () {
     this.model = null;
     this.loader = new THREE.ColladaLoader();
+    warn('`collada-model` is deprecated. Consider using `gltf-model` instead.');
   },
 
   update: function () {


### PR DESCRIPTION
Per https://github.com/aframevr/aframe/issues/3793. 

What do you think of just marking it deprecated for a release before we remove anything? Or better to just go for it?