### PR TITLE
fix fullscreen logic and test, remove duplicate success handlers

### DIFF
--- a/tests/components/sound.test.js
+++ b/tests/components/sound.test.js
@@ -250,15 +250,15 @@ suite('sound', function () {
         audioEl.setAttribute('autoplay', '');
         assetsEl.appendChild(audioEl);
         sceneEl.appendChild(assetsEl);
-        process.nextTick(function () {
+        setTimeout(function () {
           var el = document.createElement('a-entity');
-          el.setAttribute('sound', 'src', '#testogg');
           el.addEventListener('sound-loaded', function () {
             assert.ok(this.components.sound.loaded);
             done();
           });
+          el.setAttribute('sound', 'src', '#testogg');
           sceneEl.appendChild(el);
-        });
+        }, 10);
       });
     });
 

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -205,12 +205,12 @@ suite('a-scene (without renderer)', function () {
       var sceneEl = this.el;
       var fullscreenSpy;
 
-      if (sceneEl.canvas.mozRequestFullScreen) {
+      if (sceneEl.canvas.requestFullscreen) {
+        fullscreenSpy = this.sinon.spy(sceneEl.canvas, 'requestFullscreen');
+      } else if (sceneEl.canvas.mozRequestFullScreen) {
         fullscreenSpy = this.sinon.spy(sceneEl.canvas, 'mozRequestFullScreen');
       } else if (sceneEl.canvas.webkitRequestFullScreen) {
         fullscreenSpy = this.sinon.spy(sceneEl.canvas, 'webkitRequestFullscreen');
-      } else {
-        fullscreenSpy = this.sinon.spy(sceneEl.canvas, 'requestFullscreen');
       }
 
       this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(false);


### PR DESCRIPTION
**Description:**

A requestFullscreen test was failing.

The enterVRSuccess function was for fully entering success and entering fullscreen if necessary.

It was copy and pasted to enterXRSuccess with all the fullscreen logic, but we really want a separate success handler just for the XRSession. And then after all that XR stuff is done, call a complete aframe-specific enterVRSuccess handler.
