### PR TITLE
Minor fixes to A-Frame docs copy

### DIFF
--- a/docs/introduction/html-and-primitives.md
+++ b/docs/introduction/html-and-primitives.md
@@ -29,7 +29,7 @@ opening the HTML file in a browser. Since most of the Web was built on top of
 HTML, most existing tools and libraries work with A-Frame including React,
 Vue.js, Angular, d3.js, and jQuery.
 
-![HTML Scene](https://user-images.githubusercontent.com/674727/52090525-79b04d80-2566-11e9-993f-7a8b19ca25b1.png))
+![HTML Scene](https://user-images.githubusercontent.com/674727/52090525-79b04d80-2566-11e9-993f-7a8b19ca25b1.png)
 
 If you don't have too much experience with HTML, no problem! It's fairly easy
 to pick up and perhaps even easier to grasp than 2D HTML. Once you pick up the

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -176,10 +176,10 @@ step-by-step visual tutorial.
 4. [Join us on Slack](https://aframevr-slack.herokuapp.com) or [Discord] and if
 you have any questions, [search and ask on
 StackOverflow](http://stackoverflow.com/questions/ask/?tags=aframe), and
-someone try to get to you!
+someone will try to get to you!
 
 5. When you build something, share your project online and we'll try to feature
 it on [*A Week of A-Frame*](https://aframe.io/blog/)!
 
-And it really helps to have dig into the fundamentals on JavaScript and
+And it really helps to have a dig into the fundamentals on JavaScript and
 three.js. Have fun!

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -14,7 +14,7 @@ is primarily HTML and JavaScript.
 
 ## Code Editors in the Browser
 
-The fastest way to start playing from within the browser.
+The fastest way is to start playing from within the browser.
 
 ### Remix on Glitch
 
@@ -43,7 +43,7 @@ Below are a few other A-Frame Glitches for starters:
 
 ### Other Code Editors
 
-Below are a couple A-Frame starter kits on other browser-based code
+Below are a couple of A-Frame starter kits on other browser-based code
 editors. Both support remixing or forking:
 
 - [Mozilla Thimble &mdash; A-Frame](https://thimble.mozilla.org/en-US/user/ngokevin/864056)

--- a/docs/introduction/vr-headsets-and-webvr-browsers.md
+++ b/docs/introduction/vr-headsets-and-webvr-browsers.md
@@ -95,7 +95,7 @@ landscape.
 
 ## Which Platforms Does A-Frame Support?
 
-A-Frame supports mostly all platforms through browsers General platforms that
+A-Frame supports almost all platforms through browsers. General platforms that
 A-Frame supports include:
 
 - VR on desktop with a headset


### PR DESCRIPTION
**Description:** This PR fixes some very minor grammatical and typographical errors found in A-Frame's initial documentation. Nothing major.