### PR TITLE
look-controls: build camera entity matrix from initial values

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -39,6 +39,7 @@ module.exports.Component = registerComponent('look-controls', {
     this.setupMouseControls();
     this.bindMethods();
     this.el.object3D.matrixAutoUpdate = false;
+    this.el.object3D.updateMatrix();
 
     this.savedPose = {
       position: new THREE.Vector3(),


### PR DESCRIPTION
**Description:** Fix #4019, applying position, rotation, scale values specified in the HTML to the camera entity matrix

**Changes proposed:**
- Build matrix manually one time when disabling auto-update
