### PR TITLE
Exception in coordinates.js fix

### DIFF
--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -38,10 +38,10 @@ function parse (value, defaultVec) {
     y = value.y === undefined ? defaultVec && defaultVec.y : value.y;
     z = value.z === undefined ? defaultVec && defaultVec.z : value.z;
     w = value.w === undefined ? defaultVec && defaultVec.w : value.w;
-    if (x !== undefined) { value.x = parseIfString(x); }
-    if (y !== undefined) { value.y = parseIfString(y); }
-    if (z !== undefined) { value.z = parseIfString(z); }
-    if (w !== undefined) { value.w = parseIfString(w); }
+    if (x !== undefined && x !== null) { value.x = parseIfString(x); }
+    if (y !== undefined && y !== null) { value.y = parseIfString(y); }
+    if (z !== undefined && z !== null) { value.z = parseIfString(z); }
+    if (w !== undefined && w !== null) { value.w = parseIfString(w); }
     return value;
   }
 
@@ -96,7 +96,7 @@ module.exports.isCoordinate = function (value) {
 };
 
 function parseIfString (val) {
-  if (val.constructor === String) {
+  if (val !== null && val !== undefined && val.constructor === String) {
     return parseFloat(val, 10);
   }
   return val;

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -26,6 +26,11 @@ suite('utils.coordinates', function () {
         coordinates.parse('1 2.5 -3'), {x: 1, y: 2.5, z: -3});
     });
 
+    test('parses string, null defaultVec', function () {
+      assert.shallowDeepEqual(
+        coordinates.parse('1 2.5 -3', null), {x: 1, y: 2.5, z: -3});
+    });
+
     test('applies defaults to the missing values', function () {
       assert.deepEqual(
         coordinates.parse({x: 1}, {x: 0, y: 0, z: 0}), {x: 1, y: 0, z: 0});


### PR DESCRIPTION
In the case when defaultVec is null the parseIfString throws an exception, because val becomes null. 

val becomes null because of function parse: for example we have a vec3 with x, y, z and w is undefined. The defaultVec can be null. In this case, line 40 would make local var 'w' to equal to null. Then, on the line 44 it will do strict comparison with 'undefined' which fails and would call parseIfString passing null as a parameter, which will throw an exception.