### PR TITLE
tracked-controls autoHide property to configure whether it should manage entity visibility

### DIFF
--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -23,6 +23,11 @@ the entity, observes buttons state and emits appropriate events.  For non-6DOF c
 such as [daydream-controls][daydreamcontrols], a primitive arm model is used to emulate
 positional data.
 
+tracked-controls sets two components that handles different Web API versions for VR:
+
+- tracked-controls-webvr
+- tracked-controls-webxr
+
 ## Example
 
 Note that due to recent browser-specific changes, Vive controllers may be returned
@@ -35,16 +40,16 @@ so using idPrefix for Vive / OpenVR controllers is recommended.
 
 ## Value
 
-| Property          | Description                                                     | Default Value              |
-|-------------------|-----------------------------------------------------------------|----------------------------|
-| armModel          | Whether the arm model is used for positional data if absent.    | true                       |
-| controller        | Index of the controller in array returned by the Gamepad API.   | 0                          |
-| id                | Selects the controller from the Gamepad API using exact match.  |                            |
-| idPrefix          | Selects the controller from the Gamepad API using prefix match. |                            |
-| headElement       | Head element for arm model if needed (if not active camera).    |                            |
-| hand              | Which hand to use, if arm model is needed.  (left negates X)    | right                      |
-| orientationOffset | Offset to apply to model orientation.                           | x: 0, y: 0, z: 0     |
-
+| Property          | Description                                                                              | Default Value    |
+|-------------------|------------------------------------------------------------------------------------------|------------------|
+| armModel          | Whether the arm model is used for positional data if absent.                             | true             |
+| autoHide          | Whether to toggle visibility automatically when controller is connected or disconnected. | true             |
+| controller        | Index of the controller in array returned by the Gamepad API.                            | 0                |
+| id                | Selects the controller from the Gamepad API using exact match.                           |                  |
+| idPrefix          | Selects the controller from the Gamepad API using prefix match.                          |                  |
+| headElement       | Head element for arm model if needed (if not active camera).                             |                  |
+| hand              | Which hand to use, if arm model is needed.  (left negates X)                             | right            |
+| orientationOffset | Offset to apply to model orientation.                                                    | x: 0, y: 0, z: 0 |
 
 ## Events
 

--- a/src/components/tracked-controls-webvr.js
+++ b/src/components/tracked-controls-webvr.js
@@ -35,6 +35,7 @@ var EVENTS = {
  */
 module.exports.Component = registerComponent('tracked-controls-webvr', {
   schema: {
+    autoHide: {default: true},
     controller: {default: 0},
     id: {type: 'string', default: ''},
     hand: {type: 'string', default: ''},
@@ -102,7 +103,8 @@ module.exports.Component = registerComponent('tracked-controls-webvr', {
     this.controller = controller;
     // Legacy handle to the controller for old components.
     this.el.components['tracked-controls'].controller = controller;
-    this.el.object3D.visible = !!this.controller;
+
+    if (this.data.autoHide) { this.el.object3D.visible = !!this.controller; }
   },
 
   /**

--- a/src/components/tracked-controls-webxr.js
+++ b/src/components/tracked-controls-webxr.js
@@ -65,7 +65,8 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
     );
     // Legacy handle to the controller for old components.
     this.el.components['tracked-controls'].controller = this.controller;
-    this.el.object3D.visible = !!this.controller;
+
+    if (this.data.autoHide) { this.el.object3D.visible = !!this.controller; }
   },
 
   tick: function () {

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -12,6 +12,7 @@ var registerComponent = require('../core/component').registerComponent;
  */
 module.exports.Component = registerComponent('tracked-controls', {
   schema: {
+    autoHide: {default: true},
     controller: {default: 0},
     id: {type: 'string', default: ''},
     hand: {type: 'string', default: ''},


### PR DESCRIPTION
**Description:**

I don't like the new logic of tracked-controls auto-hiding my controller entities during debugging. Allow configuration of it.

**Changes proposed:**
- tracked-controls.autoHide
