### PR TITLE
Move THREE dependency to supermedium THREE fork hosted in npm (fix #3781)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "present": "0.0.6",
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
-    "three": "dmarcos/three.js#webXRSupport",
+    "super-three": "^0.101.0",
     "three-bmfont-text": "^2.1.0",
     "webvr-polyfill": "^0.10.8"
   },

--- a/src/lib/three.js
+++ b/src/lib/three.js
@@ -1,4 +1,4 @@
-var THREE = global.THREE = require('three');
+var THREE = global.THREE = require('super-three');
 
 // Allow cross-origin images to be loaded.
 
@@ -19,10 +19,10 @@ if (THREE.Cache) {
 }
 
 // TODO: Eventually include these only if they are needed by a component.
-require('three/examples/js/loaders/DRACOLoader');  // THREE.DRACOLoader
-require('three/examples/js/loaders/GLTFLoader');  // THREE.GLTFLoader
-require('three/examples/js/loaders/OBJLoader');  // THREE.OBJLoader
-require('three/examples/js/loaders/MTLLoader');  // THREE.MTLLoader
+require('super-three/examples/js/loaders/DRACOLoader');  // THREE.DRACOLoader
+require('super-three/examples/js/loaders/GLTFLoader');  // THREE.GLTFLoader
+require('super-three/examples/js/loaders/OBJLoader');  // THREE.OBJLoader
+require('super-three/examples/js/loaders/MTLLoader');  // THREE.MTLLoader
 
 THREE.DRACOLoader.prototype.crossOrigin = 'anonymous';
 THREE.GLTFLoader.prototype.crossOrigin = 'anonymous';


### PR DESCRIPTION
Moved THREE fork from personal repo to [supermedium one](https://github.com/supermedium/three.js/tree/webXRSupport). I published on npm as [super-three](https://www.npmjs.com/package/super-three). I don't get any size difference in my `three` folder. Same result as @donmccurdy ~15MB in both cases: npm and github hash. Does anybody see any difference? 


