### PR TITLE
Updated default value of pointerLockEnabled in docs

### DIFF
--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -33,7 +33,7 @@ component](camera.md).
 | reverseMouseDrag | Whether to reverse mouse drag.                                   | false         |
 | reverseTouchDrag | Whether to reverse touch drag.                                   | false         |
 | touchEnabled     | Whether to use touch controls in magic window mode.              | true          |
-| pointerLockEnabled | Whether to hide the cursor using the [Pointer Lock API][pointer-lock-api]. | true |
+| pointerLockEnabled | Whether to hide the cursor using the [Pointer Lock API][pointer-lock-api]. | false |
 
 ## Customizing look-controls
 


### PR DESCRIPTION
**Description:**

Updates default value of pointerLockEnabled of look-controls in docs. From the source, the default value is _false_.

**Changes proposed:**
- Updated docs for pointerLockEnabled in look-controls.
