### PR TITLE
grammar correction

### DIFF
--- a/docs/primitives/a-video.md
+++ b/docs/primitives/a-video.md
@@ -46,7 +46,7 @@ The video primitive plays a video as a texture on a flat plane.
 
 iOS has a lot of restrictions on playing videos in the browser. To play an inline video texture, we must:
 
-- Set the `<meta name="apple-mobile-web-app-capable" content="yes">` meta tag. A-Frame will will inject this if missing.
+- Set the `<meta name="apple-mobile-web-app-capable" content="yes">` meta tag. A-Frame will inject this if missing.
 - Set the `webkit-playsinline` and `playsinline` attribute to the video element. A-Frame will add this to all videos if missing).
 
 Since iOS 11, iOS has required user interaction to trigger video playback. This is also true on a number of Android device and


### PR DESCRIPTION
**Description:**
"A-Frame will will inject this if missing." is grammatically incorrect.

**Changes proposed:**
-  writing "A-Frame will inject this if missing." instead of "A-Frame will will inject this if missing." would be more appropriate.
