### PR TITLE
Revert "Bump THREE to 105"

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
     "super-animejs": "^3.1.0",
-    "super-three": "^0.105.1",
+    "super-three": "^0.102.2",
     "three-bmfont-text": "^2.1.0",
     "webvr-polyfill": "^0.10.10"
   },


### PR DESCRIPTION
**Description:**

We shouldn't bump three.js blindly. The latest versions of three.js remove `.setTexture2D` without an alternative so projects like Supercraft, Moon Rider, Supermedium can no longer use A-Frame master for GPU preloading. Proposing to wait until we stabilize these parts before upgrading without need.
