### PR TITLE
remove sound warning for empty src, check befor removeObject3D

### DIFF
--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -45,10 +45,7 @@ module.exports.Component = registerComponent('sound', {
 
     // Create new sound if not yet created or changing `src`.
     if (srcChanged) {
-      if (!data.src) {
-        warn('Audio source was not specified with `src`');
-        return;
-      }
+      if (!data.src) { return; }
       this.setupSound();
     }
 
@@ -104,7 +101,10 @@ module.exports.Component = registerComponent('sound', {
     var sound;
 
     this.removeEventListener();
-    this.el.removeObject3D(this.attrName);
+
+    if (this.el.getObject3D(this.attrName)) {
+      this.el.removeObject3D(this.attrName);
+    }
 
     try {
       for (i = 0; i < this.pool.children.length; i++) {


### PR DESCRIPTION
- No need for warning for setting to empty src. Sometimes intentional.
- Check before removeObject3D that sound exists.