### PR TITLE
Prevent multiple requestPresent calls if vrDevice is already presenti…

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -286,6 +286,11 @@ module.exports.AScene = registerElement('a-scene', {
               enterVRSuccess();
             });
           } else {
+            if (vrDisplay.isPresenting &&
+                !window.hasNativeWebVRImplementation) {
+              enterVRSuccess();
+              return Promise.resolve();
+            }
             var rendererSystem = this.getAttribute('renderer');
             var presentationAttributes = {
               highRefreshRate: rendererSystem.highRefreshRate,


### PR DESCRIPTION
…ng in polyfilled mode. It prevents a wrong sized canvas when entering VR in iOS. Multiple requestPresent calls are allowed in 0.9.1 for in-vr navigation but not necessary in cardboard mode since immersive navigation is not possible (fix #4142)
