### PR TITLE
Metatag to hide URL bar in iOS when entering fullscreen mode

### DIFF
--- a/src/core/scene/metaTags.js
+++ b/src/core/scene/metaTags.js
@@ -2,7 +2,7 @@ var constants = require('../../constants/');
 var extend = require('../../utils').extend;
 
 var MOBILE_HEAD_TAGS = module.exports.MOBILE_HEAD_TAGS = [
-  Meta({name: 'viewport', content: 'width=device-width,initial-scale=1,maximum-scale=1,shrink-to-fit=no,user-scalable=no,minimal-ui'}),
+  Meta({name: 'viewport', content: 'width=device-width,initial-scale=1,maximum-scale=1,shrink-to-fit=no,user-scalable=no,minimal-ui,viewport-fit=cover'}),
 
   // W3C-standardised meta tags.
   Meta({name: 'mobile-web-app-capable', content: 'yes'}),


### PR DESCRIPTION
Holy grail metatag? Tested on iPhone X and iOS 12.2