### PR TITLE
Use index to detect vive controlles since handennnes is not always ailable and determined at runtime (fix #4013)

### DIFF
--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -122,7 +122,6 @@ module.exports.Component = registerComponent('vive-controls', {
       idPrefix: GAMEPAD_ID_PREFIX,
       // Hand IDs: 0 = right, 1 = left, 2 = anything else.
       controller: data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2,
-      hand: data.hand,
       orientationOffset: data.orientationOffset
     });
 


### PR DESCRIPTION

-
