### PR TITLE
Update the A-Frame Slack link in examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -123,7 +123,7 @@
       <ul id="resources" class="resources">
         <li><a href="https://aframe.io">aframe.io</a></li>
         <li><a href="https://github.com/aframevr">GitHub</a></li>
-        <li><a href="https://aframevr-slack.herokuapp.com/">Slack</a></li>
+        <li><a href="https://aframe.io/slack-invite/">Slack</a></li>
         <li><a href="https://twitter.com/aframevr">Twitter</a></li>
         <li><a href="https://webvr.directory">Showcase Directory</a></li>
       </ul>


### PR DESCRIPTION
**Description:**
Replacing the old Slack invitation link with the new one. I did the same with docs too (https://github.com/aframevr/aframe/pull/4236).