### PR TITLE
?inspector={element} and Entity.inspect() helpers to reduce inspector friction

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -814,6 +814,15 @@ var proto = Object.create(ANode.prototype, {
     value: function (state) {
       return this.states.indexOf(state) !== -1;
     }
+  },
+
+  /**
+   * Open Inspector to this entity.
+   */
+  inspect: {
+    value: function () {
+      this.sceneEl.components.inspector.openInspector(this);
+    }
   }
 });
 


### PR DESCRIPTION
**Description:**

When working with Inspector, there's friction in refreshing the scene + opening the Inspector + searching the entity / selecting the entity + repeat.

**Changes proposed:**
- Add optional `?inspector={elementId}` URL parameter that automatically opens the Inspector and focuses on the passed-in entity (if any). Then if you are working in an Inspector workflow (e.g., tweaking an entity), just keep the URL parameter there and refresh.
- Add `Entity.inspect()` method to easily open/focus any entity in Inspector from DevTools console.

If merged, matching Inspector changes will follow.
