### PR TITLE
docs: remove link to Mozilla Thimble

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -46,7 +46,6 @@ Below are a few other A-Frame Glitches for starters:
 Below are a couple of A-Frame starter kits on other browser-based code
 editors. Both support remixing or forking:
 
-- [Mozilla Thimble &mdash; A-Frame](https://thimble.mozilla.org/en-US/user/ngokevin/864056)
 - [CodePen &mdash; A-Frame](https://codepen.io/mozvr/pen/BjygdO)
 
 ## Local Development


### PR DESCRIPTION
**Description:**
- Mozilla Thimble no longer exists (closed in 2019)
  - https://foundation.mozilla.org/en/artifacts/thimble/
    - _“Thimble **was** a browser-based code editor…”_

**Changes proposed:**
- Update links on the Installation page
- Remove the link to Mozilla Thimble code editor