### PR TITLE
fix Entity.destroy attached check

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -848,7 +848,7 @@ var proto = Object.create(ANode.prototype, {
   destroy: {
     value: function () {
       var key;
-      if (this.el.parentNode) {
+      if (this.parentNode) {
         warn('Entity can only be destroyed if detached from scenegraph.');
         return;
       }

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1541,6 +1541,23 @@ suite('a-entity component lifecycle management', function () {
       });
     });
   });
+
+  suite('destroy', function () {
+    test('does not destroy components if still attached', function () {
+      el.setAttribute('test', '');
+      const destroySpy = this.sinon.spy(el.components.test, 'destroy');
+      el.destroy();
+      assert.notOk(destroySpy.callCount);
+    });
+
+    test('destroys components if destroyed', function () {
+      el.setAttribute('test', '');
+      el.parentNode.removeChild(el);
+      const destroySpy = this.sinon.spy(el.components.test, 'destroy');
+      el.destroy();
+      assert.ok(destroySpy.callCount);
+    });
+  });
 });
 
 suite('a-entity component dependency management', function () {


### PR DESCRIPTION
**Description:**

The `Entity.destroy` attached safety check would never pass. Not a major issue since `Entity.destroy` is a manually called method and it's just a safety check in case calling `Entity.destroy` on a still-attached entity.
