### PR TITLE
Remove references to discontinued sites

### DIFF
--- a/docs/introduction/writing-a-component.md
+++ b/docs/introduction/writing-a-component.md
@@ -739,24 +739,30 @@ source on GitHub.  One way to learn is to browse the source code of other
 components to see how they're built and what use cases they provide for. Here
 are a few places to look:
 
-[registry]: https://aframe.io/registry/
 [corecomponents]: https://github.com/aframevr/aframe/tree/master/src/components
 [paintercomponents]: https://github.com/aframevr/a-painter/tree/master/src/components
 
-- [A-Frame Registry][registry] - Curated community components.
+[weekofaframe]: https://aframe.io/blog/
+[officialsite]: https://aframe.io/
+[community]: https://aframe.io/community/
+[npmcomponents]: https://www.npmjs.com/search?q=keywords:aframe&page=1&ranking=optimal
+[aframetwitter]: https://twitter.com/aframevr/
+
 - [A-Frame core components][corecomponents] - Source code of A-Frame's standard components.
 - [A-Painter components][paintercomponents] - Application-specific components for A-Painter.
+- [**A Week of A-Frame** Weekly Series][weekofaframe]
+- [Official Site][officialsite]
+- [Community][community]
+- [Components on npm][npmcomponents]
+- [Twitter][aframetwitter]
 
 ## Publishing a Component
 
 [angle]: https://www.npmjs.com/package/angle
-[awesome]: https://github.com/aframevr/awesome-aframe
-[registry]: https://aframe.io/registry/
 
 Many components in practice will be application-specific or one-off components.
 But if you wrote a component that could be useful to the community and is
-generalized enough to work in other applications, you should publish it to the
-ecosystem via [the A-Frame Registry][registry] and [`awesome-aframe`][awesome]!
+generalized enough to work in other applications, you should publish it!
 
 For a component template, we recommend using [`angle`][angle].  `angle` is a
 command-line interface for A-Frame; one of its features is to set up a
@@ -767,12 +773,6 @@ with all the other components in the ecosystem. To install the template:
 npm install -g angle && angle initcomponent
 ```
 
-[guidelines]: https://github.com/aframevr/aframe-registry#submitting-a-component
-[pr]: https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github
-
 `initcomponent` will ask for some information like the component name to get
-the template set up. Write some code, examples, and documentation, and [send a
-pull request][pr] to the [A-Frame Registry][registry] to get it featured! Follow the
-[Registry guidelines][guidelines], we'll do a quick code review, and then the
-community will be able to use your component, and hopefully send some helpful
-pull requests back if needed!
+the template set up. Write some code, examples, and documentation, and publish
+to GitHub and npm!


### PR DESCRIPTION
As discussed here: https://github.com/aframevr/aframe/issues/4419 "The A-Frame Registry" and "Awesome A-Frame" are both now discontinued. I'm not sure if there's anything that should be added in their place (how are components selected for the Inspector these days, for example?) but the last word in the Issue was "just remove the references to the registry for now", so that's what I've done. (I've also inserted the alternatives that the registry's discontinuation readme suggests in its place.)