### PR TITLE
Fix inspector toggle on US international keyboards

### DIFF
--- a/src/components/scene/inspector.js
+++ b/src/components/scene/inspector.js
@@ -59,7 +59,7 @@ module.exports.Component = registerComponent('inspector', {
    * <ctrl> + <alt> + i keyboard shortcut.
    */
   onKeydown: function (evt) {
-    var shortcutPressed = evt.keyCode === 73 && evt.ctrlKey && evt.altKey;
+    var shortcutPressed = evt.keyCode === 73 && (evt.ctrlKey && evt.altKey || evt.getModifierState('AltGraph'));
     if (!shortcutPressed) { return; }
     this.openInspector();
   },


### PR DESCRIPTION
Fixes issue #4089 
Related to aframevr/aframe-inspector#598

On US international keyboards Ctrl + Alt are combined into AltGraph. When this happens Ctrl and Alt are registered as unpressed, breaking the toggle expression.

This is fixed by adding an additional clause for the AltGraph combination.

Currently it only works once because a version of aframe-inspector without the fix is loaded. Combined with aframevr/aframe-inspector#598 everything works as expected.