### PR TITLE
Set shader precission to mediump in Mobile with no native VR. Fix problems with Adreno 300 series GPUs and improves perf. (fix #3971, #3523)

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -548,7 +548,13 @@ module.exports.AScene = registerElement('a-scene', {
         var rendererAttrString;
         var rendererConfig;
 
-        rendererConfig = {alpha: true, antialias: !isMobile, canvas: this.canvas, logarithmicDepthBuffer: false};
+        rendererConfig = {
+          alpha: true,
+          antialias: !isMobile,
+          canvas: this.canvas,
+          logarithmicDepthBuffer: false,
+          precision: isMobile && !window.hasNativeVR ? 'mediump' : 'highp'
+        };
 
         this.maxCanvasSize = {height: 1920, width: 1920};
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ window.Promise = window.Promise || require('promise-polyfill');
 window.hasNativeWebVRImplementation = !!window.navigator.getVRDisplays ||
                                       !!window.navigator.getVRDevices;
 window.hasNativeWebXRImplementation = navigator.xr !== undefined;
+window.hasNativeVR = window.hasNativeWebVRImplementation || window.hasNativeWebXRImplementation;
 
 // If native WebXR or WebVR are defined WebVRPolyfill does not initialize.
 if (!window.hasNativeWebXRImplementation && !window.hasNativeWebVRImplementation) {


### PR DESCRIPTION
This will also improve perf on mobile across the board. There might be visual differences (https://github.com/mrdoob/three.js/issues/14570). Is tradeoff worth it?
