### PR TITLE
Gracefully handle lack of profiles from Controller (old definition in…

### DIFF
--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -162,7 +162,7 @@ function findMatchingControllerWebXR (controllers, idPrefix, handedness, index, 
   for (i = 0; i < controllers.length; i++) {
     controller = controllers[i];
     profiles = controller.profiles;
-    if (profiles.length === 0) { return; }
+    if (!profiles || profiles.length === 0) { continue; }
     if (iterateProfiles) {
       for (j = 0; j < profiles.length; j++) {
         controllerMatch = profiles[j].startsWith(idPrefix);


### PR DESCRIPTION
… Mojom)

Magic Leap version 0.98 is still using an older version of WebXR that does not support the profiles field on its input sources.

This change allows it to gracefully continue on despite not having this field.

(Also, since this is an array, I think it can continue looking for a proper controller rather than returning.)