### PR TITLE
Component.load handler (fixes #3556)

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -130,7 +130,13 @@ Component.prototype = {
   tock: undefined,
 
   /**
-   * Called to start any dynamic behavior (e.g., animation, AI, events, physics).
+   * Called only once when scene is loaded or when component is attached to loaded entity.
+   */
+  load: function () { /* no-op */ },
+
+  /**
+   * Called when entity is activated, either first start or on resume
+   * (e.g., animation, AI, events, physics).
    */
   play: function () { /* no-op */ },
 
@@ -772,10 +778,22 @@ function wrapPlay (playMethod) {
   return function play () {
     var sceneEl = this.el.sceneEl;
     var shouldPlay = this.el.isPlaying && !this.isPlaying;
+
     if (!this.initialized || !shouldPlay) { return; }
-    playMethod.call(this);
+
+    // Set isPlaying.
     this.isPlaying = true;
+
+    // Attach Component.events.
     this.eventsAttach();
+
+    // Call `.load` handler.
+    if (this.isFirstLoad) {
+      this.load();
+      this.isFirstLoad = false;
+    }
+    playMethod.call(this);
+
     // Add tick behavior.
     if (!hasBehavior(this)) { return; }
     sceneEl.addBehavior(this);

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -40,6 +40,7 @@ var Component = module.exports.Component = function (el, attrValue, id) {
   this.attrName = this.name + (id ? '__' + id : '');
   this.evtDetail = {id: this.id, name: this.name};
   this.initialized = false;
+  this.isFirstLoad = true;
   this.isSingleProperty = isSingleProp(this.schema);
   this.isSinglePropertyObject = this.isSingleProperty &&
                                 isObject(parseProperty(undefined, this.schema)) &&

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -17,6 +17,7 @@ var TestComponent = {
   init: function () { },
   update: function () { },
   remove: function () { },
+  load: function () { },
   play: function () { },
   pause: function () { },
   tick: function () { },
@@ -1483,6 +1484,38 @@ suite('a-entity component lifecycle management', function () {
     sinon.assert.notCalled(TestComponent.play);
     el.play();
     sinon.assert.called(TestComponent.play);
+  });
+
+  test('does not call load on resume', function () {
+    var TestComponent = this.TestComponent.prototype;
+
+    this.sinon.spy(TestComponent, 'load');
+    el.setAttribute('test', '');
+    sinon.assert.calledOnce(TestComponent.load);
+    el.pause();
+    el.play();
+    sinon.assert.calledOnce(TestComponent.load);
+  });
+
+  test('calls load on attach once', function () {
+    var TestComponent = this.TestComponent.prototype;
+
+    this.sinon.spy(TestComponent, 'load');
+    el.setAttribute('test', '');
+    sinon.assert.calledOnce(TestComponent.load);
+    el.setAttribute('test', 'a: 5');
+    sinon.assert.calledOnce(TestComponent.load);
+  });
+
+  test('does not call load on play / resume', function () {
+    var TestComponent = this.TestComponent.prototype;
+
+    this.sinon.spy(TestComponent, 'load');
+    el.setAttribute('test', '');
+    sinon.assert.calledOnce(TestComponent.load);
+    el.pause();
+    el.play();
+    sinon.assert.calledOnce(TestComponent.load);
   });
 
   test('removes tick from scene behaviors on entity pause', function () {


### PR DESCRIPTION
**Description:**

#3556 

The `.play()` handler is currently overloaded to handle both:

- Scene / component first load.
- Resume from pause or activated from pool.

More often than not, we care more about the first case, a handler to run the component after the scene has loaded or the component is attached to an already-running scene. Common cases are waiting for things to attach to run query selectors, waiting until other components in the scene have run, waiting until ancestors have initialized in order to get accurate world transforms, or just wanting to run something while scene is actually playing. 

But with the `.play()` handler as is, we sometimes need to check it's only called on first run so that it **doesn't** run after like Inspector open/close, or being request from pool. To solve the overload, I add a `.load()` handler similar to `.play()` that is ensured to only be called once.

@donmccurdy Thoughts?

**Changes proposed:**
- `Component.load()` handler similar to `Component.play()` but is only ensured to be called called once.
- [x] Tests / docs.
