### PR TITLE
Add update method for gltf-model system

### DIFF
--- a/src/systems/gltf-model.js
+++ b/src/systems/gltf-model.js
@@ -20,6 +20,13 @@ module.exports.System = registerSystem('gltf-model', {
     this.dracoLoader = path ? new THREE.DRACOLoader() : null;
   },
 
+  update: function () {
+		if (this.dracoLoader) { return; }
+    var path = this.data.dracoDecoderPath;
+    THREE.DRACOLoader.setDecoderPath(path);
+    this.dracoLoader = path ? new THREE.DRACOLoader() : null;
+  },
+
   getDRACOLoader: function () {
     return this.dracoLoader;
   }

--- a/src/systems/gltf-model.js
+++ b/src/systems/gltf-model.js
@@ -21,8 +21,9 @@ module.exports.System = registerSystem('gltf-model', {
   },
 
   update: function () {
-		if (this.dracoLoader) { return; }
-    var path = this.data.dracoDecoderPath;
+    var path;	  
+    if (this.dracoLoader) { return; }
+    path = this.data.dracoDecoderPath;
     THREE.DRACOLoader.setDecoderPath(path);
     this.dracoLoader = path ? new THREE.DRACOLoader() : null;
   },


### PR DESCRIPTION
**Description:** gltf-model System would fail to load Draco decompressor if the system initialized before the scene was present. This was most apparent using aframe-react but will handle all cases of dynamically adding the gltf-model System to any scene through `.setAttribute`

**Changes proposed:**
- Add an update method to the gltf-model System
