### PR TITLE
only emit cursor mouseup if mousedown originated on scene

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -244,9 +244,7 @@ module.exports.Component = registerComponent('cursor', {
    *   in case user mousedowned one entity, dragged to another, and mouseupped.
    */
   onCursorUp: function (evt) {
-    if (!this.isCursorDown) {
-      return;
-    }
+    if (!this.isCursorDown) { return; }
 
     this.isCursorDown = false;
 

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -57,6 +57,7 @@ module.exports.Component = registerComponent('cursor', {
     this.cursorDownEl = null;
     this.intersectedEl = null;
     this.canvasBounds = document.body.getBoundingClientRect();
+    this.isCursorDown = false;
 
     // Debounce.
     this.updateCanvasBounds = utils.debounce(function updateCanvasBounds () {
@@ -223,6 +224,7 @@ module.exports.Component = registerComponent('cursor', {
    * Trigger mousedown and keep track of the mousedowned entity.
    */
   onCursorDown: function (evt) {
+    this.isCursorDown = true;
     // Raycast again for touch.
     if (this.data.rayOrigin === 'mouse' && evt.type === 'touchstart') {
       this.onMouseMove(evt);
@@ -242,6 +244,12 @@ module.exports.Component = registerComponent('cursor', {
    *   in case user mousedowned one entity, dragged to another, and mouseupped.
    */
   onCursorUp: function (evt) {
+    if (!this.isCursorDown) {
+      return;
+    }
+
+    this.isCursorDown = false;
+
     var data = this.data;
     this.twoWayEmit(EVENTS.MOUSEUP);
 

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -123,6 +123,7 @@ suite('cursor', function () {
       once(el, 'mouseup', function () {
         done();
       });
+      component.isCursorDown = true;
       component.onCursorUp();
     });
 
@@ -133,6 +134,7 @@ suite('cursor', function () {
       once(intersectedEl, 'mouseup', function () {
         done();
       });
+      component.isCursorDown = true;
       component.onCursorUp();
     });
 
@@ -143,6 +145,7 @@ suite('cursor', function () {
       once(el, 'click', function () {
         done();
       });
+      component.isCursorDown = true;
       component.onCursorUp();
     });
 
@@ -153,6 +156,7 @@ suite('cursor', function () {
       once(intersectedEl, 'click', function () {
         done();
       });
+      component.isCursorDown = true;
       component.onCursorUp();
     });
 
@@ -163,6 +167,7 @@ suite('cursor', function () {
       component.intersectedEl = intersectedEl;
       component.cursorDownEl = intersectedEl;
       once(intersectedEl, 'click', function () { done(); });
+      component.isCursorDown = true;
       component.onCursorUp({type: 'touchend', preventDefault: function () {}});
     });
   });


### PR DESCRIPTION
**Description:**

If the A-Frame scene is embedded, using ionic-range slider controls outside the scene and releasing inside the scene causes the slider values to be 0.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1334393/62625515-42f42f00-b91d-11e9-9c6a-dbad8fc71e35.gif)

**Changes proposed:**
- only emit cursor mouseup if mousedown originated on scene
