### PR TITLE
missing element definition in custom controls example

### DIFF
--- a/docs/introduction/interactions-and-controllers.md
+++ b/docs/introduction/interactions-and-controllers.md
@@ -472,6 +472,7 @@ AFRAME.registerComponent('custom-controls', {
 
   update: function () {
     var hand = this.data.hand;
+    var el = this.el;
     var controlConfiguration = {
       hand: hand,
       model: false,


### PR DESCRIPTION
added at the top of the update function

**Description:**
was missing

**Changes proposed:**
- added it