### PR TITLE
[docs] Add closing a-asset-item tag

### DIFF
--- a/docs/primitives/a-gltf-model.md
+++ b/docs/primitives/a-gltf-model.md
@@ -14,7 +14,7 @@ modeling program or downloaded from the web.
 ```html
 <a-scene>
   <a-assets>
-    <a-asset-item id="tree" src="tree.gltf">
+    <a-asset-item id="tree" src="tree.gltf"></a-asset-item>
   </a-assets>
 
   <!-- Using the asset management system. -->


### PR DESCRIPTION
**Description:**
I think the closing tag was omitted by mistake.

**Changes proposed:**
I've just closed the tag in the example.
