### PR TITLE
Document uppateSchema changes, add override

### DIFF
--- a/docs/core/component.md
+++ b/docs/core/component.md
@@ -473,7 +473,8 @@ AFRAME.registerComponent('sound', {
 `.updateSchema ()`, if defined, is called when certain flagged properties are
 updated to check if the schema also needs to be modified. To flag a property
 as one that triggers a schema udpate, add `schemaChange: true` to the property
-definition.
+definition. For a schema that always updates, for example to accept new
+properties, set the `schemaAlwaysUpdates` definition property to `true`.
 
 The `updateSchema` handler is often used to:
 
@@ -586,6 +587,28 @@ AFRAME.registerComponent('foo', {
   update: function () {
     // An object3D will be set using `foo__bar` as the key.
     this.el.setObject3D(this.attrName, new THREE.Mesh());
+  }
+});
+```
+
+### `schemaAlwaysUpdates`
+
+Normally, the `updateSchema` process is optimized to only rebuild the schema
+and data when specified properties change. Setting the `schemaAlwaysUpdates`
+to `true` overides this optimized behavior and updates the schema on every
+`setAttribute` call. This can be used to create a fully dynamic schema that
+expands to accept new properties as they are set.
+
+```
+AFRAME.registerComponent('foo', {
+  schemaAlwaysUpdates: true,
+  schema: {},
+  updateSchema: function (data) {
+    var newSchema = this.schema;
+    for (let key in data) {
+      newSchema[key] = { type: 'number' };
+    }
+    this.extendSchema(newSchema);
   }
 });
 ```

--- a/docs/core/component.md
+++ b/docs/core/component.md
@@ -246,7 +246,7 @@ the data to modify the entity. The handlers will usually interact with the
 | tock         | Called on each render loop or tick of the scene after the scene has rendererd. Used for post processing effects or other logic that needs to happen after the scene has been drawn.                                                                                                                                   |
 | play         | Called whenever the scene or entity plays to add any background or dynamic behavior. Also called once when the component is initialized. Used to start or resume behavior.                                                |
 | pause        | Called whenever the scene or entity pauses to remove any background or dynamic behavior. Also called when the component is removed from the entity or when the entity is detached from the scene. Used to pause behavior. |
-| updateSchema | Called whenever any of the component's properties is updated. Can be used to dynamically modify the schema.                                                                                                               |
+| updateSchema | Called when specified component properties are updated. Can be used to dynamically modify the schema.                                                                                                                     |
 ### Component Prototype Properties
 
 [scene]: ./scene.md
@@ -470,8 +470,10 @@ AFRAME.registerComponent('sound', {
 
 ### `.updateSchema (data)`
 
-`.updateSchema ()`, if defined, is called on every update in order to check if
-the schema needs to be dynamically modified.
+`.updateSchema ()`, if defined, is called when certain flagged properties are
+updated to check if the schema also needs to be modified. To flag a property
+as one that triggers a schema udpate, add `schemaChange: true` to the property
+definition.
 
 The `updateSchema` handler is often used to:
 
@@ -486,6 +488,11 @@ type of geometry:
 ```js
 AFRAME.registerComponent('geometry', {
   // ...
+  schema: {
+    // ...
+    primitive: {default: 'box', schemaChange: true},
+    // ...
+  },
   updateSchema: (newData) {
     if (newData.primitive !== this.data.primitive) {
       this.extendSchema(GEOMETRIES[newData.primitive].schema);

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -317,7 +317,7 @@ Component.prototype = {
    */
   updateComponent: function (attrValue, clobber) {
     var key;
-    var mayNeedSchemaUpdate;
+    var mayNeedSchemaUpdate = this.schemaAlwaysUpdates;
 
     if (clobber) {
       // Clobber. Rebuild.
@@ -338,7 +338,8 @@ Component.prototype = {
       return;
     }
 
-    parseProperties(attrValue, this.schema, true, this.name);
+    // Silence unknown property warning if schema will be updating
+    parseProperties(attrValue, this.schema, true, this.name, mayNeedSchemaUpdate);
 
     // Check if we need to update schema.
     if (this.schemaChangeKeys.length) {


### PR DESCRIPTION
**Description:** Congratulations on the new release! This updates the docs for the optimized approach to `updateSchema` and the new `schemaChange` flag in component property definitions. Also, if you'll accept it, adds the `schemaAlwaysUpdates` component definition property to override the optimized behavior.

I've been using `updateSchema` to give some components entirely dynamic schemas that take new properties as they come in and give them a property type definition. I couldn't figure a way to do this with the `schemaChange` flag as the updates often contain only previously unknown properties.

**Changes proposed:**
- `schemaAlwaysUpdates` component definition property
- `updateSchema` is called on every update if `schemaAlwaysUpdates` is `true`
