### PR TITLE
[docs] Update all the A-Frame Slack links in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-[slack]: https://aframevr-slack.herokuapp.com
+[slack]: https://aframe.io/slack-invite/
 [stackoverflow]: http://stackoverflow.com/questions/tagged/aframe
 
 Interested in contributing? As an open source project, we'd appreciate any help
@@ -58,7 +58,7 @@ under the [MIT License](LICENSE).
 
 1. Create something awesome like a scene, a component, or a shader.
 2. Publish your work to Github (and GitHub pages) so everyone can learn from your work.
-3. Share it on [Slack](https://aframevr-slack.herokuapp.com) or Twitter.
+3. Share it on [Slack][slack] or Twitter.
 4. Let us know about it so we can feature it on our blog: [A Week of A-Frame](https://aframe.io/blog/).
 4. For bonus points, write and publish a case study to explain how you built it.
 
@@ -96,7 +96,7 @@ Glitch and update the `src` URL.
 
 ## On Slack
 
-1. [Invite yourself](https://aframevr-slack.herokuapp.com/) to the A-Frame Slack channel.
+1. [Invite yourself][slack] to the A-Frame Slack channel.
 2. Help answer questions that people might have and welcome new people.
 3. Redirect or cross-post questions to the [Stack Overflow A-Frame tag][stackoverflow].
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ For questions and support, [ask on StackOverflow](https://stackoverflow.com/ques
 
 ## Stay in Touch
 
-- To hang out with the community, [join the A-Frame Slack](https://aframevr-slack.herokuapp.com).
+- To hang out with the community, [join the A-Frame Slack](https://aframe.io/slack-invite/).
 - [Follow `A Week of A-Frame` on the A-Frame blog](https://aframe.io/blog).
 - [Follow @aframevr on Twitter](https://twitter.com/aframevr).
 

--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -9,7 +9,7 @@ order: 14
 [ecs]: ./entity-component-system.md
 [github]: http://github.com/aframevr/aframe/
 [three]: http://threejs.org
-[slack]: https://aframe.io/slack-invite
+[slack]: https://aframe.io/slack-invite/
 [twitter]: https://twitter.com/aframevr/
 [stackoverflow]: http://stackoverflow.com/questions/tagged/aframe/
 

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -159,6 +159,7 @@ as Google, Microsoft, Oculus, and Samsung have made contributions to A-Frame.
 ## Off You Go!
 
 [Discord]: https://supermedium.com/discord
+[slack]: https://aframe.io/slack-invite/
 
 If it's your first time here, here's a plan for success for getting into
 A-Frame:
@@ -173,7 +174,7 @@ and for examples.
 3. Run through [A-Frame School](https://aframe.io/school/), a brief
 step-by-step visual tutorial.
 
-4. [Join us on Slack](https://aframe.io/slack-invite) or [Discord] and if
+4. [Join us on Slack][slack] or [Discord] and if
 you have any questions, [search and ask on
 StackOverflow](http://stackoverflow.com/questions/ask/?tags=aframe), and
 someone will try to get to you!


### PR DESCRIPTION
**Description:**
There were still some old herokuapp Slack invitation links around, so I updated them with the current one.

Related PR: https://github.com/aframevr/aframe/issues/4077

**Changes proposed:**
- Replace `https://aframevr-slack.herokuapp.com` with `https://aframe.io/slack-invite/`