### PR TITLE
light: Add THREE.RectAreaLight as option

### DIFF
--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -43,11 +43,11 @@ To manually disable the defaults, without adding other lights:
 
 All light types support a few basic properties:
 
-| Property  | Description                                                     | Default Value |
-|-----------|-----------------------------------------------------------------|---------------|
-| type      | One of `ambient`, `directional`, `hemisphere`, `point`, `spot`. | directional   |
-| color     | Light color.                                                    | #fff          |
-| intensity | Light strength.                                                 | 1.0           |
+| Property  | Description                                                             | Default Value |
+|-----------|-------------------------------------------------------------------------|---------------|
+| type      | One of `ambient`, `directional`, `hemisphere`, `point`, `spot`, `area`. | directional   |
+| color     | Light color.                                                            | #fff          |
+| intensity | Light strength.                                                         | 1.0           |
 
 ## Light Types
 
@@ -144,6 +144,28 @@ omni-directional. They mainly cast light in one direction, like the
 | distance    | Distance where intensity becomes 0. If `distance` is `0`, then the point light does not decay with distance.   | 0.0           |
 | penumbra    | Percent of the spotlight cone that is attenuated due to penumbra.                                              | 0.0           |
 | target      | element the spot should point to. set to null to transform spotlight by orientation, pointing to it's -Z axis. | null          |
+
+### Area
+
+You must include "RectAreaLightUniformsLib.js" in your project for area lights to function.
+
+The console will point out if you are missing this file or if it couldn't be loaded.
+```html
+<script src="https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js"></script>
+```
+
+Area lights can be described as "half of a point light".
+They are directional and cast light from a rectangular plane over an 180° radius.
+They, however, do not cast shadows.
+
+```html
+<a-entity light="type: area; width:0.5; height:0.5;"></a-entity>
+```
+
+| Property    | Description                                                                                                    | Default Value |
+|-------------|----------------------------------------------------------------------------------------------------------------|---------------|
+| width       | The width of the area light.                                                                    | 1             |
+| height      | The height of the area light.                                                                   | 1             |
 
 ## Configuring Shadows
 

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -1,4 +1,5 @@
-var bind = require('../utils/bind');
+LightUniformsLib.js file not present. Please include the file in your webpage using a script tag like:\n <script src="https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js"></script>');
+          break;var bind = require('../utils/bind');
 var diff = require('../utils').diff;
 var debug = require('../utils/debug');
 var registerComponent = require('../core/component').registerComponent;
