### PR TITLE
Missing colons for width attribute

### DIFF
--- a/docs/guides/building-a-minecraft-demo.md
+++ b/docs/guides/building-a-minecraft-demo.md
@@ -157,7 +157,7 @@ like decomposed to its fundamental components. `<a-box>` wraps the components:
 
 ```html
 <!-- <a-box color="red" depth="0.5" height="0.5" shader="flat" width="0.5"></a-box> -->
-<a-entity geometry="primitive: box; depth: 0.5; height: 0.5; width 0.5"
+<a-entity geometry="primitive: box; depth: 0.5; height: 0.5; width: 0.5"
           material="color: red; shader: standard"></a-entity>
 ```
 
@@ -246,7 +246,7 @@ and include it before the scene:
   </a-assets>
 
   <!-- Box with random color. -->
-  <a-entity geometry="primitive: box; depth: 0.5; height: 0.5; width 0.5"
+  <a-entity geometry="primitive: box; depth: 0.5; height: 0.5; width: 0.5"
             material="shader: standard"
             position="0 0.5 -2"
             random-color></a-entity>


### PR DESCRIPTION
**Description:**
Missing colons on the width attribute.  The a-entity rendered ok on codepen without it but when I used glitch.com the colon was required.