### PR TITLE
Use full hash for dependency to fix pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "promise-polyfill": "^3.1.0",
     "super-animejs": "^3.1.0",
     "super-three": "^0.111.5",
-    "three-bmfont-text": "dmarcos/three-bmfont-text#1babdf8507",
+    "three-bmfont-text": "dmarcos/three-bmfont-text#1babdf8507c731a18f8af3b807292e2b9740955e",
     "webvr-polyfill": "^0.10.10"
   },
   "devDependencies": {


### PR DESCRIPTION
**Description:**

Similarly as https://github.com/aframevr/aframe/pull/3749 was done to workaround pnpm not being able to resolve short hash version for dependencies https://github.com/pnpm/pnpm/issues/1127

**Changes proposed:**
- Change the hash to the full length version so that aframe works for pnpm users too.