### PR TITLE
[docs] Fix reference to rotation in position component docs

### DIFF
--- a/docs/components/position.md
+++ b/docs/components/position.md
@@ -58,7 +58,7 @@ three.js [Object3D][object3d] `.position` [Vector3][vector] versus [via
 
 This method is easier because we have access to all the [Vector3
 utilities][vector], and faster by skipping `.setAttribute` overhead and not
-needing to create an object to set rotation:
+needing to create an object to set position:
 
 ```js
 // With three.js


### PR DESCRIPTION
The documentation on setting position directly mistakenly references `rotation` when it's referring to `position`. (Presumably it was just missed when copying the same section from the rotation docs).
