### PR TITLE
Remove extra properties from objectPool objects

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -50,10 +50,22 @@ var Component = module.exports.Component = function (el, attrValue, id) {
 
   // Store component data from previous update call.
   this.attrValue = undefined;
-  this.nextData = this.isObjectBased ? this.objectPool.use() : undefined;
-  this.oldData = this.isObjectBased ? this.objectPool.use() : undefined;
-  this.previousOldData = this.isObjectBased ? this.objectPool.use() : undefined;
-  this.parsingAttrValue = this.isObjectBased ? this.objectPool.use() : undefined;
+  if (this.isObjectBased) {
+    this.nextData = this.objectPool.use();
+    // Drop any properties added by dynamic schemas in previous use
+    utils.objectPool.removeUnusedKeys(this.nextData, this.schema);
+    this.oldData = this.objectPool.use();
+    utils.objectPool.removeUnusedKeys(this.oldData, this.schema);
+    this.previousOldData = this.objectPool.use();
+    utils.objectPool.removeUnusedKeys(this.previousOldData, this.schema);
+    this.parsingAttrValue = this.objectPool.use();
+    utils.objectPool.removeUnusedKeys(this.parsingAttrValue, this.schema);
+  } else {
+    this.nextData = undefined;
+    this.oldData = undefined;
+    this.previousOldData = undefined;
+    this.parsingAttrValue = undefined;
+  }
 
   // Last value passed to updateProperties.
   this.throttledEmitComponentChanged = utils.throttle(function emitChange () {

--- a/src/utils/object-pool.js
+++ b/src/utils/object-pool.js
@@ -76,3 +76,14 @@ function clearObject (obj) {
   for (key in obj) { obj[key] = undefined; }
 }
 module.exports.clearObject = clearObject;
+
+function removeUnusedKeys (obj, schema) {
+  var key;
+  if (!obj || obj.constructor !== Object) { return; }
+  for (key in obj) {
+    if (!(key in schema)) {
+      delete obj[key];
+    }
+  }
+}
+module.exports.removeUnusedKeys = removeUnusedKeys;


### PR DESCRIPTION
@ngokevin what do you think of this approach?

**Description:** Prevents keys added to component data pooled objectss by dynamic schemas from appearing in other instances of the component. Only needs to be done on initialization because the object copy methods used in the update cycle already skip over keys with undefined values. Should have no effect for components without dynamic schemas.

Close #4012 

**Changes proposed:**
- `utils.objectPool.removeUnusedKeys` deletes properties not found in a reference object (i.e. the component template schema)
- Apply above method when fetching initial objects during component initialization
