### PR TITLE
Bump THREE to r105. Our fork restores setTexture2D until a new API is reintroduced

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "promise-polyfill": "^3.1.0",
     "style-attr": "^1.0.2",
     "super-animejs": "^3.1.0",
-    "super-three": "^0.105.1",
+    "super-three": "^0.105.2",
     "three-bmfont-text": "^2.1.0",
     "webvr-polyfill": "^0.10.10"
   },


### PR DESCRIPTION
[Reference to setTexture2D in Supermedium fork](https://github.com/supermedium/three.js/commit/8eb60fa455286136697d1eec33651614afa645e8) until a [new API is reintroduced](https://github.com/mrdoob/three.js/issues/16338) Tested with moonrider.
