### PR TITLE
Remove link to non-existent example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -163,7 +163,6 @@
       <li><a href="test/fog/">Fog</a></li>
       <li><a href="test/geometry/">Geometry</a></li>
       <li><a href="test/geometry-gallery/">Geometry Gallery</a></li>
-      <li><a href="test/geometry-merging/">Geometry Merging</a></li>
       <li><a href="test/gltf-model/">glTF Model</a></li>
       <li><a href="test/laser-controls/">Laser Controls</a></li>
       <li><a href="test/mixin/">Mixin</a></li>


### PR DESCRIPTION
Hi all, hi @dmarcos, 

Thank you for maintaining such an incredible project. I found an obsolete link to an example and have removed it.  

Cheers,
Srile
 
**Summary:**
Remove link to the non-existent "Geometry Merging" example.