### PR TITLE
fix component.events singleton, events being overridden by components of the same type

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -48,7 +48,9 @@ var Component = module.exports.Component = function (el, attrValue, id) {
   this.el.components[this.attrName] = this;
   this.objectPool = objectPools[this.name];
 
-  eventsBind(this, this.events);
+  const events = this.events;
+  this.events = {};
+  eventsBind(this, events);
 
   // Store component data from previous update call.
   this.attrValue = undefined;
@@ -588,7 +590,7 @@ Component.prototype = {
 function eventsBind (component, events) {
   var eventName;
   for (eventName in events) {
-    events[eventName] = events[eventName].bind(component);
+    component.events[eventName] = events[eventName].bind(component);
   }
 }
 

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -1159,6 +1159,36 @@ suite('Component', function () {
         });
       });
     });
+
+    test('does not collide with other component instances', function (done) {
+      registerComponent('test2', {
+        events: {
+          foo: function (evt) {
+            assert.equal(this.el.id, 'foo');
+          },
+
+          bar: function (evt) {
+            assert.equal(this.el.id, 'bar');
+          }
+        }
+      });
+
+      el.id = 'foo';
+      el.setAttribute('test2', '');
+
+      const el2 = document.createElement('a-entity');
+      el2.id = 'bar';
+      el2.setAttribute('test2', '');
+      el.appendChild(el2);
+
+      setTimeout(() => {
+        el.emit('foo', null, false);
+        el2.emit('bar', null, false);
+        setTimeout(() => {
+          done();
+        });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
**Description:**

Two component instances of same type using events API would interfere with each other.

**Changes proposed:**
- Don't overwrite the events prototype with a binded version.

