### PR TITLE
Use global polyfillconfig if available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ if (!window.hasNativeWebXRImplementation && !window.hasNativeWebVRImplementation
   // Only for iOS on versions older than 10.
   var bufferScale = isIOSOlderThan10(window.navigator.userAgent) ? 1 / window.devicePixelRatio : 1;
   var WebVRPolyfill = require('webvr-polyfill');
-  var polyfillConfig = {
+  var polyfillConfig = window.polyfillConfig || {
     BUFFER_SCALE: bufferScale,
     CARDBOARD_UI_DISABLED: true,
     ROTATE_INSTRUCTIONS_DISABLED: true


### PR DESCRIPTION
**Description:**

This introduces a capability to allow users to specify a custom polyfillconfig.

My use case is I want to set `DPDB_URL: null` so cardboard doesn't try to fetch an updated dpdb. When embedding aframe in a Cordova app, it is undesirable to perform external HTTP fetches because the app may not be in a connected state. While not strictly necessary, this avoids an extra console warning and network connection failure message.

My script looks something like this:

```
    <script>
      window.polyfillconfig = {
        BUFFER_SCALE: bufferScale,
        CARDBOARD_UI_DISABLED: true,
        ROTATE_INSTRUCTIONS_DISABLED: true
        DPDB_URL: null
      };
    </script>
    <script src="./js/aframe-master.js"></script>
```

**Changes proposed:**
- Use `window.polyfillConfig` if available
