### PR TITLE
Check for navigator.xr.requestDevice to determine if WebXR API is available

### DIFF
--- a/src/core/scene/loadingScreen.js
+++ b/src/core/scene/loadingScreen.js
@@ -15,7 +15,7 @@ window.addEventListener('vrdisplayactivate', function () {
   var vrDisplay;
 
   // WebXR takes priority if available.
-  if (navigator.xr) { return; }
+  if (navigator.xr && navigator.xr.requestDevice) { return; }
 
   vrDisplay = utils.device.getVRDisplay();
   vrManager.setDevice(vrDisplay);

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ window.Promise = window.Promise || require('promise-polyfill');
 // Check before the polyfill runs.
 window.hasNativeWebVRImplementation = !!window.navigator.getVRDisplays ||
                                       !!window.navigator.getVRDevices;
-window.hasNativeWebXRImplementation = navigator.xr !== undefined;
+window.hasNativeWebXRImplementation = navigator.xr && navigator.xr.requestDevice;
 
 // If native WebXR or WebVR are defined WebVRPolyfill does not initialize.
 if (!window.hasNativeWebXRImplementation && !window.hasNativeWebVRImplementation) {

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -3,7 +3,7 @@ var error = require('debug')('device:error');
 var vrDisplay;
 
 // Support both WebVR and WebXR APIs.
-if (navigator.xr) {
+if (navigator.xr && navigator.xr.requestDevice) {
   navigator.xr.requestDevice().then(function (device) {
     if (!device) { return; }
     device.supportsSession({immersive: true, exclusive: true}).then(function () {


### PR DESCRIPTION
All versions of Chrome now define `navigator.xr` even with webxr flags disabled and both in Windows and Mac (as reported by some users)

![image](https://cl.ly/a840cac056e9/Image%202019-03-15%20at%204.29.53%20PM.png)

Checking for `navigator.xr.requestDevice` seems to be a more reliable way to determine if WebXR API is present and available. 
