### PR TITLE
[look-controls] Fix issue accessing inspector from pointerlocked mode.

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -66,7 +66,7 @@ module.exports.Component = registerComponent('look-controls', {
     if (oldData && !data.pointerLockEnabled !== oldData.pointerLockEnabled) {
       this.removeEventListeners();
       this.addEventListeners();
-      if (this.pointerLocked) { document.exitPointerLock(); }
+      if (this.pointerLocked) { this.exitPointerLock(); }
     }
   },
 
@@ -82,10 +82,12 @@ module.exports.Component = registerComponent('look-controls', {
 
   pause: function () {
     this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
   },
 
   remove: function () {
     this.removeEventListeners();
+    if (this.pointerLocked) { this.exitPointerLock(); }
   },
 
   bindMethods: function () {
@@ -364,6 +366,12 @@ module.exports.Component = registerComponent('look-controls', {
    * Recover from Pointer Lock error.
    */
   onPointerLockError: function () {
+    this.pointerLocked = false;
+  },
+
+  // Exits pointer-locked mode.
+  exitPointerLock: function () {
+    document.exitPointerLock();
     this.pointerLocked = false;
   },
 


### PR DESCRIPTION
@ngokevin I think this fixes https://github.com/aframevr/aframe/issues/3602, but the default version of the inspector on current aframe doesn't pause/play the scene. It looks like you fixed that recently, so I updated to the master branch, but there I'm seeing the camera freeze after exiting the inspector regardless of whether pointerlock is involved. 🤔