### PR TITLE
A-Link Fix for Oculus Browser

### DIFF
--- a/src/systems/gltf-model.js
+++ b/src/systems/gltf-model.js
@@ -21,7 +21,7 @@ module.exports.System = registerSystem('gltf-model', {
   },
 
   update: function () {
-    var path;	  
+    var path;
     if (this.dracoLoader) { return; }
     path = this.data.dracoDecoderPath;
     THREE.DRACOLoader.setDecoderPath(path);

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -4,13 +4,33 @@ var vrDisplay;
 
 // Catch vrdisplayactivate early to ensure we can enter VR mode after the scene loads.
 window.addEventListener('vrdisplayactivate', function (evt) {
-  var canvasEl;
   // WebXR takes priority if available.
   if (navigator.xr) { return; }
-  canvasEl = document.createElement('canvas');
+
   vrDisplay = evt.display;
+
+  const scene = document.querySelector('a-scene');
+  const rendererSystem = scene.getAttribute('renderer');
+  const canvas = scene.canvas; // Oculus Browser will fail if we don't provide correct canvas VRLayer
+
+  // Not sure if required but seems good practise to stay consistent on request present
+  const presentationAttributes = {
+    highRefreshRate: rendererSystem.highRefreshRate,
+    foveationLevel: rendererSystem.foveationLevel
+  };
+
   // Request present immediately. a-scene will be allowed to enter VR without user gesture.
-  vrDisplay.requestPresent([{source: canvasEl}]).then(function () {}, function () {});
+  return vrDisplay.requestPresent([{
+    source: canvas,
+    attributes: presentationAttributes
+  }]).then(function () { console.warn('Succeeded to enter VR mode (`requestPresent`)'); },
+    function (err) {
+      if (err && err.message) {
+        throw new Error('Failed to enter VR mode (`requestPresent`): ' + err.message);
+      } else {
+        throw new Error('Failed to enter VR mode (`requestPresent`).');
+      }
+    });
 });
 
 // Support both WebVR and WebXR APIs.


### PR DESCRIPTION
**Description:**
The Oculus GO browser appears to refuse permission on vrDisplay.requestPresent if the correct canvas is not passed in. This causes issues when using hyperlinks ( see issue #4081 ) as A-Frame currently handles the "vrdisplayactivate" event by passing in a dummy canvas in Device.js.

**Changes proposed:**
To make the requestPresent method the same in both src/core/scene/a-scene.js and src/utils/Device.js so that some browsers (specifically the Oculus Browser on the Oculus GO) do not reject the presentation. To maintain consistency the presentation attributes are also passed in again.

_This would probably be better as a public method in device.js that both a-scene and device can call to reduce code redundancy; but I was unsure of how the A-Frame maintainers prefer to handle global functions._

**Needs Review:**
My PC died last night so this needs to be tested with other devices also (i.e. Firefox and the Vive / Oculus Rift) as they appear to be okay with the dummy canvas pass.

NOTE: I also fixed a formatting issue in an unrelated file so that I could commit.