### PR TITLE
Component.events to define event handlers ensured to be attached/detached on lifecycle (#4025)

### DIFF
--- a/docs/core/component.md
+++ b/docs/core/component.md
@@ -247,6 +247,7 @@ the data to modify the entity. The handlers will usually interact with the
 | play         | Called whenever the scene or entity plays to add any background or dynamic behavior. Also called once when the component is initialized. Used to start or resume behavior.                                                |
 | pause        | Called whenever the scene or entity pauses to remove any background or dynamic behavior. Also called when the component is removed from the entity or when the entity is detached from the scene. Used to pause behavior. |
 | updateSchema | Called whenever any of the component's properties is updated. Can be used to dynamically modify the schema.                                                                                                               |
+
 ### Component Prototype Properties
 
 [scene]: ./scene.md
@@ -407,7 +408,7 @@ AFRAME.registerComponent('tracked-controls', {
 
 ### `.tock (time, timeDelta, camera)`
 
-Identical to the tick method but invoked after the scene has rendered. 
+Identical to the tick method but invoked after the scene has rendered.
 
 The `tock` handler is used to run logic that needs access to the drawn scene before it's pushed into the headset like postprocessing effects.
 
@@ -579,6 +580,31 @@ AFRAME.registerComponent('foo', {
   update: function () {
     // An object3D will be set using `foo__bar` as the key.
     this.el.setObject3D(this.attrName, new THREE.Mesh());
+  }
+});
+```
+
+### `events`
+
+The `events` object allows for conveniently defining event handlers that get
+binded and automatically attached and detached at appropriate times during the
+component's lifecycle:
+
+- Attached on `.play()`
+- Detached on `.pause()` and `.remove()`
+
+Using `events` ensures that event handlers properly clean themselves up when
+the entity or scene is paused, or the component is detached. If a component's
+event handlers are registered manually and not detached properly, the event
+handler can still fire even after the component no longer exists.
+
+```js
+AFRAME.registerComponent('foo', {
+  events: {
+    click: function (evt) {
+      console.log('This entity was clicked!');
+      this.el.setAttribute('material', 'color', 'red');
+    }
   }
 });
 ```

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -39,9 +39,9 @@ suite('Component', function () {
           size: {default: 5}
         }
       });
-      var el = document.createElement('a-entity');
+      const el = document.createElement('a-entity');
       el.setAttribute('dummy', '');
-      var data = el.components.dummy.buildData({}, null);
+      const data = el.components.dummy.buildData({}, null);
       assert.equal(data.color, 'blue');
       assert.equal(data.size, 5);
     });
@@ -1072,7 +1072,6 @@ suite('Component', function () {
   });
 
   test('applies default array property types with no defined value', function (done) {
-    var el;
     registerComponent('test', {
       schema: {
         arr: {default: ['foo']}
@@ -1083,9 +1082,82 @@ suite('Component', function () {
         done();
       }
     });
-    el = entityFactory();
+    const el = entityFactory();
     el.addEventListener('loaded', () => {
       el.setAttribute('test', '');
+    });
+  });
+
+  suite('events', () => {
+    let component;
+    let el;
+    let fooSpy;
+
+    setup(function (done) {
+      fooSpy = this.sinon.spy();
+
+      registerComponent('test', {
+        events: {
+          foo: function (evt) {
+            assert.ok(evt);
+            assert.ok(this === component);
+            fooSpy();
+          }
+        }
+      });
+
+      helpers.elFactory().then(_el => {
+        el = _el;
+        el.setAttribute('test', '');
+        component = el.components.test;
+        done();
+      });
+    });
+
+    test('calls handler on event', function (done) {
+      el.emit('foo');
+      setTimeout(() => {
+        assert.equal(fooSpy.callCount, 1);
+        done();
+      });
+    });
+
+    test('detaches on component pause', function (done) {
+      component.pause();
+      el.emit('foo');
+      setTimeout(() => {
+        assert.notOk(fooSpy.called);
+        done();
+      });
+    });
+
+    test('detaches on component remove', function (done) {
+      el.removeAttribute('test');
+      el.emit('foo');
+      setTimeout(() => {
+        assert.notOk(fooSpy.called);
+        done();
+      });
+    });
+
+    test('detaches on entity pause', function (done) {
+      el.pause();
+      el.emit('foo');
+      setTimeout(() => {
+        assert.notOk(fooSpy.called);
+        done();
+      });
+    });
+
+    test('detaches on entity remove', function (done) {
+      el.parentNode.removeChild(el);
+      setTimeout(() => {
+        el.emit('foo');
+        setTimeout(() => {
+          assert.notOk(fooSpy.called);
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
**Description:**

Events object to define handlers that are automatically binded, attached on `play`, and detached on `pause` or `remove`.

**Benefits:**

- Ensure event handlers are turned off as expected when scene is paused (Inspector).
- Ensure event handlers are turned off as expected when component is detached (really assists with hot reloading). And convenience.
- Also on reattach (resume).
- More concise and less error-prone way of binding / adding event listeners / removing event listeners.
- Being able to see all event handlers in one place.
- Differentiate methods from event handlers.

### Before

```js
AFRAME.registerComponent('foo', {
  init: function () {
    this.click = this.click.bind(this);
    this.mouseenter = this.mouseenter.bind(this);
  },

  play: function () {
    this.el.addEventListener('click', this.click);
    this.el.addEventListener('mouseenter', this.mouseenter);
  },

  pause: function () {
    this.el.removeEventListener('click', this.click);
    this.el.removeEventListener('mouseenter', this.mouseenter);
  },
 
  remove: function () {
    this.el.removeEventListener('click', this.click);
    this.el.removeEventListener('mouseenter', this.mouseenter);
  },
 
  click: function (evt) {
      console.log('This entity was clicked!');
      this.el.setAttribute('material', 'color', 'red');
  },

  mouseenter: function (evt) {
      console.log('This entity was hovered!');
  }
});
```

### After

```js
AFRAME.registerComponent('foo', {
  events: {
    click: function (evt) {
      console.log('This entity was clicked!');
      this.el.setAttribute('material', 'color', 'red');
    },

    mouseenter: function (evt) {
      console.log('This entity was hovered!');
    }
  }
});
```

**Changes proposed:**
- `events` object to define event handlers for component instance.
