### PR TITLE
fix rotation of hand models for oculus touch controls (fixes #4388)

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -187,12 +187,12 @@ module.exports.Component = registerComponent('hand-controls', {
     // Set model.
     if (hand !== previousHand) {
       this.loader.load(MODEL_URLS[hand], function (gltf) {
-        var mesh = gltf.scene.children[0];
-        mesh.mixer = new THREE.AnimationMixer(mesh);
+        self.mesh = gltf.scene.children[0];
+        self.mesh.mixer = new THREE.AnimationMixer(self.mesh);
         self.clips = gltf.animations;
-        el.setObject3D('mesh', mesh);
-        mesh.position.set(0, 0, 0);
-        mesh.rotation.set(0, 0, 0);
+        el.setObject3D('mesh', self.mesh);
+        self.mesh.position.set(0, 0, 0);
+        self.mesh.rotation.set(0, 0, 0);
         el.setAttribute('vive-controls', controlConfiguration);
         el.setAttribute('oculus-touch-controls', controlConfiguration);
         el.setAttribute('windows-motion-controls', controlConfiguration);

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -204,6 +204,9 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   loadModel: function () {
     var data = this.data;
+    if (!data.model && this.el.components['hand-controls']) {
+      this.el.components['hand-controls'].mesh.rotation.set(0, 0, data.hand === 'left' ? Math.PI / 2 : -Math.PI / 2);
+    }
     if (!data.model) { return; }
 
     // Set the controller display model based on the data passed in.


### PR DESCRIPTION
**Description:**
Between version 1.0.0 and 1.0.1 the rotation of the hand-controls model changed such that they no longer match the users physical hand positions. They are rotated 90 off of where they should be. I created #4388 and figured I'd propose a solution. I'm not sure if there is a reason for this rotation on other devices with 6dof controllers, so I attempted to fix this from the oculus-touch-controls component. Doing this from the oculus-touch-controls component is supposed to limit this change to only rotating the hand models when the user is using oculus touch controls.
**Changes proposed:**
- store a reference to the mesh on the hand-controls component
- check for hand controls component in the oculus-touch-controls component when the component is attempting to load its own model because utils told it to inject its controls
- if the hand controls component is present then rotate the hand mesh by 90deg
