### PR TITLE
add powerPreference: "high-performance"  to webgl renderConfig

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -589,7 +589,8 @@ module.exports.AScene = registerElement('a-scene', {
           alpha: true,
           antialias: !isMobile,
           canvas: this.canvas,
-          logarithmicDepthBuffer: false
+          logarithmicDepthBuffer: false,
+          powerPreference: "high-performance"         
         };
 
         this.maxCanvasSize = {height: 1920, width: 1920};

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -590,7 +590,7 @@ module.exports.AScene = registerElement('a-scene', {
           antialias: !isMobile,
           canvas: this.canvas,
           logarithmicDepthBuffer: false,
-          powerPreference: 'high-performance'         
+          powerPreference: 'high-performance' 
         };
 
         this.maxCanvasSize = {height: 1920, width: 1920};

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -590,7 +590,7 @@ module.exports.AScene = registerElement('a-scene', {
           antialias: !isMobile,
           canvas: this.canvas,
           logarithmicDepthBuffer: false,
-          powerPreference: "high-performance"         
+          powerPreference: 'high-performance'         
         };
 
         this.maxCanvasSize = {height: 1920, width: 1920};

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -590,7 +590,7 @@ module.exports.AScene = registerElement('a-scene', {
           antialias: !isMobile,
           canvas: this.canvas,
           logarithmicDepthBuffer: false,
-          powerPreference: 'high-performance' 
+          powerPreference: 'high-performance'
         };
 
         this.maxCanvasSize = {height: 1920, width: 1920};


### PR DESCRIPTION
from https://www.khronos.org/registry/webgl/specs/latest/1.0/

```
high-performance

Indicates a request for a GPU configuration that prioritizes rendering performance over power consumption. Developers are encouraged to only specify this value if they believe it is absolutely necessary, since it may significantly decrease battery life on mobile devices. Implementations may decide to initially respect this request and, after some time, lose the context and restore a new context ignoring the request.
```
