### PR TITLE
Add vive-focus-controls

### DIFF
--- a/docs/components/vive-focus-controls.md
+++ b/docs/components/vive-focus-controls.md
@@ -1,0 +1,60 @@
+---
+title: vive-focus-controls
+type: components
+layout: docs
+parent_section: components
+source_code: src/components/vive-focus-controls.js
+
+examples: []
+---
+
+[trackedcontrols]: ./tracked-controls.md
+
+The vive-focus-controls component interfaces with the Vive Focus controller.
+It wraps the [tracked-controls component][trackedcontrols] while adding button
+mappings, events, and an Vive Focus controller model that highlights the touched
+and/or pressed buttons (trackpad, trigger).
+
+## Example
+
+```html
+<!-- Match Vive Focus controller if present, regardless of hand. -->
+<a-entity vive-focus-controls></a-entity>
+
+<!-- Match Vive Focus controller if present and for specified hand. -->
+<a-entity vive-focus-controls="hand: left"></a-entity>
+<a-entity vive-focus-controls="hand: right"></a-entity>
+```
+
+## Value
+
+| Property             | Description                                        | Default              |
+|----------------------|----------------------------------------------------|----------------------|
+| armModel             | Whether the arm model is used for positional data. | true                 |
+| buttonTouchedColor   | Button colors when touched (Trackpad only).        | #777777              |
+| buttonHighlightColor | Button colors when pressed and active.             | #FFFFFF              |
+| hand                 | The hand that will be tracked (e.g., right, left). |                      |
+| model                | Whether the Vive Focus controller model is loaded. | true                 |
+| orientationOffset    | Offset to apply to model orientation.              | x: 0, y: 0, z: 0     |
+
+## Events
+
+| Event Name         | Description           |
+| ----------         | -----------           |
+| trackpadchanged    | Trackpad changed.     |
+| trackpaddown       | Trackpad pressed.     |
+| trackpadmoved      | Trackpad axis changed.|
+| trackpadup         | Trackpad released.    |
+| trackpadtouchstart | Trackpad touched.     |
+| trackpadtouchend   | Trackpad not touched. |
+| triggerchanged     | Trigger changed.      |
+| triggerdown        | Trigger pressed.      |
+| triggerup          | Trigger released.     |
+
+As this controller's buttons are digital, the changed events only fire when
+a button is fully pressed or released (value 0 or 1).
+
+## Assets
+
+- [Controller GLTF](https://cdn.aframe.io/controllers/vive/focus-controller/focus-controller.gltf)
+

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ require('./text');
 require('./tracked-controls');
 require('./visible');
 require('./vive-controls');
+require('./vive-focus-controls');
 require('./wasd-controls');
 require('./windows-motion-controls');
 

--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -18,6 +18,7 @@ registerComponent('laser-controls', {
     el.setAttribute('oculus-go-controls', {hand: data.hand});
     el.setAttribute('oculus-touch-controls', {hand: data.hand});
     el.setAttribute('vive-controls', {hand: data.hand});
+    el.setAttribute('vive-focus-controls', {hand: data.hand});
     el.setAttribute('windows-motion-controls', {hand: data.hand});
 
     // Wait for controller to connect, or have a valid pointing pose, before creating ray
@@ -87,6 +88,10 @@ registerComponent('laser-controls', {
 
     'vive-controls': {
       cursor: {downEvents: ['triggerdown'], upEvents: ['triggerup']}
+    },
+
+    'vive-focus-controls': {
+      cursor: {downEvents: ['trackpaddown', 'triggerdown'], upEvents: ['trackpadup', 'triggerup']}
     },
 
     'windows-motion-controls': {

--- a/src/components/vive-focus-controls.js
+++ b/src/components/vive-focus-controls.js
@@ -1,0 +1,183 @@
+var registerComponent = require('../core/component').registerComponent;
+var bind = require('../utils/bind');
+var trackedControlsUtils = require('../utils/tracked-controls');
+var checkControllerPresentAndSetup = trackedControlsUtils.checkControllerPresentAndSetup;
+var emitIfAxesChanged = trackedControlsUtils.emitIfAxesChanged;
+var onButtonEvent = trackedControlsUtils.onButtonEvent;
+
+var GAMEPAD_ID_PREFIX = 'HTC Vive Focus';
+
+var VIVE_FOCUS_CONTROLLER_MODEL_URL = 'https://cdn.aframe.io/controllers/vive/focus-controller/focus-controller.gltf';
+
+/**
+ * Vive Focus controls.
+ * Interface with Vive Focus controller and map Gamepad events to
+ * controller buttons: trackpad, trigger
+ * Load a controller model and highlight the pressed buttons.
+ */
+module.exports.Component = registerComponent('vive-focus-controls', {
+  schema: {
+    hand: {default: ''},  // This informs the degenerate arm model.
+    buttonTouchedColor: {type: 'color', default: '#BBBBBB'},
+    buttonHighlightColor: {type: 'color', default: '#7A7A7A'},
+    model: {default: true},
+    rotationOffset: {default: 0},
+    armModel: {default: true}
+  },
+
+  /**
+   * Button IDs:
+   * 0 - trackpad
+   * 1 - trigger
+   */
+  mapping: {
+    axes: {trackpad: [0, 1]},
+    buttons: ['trigger', 'trackpad']
+  },
+
+  bindMethods: function () {
+    this.onModelLoaded = bind(this.onModelLoaded, this);
+    this.onControllersUpdate = bind(this.onControllersUpdate, this);
+    this.checkIfControllerPresent = bind(this.checkIfControllerPresent, this);
+    this.removeControllersUpdateListener = bind(this.removeControllersUpdateListener, this);
+    this.onAxisMoved = bind(this.onAxisMoved, this);
+  },
+
+  init: function () {
+    var self = this;
+    this.animationActive = 'pointing';
+    this.onButtonChanged = bind(this.onButtonChanged, this);
+    this.onButtonDown = function (evt) { onButtonEvent(evt.detail.id, 'down', self); };
+    this.onButtonUp = function (evt) { onButtonEvent(evt.detail.id, 'up', self); };
+    this.onButtonTouchStart = function (evt) { onButtonEvent(evt.detail.id, 'touchstart', self); };
+    this.onButtonTouchEnd = function (evt) { onButtonEvent(evt.detail.id, 'touchend', self); };
+    this.onAxisMoved = bind(this.onAxisMoved, this);
+    this.controllerPresent = false;
+    this.lastControllerCheck = 0;
+    this.bindMethods();
+    this.checkControllerPresentAndSetup = checkControllerPresentAndSetup;  // To allow mock.
+    this.emitIfAxesChanged = emitIfAxesChanged;  // To allow mock.
+  },
+
+  addEventListeners: function () {
+    var el = this.el;
+    el.addEventListener('buttonchanged', this.onButtonChanged);
+    el.addEventListener('buttondown', this.onButtonDown);
+    el.addEventListener('buttonup', this.onButtonUp);
+    el.addEventListener('touchstart', this.onButtonTouchStart);
+    el.addEventListener('touchend', this.onButtonTouchEnd);
+    el.addEventListener('model-loaded', this.onModelLoaded);
+    el.addEventListener('axismove', this.onAxisMoved);
+    this.controllerEventsActive = true;
+    this.addControllersUpdateListener();
+  },
+
+  removeEventListeners: function () {
+    var el = this.el;
+    el.removeEventListener('buttonchanged', this.onButtonChanged);
+    el.removeEventListener('buttondown', this.onButtonDown);
+    el.removeEventListener('buttonup', this.onButtonUp);
+    el.removeEventListener('touchstart', this.onButtonTouchStart);
+    el.removeEventListener('touchend', this.onButtonTouchEnd);
+    el.removeEventListener('model-loaded', this.onModelLoaded);
+    el.removeEventListener('axismove', this.onAxisMoved);
+    this.controllerEventsActive = false;
+    this.removeControllersUpdateListener();
+  },
+
+  checkIfControllerPresent: function () {
+    this.checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX,
+                                        this.data.hand ? {hand: this.data.hand} : {});
+  },
+
+  play: function () {
+    this.checkIfControllerPresent();
+    this.addControllersUpdateListener();
+  },
+
+  pause: function () {
+    this.removeEventListeners();
+    this.removeControllersUpdateListener();
+  },
+
+  injectTrackedControls: function () {
+    var el = this.el;
+    var data = this.data;
+    el.setAttribute('tracked-controls', {
+      armModel: data.armModel,
+      idPrefix: GAMEPAD_ID_PREFIX,
+      rotationOffset: data.rotationOffset
+    });
+    if (!this.data.model) { return; }
+    this.el.setAttribute('gltf-model', VIVE_FOCUS_CONTROLLER_MODEL_URL);
+  },
+
+  addControllersUpdateListener: function () {
+    this.el.sceneEl.addEventListener('controllersupdated', this.onControllersUpdate, false);
+  },
+
+  removeControllersUpdateListener: function () {
+    this.el.sceneEl.removeEventListener('controllersupdated', this.onControllersUpdate, false);
+  },
+
+  onControllersUpdate: function () {
+    this.checkIfControllerPresent();
+  },
+
+  onModelLoaded: function (evt) {
+    var controllerObject3D = evt.detail.model;
+    var buttonMeshes;
+
+    if (!this.data.model) { return; }
+    buttonMeshes = this.buttonMeshes = {};
+    buttonMeshes.trigger = controllerObject3D.getObjectByName('BumperKey');
+    buttonMeshes.triggerPressed = controllerObject3D.getObjectByName('BumperKey_Press');
+    if (buttonMeshes.triggerPressed) {
+      buttonMeshes.triggerPressed.visible = false;
+    }
+    buttonMeshes.trackpad = controllerObject3D.getObjectByName('TouchPad');
+    buttonMeshes.trackpadPressed = controllerObject3D.getObjectByName('TouchPad_Press');
+    if (buttonMeshes.trackpadPressed) {
+      buttonMeshes.trackpadPressed.visible = false;
+    }
+  },
+
+  // No analog buttons, only emits 0/1 values
+  onButtonChanged: function (evt) {
+    var button = this.mapping.buttons[evt.detail.id];
+    if (!button) return;
+    // Pass along changed event with button state, using button mapping for convenience.
+    this.el.emit(button + 'changed', evt.detail.state);
+  },
+
+  onAxisMoved: function (evt) {
+    this.emitIfAxesChanged(this, this.mapping.axes, evt);
+  },
+
+  updateModel: function (buttonName, evtName) {
+    if (!this.data.model) { return; }
+    this.updateButtonModel(buttonName, evtName);
+  },
+
+  updateButtonModel: function (buttonName, state) {
+    var buttonMeshes = this.buttonMeshes;
+    var pressedName = buttonName + 'Pressed';
+    if (!buttonMeshes || !buttonMeshes[buttonName] || !buttonMeshes[pressedName]) {
+      return;
+    }
+    var color;
+    switch (state) {
+      case 'down':
+        color = this.data.buttonHighlightColor;
+        break;
+      case 'touchstart':
+        color = this.data.buttonTouchedColor;
+        break;
+    }
+    if (color) {
+      buttonMeshes[pressedName].material.color.set(color);
+    }
+    buttonMeshes[pressedName].visible = !!color;
+    buttonMeshes[buttonName].visible = !color;
+  }
+});

--- a/tests/components/laser-controls.test.js
+++ b/tests/components/laser-controls.test.js
@@ -20,6 +20,7 @@ suite('laser-controls', function () {
       assert.ok(el.components['oculus-go-controls']);
       assert.ok(el.components['oculus-touch-controls']);
       assert.ok(el.components['vive-controls']);
+      assert.ok(el.components['vive-focus-controls']);
       assert.ok(el.components['windows-motion-controls']);
     });
 

--- a/tests/components/vive-focus-controls.test.js
+++ b/tests/components/vive-focus-controls.test.js
@@ -1,0 +1,263 @@
+/* global assert, process, setup, sinon, suite, test */
+var entityFactory = require('../helpers').entityFactory;
+
+suite('vive-focus-controls', function () {
+  setup(function (done) {
+    var el = this.el = entityFactory();
+    el.setAttribute('vive-focus-controls', 'hand: right');  // To ensure index is 0.
+    el.addEventListener('loaded', function () {
+      var component = el.components['vive-focus-controls'];
+      component.controllersWhenPresent = [{
+        id: 'HTC Vive Focus Controller',
+        index: 0,
+        hand: 'right',
+        axes: [0, 0],
+        buttons: [
+          {value: 0, pressed: false, touched: false},
+          {value: 0, pressed: false, touched: false}
+        ],
+        pose: {orientation: [1, 0, 0, 0], position: null}
+      }];
+      el.parentEl.renderer.vr.getStandingMatrix = function () {};
+      done();
+    });
+  });
+
+  suite('checkIfControllerPresent', function () {
+    test('returns not present if no controllers on first on first call', function () {
+      var el = this.el;
+      var component = el.components['vive-focus-controls'];
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+
+      component.controllerPresent = false;
+
+      component.checkIfControllerPresent();
+
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, false);
+    });
+
+    test('does not remove event listeners if no controllers', function () {
+      var el = this.el;
+      var component = el.components['vive-focus-controls'];
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+
+      component.controllerEventsActive = false;
+      component.controllerPresent = false;
+
+      component.checkIfControllerPresent();
+
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.notCalled(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, false);
+    });
+
+    test('attaches events if controller is newly present', function () {
+      var el = this.el;
+      var component = el.components['vive-focus-controls'];
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
+
+      component.controllerPresent = false;
+
+      component.checkIfControllerPresent();
+
+      sinon.assert.calledOnce(injectTrackedControlsSpy);
+      sinon.assert.calledOnce(addEventListenersSpy);
+      sinon.assert.notCalled(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, true);
+    });
+
+    test('does not inject/attach events again if controller already present', function () {
+      var el = this.el;
+      var component = el.components['vive-focus-controls'];
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
+
+      component.controllerEventsActive = true;
+      component.controllerPresent = true;
+
+      component.checkIfControllerPresent();
+
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.notCalled(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, true);
+    });
+
+    test('removes event listeners if controller disappears', function () {
+      var el = this.el;
+      var component = el.components['vive-focus-controls'];
+      var addEventListenersSpy = sinon.spy(component, 'addEventListeners');
+      var injectTrackedControlsSpy = sinon.spy(component, 'injectTrackedControls');
+      var removeEventListenersSpy = sinon.spy(component, 'removeEventListeners');
+
+      el.sceneEl.systems['tracked-controls'].controllers = [];
+
+      component.controllerEventsActive = true;
+      component.controllerPresent = true;
+
+      component.checkIfControllerPresent();
+
+      sinon.assert.notCalled(injectTrackedControlsSpy);
+      sinon.assert.notCalled(addEventListenersSpy);
+      sinon.assert.calledOnce(removeEventListenersSpy);
+      assert.strictEqual(component.controllerPresent, false);
+    });
+  });
+
+  suite('axismove', function () {
+    test('emits trackpadmoved on axismove', function (done) {
+      var el = this.el;
+      setupTestControllers(el);
+
+      // Configure the event state for which we'll use the axis state for verification.
+      const eventState = {axis: [0.1, 0.2], changed: [true, false]};
+
+      el.addEventListener('trackpadmoved', function (evt) {
+        assert.equal(evt.detail.x, eventState.axis[0]);
+        assert.equal(evt.detail.y, eventState.axis[1]);
+        done();
+      });
+
+      el.emit('axismove', eventState);
+    });
+
+    test('does not emit trackpadmoved on axismove with no changes', function (done) {
+      var el = this.el;
+      setupTestControllers(el);
+
+      // Fail purposely.
+      el.addEventListener('trackpadmoved', function (evt) {
+        assert.fail('trackpadmoved was called when there was no change.');
+      });
+
+      el.emit('axismove', {axis: [0.1, 0.2], changed: [false, false]});
+      setTimeout(() => { done(); });
+    });
+  });
+
+  suite('buttonchanged', function () {
+    [ { button: 'trigger', id: 0 },
+      { button: 'trackpad', id: 1 }
+    ].forEach(function (buttonDescription) {
+      test('if we get buttonchanged for button ' + buttonDescription.id + ', emit ' + buttonDescription.button + 'changed', function (done) {
+        var el = this.el;
+        setupTestControllers(el);
+
+        // Configure the expected event state and use it to fire the event.
+        const eventState = {value: 0.5, pressed: true, touched: true};
+
+        el.addEventListener(buttonDescription.button + 'changed', function (evt) {
+          assert.deepEqual(evt.detail, eventState);
+          done();
+        });
+
+        el.emit('buttonchanged', {id: buttonDescription.id, state: eventState});
+      });
+
+      test('if we get buttondown for button ' + buttonDescription.id + ', emit ' + buttonDescription.button + 'down', function (done) {
+        var el = this.el;
+        setupTestControllers(el);
+
+        el.addEventListener(buttonDescription.button + 'down', function (evt) {
+          done();
+        });
+
+        el.emit('buttondown', {id: buttonDescription.id});
+      });
+
+      test('if we get buttonup for button ' + buttonDescription.id + ', emit ' + buttonDescription.button + 'up', function (done) {
+        var el = this.el;
+        setupTestControllers(el);
+
+        el.addEventListener(buttonDescription.button + 'up', function (evt) {
+          done();
+        });
+
+        el.emit('buttonup', {id: buttonDescription.id});
+      });
+    });
+  });
+
+  suite('armModel', function () {
+    test('does not apply armModel if armModel disabled', function () {
+      var el = this.el;
+      el.setAttribute('vive-focus-controls', 'armModel', false);
+      setupTestControllers(el);
+
+      var trackedControls = el.components['tracked-controls'];
+      var applyArmModelSpy = sinon.spy(trackedControls, 'applyArmModel');
+      trackedControls.tick();
+
+      // Verify that the function which applies arm model is not called when disabled.
+      sinon.assert.notCalled(applyArmModelSpy);
+
+      // Additionally verify that no other offets have been applied.
+      assert.strictEqual(el.object3D.position.x, 0);
+      assert.strictEqual(el.object3D.position.y, 0);
+      assert.strictEqual(el.object3D.position.z, 0);
+    });
+
+    test('applies armModel if armModel enabled', function () {
+      var el = this.el;
+      el.setAttribute('vive-focus-controls', 'armModel', true);
+      setupTestControllers(el);
+
+      var trackedControls = el.components['tracked-controls'];
+      var applyArmModelSpy = sinon.spy(trackedControls, 'applyArmModel');
+      trackedControls.tick();
+
+      // Verify that the function which applies arm model is called.
+      sinon.assert.calledOnce(applyArmModelSpy);
+    });
+
+    test('verifies armModel position is applied for the right hand', function () {
+      var el = this.el;
+      el.setAttribute('vive-focus-controls', 'armModel', true);
+      setupTestControllers(el);
+
+      var trackedControls = el.components['tracked-controls'];
+      trackedControls.tick();
+      assert.ok(el.object3D.position.x > 0);
+    });
+
+    test('verifies armModel position is applied for the left hand', function () {
+      var el = this.el;
+      el.setAttribute('vive-focus-controls', 'armModel', true);
+      el.setAttribute('vive-focus-controls', 'hand', 'left');
+      el.components['vive-focus-controls'].controllersWhenPresent[0].hand = 'left';
+      setupTestControllers(el);
+
+      var trackedControls = el.components['tracked-controls'];
+      trackedControls.tick();
+      assert.ok(el.object3D.position.x < 0);
+    });
+  });
+
+  /**
+   * Establishes the baseline set of controllers needed for the tests to run.
+   *
+   * @param {object} el - The current entity factory.
+   */
+  function setupTestControllers (el) {
+    var component = el.components['vive-focus-controls'];
+    el.sceneEl.systems['tracked-controls'].controllers = component.controllersWhenPresent;
+    component.checkIfControllerPresent();
+  }
+});


### PR DESCRIPTION
**Description:** Adds a controller component for the Vive Focus 3DOF controller (usable with A-Frame via Firefox Reality browser)

Note that, at present, Firefox Reality is presenting the focus controller in the Gamepad API as a Gear VR controller, so this component won't activate until that is changed (MozillaReality/FirefoxReality#812). 
[Here is the gltf with working button highlights](https://github.com/aframevr/aframe/files/2609290/focus-controller.zip).

GLTF model provided by @3DataSean & @Dulce303

