### PR TITLE
Fixed camera rig typo in a-camera.md

### DIFF
--- a/docs/primitives/a-camera.md
+++ b/docs/primitives/a-camera.md
@@ -46,7 +46,7 @@ while still allowing the tracked area to be moved independently around the
 scene.
 
 ```html
-<a-entity id="#rig" position="25 10 0">
+<a-entity id="rig" position="25 10 0">
   <a-camera id="camera"></a-camera>
 </a-entity>
 ```


### PR DESCRIPTION
**Description:**

Changed `id="#rig"` to `id="rig"` in camera documentation.