@@ -270,7 +271,7 @@ module.exports.Component = registerComponent('light', {
         THREE.RectAreaLightUniformsLib.init();
 
         if (THREE.RectAreaLightUniformsLib === undefined) {
-          warn('RectAreaLightUniformsLib.js file not present. Please include the file in your webpage using a script tag like:\n <script src="https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js"></script>');
+          warn('RectAreaLightUniformsLib.js not found. Please include the file in your project using a script tag (it MUST load after aframe does):\n <script src="https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js"></script>');
           break;
         } else {
           return new THREE.RectAreaLight(color, intensity, width, height);
@@ -278,7 +279,7 @@ module.exports.Component = registerComponent('light', {
       }
       default: {
         warn('%s is not a valid light type. ' +
-           'Choose from ambient, directional, hemisphere, point, spot.', type);
+           'Choose from ambient, directional, hemisphere, point, spot, area.', type);
       }
     }
   },

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -19,8 +19,8 @@ module.exports.Component = registerComponent('light', {
     distance: {default: 0.0, min: 0, if: {type: ['point', 'spot']}},
     intensity: {default: 1.0, min: 0, if: {type: ['ambient', 'directional', 'hemisphere', 'point', 'spot', 'area']}},
     penumbra: {default: 0, min: 0, max: 1, if: {type: ['spot']}},
-    width: {default: 0.5, min: 0, if: {type: ['area']}},
-    height: {default: 0.5, min: 0, if: {type: ['area']}},
+    width: {default: 1, min: 0, if: {type: ['area']}},
+    height: {default: 1, min: 0, if: {type: ['area']}},
     type: {
       default: 'directional',
       oneOf: ['ambient', 'directional', 'hemisphere', 'point', 'spot', 'area'],

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -19,6 +19,8 @@ module.exports.Component = registerComponent('light', {
     distance: {default: 0.0, min: 0, if: {type: ['point', 'spot']}},
     intensity: {default: 1.0, min: 0, if: {type: ['ambient', 'directional', 'hemisphere', 'point', 'spot']}},
     penumbra: {default: 0, min: 0, max: 1, if: {type: ['spot']}},
+    width: {default: 1, min: 0, if: {type: ['area']}},
+    height: {default: 1, min: 0, if: {type: ['area']}},
     type: {
       default: 'directional',
       oneOf: ['ambient', 'directional', 'hemisphere', 'point', 'spot'],
@@ -220,6 +222,8 @@ module.exports.Component = registerComponent('light', {
     this.rendererSystem.applyColorCorrection(groundColor);
     groundColor = groundColor.getHex();
     var intensity = data.intensity;
+    var width = data.width;
+    var height = data.height;
     var type = data.type;
     var target = data.target;
     var light = null;
@@ -262,7 +266,16 @@ module.exports.Component = registerComponent('light', {
         }
         return light;
       }
+      case 'area': {
+        THREE.RectAreaLightUniformsLib.init();
 
+        if (THREE.RectAreaLightUniformsLib === undefined) {
+          warn('RectAreaLightUniformsLib.js file not present. Please include the file in your webpage using a script tag like:\n <script src="https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js"></script>');
+          break;
+        } else {
+          return new THREE.RectAreaLight(color, intensity, width, height);
+        }
+      }
       default: {
         warn('%s is not a valid light type. ' +
            'Choose from ambient, directional, hemisphere, point, spot.', type);

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -273,7 +273,7 @@ module.exports.Component = registerComponent('light', {
           break;
         } else {
           THREE.RectAreaLightUniformsLib.init();
-          return new THREE.RectAreaLight(color, intensity * 8 / intensitycalc, width, height);
+          return new THREE.RectAreaLight(color, intensity * 32 / intensitycalc, width, height);
         }
       }
       default: {

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -1,5 +1,4 @@
-LightUniformsLib.js file not present. Please include the file in your webpage using a script tag like:\n <script src="https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js"></script>');
-          break;var bind = require('../utils/bind');
+var bind = require('../utils/bind');
 var diff = require('../utils').diff;
 var debug = require('../utils/debug');
 var registerComponent = require('../core/component').registerComponent;

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -267,12 +267,13 @@ module.exports.Component = registerComponent('light', {
         return light;
       }
       case 'area': {
+        var intensitycalc = width + height;
         if (THREE.RectAreaLightUniformsLib === undefined) {
           warn('RectAreaLightUniformsLib.js not found. Please include the file in your project using a script tag (it MUST load after aframe does):\n<script src="https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js"></script>');
           break;
         } else {
           THREE.RectAreaLightUniformsLib.init();
-          return new THREE.RectAreaLight(color, intensity, width, height);
+          return new THREE.RectAreaLight(color, intensity * 8 / intensitycalc, width, height);
         }
       }
       default: {

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -273,7 +273,7 @@ module.exports.Component = registerComponent('light', {
           break;
         } else {
           THREE.RectAreaLightUniformsLib.init();
-          return new THREE.RectAreaLight(color, intensity * 32 / intensitycalc, width, height);
+          return new THREE.RectAreaLight(color, intensity * 16 / intensitycalc, width, height);
         }
       }
       default: {

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -18,13 +18,13 @@ module.exports.Component = registerComponent('light', {
     groundColor: {type: 'color', if: {type: ['hemisphere']}},
     decay: {default: 1, if: {type: ['point', 'spot']}},
     distance: {default: 0.0, min: 0, if: {type: ['point', 'spot']}},
-    intensity: {default: 1.0, min: 0, if: {type: ['ambient', 'directional', 'hemisphere', 'point', 'spot']}},
+    intensity: {default: 1.0, min: 0, if: {type: ['ambient', 'directional', 'hemisphere', 'point', 'spot', 'area']}},
     penumbra: {default: 0, min: 0, max: 1, if: {type: ['spot']}},
-    width: {default: 1, min: 0, if: {type: ['area']}},
-    height: {default: 1, min: 0, if: {type: ['area']}},
+    width: {default: 0.5, min: 0, if: {type: ['area']}},
+    height: {default: 0.5, min: 0, if: {type: ['area']}},
     type: {
       default: 'directional',
-      oneOf: ['ambient', 'directional', 'hemisphere', 'point', 'spot'],
+      oneOf: ['ambient', 'directional', 'hemisphere', 'point', 'spot', 'area'],
       schemaChange: true
     },
     target: {type: 'selector', if: {type: ['spot', 'directional']}},

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -267,12 +267,11 @@ module.exports.Component = registerComponent('light', {
         return light;
       }
       case 'area': {
-        THREE.RectAreaLightUniformsLib.init();
-
         if (THREE.RectAreaLightUniformsLib === undefined) {
-          warn('RectAreaLightUniformsLib.js not found. Please include the file in your project using a script tag (it MUST load after aframe does):\n <script src="https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js"></script>');
+          warn('RectAreaLightUniformsLib.js not found. Please include the file in your project using a script tag (it MUST load after aframe does):\n<script src="https://threejs.org/examples/js/lights/RectAreaLightUniformsLib.js"></script>');
           break;
         } else {
+          THREE.RectAreaLightUniformsLib.init();
           return new THREE.RectAreaLight(color, intensity, width, height);
         }
       }


### PR DESCRIPTION
**Description:**
Area lights as an option. 
The intensity is much darker than other light types, so I multiply the intensity by 32, and also I attenuate the intensity if the area light gets larger.
I can't tell how to do the attenuation math every frame though, so it's just on initial load.