### PR TITLE
fix exponential deceleration in wasd-controls (fixes #4241)

### DIFF
--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -101,10 +101,10 @@ module.exports.Component = registerComponent('wasd-controls', {
     var scaledEasing = Math.pow(1 / this.easing, delta * 60);
     // Velocity Easing.
     if (velocity[adAxis] !== 0) {
-      velocity[adAxis] -= velocity[adAxis] * scaledEasing;
+      velocity[adAxis] = velocity[adAxis] * scaledEasing;
     }
     if (velocity[wsAxis] !== 0) {
-      velocity[wsAxis] -= velocity[wsAxis] * scaledEasing;
+      velocity[wsAxis] = velocity[wsAxis] * scaledEasing;
     }
 
     // Clamp velocity easing.


### PR DESCRIPTION
**Description:**

This PR fixes a problem with the implementation. of exponential deceleration in `wasd-controls`. The current implementation yields sudden stops when two frames are rendered in quick succession (significantly faster than the expected frame rate) and sudden jumps (in the order of several meters) in case of significant frame drops.

**Changes proposed:**

The velocity update has been fixed according to the Stack Overflow question originally linked in the source code.

See also the discussion in #4241.
