### PR TITLE
respect embedded on loading screen

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -82,12 +82,15 @@ module.exports.AScene = registerElement('a-scene', {
     attachedCallback: {
       value: function () {
         var self = this;
+        var embedded = this.hasAttribute('embedded');
         // Renderer initialization
         setupCanvas(this);
         this.setupRenderer();
 
         this.resize();
-        this.addFullScreenStyles();
+        if (!embedded) {
+          this.addFullScreenStyles();
+        }
         initPostMessageAPI(this);
 
         initMetaTags(this);

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -88,9 +88,7 @@ module.exports.AScene = registerElement('a-scene', {
         this.setupRenderer();
 
         this.resize();
-        if (!embedded) {
-          this.addFullScreenStyles();
-        }
+        if (!embedded) { this.addFullScreenStyles(); }
         initPostMessageAPI(this);
 
         initMetaTags(this);

--- a/src/core/scene/loadingScreen.js
+++ b/src/core/scene/loadingScreen.js
@@ -75,7 +75,8 @@ module.exports.remove = function remove () {
 };
 
 function resize (camera) {
-  var size = getSceneCanvasSize(sceneEl.canvas, false, sceneEl.maxCanvasSize, sceneEl.is('vr-mode'));
+  var embedded = sceneEl.hasAttribute('embedded');
+  var size = getSceneCanvasSize(sceneEl.canvas, embedded, sceneEl.maxCanvasSize, sceneEl.is('vr-mode'));
   camera.aspect = size.width / size.height;
   camera.updateProjectionMatrix();
    // Notify renderer of size change.


### PR DESCRIPTION
**Description:**
Currently regardless of existing _embedded_ attribute loading screen is always in fullscreen

**Changes proposed:**
if a scene has _embedded_ attribute it should apply to loading screen as well
