### PR TITLE
[docs] Update text.md

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -183,7 +183,7 @@ Lastly, you should specify the character set used in your HTML by using `<meta>`
   <body>
     <a-scene>
       <a-sky color="lightblue"></a-sky>
-      <a-text value="ABCあいうえお日本語" font="custom-msdf.json" negate="false" scale="2 2 1" position="-2 2 -4"></a-text>
+      <a-text value="ABCあいうえお日本語" font="custom-msdf.json" font-image="custom-msdf.png" negate="false" scale="2 2 1" position="-2 2 -4"></a-text>
     </a-scene>
   </body>
 </html>


### PR DESCRIPTION
**Description:**
To render Japanese text using `<a-text>` tag, `font-image` parameter is also required.

**Changes proposed:**
- Add `font-image` parameter to `<a-text>` tag  in "Non-ASCII Characters".