### PR TITLE
Fix typo in entity docs [docs]

### DIFF
--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -388,7 +388,7 @@ attribute from the DOM, `removeAttribute` will also detach the component from
 the entity, invoking the component's `remove` lifecycle method.
 
 ```js
-entity.removeAttribute('goemetry');  // Detach the geometry component.
+entity.removeAttribute('geometry');  // Detach the geometry component.
 entity.removeAttribute('sound');  // Detach the sound component.
 ```
 


### PR DESCRIPTION
**Description:**
Noticed geometry was spelled wrong in the documentation for entity

**Changes proposed:**
- Fixes spelling
