### PR TITLE
update three.js introduction docs with new api requiring targets

### DIFF
--- a/docs/components/camera.md
+++ b/docs/components/camera.md
@@ -127,12 +127,12 @@ AFRAME.registerComponent('rotation-reader', {
    */
   tick: (function () {
     var position = new THREE.Vector3();
-    var rotation = new THREE.Euler();
+    var quaternion = new THREE.Quaternion();
 
     return function () {
       this.el.object3D.getWorldPosition(position);
-      this.el.object3D.getWorldRotation(rotation);
-      // position and rotation now contain vector and euler in world space.
+      this.el.object3D.getWorldQuaternion(quaternion);
+      // position and rotation now contain vector and quaternion in world space.
     };
   })
 });

--- a/docs/introduction/developing-with-threejs.md
+++ b/docs/introduction/developing-with-threejs.md
@@ -218,13 +218,15 @@ three.js defaults `Object3D.matrixAutoUpdate` to `true`. We can use three.js's
 To get the world position of an `Object3D`:
 
 ```js
-entityEl.object3D.getWorldPosition(new THREE.Vector3);
+var worldPosition = new THREE.Vector3();
+entityEl.object3D.getWorldPosition(worldPosition);
 ```
 
 To get the world rotation of an `Object3D`:
 
 ```js
-entityEl.object3D.getWorldQuaternion(new THREE.Quaternion);
+var worldQuaternion = new THREE.Quaternion();
+entityEl.object3D.getWorldQuaternion(worldQuaternion);
 ```
 
 three.js `Object3D` has [more functions available for local-to-world transforms][object3d]:

--- a/docs/introduction/developing-with-threejs.md
+++ b/docs/introduction/developing-with-threejs.md
@@ -213,26 +213,26 @@ accomplished with matrices, but three.js provides helpers to make them easier.
 
 Normally, we'd need to call `.updateMatrixWorld ()` on parent `Object3D`s, but
 three.js defaults `Object3D.matrixAutoUpdate` to `true`. We can use three.js's
-`.getWorldPosition ()` and `.getWorldRotation ()`.
+`.getWorldPosition (vector)` and `.getWorldQuaternion (quaternion)`.
 
 To get the world position of an `Object3D`:
 
 ```js
-entityEl.object3D.getWorldPosition();
+entityEl.object3D.getWorldPosition(new THREE.Vector3);
 ```
 
 To get the world rotation of an `Object3D`:
 
 ```js
-entityEl.object3D.getWorldRotation();
+entityEl.object3D.getWorldQuaternion(new THREE.Quaternion);
 ```
 
 three.js `Object3D` has [more functions available for local-to-world transforms][object3d]:
 
 - `.localToWorld (vector)`
-- `.getWorldDirection ()`
-- `.getWorldQuaternion ()`
-- `.getWorldScale ()`
+- `.getWorldDirection (vector)`
+- `.getWorldQuaternion (quaternion)`
+- `.getWorldScale (vector)`
 
 ### World to Local Transforms
 


### PR DESCRIPTION
**Description:**
update docs to use new three.js methods and provide targets to prevent
warnings.

related to #3900

