### PR TITLE
Add support for WebXR gamepads module (fix #4322)

### DIFF
--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -1,4 +1,3 @@
-
 var registerComponent = require('../core/component').registerComponent;
 var utils = require('../utils/');
 

--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -1,3 +1,4 @@
+
 var registerComponent = require('../core/component').registerComponent;
 var utils = require('../utils/');
 
@@ -13,8 +14,7 @@ registerComponent('laser-controls', {
     var data = this.data;
     var el = this.el;
     var self = this;
-    var modelEnabled = this.data.model && !this.el.sceneEl.hasWebXR;
-    var controlsConfiguration = {hand: data.hand, model: modelEnabled};
+    var controlsConfiguration = {hand: data.hand, model: true};
 
     // Set all controller models.
     el.setAttribute('daydream-controls', controlsConfiguration);
@@ -24,9 +24,6 @@ registerComponent('laser-controls', {
     el.setAttribute('vive-controls', controlsConfiguration);
     el.setAttribute('vive-focus-controls', controlsConfiguration);
     el.setAttribute('windows-motion-controls', controlsConfiguration);
-
-    // WebXR doesn't allow to discriminate between controllers, a default model is used.
-    if (this.data.model && this.el.sceneEl.hasWebXR) { this.initDefaultModel(); }
 
     // Wait for controller to connect, or have a valid pointing pose, before creating ray
     el.addEventListener('controllerconnected', createRay);
@@ -105,15 +102,5 @@ registerComponent('laser-controls', {
       cursor: {downEvents: ['triggerdown'], upEvents: ['triggerup']},
       raycaster: {showLine: false}
     }
-  },
-
-  initDefaultModel: function () {
-    var modelEl = this.modelEl = document.createElement('a-entity');
-    modelEl.setAttribute('geometry', {
-      primitive: 'sphere',
-      radius: 0.03
-    });
-    modelEl.setAttribute('material', {color: this.data.color});
-    this.el.appendChild(modelEl);
   }
 });

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -40,14 +40,14 @@ var CONTROLLER_PROPERTIES = {
     left: {
       modelUrl: TOUCH_GEN2_CONTROLLER_MODEL_BASE_URL + 'gen2-left.gltf',
       rayOrigin: {origin: {x: -0.01, y: 0, z: 0}, direction: {x: 0, y: -0.8, z: -1}},
-      modelPivotOffset: new THREE.Vector3(0, 0.012, 0),
-      modelPivotRotation: new THREE.Euler(-Math.PI / 2, 0, 0)
+      modelPivotOffset: new THREE.Vector3(0, 0, 0),
+      modelPivotRotation: new THREE.Euler(0, 0, 0)
     },
     right: {
       modelUrl: TOUCH_GEN2_CONTROLLER_MODEL_BASE_URL + 'gen2-right.gltf',
       rayOrigin: {origin: {x: 0.01, y: 0, z: 0}, direction: {x: 0, y: -0.8, z: -1}},
-      modelPivotOffset: new THREE.Vector3(0, 0.012, 0),
-      modelPivotRotation: new THREE.Euler(-Math.PI / 2, 0, 0)
+      modelPivotOffset: new THREE.Vector3(0, 0, 0),
+      modelPivotRotation: new THREE.Euler(0, 0, 0)
     }
   }
 };

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -83,7 +83,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     buttonTouchColor: {type: 'color', default: '#8AB'},
     buttonHighlightColor: {type: 'color', default: '#2DF'},  // Light blue.
     model: {default: true},
-    controllerType: {default: 'oculus_touch_gen2', oneOf: ['auto', 'oculus_touch_gen1', 'oculus_touch_gen2']},
+    controllerType: {default: 'auto', oneOf: ['auto', 'oculus_touch_gen1', 'oculus_touch_gen2']},
     orientationOffset: {type: 'vec3', default: {x: 43, y: 0, z: 0}}
   },
 

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -11,9 +11,10 @@ var isOculusBrowser = require('../utils/').device.isOculusBrowser();
 var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;
 
 var GAMEPAD_ID_WEBXR = 'oculus-touch';
+var GAMEPAD_ID_WEBVR = 'Oculus Touch';
 
 // Prefix for Gen1 and Gen2 Oculus Touch Controllers.
-var GAMEPAD_ID_PREFIX = isWebXRAvailable ? GAMEPAD_ID_WEBXR : 'Oculus Touch';
+var GAMEPAD_ID_PREFIX = isWebXRAvailable ? GAMEPAD_ID_WEBXR : GAMEPAD_ID_WEBVR;
 
 // First generation model URL.
 var TOUCH_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/oculus/oculus-touch-controller-';
@@ -52,7 +53,44 @@ var CONTROLLER_PROPERTIES = {
   }
 };
 
