### PR TITLE
Remove unused reference to thumb events

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -27,7 +27,6 @@ var EVENTS = {};
 EVENTS[ANIMATIONS.fist] = 'grip';
 EVENTS[ANIMATIONS.thumbUp] = 'pistol';
 EVENTS[ANIMATIONS.point] = 'pointing';
-EVENTS[ANIMATIONS.thumb] = 'thumb';
 
 /**
  * Hand controls component that abstracts 6DoF controls:
@@ -378,7 +377,7 @@ function getGestureEventName (gesture, active) {
   if (eventName === 'grip') {
     return eventName + (active ? 'close' : 'open');
   }
-  if (eventName === 'point' || eventName === 'thumb') {
+  if (eventName === 'point') {
     return eventName + (active ? 'up' : 'down');
   }
   if (eventName === 'pointing' || eventName === 'pistol') {


### PR DESCRIPTION
`ANIMATIONS.thumb` did not exist,  so "thumb" events would never be triggered

**Description:**

I actually have very little context on the workings of the events in VR and A-Frame - I was actually just reading through the docs for the first time. The docs linked to this source code as an example of how controllers work, and I noticed this dead code. I'm not sure if it's a bug that should be rectified (i.e., there _should_ be a `thumb` event), or if my cleanup PR is sufficient. Please let me know.

**Changes proposed:**
- Clean up dead code