### PR TITLE
highRefreshRate property to enable 72hz mode on Oculus Browser (fix #3943)

### DIFF
--- a/docs/components/renderer.md
+++ b/docs/components/renderer.md
@@ -29,7 +29,7 @@ The `renderer` system configures a scene's
 |-------------------------|---------------------------------------------------------------------------------|---------------|
 | antialias               | Whether to perform antialiasing. If `auto`, antialiasing is disabled on mobile. | auto          |
 | colorManagement         | Whether to use a color-managed linear workflow.                                 | false         |
-| highRefreshRate         | Oculus Browser has a 72hz optional mode vs. the default 60hz                                 | false         |
+| highRefreshRate         | Toggles 72hz mode on Oculus Browser. Defaults to 60hz.                          | false         |
 | sortObjects             | Whether to sort objects before rendering.                                       | false         |
 | physicallyCorrectLights | Whether to use physically-correct light attenuation.                            | false         |
 | maxCanvasWidth          | Maximum canvas width. Uses the size multiplied by device pixel ratio. Does not limit canvas width if set to -1.                                | 1920            |

--- a/docs/components/renderer.md
+++ b/docs/components/renderer.md
@@ -29,6 +29,7 @@ The `renderer` system configures a scene's
 |-------------------------|---------------------------------------------------------------------------------|---------------|
 | antialias               | Whether to perform antialiasing. If `auto`, antialiasing is disabled on mobile. | auto          |
 | colorManagement         | Whether to use a color-managed linear workflow.                                 | false         |
+| highRefreshRate         | Oculus Browser has a 72hz optional mode vs. the default 60hz                                 | false         |
 | sortObjects             | Whether to sort objects before rendering.                                       | false         |
 | physicallyCorrectLights | Whether to use physically-correct light attenuation.                            | false         |
 | maxCanvasWidth          | Maximum canvas width. Uses the size multiplied by device pixel ratio. Does not limit canvas width if set to -1.                                | 1920            |

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -41,6 +41,7 @@ module.exports.AScene = registerElement('a-scene', {
         this.isIOS = isIOS;
         this.isMobile = isMobile;
         this.hasWebXR = isWebXRAvailable;
+        this.highRefreshRate = false;
         this.isScene = true;
         this.object3D = new THREE.Scene();
         var self = this;
@@ -289,8 +290,10 @@ module.exports.AScene = registerElement('a-scene', {
               enterVRSuccess();
               return Promise.resolve();
             }
-            return vrDisplay.requestPresent([{source: this.canvas}]).then(
-              enterVRSuccess, enterVRFailure);
+            return vrDisplay.requestPresent([{
+              source: this.canvas,
+              attributes: {highRefreshRate: this.highRefreshRate}
+            }]).then(enterVRSuccess, enterVRFailure);
           }
           return Promise.resolve();
         }

--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -11,6 +11,7 @@ var warn = debug('components:renderer:warn');
 module.exports.System = registerSystem('renderer', {
   schema: {
     antialias: {default: 'auto', oneOf: ['true', 'false', 'auto']},
+    highRefreshRate: {default: false},
     logarithmicDepthBuffer: {default: 'auto', oneOf: ['true', 'false', 'auto']},
     maxCanvasWidth: {default: 1920},
     maxCanvasHeight: {default: 1920},
@@ -28,6 +29,7 @@ module.exports.System = registerSystem('renderer', {
 
     renderer.sortObjects = data.sortObjects;
     renderer.physicallyCorrectLights = data.physicallyCorrectLights;
+    sceneEl.highRefreshRate = data.highRefreshRate;
 
     if (data.colorManagement || data.gammaOutput) {
       renderer.gammaOutput = true;

--- a/tests/systems/renderer.test.js
+++ b/tests/systems/renderer.test.js
@@ -10,6 +10,7 @@ suite('renderer', function () {
   test('default initialization', function (done) {
     var sceneEl = createScene();
     sceneEl.addEventListener('loaded', function () {
+      assert.notOk(sceneEl.highRefreshRate);
       assert.notOk(sceneEl.renderer.gammaOutput);
       assert.notOk(sceneEl.renderer.gammaFactor);
       assert.notOk(sceneEl.renderer.sortObjects);
@@ -45,6 +46,16 @@ suite('renderer', function () {
     sceneEl.setAttribute('renderer', 'physicallyCorrectLights: true;');
     sceneEl.addEventListener('loaded', function () {
       assert.ok(sceneEl.renderer.physicallyCorrectLights);
+      done();
+    });
+    document.body.appendChild(sceneEl);
+  });
+
+  test('change renderer highRefreshRate', function (done) {
+    var sceneEl = createScene();
+    sceneEl.setAttribute('renderer', 'highRefreshRate: true');
+    sceneEl.addEventListener('loaded', function () {
+      assert.ok(sceneEl.highRefreshRate);
       done();
     });
     document.body.appendChild(sceneEl);


### PR DESCRIPTION
the `highRefreshRate` flag on `requestPresent` does not seem to have any effect. Enabling high Refresh Rate on `chrome://flags` does work as expected.

@DigiTec Am I doing things correctly? I added a console message that shows the frame time.

This is WIP simplified for evaluation. The final API will use the renderer component.