### PR TITLE
Fixing issue #4198: VR deep-linking / VR navigation doesn't work.

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -314,11 +314,7 @@ module.exports.AScene = registerElement('a-scene', {
           // to setup everything from there. Thus, we need to emulate another vrdisplaypresentchange
           // for the actual requestPresent. Need to make sure there are no issues with firing the
           // vrdisplaypresentchange multiple times.
-          var event = new CustomEvent('vrdisplaypresentchange', {
-            detail: {
-              display: utils.device.getVRDisplay()
-            }
-          });
+          var event = new CustomEvent('vrdisplaypresentchange', {detail: {display: utils.device.getVRDisplay()}});
           window.dispatchEvent(event);
 
           self.addState('vr-mode');

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -10,6 +10,7 @@ var utils = require('../../utils/');
 // Require after.
 var AEntity = require('../a-entity');
 var ANode = require('../a-node');
+var CustomEvent = require('custom-event');
 var initPostMessageAPI = require('./postMessage');
 
 var bind = utils.bind;
@@ -309,6 +310,18 @@ module.exports.AScene = registerElement('a-scene', {
 
         // Callback that happens on enter VR success or enter fullscreen (any API).
         function enterVRSuccess () {
+          // vrdisplaypresentchange fires only once when the first requestPresent is completed;
+          // the first requestPresent could be called from ondisplayactivate and there is no way
+          // to setup everything from there. Thus, we need to emulate another vrdisplaypresentchange
+          // for the actual requestPresent. Need to make sure there are no issues with firing the
+          // vrdisplaypresentchange multiple times.
+          var event = new CustomEvent('vrdisplaypresentchange', {
+            detail: {
+              display: utils.device.getVRDisplay()
+            }
+          });
+          window.dispatchEvent(event);
+
           self.addState('vr-mode');
           self.emit('enter-vr', {target: self});
           // Lock to landscape orientation on mobile.

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -1,4 +1,4 @@
-/* global Promise, screen */
+/* global Promise, screen, CustomEvent */
 var initMetaTags = require('./metaTags').inject;
 var initWakelock = require('./wakelock');
 var loadingScreen = require('./loadingScreen');
@@ -10,7 +10,6 @@ var utils = require('../../utils/');
 // Require after.
 var AEntity = require('../a-entity');
 var ANode = require('../a-node');
-var CustomEvent = require('custom-event');
 var initPostMessageAPI = require('./postMessage');
 
 var bind = utils.bind;

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -9,6 +9,9 @@ window.addEventListener('vrdisplayactivate', function (evt) {
   if (navigator.xr) { return; }
   canvasEl = document.createElement('canvas');
   vrDisplay = evt.display;
+  // We need to make sure the canvas has a WebGL context associated with it.
+  // Otherwise, the requestPresent could be denied.
+  canvasEl.getContext('webgl', {});
   // Request present immediately. a-scene will be allowed to enter VR without user gesture.
   vrDisplay.requestPresent([{source: canvasEl}]).then(function () {}, function () {});
 });


### PR DESCRIPTION
**Description:**
Fixing issue #4198: VR deep-linking / VR navigation doesn't work.

**Changes proposed:**
- Canvas must have gl context associated with it for requestPresent to work;
- onVRDisplayPresentChange by spec is called only once for the first requestPresent (which might be called from the ondisplayactivate and can't init all the data); so, firing the second event "artificially".