-var BUTTONS_MAPPING = isWebXRAvailable ? {
+/**
+ * Button indices:
+ * 0 - thumbstick (which has separate axismove / thumbstickmoved events)
+ * 1 - trigger (with analog value, which goes up to 1)
+ * 2 - grip (with analog value, which goes up to 1)
+ * 3 - X (left) or A (right)
+ * 4 - Y (left) or B (right)
+ * 5 - surface (touch only)
+ */
+var INPUT_MAPPING_WEBVR = {
+  left: {
+    axes: {thumbstick: [0, 1]},
+    buttons: ['thumbstick', 'trigger', 'grip', 'xbutton', 'ybutton', 'surface']
+  },
+  right: {
+    axes: {thumbstick: [0, 1]},
+    buttons: ['thumbstick', 'trigger', 'grip', 'abutton', 'bbutton', 'surface']
+  }
+};
+
+/**
+ * Button indices:
+ * 0 - trigger
+ * 1 - grip
+ * 2 - none
+ * 3 - thumbstick
+ * 4 - X or A button
+ * 5 - Y or B button
+ * 6 - surface
+ *
+ * Axis:
+ * 0 - none
+ * 1 - none
+ * 2 - thumbstick
+ * 3 - thumbstick
+ * Reference: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/oculus/oculus-touch.json
+ */
+var INPUT_MAPPING_WEBXR = {
   left: {
     axes: {thumbstick: [2, 3]},
     buttons: ['trigger', 'grip', 'none', 'thumbstick', 'xbutton', 'ybutton', 'surface']
@@ -60,16 +98,10 @@ var BUTTONS_MAPPING = isWebXRAvailable ? {
   right: {
     axes: {thumbstick: [2, 3]},
     buttons: ['trigger', 'grip', 'none', 'thumbstick', 'abutton', 'bbutton', 'surface']
-  }} : {
-    left: {
-      axes: {thumbstick: [0, 1]},
-      buttons: ['thumbstick', 'trigger', 'grip', 'xbutton', 'ybutton', 'surface']
-    },
-    right: {
-      axes: {thumbstick: [0, 1]},
-      buttons: ['thumbstick', 'trigger', 'grip', 'abutton', 'bbutton', 'surface']
-    }
-  };
+  }
+};
+
+var INPUT_MAPPING = isWebXRAvailable ? INPUT_MAPPING_WEBXR : INPUT_MAPPING_WEBVR;
 
 /**
  * Oculus Touch controls.
@@ -88,16 +120,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     orientationOffset: {type: 'vec3', default: {x: 43, y: 0, z: 0}}
   },
 
-  /**
-   * Button IDs:
-   * 0 - thumbstick (which has separate axismove / thumbstickmoved events)
-   * 1 - trigger (with analog value, which goes up to 1)
-   * 2 - grip (with analog value, which goes up to 1)
-   * 3 - X (left) or A (right)
-   * 4 - Y (left) or B (right)
-   * 5 - surface (touch only)
-   */
-  mapping: BUTTONS_MAPPING,
+  mapping: INPUT_MAPPING,
 
   bindMethods: function () {
     this.onModelLoaded = bind(this.onModelLoaded, this);

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -7,8 +7,13 @@ var checkControllerPresentAndSetup = trackedControlsUtils.checkControllerPresent
 var emitIfAxesChanged = trackedControlsUtils.emitIfAxesChanged;
 var onButtonEvent = trackedControlsUtils.onButtonEvent;
 
+var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;
+
+var GAMEPAD_ID_WEBXR = 'oculus-touch';
+
 // Prefix for Gen1 and Gen2 Oculus Touch Controllers.
-var GAMEPAD_ID_PREFIX = 'Oculus Touch';
+var GAMEPAD_ID_PREFIX = isWebXRAvailable ? GAMEPAD_ID_WEBXR : 'Oculus Touch';
+
 // First generation model URL.
 var TOUCH_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/oculus/oculus-touch-controller-';
 // For now the generation 2 model is the same as the original until a new one is prepared for upload.
@@ -59,7 +64,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     buttonTouchColor: {type: 'color', default: '#8AB'},
     buttonHighlightColor: {type: 'color', default: '#2DF'},  // Light blue.
     model: {default: true},
-    controllerType: {default: 'auto', oneOf: ['auto', 'oculus_touch_gen1', 'oculus_touch_gen2']},
+    controllerType: {default: 'oculus_touch_gen2', oneOf: ['auto', 'oculus_touch_gen1', 'oculus_touch_gen2']},
     orientationOffset: {type: 'vec3', default: {x: 43, y: 0, z: 0}}
   },
 
@@ -169,8 +174,11 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   injectTrackedControls: function () {
     var data = this.data;
+    var webXRId = GAMEPAD_ID_WEBXR;
+    var webVRId = data.hand === 'right' ? 'Oculus Touch (Right)' : 'Oculus Touch (Left)';
+    var id = isWebXRAvailable ? webXRId : webVRId;
     this.el.setAttribute('tracked-controls', {
-      id: data.hand === 'right' ? 'Oculus Touch (Right)' : 'Oculus Touch (Left)',
+      id: id,
       controller: 0,
       hand: data.hand,
       orientationOffset: data.orientationOffset

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -7,6 +7,7 @@ var checkControllerPresentAndSetup = trackedControlsUtils.checkControllerPresent
 var emitIfAxesChanged = trackedControlsUtils.emitIfAxesChanged;
 var onButtonEvent = trackedControlsUtils.onButtonEvent;
 
+var isOculusBrowser = require('../utils/').device.isOculusBrowser();
 var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;
 
 var GAMEPAD_ID_WEBXR = 'oculus-touch';
@@ -19,9 +20,9 @@ var TOUCH_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/oculus/
 // For now the generation 2 model is the same as the original until a new one is prepared for upload.
 var TOUCH_GEN2_CONTROLLER_MODEL_BASE_URL = TOUCH_CONTROLLER_MODEL_BASE_URL;
 
-var CONTROLLER_DEFAULT = 'oculusTouchGen1';
+var CONTROLLER_DEFAULT = 'oculus-touch';
 var CONTROLLER_PROPERTIES = {
-  oculusTouchGen1: {
+  'oculus-touch': {
     left: {
       modelUrl: TOUCH_CONTROLLER_MODEL_BASE_URL + 'left.gltf',
       rayOrigin: {origin: {x: 0.008, y: -0.01, z: 0}, direction: {x: 0, y: -0.8, z: -1}},
@@ -35,18 +36,18 @@ var CONTROLLER_PROPERTIES = {
       modelPivotRotation: new THREE.Euler(0, 0, 0)
     }
   },
-  oculusTouchGen2: {
+  'oculus-touch-v2': {
     left: {
       modelUrl: TOUCH_GEN2_CONTROLLER_MODEL_BASE_URL + 'gen2-left.gltf',
       rayOrigin: {origin: {x: -0.01, y: 0, z: 0}, direction: {x: 0, y: -0.8, z: -1}},
       modelPivotOffset: new THREE.Vector3(0, 0.012, 0),
-      modelPivotRotation: new THREE.Euler(-Math.PI / 4, 0, 0)
+      modelPivotRotation: new THREE.Euler(-Math.PI / 2, 0, 0)
     },
     right: {
       modelUrl: TOUCH_GEN2_CONTROLLER_MODEL_BASE_URL + 'gen2-right.gltf',
       rayOrigin: {origin: {x: 0.01, y: 0, z: 0}, direction: {x: 0, y: -0.8, z: -1}},
       modelPivotOffset: new THREE.Vector3(0, 0.012, 0),
-      modelPivotRotation: new THREE.Euler(-Math.PI / 4, 0, 0)
+      modelPivotRotation: new THREE.Euler(-Math.PI / 2, 0, 0)
     }
   }
 };
@@ -83,7 +84,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     buttonTouchColor: {type: 'color', default: '#8AB'},
     buttonHighlightColor: {type: 'color', default: '#2DF'},  // Light blue.
     model: {default: true},
-    controllerType: {default: 'auto', oneOf: ['auto', 'oculus_touch_gen1', 'oculus_touch_gen2']},
+    controllerType: {default: 'auto', oneOf: ['auto', 'oculus-touch', 'oculus-touch-v2']},
     orientationOffset: {type: 'vec3', default: {x: 43, y: 0, z: 0}}
   },
 
@@ -173,11 +174,11 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
         var displayName = trackedControlsSystem.vrDisplay.displayName;
         // The Oculus Quest uses the updated generation 2 inside-out tracked controllers so update the displayModel.
         if (/^Oculus Quest$/.test(displayName)) {
-          this.displayModel = CONTROLLER_PROPERTIES['oculusTouchGen2'];
+          this.displayModel = CONTROLLER_PROPERTIES['oculus-touch-v2'];
         }
       }
+      if (isOculusBrowser) { this.displayModel = CONTROLLER_PROPERTIES['oculus-touch-v2']; }
     }
-
     var modelUrl = this.displayModel[data.hand].modelUrl;
     this.el.setAttribute('gltf-model', 'url(' + modelUrl + ')');
   },

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -51,6 +51,25 @@ var CONTROLLER_PROPERTIES = {
   }
 };
 
+var BUTTONS_MAPPING = isWebXRAvailable ? {
+  left: {
+    axes: {thumbstick: [2, 3]},
+    buttons: ['trigger', 'grip', 'none', 'thumbstick', 'xbutton', 'ybutton', 'surface']
+  },
+  right: {
+    axes: {thumbstick: [2, 3]},
+    buttons: ['trigger', 'grip', 'none', 'thumbstick', 'abutton', 'bbutton', 'surface']
+  }} : {
+    left: {
+      axes: {thumbstick: [0, 1]},
+      buttons: ['thumbstick', 'trigger', 'grip', 'xbutton', 'ybutton', 'surface']
+    },
+    right: {
+      axes: {thumbstick: [0, 1]},
+      buttons: ['thumbstick', 'trigger', 'grip', 'abutton', 'bbutton', 'surface']
+    }
+  };
+
 /**
  * Oculus Touch controls.
  * Interface with Oculus Touch controllers and map Gamepad events to
@@ -77,16 +96,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
    * 4 - Y (left) or B (right)
    * 5 - surface (touch only)
    */
-  mapping: {
-    left: {
-      axes: {thumbstick: [0, 1]},
-      buttons: ['thumbstick', 'trigger', 'grip', 'xbutton', 'ybutton', 'surface']
-    },
-    right: {
-      axes: {thumbstick: [0, 1]},
-      buttons: ['thumbstick', 'trigger', 'grip', 'abutton', 'bbutton', 'surface']
-    }
-  },
+  mapping: BUTTONS_MAPPING,
 
   bindMethods: function () {
     this.onModelLoaded = bind(this.onModelLoaded, this);
@@ -203,7 +213,6 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     var button = this.mapping[this.data.hand].buttons[evt.detail.id];
     var buttonMeshes = this.buttonMeshes;
     var analogValue;
-
     if (!button) { return; }
 
     if (button === 'trigger' || button === 'grip') { analogValue = evt.detail.state.value; }

--- a/src/components/tracked-controls-webxr.js
+++ b/src/components/tracked-controls-webxr.js
@@ -12,6 +12,7 @@ var EVENTS = {
 
 module.exports.Component = registerComponent('tracked-controls-webxr', {
   schema: {
+    id: {type: 'string', default: ''},
     hand: {type: 'string', default: ''}
   },
 
@@ -82,6 +83,7 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
   updateController: function () {
     this.controller = controllerUtils.findMatchingControllerWebXR(
       this.system.controllers,
+      this.data.id,
       this.data.hand
     );
     // Legacy handle to the controller for old components.

--- a/src/components/tracked-controls-webxr.js
+++ b/src/components/tracked-controls-webxr.js
@@ -1,6 +1,15 @@
 var controllerUtils = require('../utils/tracked-controls');
 var registerComponent = require('../core/component').registerComponent;
 
+var EVENTS = {
+  AXISMOVE: 'axismove',
+  BUTTONCHANGED: 'buttonchanged',
+  BUTTONDOWN: 'buttondown',
+  BUTTONUP: 'buttonup',
+  TOUCHSTART: 'touchstart',
+  TOUCHEND: 'touchend'
+};
+
 module.exports.Component = registerComponent('tracked-controls-webxr', {
   schema: {
     hand: {type: 'string', default: ''}
@@ -11,7 +20,13 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
     this.updateController = this.updateController.bind(this);
     this.emitButtonUpEvent = this.emitButtonUpEvent.bind(this);
     this.emitButtonDownEvent = this.emitButtonDownEvent.bind(this);
-    this.buttonEventDetails = {id: 'trigger', state: {pressed: false}};
+
+    this.selectEventDetails = {id: 'trigger', state: {pressed: false}};
+    this.buttonEventDetails = {};
+    this.buttonStates = this.el.components['tracked-controls'].buttonStates = {};
+    this.axis = this.el.components['tracked-controls'].axis = [0, 0, 0];
+    this.changedAxes = [];
+    this.axisMoveEventDetail = {axis: this.axis, changed: this.changedAxes};
   },
 
   play: function () {
@@ -45,17 +60,19 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
 
   emitButtonDownEvent: function (evt) {
     if (!this.controller || evt.inputSource.handedness !== this.data.hand) { return; }
-    this.buttonEventDetails.state.pressed = true;
-    this.el.emit('buttondown', this.buttonEventDetails);
-    this.el.emit('buttonchanged', this.buttonEventDetails);
+    if (this.controller.gamepad) { return; }
+    this.selectEventDetails.state.pressed = true;
+    this.el.emit('buttondown', this.selectEventDetails);
+    this.el.emit('buttonchanged', this.selectEventDetails);
     this.el.emit('triggerdown');
   },
 
   emitButtonUpEvent: function (evt) {
     if (!this.controller || evt.inputSource.handedness !== this.data.hand) { return; }
-    this.buttonEventDetails.state.pressed = false;
-    this.el.emit('buttonup', this.buttonEventDetails);
-    this.el.emit('buttonchanged', this.buttonEventDetails);
+    if (this.controller.gamepad) { return; }
+    this.selectEventDetails.state.pressed = false;
+    this.el.emit('buttonup', this.selectEventDetails);
+    this.el.emit('buttonchanged', this.selectEventDetails);
     this.el.emit('triggerup');
   },
 
@@ -74,13 +91,149 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
   },
 
   tick: function () {
-    var pose;
     var sceneEl = this.el.sceneEl;
-    var object3D = this.el.object3D;
     if (!this.controller || !sceneEl.frame) { return; }
-    pose = sceneEl.frame.getPose(this.controller.targetRaySpace, this.system.referenceSpace);
+    this.pose = sceneEl.frame.getPose(this.controller.targetRaySpace, this.system.referenceSpace);
+    this.updatePose();
+    this.updateButtons();
+  },
+
+  updatePose: function () {
+    var object3D = this.el.object3D;
+    var pose = this.pose;
     if (!pose) { return; }
     object3D.matrix.elements = pose.transform.matrix;
     object3D.matrix.decompose(object3D.position, object3D.rotation, object3D.scale);
+  },
+
+  /**
+   * Handle button changes including axes, presses, touches, values.
+   */
+  updateButtons: function () {
+    var buttonState;
+    var id;
+    var controller = this.controller;
+    var gamepad;
+    if (!controller || !controller.gamepad) { return; }
+
+    gamepad = controller.gamepad;
+    // Check every button.
+    for (id = 0; id < gamepad.buttons.length; ++id) {
+      // Initialize button state.
+      if (!this.buttonStates[id]) {
+        this.buttonStates[id] = {pressed: false, touched: false, value: 0};
+      }
+      if (!this.buttonEventDetails[id]) {
+        this.buttonEventDetails[id] = {id: id, state: this.buttonStates[id]};
+      }
+
+      buttonState = gamepad.buttons[id];
+      this.handleButton(id, buttonState);
+    }
+    // Check axes.
+    this.handleAxes();
+  },
+
+  /**
+   * Handle presses and touches for a single button.
+   *
+   * @param {number} id - Index of button in Gamepad button array.
+   * @param {number} buttonState - Value of button state from 0 to 1.
+   * @returns {boolean} Whether button has changed in any way.
+   */
+  handleButton: function (id, buttonState) {
+    var changed;
+    changed = this.handlePress(id, buttonState) |
+              this.handleTouch(id, buttonState) |
+              this.handleValue(id, buttonState);
+    if (!changed) { return false; }
+    this.el.emit(EVENTS.BUTTONCHANGED, this.buttonEventDetails[id], false);
+    return true;
+  },
+
+  /**
+   * An axis is an array of values from -1 (up, left) to 1 (down, right).
+   * Compare each component of the axis to the previous value to determine change.
+   *
+   * @returns {boolean} Whether axes changed.
+   */
+  handleAxes: function () {
+    var changed = false;
+    var controllerAxes = this.controller.gamepad.axes;
+    var i;
+    var previousAxis = this.axis;
+    var changedAxes = this.changedAxes;
+
+    // Check if axis changed.
+    this.changedAxes.length = 0;
+    for (i = 0; i < controllerAxes.length; ++i) {
+      changedAxes.push(previousAxis[i] !== controllerAxes[i]);
+      if (changedAxes[i]) { changed = true; }
+    }
+    if (!changed) { return false; }
+
+    this.axis.length = 0;
+    for (i = 0; i < controllerAxes.length; i++) {
+      this.axis.push(controllerAxes[i]);
+    }
+    this.el.emit(EVENTS.AXISMOVE, this.axisMoveEventDetail, false);
+    return true;
+  },
+
+  /**
+   * Determine whether a button press has occured and emit events as appropriate.
+   *
+   * @param {string} id - ID of the button to check.
+   * @param {object} buttonState - State of the button to check.
+   * @returns {boolean} Whether button press state changed.
+   */
+  handlePress: function (id, buttonState) {
+    var evtName;
+    var previousButtonState = this.buttonStates[id];
+
+    // Not changed.
+    if (buttonState.pressed === previousButtonState.pressed) { return false; }
+
+    evtName = buttonState.pressed ? EVENTS.BUTTONDOWN : EVENTS.BUTTONUP;
+    this.el.emit(evtName, this.buttonEventDetails[id], false);
+    previousButtonState.pressed = buttonState.pressed;
+    return true;
+  },
+
+  /**
+   * Determine whether a button touch has occured and emit events as appropriate.
+   *
+   * @param {string} id - ID of the button to check.
+   * @param {object} buttonState - State of the button to check.
+   * @returns {boolean} Whether button touch state changed.
+   */
+  handleTouch: function (id, buttonState) {
+    var evtName;
+    var previousButtonState = this.buttonStates[id];
+
+    // Not changed.
+    if (buttonState.touched === previousButtonState.touched) { return false; }
+
+    evtName = buttonState.touched ? EVENTS.TOUCHSTART : EVENTS.TOUCHEND;
+    this.el.emit(evtName, this.buttonEventDetails[id], false);
+    previousButtonState.touched = buttonState.touched;
+    return true;
+  },
+
+  /**
+   * Determine whether a button value has changed.
+   *
+   * @param {string} id - Id of the button to check.
+   * @param {object} buttonState - State of the button to check.
+   * @returns {boolean} Whether button value changed.
+   */
+  handleValue: function (id, buttonState) {
+    var previousButtonState = this.buttonStates[id];
+
+    // Not changed.
+    if (buttonState.value === previousButtonState.value) { return false; }
+
+    previousButtonState.value = buttonState.value;
+    return true;
   }
 });

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -9,7 +9,46 @@ var onButtonEvent = trackedControlsUtils.onButtonEvent;
 var VIVE_CONTROLLER_MODEL_OBJ_URL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.obj';
 var VIVE_CONTROLLER_MODEL_OBJ_MTL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.mtl';
 
-var GAMEPAD_ID_PREFIX = 'OpenVR ';
+var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;
+
+var GAMEPAD_ID_WEBXR = 'htc-vive';
+var GAMEPAD_ID_WEBVR = 'OpenVR ';
+
+// Prefix for Gen1 and Gen2 Oculus Touch Controllers.
+var GAMEPAD_ID_PREFIX = isWebXRAvailable ? GAMEPAD_ID_WEBXR : GAMEPAD_ID_WEBVR;
+
+/**
+ * Button IDs:
+ * 0 - trackpad
+ * 1 - trigger (intensity value from 0.5 to 1)
+ * 2 - grip
+ * 3 - menu (dispatch but better for menu options)
+ * 4 - system (never dispatched on this layer)
+ */
+var INPUT_MAPPING_WEBVR = {
+  axes: {trackpad: [0, 1]},
+  buttons: ['trackpad', 'trigger', 'grip', 'menu', 'system']
+};
+
+/**
+ * Button IDs:
+ * 0 - trigger
+ * 1 - squeeze
+ * 2 - touchpad
+ * 3 - none (dispatch but better for menu options)
+ * 4 - menu (never dispatched on this layer)
+ *
+ * Axis:
+ * 0 - touchpad x axis
+ * 1 - touchpad y axis
+ * Reference: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/htc/htc-vive.json
+ */
+var INPUT_MAPPING_WEBXR = {
+  axes: {thumbstick: [0, 1]},
+  buttons: ['trigger', 'squeeze', 'touchpad', 'none', 'menu']
+};
+
+var INPUT_MAPPING = isWebXRAvailable ? INPUT_MAPPING_WEBXR : INPUT_MAPPING_WEBVR;
 
 /**
  * Vive controls.
@@ -26,18 +65,7 @@ module.exports.Component = registerComponent('vive-controls', {
     orientationOffset: {type: 'vec3'}
   },
 
-  /**
-   * Button IDs:
-   * 0 - trackpad
-   * 1 - trigger (intensity value from 0.5 to 1)
-   * 2 - grip
-   * 3 - menu (dispatch but better for menu options)
-   * 4 - system (never dispatched on this layer)
-   */
-  mapping: {
-    axes: {trackpad: [0, 1]},
-    buttons: ['trackpad', 'trigger', 'grip', 'menu', 'system']
-  },
+  mapping: INPUT_MAPPING,
 
   init: function () {
     var self = this;

--- a/src/components/windows-motion-controls.js
+++ b/src/components/windows-motion-controls.js
@@ -19,7 +19,7 @@ var MODEL_FILENAMES = { left: 'left.glb', right: 'right.glb', default: 'universa
 
 var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;
 
-var GAMEPAD_ID_WEBXR = 'microsoft-mixed-reality';
+var GAMEPAD_ID_WEBXR = 'windows-mixed-reality';
 var GAMEPAD_ID_WEBVR = 'Spatial Controller (Spatial Interaction Source) ';
 var GAMEPAD_ID_PATTERN = /([0-9a-zA-Z]+-[0-9a-zA-Z]+)$/;
 

--- a/src/components/windows-motion-controls.js
+++ b/src/components/windows-motion-controls.js
@@ -17,8 +17,69 @@ var DEFAULT_HANDEDNESS = require('../constants').DEFAULT_HANDEDNESS;
 var MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/microsoft/';
 var MODEL_FILENAMES = { left: 'left.glb', right: 'right.glb', default: 'universal.glb' };
 
-var GAMEPAD_ID_PREFIX = 'Spatial Controller (Spatial Interaction Source) ';
+var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;
+
+var GAMEPAD_ID_WEBXR = 'microsoft-mixed-reality';
+var GAMEPAD_ID_WEBVR = 'Spatial Controller (Spatial Interaction Source) ';
 var GAMEPAD_ID_PATTERN = /([0-9a-zA-Z]+-[0-9a-zA-Z]+)$/;
+
+var GAMEPAD_ID_PREFIX = isWebXRAvailable ? GAMEPAD_ID_WEBXR : GAMEPAD_ID_WEBVR;
+
+var INPUT_MAPPING_WEBVR = {
+  // A-Frame specific semantic axis names
+  axes: {'thumbstick': [0, 1], 'trackpad': [2, 3]},
+  // A-Frame specific semantic button names
+  buttons: ['thumbstick', 'trigger', 'grip', 'menu', 'trackpad'],
+  // A mapping of the semantic name to node name in the glTF model file,
+  // that should be transformed by axis value.
+  // This array mirrors the browser Gamepad.axes array, such that
+  // the mesh corresponding to axis 0 is in this array index 0.
+  axisMeshNames: [
+    'THUMBSTICK_X',
+    'THUMBSTICK_Y',
+    'TOUCHPAD_TOUCH_X',
+    'TOUCHPAD_TOUCH_Y'
+  ],
+  // A mapping of the semantic name to button node name in the glTF model file,
+  // that should be transformed by button value.
+  buttonMeshNames: {
+    'trigger': 'SELECT',
+    'menu': 'MENU',
+    'grip': 'GRASP',
+    'thumbstick': 'THUMBSTICK_PRESS',
+    'trackpad': 'TOUCHPAD_PRESS'
+  },
+  pointingPoseMeshName: 'POINTING_POSE'
+};
+
+var INPUT_MAPPING_WEBXR = {
+  // A-Frame specific semantic axis names
+  axes: {'touchpad': [0, 1], 'thumbstick': [2, 3]},
+  // A-Frame specific semantic button names
+  buttons: ['trigger', 'squeeze', 'touchpad', 'thumbstick', 'menu'],
+  // A mapping of the semantic name to node name in the glTF model file,
+  // that should be transformed by axis value.
+  // This array mirrors the browser Gamepad.axes array, such that
+  // the mesh corresponding to axis 0 is in this array index 0.
+  axisMeshNames: [
+    'TOUCHPAD_TOUCH_X',
+    'TOUCHPAD_TOUCH_X',
+    'THUMBSTICK_X',
+    'THUMBSTICK_Y'
+  ],
+  // A mapping of the semantic name to button node name in the glTF model file,
+  // that should be transformed by button value.
+  buttonMeshNames: {
+    'trigger': 'SELECT',
+    'menu': 'MENU',
+    'squeeze': 'GRASP',
+    'thumbstick': 'THUMBSTICK_PRESS',
+    'touchpad': 'TOUCHPAD_PRESS'
+  },
+  pointingPoseMeshName: 'POINTING_POSE'
+};
+
+var INPUT_MAPPING = isWebXRAvailable ? INPUT_MAPPING_WEBXR : INPUT_MAPPING_WEBVR;
 
 /**
  * Windows Motion Controller controls.
@@ -38,32 +99,7 @@ module.exports.Component = registerComponent('windows-motion-controls', {
     hideDisconnected: {default: true}
   },
 
-  mapping: {
-    // A-Frame specific semantic axis names
-    axes: {'thumbstick': [0, 1], 'trackpad': [2, 3]},
-    // A-Frame specific semantic button names
-    buttons: ['thumbstick', 'trigger', 'grip', 'menu', 'trackpad'],
-    // A mapping of the semantic name to node name in the glTF model file,
-    // that should be transformed by axis value.
-    // This array mirrors the browser Gamepad.axes array, such that
-    // the mesh corresponding to axis 0 is in this array index 0.
-    axisMeshNames: [
-      'THUMBSTICK_X',
-      'THUMBSTICK_Y',
-      'TOUCHPAD_TOUCH_X',
-      'TOUCHPAD_TOUCH_Y'
-    ],
-    // A mapping of the semantic name to button node name in the glTF model file,
-    // that should be transformed by button value.
-    buttonMeshNames: {
-      'trigger': 'SELECT',
-      'menu': 'MENU',
-      'grip': 'GRASP',
-      'thumbstick': 'THUMBSTICK_PRESS',
-      'trackpad': 'TOUCHPAD_PRESS'
-    },
-    pointingPoseMeshName: 'POINTING_POSE'
-  },
+  mapping: INPUT_MAPPING,
 
   bindMethods: function () {
     this.onModelError = bind(this.onModelError, this);

--- a/src/components/windows-motion-controls.js
+++ b/src/components/windows-motion-controls.js
@@ -207,7 +207,7 @@ module.exports.Component = registerComponent('windows-motion-controls', {
     var hand = this.data.hand;
     var filename;
 
-    if (controller) {
+    if (controller && !window.hasNativeWebXRImplementation) {
       // Read hand directly from the controller, rather than this.data, as in the case that the controller
       // is unhanded this.data will still have 'left' or 'right' (depending on what the user inserted in to the scene).
       // In this case, we want to load the universal model, so need to get the '' from the controller.

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -463,7 +463,7 @@ module.exports.AScene = registerElement('a-scene', {
         // Polyfill places display inside the detail property
         var display = evt.display || evt.detail.display;
         // Entering VR.
-        if (display.isPresenting) {
+        if (display && display.isPresenting) {
           this.enterVR();
           return;
         }

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -74,7 +74,7 @@ function isControllerPresentWebVR (component, idPrefix, queryObject) {
  *
  * @param {object} component - Tracked controls component.
  */
-function isControllerPresentWebXR (component, idPrefix, queryObject) {
+function isControllerPresentWebXR (component, id, queryObject) {
   var controllers;
   var sceneEl = component.el.sceneEl;
   var trackedControlsSystem = sceneEl && sceneEl.systems['tracked-controls-webxr'];
@@ -83,7 +83,7 @@ function isControllerPresentWebXR (component, idPrefix, queryObject) {
   controllers = trackedControlsSystem.controllers;
   if (!controllers || !controllers.length) { return false; }
 
-  return findMatchingControllerWebXR(controllers, queryObject.hand);
+  return findMatchingControllerWebXR(controllers, id, queryObject.hand);
 }
 
 module.exports.isControllerPresentWebVR = isControllerPresentWebVR;
@@ -148,13 +148,16 @@ function findMatchingControllerWebVR (controllers, filterIdExact, filterIdPrefix
   return undefined;
 }
 
-function findMatchingControllerWebXR (controllers, handedness) {
+function findMatchingControllerWebXR (controllers, id, handedness) {
   var i;
+  var controller;
   var controllerHandedness;
   for (i = 0; i < controllers.length; i++) {
-    controllerHandedness = controllers[i].handedness;
+    controller = controllers[i];
+    if (controller.profiles[0] !== id) { continue; }
+    controllerHandedness = controller.handedness;
     if (!handedness || (controllerHandedness === '' && handedness === 'right') ||
-        controllers[i].handedness === handedness) {
+        controller.handedness === handedness) {
       return controllers[i];
     }
   }

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -1,7 +1,6 @@
 var DEFAULT_HANDEDNESS = require('../constants').DEFAULT_HANDEDNESS;
 var AXIS_LABELS = ['x', 'y', 'z', 'w'];
 var NUM_HANDS = 2;  // Number of hands in a pair. Should always be 2.
-var isOculusBrowser = require('./device').isOculusBrowser();
 
 /**
  * Called on controller component `.play` handlers.
@@ -151,15 +150,18 @@ function findMatchingControllerWebVR (controllers, filterIdExact, filterIdPrefix
 
 function findMatchingControllerWebXR (controllers, idPrefix, handedness) {
   var i;
+  var j;
   var controller;
-  var controllerMatch;
+  var controllerMatch = false;
   var controllerHandedness;
+  var profiles;
   for (i = 0; i < controllers.length; i++) {
     controller = controllers[i];
-    // Hack needed in Oculus Browser 7 because the profiles array
-    // of the WebXR gamepad module is not populated. Fix expected in Oculus Browser 7.1
-    controllerMatch = controller.profiles[0] && controller.profiles[0].startsWith(idPrefix) ||
-      isOculusBrowser && idPrefix === 'oculus-touch';
+    profiles = controller.profiles;
+    for (j = 0; j < profiles.length; j++) {
+      controllerMatch = profiles[j].startsWith(idPrefix);
+      if (controllerMatch) { break; }
+    }
     if (!controllerMatch) { continue; }
     controllerHandedness = controller.handedness;
     if (!handedness || (controllerHandedness === '' && handedness === 'right') ||

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -154,7 +154,7 @@ function findMatchingControllerWebXR (controllers, id, handedness) {
   var controllerHandedness;
   for (i = 0; i < controllers.length; i++) {
     controller = controllers[i];
-    if (controller.profiles[0] !== id) { continue; }
+    if (id && controller.profiles[0] && controller.profiles[0] !== id) { continue; }
     controllerHandedness = controller.handedness;
     if (!handedness || (controllerHandedness === '' && handedness === 'right') ||
         controller.handedness === handedness) {

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -1,6 +1,7 @@
 var DEFAULT_HANDEDNESS = require('../constants').DEFAULT_HANDEDNESS;
 var AXIS_LABELS = ['x', 'y', 'z', 'w'];
 var NUM_HANDS = 2;  // Number of hands in a pair. Should always be 2.
+var isOculusBrowser = require('./device').isOculusBrowser();
 
 /**
  * Called on controller component `.play` handlers.
@@ -148,13 +149,18 @@ function findMatchingControllerWebVR (controllers, filterIdExact, filterIdPrefix
   return undefined;
 }
 
-function findMatchingControllerWebXR (controllers, id, handedness) {
+function findMatchingControllerWebXR (controllers, idPrefix, handedness) {
   var i;
   var controller;
+  var controllerMatch;
   var controllerHandedness;
   for (i = 0; i < controllers.length; i++) {
     controller = controllers[i];
-    if (id && controller.profiles[0] && controller.profiles[0] !== id) { continue; }
+    // Hack needed in Oculus Browser 7 because the profiles array
+    // of the WebXR gamepad module is not populated. Fix expected in Oculus Browser 7.1
+    controllerMatch = controller.profiles[0] && controller.profiles[0].startsWith(idPrefix) ||
+      isOculusBrowser && idPrefix === 'oculus-touch';
+    if (!controllerMatch) { continue; }
     controllerHandedness = controller.handedness;
     if (!handedness || (controllerHandedness === '' && handedness === 'right') ||
         controller.handedness === handedness) {

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -37,7 +37,7 @@ module.exports.checkControllerPresentAndSetup = function (component, idPrefix, q
   // Update controller presence.
   if (isPresent) {
     component.injectTrackedControls();
-    if (!hasWebXR) { component.addEventListeners(); }
+    component.addEventListeners();
     el.emit('controllerconnected', {name: component.name, component: component});
   } else {
     component.removeEventListeners();

--- a/tests/components/tracked-controls-webxr.test.js
+++ b/tests/components/tracked-controls-webxr.test.js
@@ -1,7 +1,7 @@
 /* global assert, process, setup, sinon, suite, test, THREE */
 const entityFactory = require('../helpers').entityFactory;
 
-suite('tracked-controls-webxr', function () {
+suite.only('tracked-controls-webxr', function () {
   var component;
   var controller;
   var el;
@@ -15,7 +15,10 @@ suite('tracked-controls-webxr', function () {
       el.sceneEl.addEventListener('loaded', function () {
         system = el.sceneEl.systems['tracked-controls-webxr'];
         el.components['tracked-controls'] = {};
-        controller = {handedness: 'left'};
+        controller = {
+          handedness: 'left',
+          profiles: []
+        };
         system.controllers = [controller];
         el.setAttribute('tracked-controls-webxr', {'hand': 'right'});
         component = el.components['tracked-controls-webxr'];
@@ -27,7 +30,7 @@ suite('tracked-controls-webxr', function () {
   suite('updateGamepad', function () {
     test('matches controller with same hand', function () {
       assert.strictEqual(component.controller, undefined);
-      el.setAttribute('tracked-controls-webxr', {'hand': 'left'});
+      el.setAttribute('tracked-controls-webxr', {hand: 'left'});
       component.updateController();
       assert.equal(component.controller, controller);
     });

--- a/tests/components/tracked-controls-webxr.test.js
+++ b/tests/components/tracked-controls-webxr.test.js
@@ -1,7 +1,7 @@
 /* global assert, process, setup, sinon, suite, test, THREE */
 const entityFactory = require('../helpers').entityFactory;
 
-suite.only('tracked-controls-webxr', function () {
+suite('tracked-controls-webxr', function () {
   var component;
   var controller;
   var el;

--- a/tests/components/tracked-controls-webxr.test.js
+++ b/tests/components/tracked-controls-webxr.test.js
@@ -17,7 +17,7 @@ suite('tracked-controls-webxr', function () {
         el.components['tracked-controls'] = {};
         controller = {
           handedness: 'left',
-          profiles: []
+          profiles: ['test']
         };
         system.controllers = [controller];
         el.setAttribute('tracked-controls-webxr', {'hand': 'right'});


### PR DESCRIPTION
Work in progress with initial support for the gamepads module. @klausw What's the recommended way to identify the controller vendor to load the appropriate model? I see that the gamepad id is not populated and there's an entry in the `XRInputSource .profiles` that says `oculus-touch` for the Oculus Rift headset. Is there a list of vendor strings anywhere? Is the vendor name always guaranteed to be in the first position of the profiles array? Thank you very much.