### PR TITLE
bump threejs to 0.98.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "present": "0.0.6",
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
-    "three": "0.95.0",
+    "three": "0.98.0",
     "three-bmfont-text": "^2.1.0",
     "webvr-polyfill": "^0.10.5"
   },


### PR DESCRIPTION
threejs 98r release  have some nice  Webvr commits like

https://github.com/mrdoob/three.js/pull/14950

tested on my private project without any problems

**Description:**

**Changes proposed:**
-
-
-
