### PR TITLE
Fixed yOffset not being used to change y position of text

### DIFF
--- a/src/components/text.js
+++ b/src/components/text.js
@@ -328,7 +328,7 @@ module.exports.Component = registerComponent('text', {
 
     // Position and scale mesh to apply layout.
     mesh.position.x = x * textScale + data.xOffset;
-    mesh.position.y = y * textScale;
+    mesh.position.y = y * textScale + data.yOffset;
     // Place text slightly in front to avoid Z-fighting.
     mesh.position.z = data.zOffset;
     mesh.scale.set(textScale, -1 * textScale, textScale);


### PR DESCRIPTION

addresses issue mentioned in  #3762

simply included (+ data.yOffset) to mesh position of text
`mesh.position.y = y * textScale + data.yOffset;`