### PR TITLE
Fix spew about rotationOffset not in schema

### DIFF
--- a/src/components/oculus-go-controls.js
+++ b/src/components/oculus-go-controls.js
@@ -22,7 +22,7 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     buttonTouchedColor: {type: 'color', default: '#BBBBBB'},
     buttonHighlightColor: {type: 'color', default: '#7A7A7A'},
     model: {default: true},
-    rotationOffset: {default: 0},
+    orientationOffset: {type: 'vec3'},
     armModel: {default: true}
   },
 
@@ -105,7 +105,7 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     el.setAttribute('tracked-controls', {
       armModel: data.armModel,
       idPrefix: GAMEPAD_ID_PREFIX,
-      rotationOffset: data.rotationOffset
+      orientationOffset: data.orientationOffset
     });
     if (!this.data.model) { return; }
     this.el.setAttribute('gltf-model', OCULUS_GO_CONTROLLER_MODEL_URL);

--- a/src/components/vive-focus-controls.js
+++ b/src/components/vive-focus-controls.js
@@ -21,7 +21,7 @@ module.exports.Component = registerComponent('vive-focus-controls', {
     buttonTouchedColor: {type: 'color', default: '#BBBBBB'},
     buttonHighlightColor: {type: 'color', default: '#7A7A7A'},
     model: {default: true},
-    rotationOffset: {default: 0},
+    orientationOffset: {type: 'vec3'},
     armModel: {default: true}
   },
 
@@ -105,7 +105,7 @@ module.exports.Component = registerComponent('vive-focus-controls', {
     el.setAttribute('tracked-controls', {
       armModel: data.armModel,
       idPrefix: GAMEPAD_ID_PREFIX,
-      rotationOffset: data.rotationOffset
+      orientationOffset: data.orientationOffset
     });
     if (!this.data.model) { return; }
     this.el.setAttribute('gltf-model', VIVE_FOCUS_CONTROLLER_MODEL_URL);


### PR DESCRIPTION
**Description:**

According to the change logs, this was renamed to orientationOffset in 0.8.2 (April 15, 2018) as a bug fix. Most likely the Oculus Go controls overlapped with this release timing and the Vive Focus controls were copied from the Go (guess work).

I'm just updating the properties and verifying that during npm run test we no longer see log spew about this infraction. Assumption is that some offset orientation capabilities now work on tracked-controls that was not working because of the bad name.

```javascript
    object3D.rotateX(this.data.orientationOffset.x * THREE.Math.DEG2RAD);
    object3D.rotateY(this.data.orientationOffset.y * THREE.Math.DEG2RAD);
    object3D.rotateZ(this.data.orientationOffset.z * THREE.Math.DEG2RAD);
```

**Changes proposed:**
- Replace rotationOffset with orientationOffset
