### PR TITLE
Oculus go controls tests

### DIFF
--- a/tests/components/oculus-go-controls.test.js
+++ b/tests/components/oculus-go-controls.test.js
@@ -48,7 +48,7 @@ suite('oculus-go-controls', function () {
      *
      * @param {object} component - The oculus-go-controls component to verify fields.
      */
-    function verifyControllerSetup(component) {
+    function verifyControllerSetup (component) {
       sinon.assert.calledOnce(injectTrackedControlsSpy);
       sinon.assert.calledOnce(addEventListenersSpy);
       sinon.assert.notCalled(removeEventListenersSpy);


### PR DESCRIPTION
**Description:**

Fixes up tests to be more consistent for the Oculus GO controls and rely more heavily on the setup methods and state rather than trying to mock state (no reason to mock state if we can effectively use the system to set everything up). Since the tests bootstrap through all cases, we can be assured that tests later in the series that rely on capabilities earlier will have a canary test fail first.

This points out there is a lot of potential to have a suite like this shared by all with the right factoring. I will convert two more of the controls suites to use similar methodology and then see if commonality can be lifted out. For now, this makes the Go controls and tests easier for me to maintain and improve.

**Changes proposed:**
- Factor our better setup functionality for each test.
- Remove redundancy and rely on helpers for validation of common state.
- Remove a redundant test that wasn't testing a unique conditional state.
