### PR TITLE
WebGL2Renderer (WIP)

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -578,6 +578,18 @@ module.exports.AScene = registerElement('a-scene', {
             rendererConfig.logarithmicDepthBuffer = rendererAttr.logarithmicDepthBuffer === 'true';
           }
 
+          if (rendererAttr.webgl2 && rendererAttr.webgl2 === 'true') {
+            rendererConfig.context = this.canvas.getContext('webgl2', {
+              alpha: rendererConfig.alpha,
+              depth: true,
+              stencil: true,
+              antialias: rendererConfig.antialias,
+              premultipliedAlpha: true,
+              preserveDrawingBuffer: false,
+              powerPreference: 'default'
+            });
+          }
+
           this.maxCanvasSize = {
             width: rendererAttr.maxCanvasWidth
               ? parseInt(rendererAttr.maxCanvasWidth)

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -11,6 +11,7 @@ var utils = require('../../utils/');
 var AEntity = require('../a-entity');
 var ANode = require('../a-node');
 var initPostMessageAPI = require('./postMessage');
+var shaders = require('../shader').shaders;
 
 var bind = utils.bind;
 var isIOS = utils.device.isIOS();
@@ -592,6 +593,58 @@ module.exports.AScene = registerElement('a-scene', {
             if (context) {
               console.log('Using WebGL 2.0 context.');
               rendererConfig.context = context;
+
+              var versionRegex = /^\s*#version\s+300\s+es\s*\n/;
+
+              for (var shaderName in shaders) {
+                var shader = shaders[shaderName];
+
+                var shaderProto = shader.Shader.prototype;
+
+                if (!shaderProto.raw) {
+                  continue;
+                }
+
+                var vertexShader = shaderProto.vertexShader;
+                var fragmentShader = shaderProto.fragmentShader;
+
+                var isGLSL3ShaderMaterial = false;
+
+                if (vertexShader.match(versionRegex) !== null && fragmentShader.match(versionRegex) !== null) {
+                  isGLSL3ShaderMaterial = true;
+
+                  vertexShader = vertexShader.replace(versionRegex, '');
+                  fragmentShader = fragmentShader.replace(versionRegex, '');
+                }
+
+                // GLSL 3.0 conversion
+                const prefixVertex = [
+                  '#version 300 es\n',
+                  '#define attribute in',
+                  '#define varying out',
+                  '#define texture2D texture'
+                ].join('\n') + '\n';
+
+                const prefixFragment = [
+                  '#version 300 es\n',
+                  '#define varying in',
+                  isGLSL3ShaderMaterial ? '' : 'out highp vec4 pc_fragColor;',
+                  isGLSL3ShaderMaterial ? '' : '#define gl_FragColor pc_fragColor',
+                  '#define gl_FragDepthEXT gl_FragDepth',
+                  '#define texture2D texture',
+                  '#define textureCube texture',
+                  '#define texture2DProj textureProj',
+                  '#define texture2DLodEXT textureLod',
+                  '#define texture2DProjLodEXT textureProjLod',
+                  '#define textureCubeLodEXT textureLod',
+                  '#define texture2DGradEXT textureGrad',
+                  '#define texture2DProjGradEXT textureProjGrad',
+                  '#define textureCubeGradEXT textureGrad'
+                ].join('\n') + '\n';
+
+                shaderProto.vertexShader = prefixVertex + vertexShader;
+                shaderProto.fragmentShader = prefixFragment + fragmentShader;
+              }
             } else {
               console.log('No WebGL 2.0 context available. Falling back to WebGL 1.0');
             }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -579,7 +579,7 @@ module.exports.AScene = registerElement('a-scene', {
           }
 
           if (rendererAttr.webgl2 && rendererAttr.webgl2 === 'true') {
-            rendererConfig.context = this.canvas.getContext('webgl2', {
+            const context = this.canvas.getContext('webgl2', {
               alpha: rendererConfig.alpha,
               depth: true,
               stencil: true,
@@ -588,6 +588,13 @@ module.exports.AScene = registerElement('a-scene', {
               preserveDrawingBuffer: false,
               powerPreference: 'default'
             });
+
+            if (context) {
+              console.log('Using WebGL 2.0 context.');
+              rendererConfig.context = context;
+            } else {
+              console.log('No WebGL 2.0 context available. Falling back to WebGL 1.0');
+            }
           }
 
           this.maxCanvasSize = {

--- a/src/shaders/msdf.js
+++ b/src/shaders/msdf.js
@@ -49,10 +49,10 @@ module.exports.Shader = registerShader('msdf', {
     '#define MODIFIED_ALPHATEST (0.02 * isBigEnough / BIG_ENOUGH)',
 
     'void main() {',
-    '  vec3 sample = texture2D(map, vUV).rgb;',
-    '  if (negate) { sample = 1.0 - sample; }',
+    '  vec3 tSample = texture2D(map, vUV).rgb;',
+    '  if (negate) { tSample = 1.0 - tSample; }',
 
-    '  float sigDist = median(sample.r, sample.g, sample.b) - 0.5;',
+    '  float sigDist = median(tSample.r, tSample.g, tSample.b) - 0.5;',
     '  float alpha = clamp(sigDist / fwidth(sigDist) + 0.5, 0.0, 1.0);',
     '  float dscale = 0.353505;',
     '  vec2 duv = dscale * (dFdx(vUV) + dFdy(vUV));',

--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -19,7 +19,8 @@ module.exports.System = registerSystem('renderer', {
     precision: {default: 'high', oneOf: ['high', 'medium', 'low']},
     sortObjects: {default: false},
     colorManagement: {default: false},
-    gammaOutput: {default: false}
+    gammaOutput: {default: false},
+    webgl2: {default: false}
   },
 
   init: function () {


### PR DESCRIPTION
**Description:**
In Hubs we'd like to use ETC2 texture compression for reducing texture upload times. The [WEBGL_compressed_texture_etc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/) WebGL extension is only available in WebGL2. Three.js has shipped a WebGL2Renderer, but it's not finished yet. This PR adds a `webgl2` property to `renderer` that creates a WebGL2RenderingContext and passes it to the WebGLRenderer. This causes shaders to be upgraded to OpenGL ES 3.0 and we can also use all of the WebGL2 extensions.

We're currently merging this into Hubs, but I could understand if you want to hold off on adding this upstream. Regardless, feedback is welcome!

**Changes proposed:**
- Add `webgl2` property to `renderer`
- Upgrade shaders at runtime to OpenGL ES 3.0
- Remove reserved keyword `sampler` from msdf shader.

**To Do:**
- [ ] Determine how best to upgrade RawShaderMaterials on `AFRAME.registerShader()`
- [ ] Add documentation
