### PR TITLE
[docs] give an HTML example for the follow component

### DIFF
--- a/docs/introduction/writing-a-component.md
+++ b/docs/introduction/writing-a-component.md
@@ -634,6 +634,15 @@ AFRAME.registerComponent('follow', {
 });
 ```
 
+Later, when we use this component via HTML, the syntax will look like:
+
+```html
+<a-scene>
+  <a-box id="target-box" color="#5E82C5" position="-3 0 -5"></a-box>
+  <a-box follow="target: #target-box; speed: 1" color="#FF6B6B" position="3 0 -5"></a-box>
+</a-scene>
+```
+
 ### Creating a Helper Vector
 
 Since the `.tick()` handler will be called on every frame (e.g., 90 times per


### PR DESCRIPTION
**Description:**
I noticed there's no HTML code provided for the [follow component example](https://aframe.io/docs/0.9.0/introduction/writing-a-component.html#schema-and-api-1), so I went ahead and added one, similar to the [box component's](https://aframe.io/docs/0.9.0/introduction/writing-a-component.html#schema-and-api) HTML example.

**Changes proposed:**
- Add an HTML example for to the follow component