### PR TITLE
Fix for missing controllers in Moon Rider

### DIFF
--- a/src/components/tracked-controls-webxr.js
+++ b/src/components/tracked-controls-webxr.js
@@ -32,6 +32,10 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
     this.axisMoveEventDetail = {axis: this.axis, changed: this.changedAxes};
   },
 
+  update: function () {
+    this.updateController();
+  },
+
   play: function () {
     var sceneEl = this.el.sceneEl;
     this.updateController();

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -34,6 +34,7 @@ module.exports.Component = registerComponent('tracked-controls', {
         index: data.controller,
         iterateControllerProfiles: data.iterateControllerProfiles
       });
+      el.components["tracked-controls-webxr"].updateController();
     } else {
       el.setAttribute('tracked-controls-webvr', data);
     }

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -34,7 +34,6 @@ module.exports.Component = registerComponent('tracked-controls', {
         index: data.controller,
         iterateControllerProfiles: data.iterateControllerProfiles
       });
-      el.components['tracked-controls-webxr'].updateController();
     } else {
       el.setAttribute('tracked-controls-webvr', data);
     }

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -34,7 +34,7 @@ module.exports.Component = registerComponent('tracked-controls', {
         index: data.controller,
         iterateControllerProfiles: data.iterateControllerProfiles
       });
-      el.components["tracked-controls-webxr"].updateController();
+      el.components['tracked-controls-webxr'].updateController();
     } else {
       el.setAttribute('tracked-controls-webvr', data);
     }


### PR DESCRIPTION
This issue was discovered in Moon Rider after moving to WebXR. See https://github.com/supermedium/moonrider/issues/98

Because of a timing issue, when `updateController` is called by the event, the `update` in this function didn't execute yet so no controllers were visible the first time you entered an immersive session.

**Description:**

**Changes proposed:**
-
-
-
