### PR TITLE
[cursor] update mouse event listeners on resume

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -129,6 +129,8 @@ module.exports.Component = registerComponent('cursor', {
     el.sceneEl.addEventListener('rendererresize', this.updateCanvasBounds);
     window.addEventListener('resize', this.updateCanvasBounds);
     window.addEventListener('scroll', this.updateCanvasBounds);
+
+    this.updateMouseEventListeners();
   },
 
   removeEventListeners: function () {


### PR DESCRIPTION
Mouse cursor after resuming did not re-enable.