### PR TITLE
Fixes #3592: Fix resolution drop on exiting VR mode

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -394,6 +394,7 @@ module.exports.AScene = registerElement('a-scene', {
           if (self.hasAttribute('embedded')) { self.removeFullScreenStyles(); }
           self.resize();
           if (self.isIOS) { utils.forceCanvasResizeSafariMobile(self.canvas); }
+          self.renderer.setPixelRatio(window.devicePixelRatio);
           self.emit('exit-vr', {target: self});
         }
 

--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -39,6 +39,7 @@ setup(function () {
     getContext: function () { return undefined; },
     setAnimationLoop: function () {},
     setSize: function () {},
+    setPixelRatio: function () {},
     shadowMap: {}
   };
 });

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -237,11 +237,14 @@ suite('a-scene (without renderer)', function () {
       sceneEl.canvas = document.createElement('canvas');
 
       // Stub renderer.
-      sceneEl.renderer = {vr: {
-        getDevice: function () {},
-        setDevice: function () {},
-        setPoseTarget: function () {}
-      }};
+      sceneEl.renderer = {
+        vr: {
+          getDevice: function () {},
+          setDevice: function () {},
+          setPoseTarget: function () {}
+        },
+        setPixelRatio: function () {}
+      };
 
       sceneEl.addState('vr-mode');
     });


### PR DESCRIPTION
**Description:**
Initial pixel ratio is set when setting up the renderer. After exiting VR mode it somehow gets reset. Additional `setPixelRatio` call on exiting VR mode fixes this issue.

**Changes proposed:**
- set correct pixel ratio on exiting VR mode
