### PR TITLE
hide annoying navigation buttons on android

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -797,7 +797,8 @@ function requestFullscreen (canvas) {
     canvas.webkitRequestFullscreen ||
     canvas.mozRequestFullScreen ||  // The capitalized `S` is not a typo.
     canvas.msRequestFullscreen;
-  requestFullscreen.apply(canvas, [{ navigationUI: "hide" }]); //hide annoying navigation buttons on android
+  // Hide navigation buttons on Android.
+  requestFullscreen.apply(canvas, [{navigationUI: 'hide'}]);
 }
 
 function exitFullscreen () {

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -797,7 +797,7 @@ function requestFullscreen (canvas) {
     canvas.webkitRequestFullscreen ||
     canvas.mozRequestFullScreen ||  // The capitalized `S` is not a typo.
     canvas.msRequestFullscreen;
-  requestFullscreen.apply(canvas);
+  requestFullscreen.apply(canvas, [{ navigationUI: "hide" }]); //hide annoying navigation buttons on android
 }
 
 function exitFullscreen () {


### PR DESCRIPTION
**Description:**
In fullscreen mode chrome for android keeps showing system navigation UI
**Changes proposed:**
- Additional options for requestFullscreen function fixes that and shouldn't affect other platforms/browsers

