### PR TITLE
fixes 'loading-screen ignores enabled: true'

### DIFF
--- a/src/core/scene/loadingScreen.js
+++ b/src/core/scene/loadingScreen.js
@@ -15,7 +15,7 @@ module.exports.setup = function setup (el, getCanvasSize) {
   var loaderAttribute = sceneEl.hasAttribute(ATTR_NAME) ? styleParser.parse(sceneEl.getAttribute(ATTR_NAME)) : undefined;
   var dotsColor = loaderAttribute && loaderAttribute.dotsColor || 'white';
   var backgroundColor = loaderAttribute && loaderAttribute.backgroundColor || '#24CAFF';
-  var loaderEnabled = loaderAttribute === undefined || loaderAttribute.enabled === true || loaderAttribute.enabled === undefined; // true default
+  var loaderEnabled = loaderAttribute === undefined || loaderAttribute.enabled === 'true' || loaderAttribute.enabled === undefined; // true default
   var loaderScene;
   var sphereGeometry;
   var sphereMaterial;

--- a/tests/core/loadingScreen.test.js
+++ b/tests/core/loadingScreen.test.js
@@ -27,6 +27,16 @@ helpers.getSkipCISuite()('loadingScreen', function () {
       });
     });
 
+    test('adds title element if enabled is true', function (done) {
+      var el = this.el = document.createElement('a-scene');
+      el.setAttribute('loading-screen', 'enabled: true');
+      document.body.appendChild(el);
+      el.addEventListener('loaded', function () {
+        assert.ok(el.querySelector('.a-loader-title'));
+        done();
+      });
+    });
+
     teardown(function () {
       document.body.removeChild(this.el);
     });


### PR DESCRIPTION
**Description:**
loading-screen ignores _enabled_ property when it is set to _true_
