### PR TITLE
Fix a-asset-item binary glTF file loading

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -253,7 +253,7 @@ function extractDomain (url) {
 function inferResponseType (src) {
   var dotLastIndex = src.lastIndexOf('.');
   if (dotLastIndex >= 0) {
-    var extension = src.slice(dotLastIndex, src.length);
+    var extension = src.slice(dotLastIndex, src.search(/\?|#|$/));
     if (extension === '.gltf' || extension === '.glb') {
       return 'arraybuffer';
     }

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -7,6 +7,8 @@ var THREE = require('../lib/three');
 var fileLoader = new THREE.FileLoader();
 var warn = debug('core:a-assets:warn');
 
+var GLTF_HEADER_MAGIC = 'glTF';
+
 /**
  * Asset management system. Handles blocking on asset loading.
  */
@@ -104,10 +106,19 @@ registerElement('a-asset-item', {
       value: function () {
         var self = this;
         var src = this.getAttribute('src');
-        fileLoader.setResponseType(
-          this.getAttribute('response-type') || inferResponseType(src));
+        var responseType = this.getAttribute('response-type');
+
+        fileLoader.setResponseType(responseType || 'text');
+
         fileLoader.load(src, function handleOnLoad (response) {
-          self.data = response;
+          // if the response type is not given, check for the GLTF header
+          // and convert the response to an arraybuffer if it is present.
+          if (!responseType && (response.indexOf(GLTF_HEADER_MAGIC) === 0)) {
+            self.data = getArrayBuffer(response);
+          } else {
+            self.data = response;
+          }
+
           /*
             Workaround for a Chrome bug. If another XHR is sent to the same url before the
             previous one closes, the second request never finishes.
@@ -242,22 +253,20 @@ function extractDomain (url) {
 }
 
 /**
- * Infer response-type attribute from src.
- * Default is text(default XMLHttpRequest.responseType)
- * but we use arraybuffer for .gltf and .glb files
- * because of THREE.GLTFLoader specification.
- *
- * @param {string} src
- * @returns {string}
+ * getArrayBuffer accepts a string and returns it as an array buffer.
+ * @param {string} string
+ * @returns {arraybuffer}
  */
-function inferResponseType (src) {
-  var dotLastIndex = src.lastIndexOf('.');
-  if (dotLastIndex >= 0) {
-    var extension = src.slice(dotLastIndex, src.search(/\?|#|$/));
-    if (extension === '.gltf' || extension === '.glb') {
-      return 'arraybuffer';
-    }
+function getArrayBuffer (string) {
+  // utf-16 has 2 bytes for each char
+  var buffer = new ArrayBuffer(string.length * 2);
+  var view = new Uint16Array(buffer);
+
+  for (var i = 0, len = string.length; i < len; i++) {
+    view[i] = string.charCodeAt(i);
   }
-  return 'text';
+
+  return buffer;
 }
-module.exports.inferResponseType = inferResponseType;
+
+module.exports.getArrayBuffer = getArrayBuffer;

--- a/tests/assets/dummy/dummy.glb
+++ b/tests/assets/dummy/dummy.glb
@@ -1,1 +1,1 @@
-dummy file for a-assets.test.js
+glTF gdummy file for a-assets.test.js

--- a/tests/assets/dummy/dummy.gltf
+++ b/tests/assets/dummy/dummy.gltf
@@ -1,1 +1,1 @@
-dummy file for a-assets.test.js
+glTF dummy file for a-assets.test.js

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -1,7 +1,6 @@
 /* global assert, setup, suite, test */
 var THREE = require('lib/three');
-
-var inferResponseType = require('core/a-assets').inferResponseType;
+var aAssets = require('core/a-assets');
 
 var IMG_SRC = '/base/tests/assets/test.png';
 var XHR_SRC = '/base/tests/assets/dummy/dummy.txt';
@@ -279,9 +278,9 @@ suite('a-asset-item', function () {
     document.body.appendChild(this.sceneEl);
   });
 
-  test('loads from cache as arraybuffer without response-type attribute', function (done) {
+  test('loads GLB from cache as arraybuffer without response-type attribute', function (done) {
     var assetItem = document.createElement('a-asset-item');
-    assetItem.setAttribute('src', XHR_SRC);
+    assetItem.setAttribute('src', XHR_SRC_GLB);
     assetItem.addEventListener('loaded', function (evt) {
       assert.ok(assetItem.data !== null);
       assert.ok(assetItem.data instanceof ArrayBuffer);
@@ -316,21 +315,12 @@ suite('a-asset-item', function () {
     document.body.appendChild(this.sceneEl);
   });
 
-  suite('inferResponseType', function () {
-    test('returns text as default', function () {
-      assert.equal(inferResponseType(XHR_SRC), 'text');
-    });
-
-    test('returns arraybuffer for .gltf file', function () {
-      assert.equal(inferResponseType(XHR_SRC_GLTF), 'arraybuffer');
-    });
-
-    test('returns arraybuffer for .glb file', function () {
-      assert.equal(inferResponseType(XHR_SRC_GLB), 'arraybuffer');
-    });
-
-    test('returns arraybuffer for .glb file with query string', function () {
-      assert.equal(inferResponseType(XHR_SRC_GLB + '?a=1'), 'arraybuffer');
+  suite('getArrayBuffer', function () {
+    test('getArrayBuffer returns correct array buffer', function () {
+      var arraybuffer = aAssets.getArrayBuffer('hi');
+      var charCodes = new Uint16Array(arraybuffer);
+      assert.equal(String.fromCharCode(charCodes[0]), 'h');
+      assert.equal(String.fromCharCode(charCodes[1]), 'i');
     });
   });
 });

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -328,5 +328,9 @@ suite('a-asset-item', function () {
     test('returns arraybuffer for .glb file', function () {
       assert.equal(inferResponseType(XHR_SRC_GLB), 'arraybuffer');
     });
+
+    test('returns arraybuffer for .glb file with query string', function () {
+      assert.equal(inferResponseType(XHR_SRC_GLB + '?a=1'), 'arraybuffer');
+    });
   });
 });


### PR DESCRIPTION
**Description:**
Fixes loading of binary glTF files by determining the file type using the glTF header. #4219 

**Changes proposed:**
- When loading resources using a-asset-item, aframe determines the response type (text or arraybuffer) by checking to see if the requested resource has a .glb/.gltf file extension. This solution failed when loading resources with query parameters at the end (e.g` /file.glb?version=1`). This fix checks for the presence of the glTF magic number in the response body to determine if it should be treated as binary glTF data or text.