### PR TITLE
[docs] describe order of applying scale, rotation, position (closes aframevr/aframe#2591)

### DIFF
--- a/docs/components/position.md
+++ b/docs/components/position.md
@@ -84,3 +84,11 @@ To reflect updates done at the three.js level, A-Frame returns the actual
 modifying the return value will modify the entity itself.
 
 See also [reading position and rotation of the camera](./camera.md#reading-position-or-rotation-of-the-camera).
+
+### Order of Transformations
+
+Transformations are applied to entities in this order:
+
+* [scale](scale.md)
+* [rotation](rotation.md)
+* position/translation

--- a/docs/components/rotation.md
+++ b/docs/components/rotation.md
@@ -85,3 +85,11 @@ A-Frame will convert from radians and degrees and return a normal JavaScript
 object with x/y/z properties.
 
 See also [reading position and rotation of the camera](./camera.md#reading-position-or-rotation-of-the-camera).
+
+### Order of Transformations
+
+Transformations are applied to entities in this order:
+
+* [scale](scale.md)
+* rotation
+* [position/translation](position.md)

--- a/docs/components/scale.md
+++ b/docs/components/scale.md
@@ -87,3 +87,11 @@ el.object3D.scale.sub(someOtherVector);
 To reflect updates done at the three.js level, A-Frame returns the actual
 `Object3D.scale` vector object when doing `.getAttribute('scale')`. Note
 modifying the return value will modify the entity itself.
+
+### Order of Transformations
+
+Transformations are applied to entities in this order:
+
+* scale
+* [rotation](rotation.md)
+* [position/translation](position.md)


### PR DESCRIPTION
Adds a section to the end of the scale, rotation, and position components describing the order in which those transformations are applied to entities. Closes aframevr/aframe#2591.