### PR TITLE
Verify fullscreenElement before exiting fullscreen. Chrome m71+ returns error withouth this check (fix #4136)

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -805,6 +805,11 @@ function requestFullscreen (canvas) {
 }
 
 function exitFullscreen () {
+  var fullscreenEl =
+    document.fullscreenElement ||
+    document.webkitFullscreenElement ||
+    document.mozFullScreenElement;
+  if (!fullscreenEl) { return; }
   if (document.exitFullscreen) {
     document.exitFullscreen();
   } else if (document.mozCancelFullScreen) {


### PR DESCRIPTION
Solution found here: https://github.com/jpilfold/ngx-image-viewer/issues/23
