### PR TITLE
Doc, Fix example for 'Reading World Position or Rotation of the Camera'

### DIFF
--- a/docs/components/camera.md
+++ b/docs/components/camera.md
@@ -134,6 +134,6 @@ AFRAME.registerComponent('rotation-reader', {
       this.el.object3D.getWorldQuaternion(quaternion);
       // position and rotation now contain vector and quaternion in world space.
     };
-  })
+  })()
 });
 ```


### PR DESCRIPTION
In `docs/components/camera.md`, the defined function was not immediately invoked.

**Changes proposed:**
- add `()` to invoke the function
