### PR TITLE
My Changes (fixes #3865)

### DIFF
--- a/src/extras/primitives/primitives/a-camera.js
+++ b/src/extras/primitives/primitives/a-camera.js
@@ -5,7 +5,7 @@ registerPrimitive('a-camera', {
     'camera': {},
     'look-controls': {},
     'wasd-controls': {},
-    'position': {y: 1.6}
+    'position': {x: 0, y: 1.6, z: 0}
   },
 
   mappings: {


### PR DESCRIPTION
#3865 
**Description:**
When using position coupled with look-controls and the scene does not have webxr.
Then there is a matrix update performed.
In order for this to work, the position should be fully defined, other x and z values are undefined and result in no sky image being shown
**Changes proposed:**
- update a-camera default Component position to be fully defined
