### PR TITLE
tracked-controls allow matrixautoupdate for camera rig since matrix is decomposed anyways

### DIFF
--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -186,7 +186,6 @@ module.exports.Component = registerComponent('tracked-controls', {
     // Apply transforms, if 6DOF and in VR.
     if (vrDisplay && pose.position) {
       standingMatrix = this.el.sceneEl.renderer.vr.getStandingMatrix();
-      object3D.matrixAutoUpdate = false;
       object3D.matrix.compose(object3D.position, object3D.quaternion, object3D.scale);
       object3D.matrix.multiplyMatrices(standingMatrix, object3D.matrix);
       object3D.matrix.decompose(object3D.position, object3D.quaternion, object3D.scale);
@@ -195,9 +194,6 @@ module.exports.Component = registerComponent('tracked-controls', {
     object3D.rotateX(this.data.orientationOffset.x * THREE.Math.DEG2RAD);
     object3D.rotateY(this.data.orientationOffset.y * THREE.Math.DEG2RAD);
     object3D.rotateZ(this.data.orientationOffset.z * THREE.Math.DEG2RAD);
-
-    object3D.updateMatrix();
-    object3D.matrixWorldNeedsUpdate = true;
   },
 
   /**


### PR DESCRIPTION
**Description:**

Seems like the matrix auto update disabled would prevent like controllers following the camera if the camera rig was moved. I don't see need to disable autoupdate since the matrix calculations are flushed with decompose.

To test:

1. Have a camera rig with controllers.
2. Go into VR with Vive/Rift.
3. Move camera rig position via command line.

The controllers don't follow you.

**Changes proposed:**
- Enabled tracked-controls matrixAutoUpdate
- Was hard to write a test since would have to run the three.js renderer to test matrix auto update logic.

