### PR TITLE
Prevent jumping tracked controllers due to switing between 6DOF and 3DOF

### DIFF
--- a/src/components/tracked-controls-webvr.js
+++ b/src/components/tracked-controls-webvr.js
@@ -42,7 +42,7 @@ module.exports.Component = registerComponent('tracked-controls-webvr', {
     idPrefix: {type: 'string', default: ''},
     orientationOffset: {type: 'vec3'},
     // Arm model parameters when not 6DoF.
-    armModel: {default: true},
+    armModel: {default: false},
     headElement: {type: 'selector'}
   },
 

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -19,7 +19,7 @@ module.exports.Component = registerComponent('tracked-controls', {
     idPrefix: {type: 'string', default: ''},
     orientationOffset: {type: 'vec3'},
     // Arm model parameters when not 6DoF.
-    armModel: {default: true},
+    armModel: {default: false},
     headElement: {type: 'selector'},
     iterateControllerProfiles: {default: false}
   },


### PR DESCRIPTION
**Description:**

I've noticed a very annoying issue when using my Rift S with A-Frame applications. When the controllers are held still near the periphery of the field of view, they can jump back and forth quite a lot. The issue goes away when they are moved around a bit, but then reappears if they are held still for a while.

This is on Firefox 72.0.1 and various aframe versions, including 1.0.3

I've tracked it down, and it seems that when the controller is in the center of view or moving, the WebVR controller pose contains the `position` attribute, but when it is stationary on the periphery, it does not contain the `position` attribute. When the `position` attribute is missing, the `tracked-controls-webvr` instantly switches to using the 3DOF arm model, putting the controller in a completely different position. When the controller starts moving again, it switches back to 6DOF mode, again causing a very annoying jump as it goes back to the tracked position.

**Changes proposed:**

- Keep track of whether the controller pose ever contains the `position` attribute. If it does, then do not switch to 3DOF arm model mode if `position` goes away.
