### PR TITLE
added +/- for clarity

### DIFF
--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -160,7 +160,7 @@ additional properties:
 | Property            | Light type      | Description                                                                                                                                | Default Value |
 |---------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | castShadow          |                 | Whether this light casts shadows on the scene.                                                                                             | false         |
-| shadowBias          |                 | Offset depth when deciding whether a surface is in shadow. Tiny adjustments here (in the order of 0.0001) may reduce artifacts in shadows. | 0             |
+| shadowBias          |                 | Offset depth when deciding whether a surface is in shadow. Tiny adjustments here (in the order of +/-0.0001) may reduce artifacts in shadows. | 0             |
 | shadowCameraBottom  | `directional`   | Bottom plane of shadow camera frustum.                                                                                                     | -5            |
 | shadowCameraFar     |                 | Far plane of shadow camera frustum.                                                                                                        | 500           |
 | shadowCameraFov     | `point`, `spot` | Shadow camera's FOV.                                                                                                                       | 50            |


### PR DESCRIPTION
Initially, I wasn't aware that shadowBias could also have negative values.
For example, in a scene I needed a value of -0.001 to make the artifacts go away, as discussed in this thread:
https://aframevr.slack.com/archives/C0FABCPJQ/p1578640473070500

With the +/-, I hope to hint that people try out both positive and negative values.

**Description:**

**Changes proposed:**
-
-
-
