### PR TITLE
Update a-register-element.js

### DIFF
--- a/src/core/a-register-element.js
+++ b/src/core/a-register-element.js
@@ -66,7 +66,7 @@ module.exports.registerElement = function (tagName, obj) {
     }
   });
 
-  return document.registerElement(tagName, newObj);
+  return window.customElements.define(tagName, newObj);
 };
 
 /**


### PR DESCRIPTION
**Description:**
Warning fix for aframe Google Chrome,Firefox,IE,Safari (both desktop and mobile)
[Deprecation] document.registerElement is deprecated and will be removed in M73, around March 2019. Please use window.customElements.define instead. See https://www.chromestatus.com/features/4642138092470272
and
https://developer.mozilla.org/en-US/docs/Web/API/Document/registerElement
 for more details.
module.exports.registerElement @ a-register-element.js:69
index.js:83 A-Frame Version: 0.8.2 (Date 2018-04-15, Commit #b20527f)
index.js:84 three Version: github:supermedium/three.js#r90fixMTLLoader
index.js:85 WebVR Polyfill Version: ^0.10.5
three.js:20901 THREE.WebGLRenderer 90

**Changes proposed:**
-Changed document.registerElement to
window.customElements.define
