### PR TITLE
Clear references to freed pooled memory to avoid double free

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -678,6 +678,8 @@ function wrapRemove (removeMethod) {
     this.objectPool.recycle(this.attrValue);
     this.objectPool.recycle(this.oldData);
     this.objectPool.recycle(this.parsingAttrValue);
+
+    this.attrValue = this.oldData = this.parsingAttrValue = undefined;
   };
 }
 


### PR DESCRIPTION
Currently the `remove` handler recycles some of the objects on a component. However, if `remove` is called more than once on a component the memory is double free'd, resulting in corruption due to re-use of the same object in multiple places. This seems to be possible if a component calls `remove()` inside of `update()` -- a-frame will also call remove as part of the `removeAttribute` handler if the component is then taken off of the DOM element.

https://github.com/donmccurdy/aframe-physics-system/blob/master/src/components/constraint.js#L51

(This seems like a separate issue that may be worth addressing in another PR, since it seems bad that `remove` can be called multiple time.)

In any case, after `recycle()`'ing memory, all references to that memory should be cleared regardless, so this PR addresses that problem with the `remove` handler by clearing the references after calling `recycle`.