### PR TITLE
Clarify seamless VR link traversal

### DIFF
--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -19,6 +19,8 @@ across pages, the following conditions must apply:
 - The browser is up-to-date with the WebVR specification and implements the `vrdisplayactivate` event.
 - The destination web page listens to the window [`vrdisplayactivate`] event and enters VR.
 
+> N.B. Currently, VR is only maintained when using desktop VR such as HTC Vive, not google cardboard or even 2d browser fullscreen
+
 ## Link UX
 
 A link in VR can be anything such as grabbing onto an object, placing something


### PR DESCRIPTION
**Description:**

We should make it clear that the VR experience is only seamless on Vive et al. We are not managing our user's expectations correctly, see https://github.com/aframevr/aframe/issues/1473

**Changes proposed:**
- Vive works
- Cardboard doesn't work
- regular fullscreen doesn't work
