### PR TITLE
Emit event when a headset is connected

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -4,13 +4,17 @@ var vrDisplay;
 if (navigator.xr) {
   navigator.xr.requestDevice().then(function (device) {
     device.supportsSession({immersive: true, exclusive: true}).then(function () {
+      var sceneEl = document.querySelector('a-scene');
       vrDisplay = device;
+      if (sceneEl) { sceneEl.emit('displayconnected', {vrDisplay: vrDisplay}); }
     });
   });
 } else {
   if (navigator.getVRDisplays) {
     navigator.getVRDisplays().then(function (displays) {
+      var sceneEl = document.querySelector('a-scene');
       vrDisplay = displays.length && displays[0];
+      if (sceneEl) { sceneEl.emit('displayconnected', {vrDisplay: vrDisplay}); }
     });
   }
 }


### PR DESCRIPTION
`navigator.getVRDisplays` (WebVR) and `navigator.xr.requestDevice` (WebXR) are both asynchronous. An event makes easier to detect when a headset is connected and implement enter VR UIs / workflows.
