### PR TITLE
Fix coordinates stringify for zeroed coordinates

### DIFF
--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -76,8 +76,8 @@ function stringify (data) {
   var str;
   if (typeof data !== OBJECT) { return data; }
   str = data.x + ' ' + data.y;
-  if (data.z) { str += ' ' + data.z; }
-  if (data.w) { str += ' ' + data.w; }
+  if (data.z != null) { str += ' ' + data.z; }
+  if (data.w != null) { str += ' ' + data.w; }
   return str;
 }
 module.exports.stringify = stringify;

--- a/tests/utils/coordinates.test.js
+++ b/tests/utils/coordinates.test.js
@@ -71,9 +71,16 @@ suite('utils.coordinates', function () {
     test('stringifies a vec3', function () {
       assert.equal(coordinates.stringify({x: 1, y: 2, z: -3}), '1 2 -3');
     });
+    test('stringifies a zeroed vec3', function () {
+      assert.equal(coordinates.stringify({x: 0, y: 0, z: 0}), '0 0 0');
+    });
 
     test('stringifies a vec4', function () {
       assert.equal(coordinates.stringify({x: 1, y: 2, z: -3, w: -4}), '1 2 -3 -4');
+    });
+
+    test('stringifies a zeroed vec4', function () {
+      assert.equal(coordinates.stringify({x: 0, y: 0, z: 0, w: 0}), '0 0 0 0');
     });
 
     test('returns already-stringified string', function () {


### PR DESCRIPTION
**Description:** Fix #4015  - z/w values not appearing in stringified coordinates when 0

**Changes proposed:**
- Check for null or undefined instead of truthiness when inferring presence of z & w coordinate dimensions
