### PR TITLE
When creating custom controls you need to explicitly define the camera

### DIFF
--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -59,3 +59,9 @@ replace the `require` statements with A-Frame globals (e.g.,
 If you want to create your own component for look controls, you will have to
 copy and paste the HMD-tracking bits into your component. In the future, we may
 have a system for people to more easily create their controls.
+
+When creating custom controls eg `touch-controls` you need to explicitly define the camera ie
+
+```html
+<a-entity camera touch-controls></a-entity>
+```


### PR DESCRIPTION
**Description:**

I found when I was creating custom controls I had some issues. I initially tried the following

```html
<a-entity touch-controls></a-entity>
```

But when I explicity added the camera my controls worked fine

```html
<a-entity camera touch-controls></a-entity>
```

**Changes proposed:**

Add to caveats section of the documentation