### PR TITLE
don't ignore boolean values in flushToDOM

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -240,8 +240,7 @@ Component.prototype = {
    */
   flushToDOM: function (isDefault) {
     var attrValue = isDefault ? this.data : this.attrValue;
-    //  don't ignore boolean values
-    if (!attrValue && typeof attrValue !== 'boolean') { return; }
+    if (attrValue === null || attrValue === undefined) { return; }
     window.HTMLElement.prototype.setAttribute.call(this.el, this.attrName,
                                                    this.stringify(attrValue));
   },

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -240,7 +240,8 @@ Component.prototype = {
    */
   flushToDOM: function (isDefault) {
     var attrValue = isDefault ? this.data : this.attrValue;
-    if (!attrValue) { return; }
+    //  don't ignore boolean values
+    if (!attrValue && typeof attrValue !== 'boolean') { return; }
     window.HTMLElement.prototype.setAttribute.call(this.el, this.attrName,
                                                    this.stringify(attrValue));
   },

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -979,6 +979,16 @@ suite('Component', function () {
       sinon.assert.notCalled(updateStub);
       assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), 'color: blue');
     });
+
+    test('flushes false boolean', function () {
+      var el = document.createElement('a-entity');
+      registerComponent('dummy', {
+        schema: {isDurrr: {default: true}}
+      });
+      el.setAttribute('dummy', {isDurrr: false});
+      el.components.dummy.flushToDOM();
+      assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), 'isDurrr: false');
+    });
   });
 
   suite('play', function () {


### PR DESCRIPTION
**Description:**
flushToDOM is not working for boolean values
eg: if you flushToDOM visible component it won't work for false value
This is piece of code that has the problem
```javascript
flushToDOM: function (isDefault) {
    var attrValue = isDefault ? this.data : this.attrValue;
    if (!attrValue) { return; }
    window.HTMLElement.prototype.setAttribute.call(this.el, this.attrName, this.stringify(attrValue));
},
```

**Changes proposed:**
My suggestion to add a boolean check for the attrValue

```javascript
flushToDOM: function (isDefault) {
    var attrValue = isDefault ? this.data : this.attrValue;
    //  don't ignore boolean values
    if (!attrValue && typeof attrValue !== 'boolean') { return; }
    window.HTMLElement.prototype.setAttribute.call(this.el, this.attrName, this.stringify(attrValue));
},
```


