### PR TITLE
rotate hand models if webxr api is being used

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -180,19 +180,19 @@ module.exports.Component = registerComponent('hand-controls', {
     // Get common configuration to abstract different vendor controls.
     controlConfiguration = {
       hand: hand,
-      model: false,
-      orientationOffset: {x: 0, y: 0, z: hand === 'left' ? 90 : -90}
+      model: false
     };
 
     // Set model.
     if (hand !== previousHand) {
       this.loader.load(MODEL_URLS[hand], function (gltf) {
         var mesh = gltf.scene.children[0];
+        var handModelOrientation = hand === 'left' ? Math.PI / 2 : -Math.PI / 2;
         mesh.mixer = new THREE.AnimationMixer(mesh);
         self.clips = gltf.animations;
         el.setObject3D('mesh', mesh);
         mesh.position.set(0, 0, 0);
-        mesh.rotation.set(0, 0, 0);
+        mesh.rotation.set(0, 0, handModelOrientation);
         el.setAttribute('vive-controls', controlConfiguration);
         el.setAttribute('oculus-touch-controls', controlConfiguration);
         el.setAttribute('windows-motion-controls', controlConfiguration);


### PR DESCRIPTION
**Description:**
Between version 1.0.0 and 1.0.1 the rotation of the hand-controls model changed such that they no longer match the users physical hand positions. They are rotated 90 off of where they should be. I created #4388 and figured I'd propose a solution.

Webxr controller orientation seems to be what is causing this improper rotation on the oculus quest browser (where the webxr api is avialable). In the firefox reality browser (no webxr api currently) on quest the rotation is correct. This change fixes the hand rotation if aframe is using the webXR api.

**Changes proposed:**
- check for xr on the navigator in the hand-controls component
- if xr available the hand models should be rotated
- if xr not available the hand models will match controller orientations

closed #4389 in favor of this solution