### PR TITLE
Fix the animation component for custom vec3 properties

### DIFF
--- a/src/components/animation.js
+++ b/src/components/animation.js
@@ -401,7 +401,7 @@ module.exports.Component = registerComponent('animation', {
     config.update = (function () {
       var lastValue = {};
       return function (anim) {
-        var value = anim.animations[0].target;
+        var value = anim.animatables[0].target;
 
         // Animate rotation through radians.
         // For animation timeline.

--- a/tests/components/animation.test.js
+++ b/tests/components/animation.test.js
@@ -1,5 +1,7 @@
 /* global assert, setup, suite, test, THREE */
 var entityFactory = require('../helpers').entityFactory;
+var components = require('index').components;
+var registerComponent = require('index').registerComponent;
 
 suite('animation', function () {
   var component;
@@ -184,6 +186,10 @@ suite('animation', function () {
   });
 
   suite('vec3 animation', () => {
+    setup(function () {
+      components.dummy = undefined;
+    });
+
     test('can animate vec3', function () {
       el.setAttribute('animation', {
         property: 'position',
@@ -228,6 +234,54 @@ suite('animation', function () {
       assert.equal(el.object3D.rotation.x, THREE.Math.degToRad(30));
       assert.equal(el.object3D.rotation.y, THREE.Math.degToRad(60));
       assert.equal(el.object3D.rotation.z, THREE.Math.degToRad(90));
+    });
+
+    test('can animate vec3 single-property custom component', function () {
+      registerComponent('dummy', {
+        schema: {type: 'vec3'}
+      });
+      el.setAttribute('dummy');
+      el.setAttribute('animation', {
+        property: 'dummy',
+        dur: 1000,
+        from: '1 1 1',
+        to: '0 0 0'
+      });
+      component.tick(0, 1);
+      assert.equal(el.components.dummy.data.x, 1);
+      assert.equal(el.components.dummy.data.y, 1);
+      assert.equal(el.components.dummy.data.z, 1);
+      component.tick(0, 500);
+      assert.ok(el.components.dummy.data.x > 0);
+      assert.ok(el.components.dummy.data.x < 1);
+      component.tick(0, 500);
+      assert.equal(el.components.dummy.data.x, 0);
+      assert.equal(el.components.dummy.data.y, 0);
+      assert.equal(el.components.dummy.data.z, 0);
+    });
+
+    test('can animate vec3 property of custom component', function () {
+      registerComponent('dummy', {
+        schema: {vector: {type: 'vec3'}}
+      });
+      el.setAttribute('dummy', '');
+      el.setAttribute('animation', {
+        property: 'dummy.vector',
+        dur: 1000,
+        from: '1 1 1',
+        to: '0 0 0'
+      });
+      component.tick(0, 1);
+      assert.equal(el.components.dummy.data.vector.x, 1);
+      assert.equal(el.components.dummy.data.vector.y, 1);
+      assert.equal(el.components.dummy.data.vector.z, 1);
+      component.tick(0, 500);
+      assert.ok(el.components.dummy.data.vector.x > 0);
+      assert.ok(el.components.dummy.data.vector.x < 1);
+      component.tick(0, 500);
+      assert.equal(el.components.dummy.data.vector.x, 0);
+      assert.equal(el.components.dummy.data.vector.y, 0);
+      assert.equal(el.components.dummy.data.vector.z, 0);
     });
   });
 


### PR DESCRIPTION
**Description:**

Fix the `animation` component to correctly animate `vec3` properties of custom components. The current implementation handles the cases for `position`, `scale` and `rotation` but does not handle custom properties that do not represent properties of `Object3D` (`PROP_POSITION`, `PROP_ROTATION`, `PROP_SCALE`).

**Changes proposed:**
- Change the `animations` property reference used for custom `vec3` properties
 https://github.com/aframevr/aframe/blob/ff2c7a4b0d6eba24ab538fb2e66a22efcfafbd5e/src/components/animation.js#L404
  to `animatables` as is used for `position`, `scale` and `rotation`
 https://github.com/aframevr/aframe/blob/ff2c7a4b0d6eba24ab538fb2e66a22efcfafbd5e/src/components/animation.js#L377


**My thanks:**

You all really inspire me ❤️ I am so grateful for all the hard work you've all put into developing A-Frame, and your commitment to an open VR web (sorry for being unprofessional and including this message in an PR).