### PR TITLE
Fix source path in renderer.md

### DIFF
--- a/docs/components/renderer.md
+++ b/docs/components/renderer.md
@@ -3,7 +3,7 @@ title: renderer
 type: components
 layout: docs
 parent_section: components
-source_code: src/components/renderer.js
+source_code: src/systems/renderer.js
 examples: []
 ---
 


### PR DESCRIPTION
**Description:**
In the renderer docs tab, when **View Source** is clicked it redirects to 404 because the path is _src/components/*_ instead of _src/systems/*_

There seems to be no change at line 103, im not sure why anything got included in the _diff_ since i've only touched the _source_code_ at line 6. 

**Changes proposed:**
- Change the path
