### PR TITLE
Don't set the obj-model attribute if it's not null

### DIFF
--- a/src/components/daydream-controls.js
+++ b/src/components/daydream-controls.js
@@ -107,7 +107,9 @@ module.exports.Component = registerComponent('daydream-controls', {
       idPrefix: GAMEPAD_ID_PREFIX,
       orientationOffset: data.orientationOffset
     });
-    if (!this.data.model) { return; }
+    if (!this.data.model || this.el.getAttribute('obj-model') !== null) {
+      return;
+    }
     this.el.setAttribute('obj-model', {
       obj: DAYDREAM_CONTROLLER_MODEL_OBJ_URL,
       mtl: DAYDREAM_CONTROLLER_MODEL_OBJ_MTL

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -106,7 +106,9 @@ module.exports.Component = registerComponent('gearvr-controls', {
       idPrefix: GAMEPAD_ID_PREFIX,
       orientationOffset: data.orientationOffset
     });
-    if (!this.data.model) { return; }
+    if (!this.data.model || this.el.getAttribute('obj-model') !== null) {
+      return;
+    }
     this.el.setAttribute('obj-model', {
       obj: GEARVR_CONTROLLER_MODEL_OBJ_URL,
       mtl: GEARVR_CONTROLLER_MODEL_OBJ_MTL

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -121,7 +121,9 @@ module.exports.Component = registerComponent('vive-controls', {
     });
 
     // Load model.
-    if (!this.data.model) { return; }
+    if (!this.data.model || this.el.getAttribute('obj-model') !== null) {
+      return;
+    }
     this.el.setAttribute('obj-model', {
       obj: VIVE_CONTROLLER_MODEL_OBJ_URL,
       mtl: VIVE_CONTROLLER_MODEL_OBJ_MTL


### PR DESCRIPTION
Fixes #4306

**Description:**

Tentative PR (sorry I'm new to this code base): if this is the right way to go I'll add tests. 

**Changes proposed:**

Set the attribute `obj-model` on controllers only if it does not exist already on the target element.