### PR TITLE
Change the isIOSOlderThan10 so it doesn't catch Chrome Webview

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -92,7 +92,7 @@ module.exports.isLandscape = function () {
  * Check if device is iOS and older than version 10.
  */
 module.exports.isIOSOlderThan10 = function (userAgent) {
-  return /(iphone|ipod|ipad).*os.(7|8|9)/i.test(userAgent);
+  return /(iphone|ipod|ipad).*os.(7_|8_|9_)/i.test(userAgent);
 };
 
 /**

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -35,6 +35,11 @@ suite('isIOSOlderThan10', function () {
     assert.notOk(device.isIOSOlderThan10(v11));
     assert.notOk(device.isIOSOlderThan10(v12));
   });
+
+  test('is false for webview', function(){
+    var chromeiOS = `Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/70.0.3538.60 Mobile/15E148 Safari/605.1`;
+    assert.notOk(device.isIOSOlderThan10(chromeiOS));
+  })
 });
 
 suite('environment', function () {

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -36,10 +36,10 @@ suite('isIOSOlderThan10', function () {
     assert.notOk(device.isIOSOlderThan10(v12));
   });
 
-  test('is false for webview', function(){
+  test('is false for webview', function () {
     var chromeiOS = `Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/70.0.3538.60 Mobile/15E148 Safari/605.1`;
     assert.notOk(device.isIOSOlderThan10(chromeiOS));
-  })
+  });
 });
 
 suite('environment', function () {


### PR DESCRIPTION
**Description:**

The `*` in the regex was catching the UA of the Chrome Webview on iOS. 

**Changes proposed:**
- Check for an underscore after the version number

** Notes **

There might be a better regex to accomplish this. 