### PR TITLE
if el is undefined on remove child entity, call removeFromParent

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -261,7 +261,9 @@ var proto = Object.create(ANode.prototype, {
       if (el) {
         this.object3D.remove(el.object3D);
       } else {
-        this.object3D.remove(...this.object3D.children);
+        while (this.object3D.children.length) {
+          this.object3D.remove(this.object3D.children[0]);
+        }
         this.parentNode.removeChild(this);
       }
     }

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -258,7 +258,11 @@ var proto = Object.create(ANode.prototype, {
    */
   remove: {
     value: function (el) {
-      this.object3D.remove(el.object3D);
+      if (el) {
+        this.object3D.remove(el.object3D);
+      } else {
+        this.object3D.remove(...this.object3D.children);
+      }
     }
   },
 

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -261,9 +261,6 @@ var proto = Object.create(ANode.prototype, {
       if (el) {
         this.object3D.remove(el.object3D);
       } else {
-        while (this.object3D.children.length) {
-          this.object3D.remove(this.object3D.children[0]);
-        }
         this.parentNode.removeChild(this);
       }
     }

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -262,6 +262,7 @@ var proto = Object.create(ANode.prototype, {
         this.object3D.remove(el.object3D);
       } else {
         this.object3D.remove(...this.object3D.children);
+        this.parentNode.removeChild(this);
       }
     }
   },

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1522,6 +1522,25 @@ suite('a-entity component lifecycle management', function () {
     el.play();
     assert.equal(el.sceneEl.behaviors.tock.indexOf(testComponentInstance), -1);
   });
+
+  suite('remove', function () {
+    test('detaches if called with no arguments', function (done) {
+      el.remove();
+      setTimeout(() => {
+        assert.notOk(el.parentNode);
+        done();
+      });
+    });
+
+    test('detaches child object3D if called with child', function (done) {
+      const childrenLength = el.parentNode.object3D.children.length;
+      el.parentNode.remove(el);
+      setTimeout(() => {
+        assert.ok(el.parentNode.object3D.children.length < childrenLength);
+        done();
+      });
+    });
+  });
 });
 
 suite('a-entity component dependency management', function () {


### PR DESCRIPTION
**Description:**

We're trying to get aframe to work in a stencil.js render method.

Before adding this fix we were seeing the following error when entities were removed from the VDOM:

`Cannot read property 'object3D' of undefined`

This was caused by `el` being undefined here:

```
remove: {
  value: function (el) {
    this.object3D.remove(el.object3D);
  }
},
```

**Changes proposed:**

If `el` is undefined, use `this.removeFromParent()`:

```
remove: {
  value: function (el) {
    if (el) {
      this.object3D.remove(el.object3D);
    } else {
      this.removeFromParent();
    }
  }
},
```

We're sure this is probably naive, but would love to hear why!