### PR TITLE
merge vec3 attrValue with data on vec3 updates, to handle non-defined x y or z vals

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -329,6 +329,9 @@ Component.prototype = {
 
     // Apply new value to this.data in place since direct update.
     if (this.isSingleProperty) {
+      if (this.isObjectBased) {
+        parseProperty(attrValue, this.schema);
+      }
       // Single-property (already parsed).
       this.data = attrValue;
       return;

--- a/tests/components/position.test.js
+++ b/tests/components/position.test.js
@@ -49,5 +49,13 @@ suite('position', function () {
       assert.equal(el.object3D.position.y, 2);
       assert.equal(el.object3D.position.z, 3);
     });
+
+    test('can set position with incomplete object', function () {
+      var el = this.el;
+      el.setAttribute('position', {y: 2});
+      assert.equal(el.object3D.position.x, 0);
+      assert.equal(el.object3D.position.y, 2);
+      assert.equal(el.object3D.position.z, 0);
+    });
   });
 });


### PR DESCRIPTION
**Description:**

vec3 is single-prop so it was being applied literally (`{y:2}` would have x and z undefined).

This applies object-based values with an extend.

