### PR TITLE
Fallback to WebVR on Oculus Browser

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -338,7 +338,7 @@ module.exports.AScene = registerElement('a-scene', {
           self.addState('vr-mode');
           self.emit('enter-vr', {target: self});
           // Lock to landscape orientation on mobile.
-          if (!navigator.xr && self.isMobile && screen.orientation && screen.orientation.lock) {
+          if (!isWebXRAvailable && self.isMobile && screen.orientation && screen.orientation.lock) {
             screen.orientation.lock('landscape');
           }
           self.addFullScreenStyles();

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
 // Polyfill `Promise`.
 window.Promise = window.Promise || require('promise-polyfill');
 
+var isOculusBrowser = /(OculusBrowser)/i.test(window.navigator.userAgent);
+
 // WebVR polyfill
 // Check before the polyfill runs.
 window.hasNativeWebVRImplementation = !!window.navigator.getVRDisplays ||
                                       !!window.navigator.getVRDevices;
-window.hasNativeWebXRImplementation = navigator.xr !== undefined;
+window.hasNativeWebXRImplementation = !isOculusBrowser && navigator.xr !== undefined;
 
 // If native WebXR or WebVR are defined WebVRPolyfill does not initialize.
 if (!window.hasNativeWebXRImplementation && !window.hasNativeWebVRImplementation) {

--- a/src/systems/tracked-controls-webvr.js
+++ b/src/systems/tracked-controls-webvr.js
@@ -1,5 +1,6 @@
 var registerSystem = require('../core/system').registerSystem;
 var utils = require('../utils');
+var isWebXRAvailable = utils.device.isWebXRAvailable;
 
 /**
  * Tracked controls system.
@@ -16,7 +17,7 @@ module.exports.System = registerSystem('tracked-controls-webvr', {
     this.throttledUpdateControllerList = utils.throttle(this.updateControllerList, 500, this);
 
     // Don't use WebVR if WebXR is available?
-    if (navigator.xr) { return; }
+    if (isWebXRAvailable) { return; }
 
     if (!navigator.getVRDisplays) { return; }
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -4,11 +4,17 @@ var vrDisplay;
 var supportsVRSession = false;
 var supportsARSession = false;
 
+/**
+ * Oculus Browser 7 doesn't support the WebXR gamepads module.
+ * We fallback to WebVR API and will hotfix when implementation is complete.
+ */
+var isWebXRAvailable = module.exports.isWebXRAvailable = !isOculusBrowser() && navigator.xr !== undefined;
+
 // Catch vrdisplayactivate early to ensure we can enter VR mode after the scene loads.
 window.addEventListener('vrdisplayactivate', function (evt) {
   var canvasEl;
   // WebXR takes priority if available.
-  if (navigator.xr) { return; }
+  if (isWebXRAvailable) { return; }
   canvasEl = document.createElement('canvas');
   vrDisplay = evt.display;
   // We need to make sure the canvas has a WebGL context associated with it.
@@ -19,7 +25,7 @@ window.addEventListener('vrdisplayactivate', function (evt) {
 });
 
 // Support both WebVR and WebXR APIs.
-if (navigator.xr) {
+if (isWebXRAvailable) {
   var updateEnterInterfaces = function () {
     var sceneEl = document.querySelector('a-scene');
     if (sceneEl.hasLoaded) {
@@ -40,7 +46,6 @@ if (navigator.xr) {
 
     navigator.xr.isSessionSupported('immersive-ar').then(function (supported) {
       supportsARSession = supported;
-
       updateEnterInterfaces();
     }).catch(errorHandler);
   } else if (navigator.xr.supportsSession) {
@@ -67,8 +72,6 @@ if (navigator.xr) {
     });
   }
 }
-
-module.exports.isWebXRAvailable = navigator.xr !== undefined;
 
 function getVRDisplay () { return vrDisplay; }
 module.exports.getVRDisplay = getVRDisplay;


### PR DESCRIPTION
The WebXR implementation in Oculus Browser 7 is missing the gamepads module. We need to fallback to WebVR to be able to access the controller buttons and axis. We can start using WebXR when 7.1 [ships in Jan / Feb](https://immersiveweb.dev/#aframevr)