### PR TITLE
Replace isOculusGo with isMobileVR function (fix #4032)

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -32,17 +32,7 @@ function checkHeadsetConnected () { return !!getVRDisplay(); }
 module.exports.checkHeadsetConnected = checkHeadsetConnected;
 
 /**
- * Check for positional tracking.
- */
-function checkHasPositionalTracking () {
-  var vrDisplay = getVRDisplay();
-  if (isMobile() || isGearVR() || isOculusGo()) { return false; }
-  return vrDisplay && vrDisplay.capabilities.hasPosition;
-}
-module.exports.checkHasPositionalTracking = checkHasPositionalTracking;
-
-/**
- * Checks if browser is mobile.
+ * Checks if browser is mobile and not stand-alone dedicated vr device.
  * @return {Boolean} True if mobile browser detected.
  */
 var isMobile = (function () {
@@ -55,7 +45,7 @@ var isMobile = (function () {
     if (isIOS() || isTablet() || isR7()) {
       _isMobile = true;
     }
-    if (isOculusGo()) {
+    if (isMobileVR()) {
       _isMobile = false;
     }
   })(window.navigator.userAgent || window.navigator.vendor || window.opera);
@@ -79,18 +69,13 @@ function isIOS () {
 }
 module.exports.isIOS = isIOS;
 
-function isGearVR () {
-  return /SamsungBrowser.+Mobile VR/i.test(window.navigator.userAgent);
-}
-module.exports.isGearVR = isGearVR;
-
 /**
- *  Detect Oculus Go device
+ *  Detect browsers in Stand-Alone headsets
  */
-function isOculusGo () {
-  return /Pacific Build.+OculusBrowser.+SamsungBrowser.+Mobile VR/i.test(window.navigator.userAgent);
+function isMobileVR () {
+  return /(OculusBrowser)|(SamsungBrowser)|(Mobile VR)/i.test(window.navigator.userAgent);
 }
-module.exports.isOculusGo = isOculusGo;
+module.exports.isMobileVR = isMobileVR;
 
 function isR7 () {
   return /R7 Build/.test(window.navigator.userAgent);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -27,8 +27,7 @@ module.exports.checkHeadsetConnected = function () {
   return device.checkHeadsetConnected(arguments);
 };
 module.exports.isGearVR = function () {
-  warn('`utils.isGearVR` has moved to `utils.device.isGearVR`');
-  return device.isGearVR(arguments);
+  warn('`utils.isGearVR` has been deprecated, use `utils.device.isMobileVR`');
 };
 module.exports.isIOS = function () {
   warn('`utils.isIOS` has moved to `utils.device.isIOS`');


### PR DESCRIPTION
This combines `isGearVR` / `isOculusGo` into an `isMobileVR` function to differentiate from `isMobile` (aka Cardboard / Magic Window). Considers Samsung Internet, Firefox Reality and Oculus Browser

Also removes unused `checkHasPositionalTracking ` function