### PR TITLE
Change WebXR controller matching rule. If handedness not defined it ma…

### DIFF
--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -150,8 +150,11 @@ function findMatchingControllerWebVR (controllers, filterIdExact, filterIdPrefix
 
 function findMatchingControllerWebXR (controllers, handedness) {
   var i;
+  var controllerHandedness;
   for (i = 0; i < controllers.length; i++) {
-    if (controllers[i].handedness === handedness) {
+    controllerHandedness = controllers[i].handedness;
+    if (!handedness || (controllerHandedness === '' && handedness === 'right') ||
+        controllers[i].handedness === handedness) {
       return controllers[i];
     }
   }


### PR DESCRIPTION
…tches any controller. If controller does not have handedness it matches right handed component

