### PR TITLE
axismove event: axis and changed values fixed for Oculus Quest (fixes #4472)

### DIFF
--- a/src/components/tracked-controls-webvr.js
+++ b/src/components/tracked-controls-webvr.js
@@ -261,14 +261,14 @@ module.exports.Component = registerComponent('tracked-controls-webvr', {
     var changedAxes = this.changedAxes;
 
     // Check if axis changed.
-    this.changedAxes.length = 0;
+    this.changedAxes.splice(0, this.changedAxes.length);
     for (i = 0; i < controllerAxes.length; ++i) {
       changedAxes.push(previousAxis[i] !== controllerAxes[i]);
       if (changedAxes[i]) { changed = true; }
     }
     if (!changed) { return false; }
 
-    this.axis.length = 0;
+    this.axis.splice(0, this.axis.length);
     for (i = 0; i < controllerAxes.length; i++) {
       this.axis.push(controllerAxes[i]);
     }

--- a/src/components/tracked-controls-webxr.js
+++ b/src/components/tracked-controls-webxr.js
@@ -180,14 +180,14 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
     var changedAxes = this.changedAxes;
 
     // Check if axis changed.
-    this.changedAxes.length = 0;
+    this.changedAxes.splice(0, this.changedAxes.length);
     for (i = 0; i < controllerAxes.length; ++i) {
       changedAxes.push(previousAxis[i] !== controllerAxes[i]);
       if (changedAxes[i]) { changed = true; }
     }
     if (!changed) { return false; }
 
-    this.axis.length = 0;
+    this.axis.splice(0, this.axis.length);
     for (i = 0; i < controllerAxes.length; i++) {
       this.axis.push(controllerAxes[i]);
     }


### PR DESCRIPTION
**Description:**
To empty an array using `array.length = 0` maybe not supported by all the browsers. 
It has been replaced by `array.splice(0, array.length)`.
Reference: https://stackoverflow.com/questions/1232040/how-do-i-empty-an-array-in-javascript

