### PR TITLE
fix ie 11 fullscreen mode bug

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -842,6 +842,7 @@ function setupCanvas (sceneEl) {
   document.addEventListener('fullscreenchange', onFullScreenChange);
   document.addEventListener('mozfullscreenchange', onFullScreenChange);
   document.addEventListener('webkitfullscreenchange', onFullScreenChange);
+  document.addEventListener('MSFullscreenChange', onFullScreenChange); 
 
   // Prevent overscroll on mobile.
   canvasEl.addEventListener('touchmove', function (event) { event.preventDefault(); });

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -842,7 +842,7 @@ function setupCanvas (sceneEl) {
   document.addEventListener('fullscreenchange', onFullScreenChange);
   document.addEventListener('mozfullscreenchange', onFullScreenChange);
   document.addEventListener('webkitfullscreenchange', onFullScreenChange);
-  document.addEventListener('MSFullscreenChange', onFullScreenChange); 
+  document.addEventListener('MSFullscreenChange', onFullScreenChange);
 
   // Prevent overscroll on mobile.
   canvasEl.addEventListener('touchmove', function (event) { event.preventDefault(); });


### PR DESCRIPTION
exit fullscreen mode in IE correctly

**Description:**
Currently fullscreen mode is not exited correctly in IE11 on a Desktop device. It is only possible to see images in fullscreen once. As soon as fullscreen is exited, fullscreen button is gone. 
**Changes proposed:**
- add exit fullscreen mode event listener for IE
