### PR TITLE
Updating webvr-polyfill to 0.10.10 

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "style-attr": "^1.0.2",
     "super-three": "^0.101.0",
     "three-bmfont-text": "^2.1.0",
-    "webvr-polyfill": "^0.10.8"
+    "webvr-polyfill": "^0.10.10"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
Webvr-polyfill 0.10.10 contains a critical fix for Oculus Browser.

**Description:**
Webvr-polyfill of older versions with Oculus Browser (and potentially other browsers, especially Chromium based) could fail to detect presence of WebVR support.

**Changes proposed:**
The important fix in webvr-polyfill: https://github.com/immersive-web/webvr-polyfill/commit/e2958490653bfcda4df83881d554bcdb641cf45b. So, updating dependency to 0.10.10 should fix the issue.
