### PR TITLE
Add alpha property to renderer to disable transparent backbuffer

### DIFF
--- a/docs/components/renderer.md
+++ b/docs/components/renderer.md
@@ -36,6 +36,7 @@ The `renderer` system configures a scene's
 | maxCanvasHeight         | Maximum canvas height. Behaves the same as maxCanvasWidth.                      | 1920          |
 | logarithmicDepthBuffer  | Whether to use a logarithmic depth buffer.                                      | auto          |
 | precision  |       Fragment shader [precision][precision] : low, medium or high.                                | high          |
+| alpha                   | Whether the canvas should contain an alpha buffer.                              | true          |
 
 > **NOTE:** Once the scene is initialized, these properties may no longer be changed.
 
@@ -83,3 +84,7 @@ large differences of scale and distance.
 ### Precision
 
 Set precision in fragment shaders. Main use is to address issues in older hardware / drivers. Adreno 300 series GPU based phones are [particularly problematic](https://github.com/mrdoob/three.js/issues/14137). You can set to `mediump` as a workaround. It will improve performance, in mobile in particular but be aware that might cause visual artifacts in shaders / textures.
+
+### alpha
+
+Whether the canvas should contain an alpha buffer. If this is true the renderer will have a transparent backbuffer and the canvas can be composited with the rest of the webpage. [See here for more info.](https://webglfundamentals.org/webgl/lessons/webgl-and-alpha.html)

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -578,6 +578,10 @@ module.exports.AScene = registerElement('a-scene', {
             rendererConfig.logarithmicDepthBuffer = rendererAttr.logarithmicDepthBuffer === 'true';
           }
 
+          if (rendererAttr.alpha) {
+            rendererConfig.alpha = rendererAttr.alpha === 'true';
+          }
+
           this.maxCanvasSize = {
             width: rendererAttr.maxCanvasWidth
               ? parseInt(rendererAttr.maxCanvasWidth)

--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -19,7 +19,8 @@ module.exports.System = registerSystem('renderer', {
     precision: {default: 'high', oneOf: ['high', 'medium', 'low']},
     sortObjects: {default: false},
     colorManagement: {default: false},
-    gammaOutput: {default: false}
+    gammaOutput: {default: false},
+    alpha: { default: true }
   },
 
   init: function () {


### PR DESCRIPTION
**Description:**
In Hubs we saw a few bugs with glTF models where models would render completely white or black depending on the platform. We traced it back to glTF models with transparent baseColor textures and no blend mode. Three.js still writes these alpha values to the frame buffer even if `transparent` is set to false. If the WebGLRenderingContext is passed `alpha: true` then the backbuffer is transparent and whatever is behind the canvas is used as the backbuffer.

**Changes proposed:**
- Add the `alpha` property to the `renderer` attributes to allow for disabling the transparent backbuffer.
