### PR TITLE
Fixed broken link to vr best practices from oculus

### DIFF
--- a/docs/introduction/best-practices.md
+++ b/docs/introduction/best-practices.md
@@ -247,7 +247,7 @@ performance code because they will be run 90 times per second.
 
 ## VR Design
 
-[oculus]: https://developer.oculus.com/documentation/intro-vr/latest/concepts/bp_intro/
+[oculus]: https://developer.oculus.com/design/latest/concepts/book-bp/
 
 Designing for VR is different than designing for flat experiences. As a new
 medium, there are new sets of best practices to follow, especially to maintain


### PR DESCRIPTION
**Description:**
Fixing a broken link

**Changes proposed:**
- Changing the link to the new one found by using the wayback machine and being forwarded to new link.
