### PR TITLE
Fix typo in webxr system for feature warning

### DIFF
--- a/src/systems/webxr.js
+++ b/src/systems/webxr.js
@@ -29,7 +29,7 @@ module.exports.System = registerSystem('webxr', {
     if (feature === 'viewer' || feature === 'local') return true;
 
     if (this.sessionConfiguration.requiredFeatures.includes(feature) ||
-        this.sessionConfiguration.requiredFeatures.includes(feature)) {
+        this.sessionConfiguration.optionalFeatures.includes(feature)) {
       return true;
     }
 


### PR DESCRIPTION
**Description:**

It's supposed to check both optional and required features, but accidentally checked requiredFeatures twice due to a cut&paste error, leading to spurious warnings.