### PR TITLE
Add webxr referenceSpaceType schema entry and documentation

### DIFF
--- a/docs/components/webxr.md
+++ b/docs/components/webxr.md
@@ -26,11 +26,41 @@ them.
 
 | Property                | Description                                                    | Default Value |
 |-------------------------|----------------------------------------------------------------|---------------|
+| referenceSpaceType      | The scene's reference space type for camera and controllers.   | local-floor   |
 | requiredFeatures        | Required WebXR session features.                               | local-floor   |
 | optionalFeatures        | Optional WebXR session features.                               | bounded-floor |
 | overlayElement          | Element selector for use as a WebXR DOM Overlay in AR mode.    | null          |
 
 > **NOTE:** Once the scene is initialized, these properties may no longer be changed.
+
+### referenceSpaceType
+
+Name of the reference space used by default for the scene, must be one of the
+entries in [reference space names](https://immersive-web.github.io/webxr/#xrreferencespace).
+
+| Name | Description |
+|------|-------------|
+| viewer | Rigidly attached to the camera and moves/rotates with it |
+| local | Origin is an arbitrary point close to the user's head location at session start. |
+| local-floor | Origin is an arbitrary point close to the user's feet at session start. |
+| bounded-floor | Same as local-floor, but supports room-scale tracking with safety bounds. |
+| unbounded | Same as local, but supports large-scale movement beyond ~5 meters / 15 feet. |
+
+The default 'local-floor' should work reasonably well on all systems, but please
+be aware that the floor position may be a rough estimate for 3DoF VR systems, or
+for handheld AR. For AR applications that need accurate floor location, it's
+recommended to use type 'local' along with world hit testing or plane detection.
+
+Make sure the reference space name is included in `requiredFeatures`. ('viewer' and
+'local' are automatically available, all others must be requested as features.)
+
+Applications are free to use additional reference spaces internally, but it's
+important that the viewer (camera) and controllers are consistent.
+
+For consistency when used in components, this name is available as
+`sceneEl.systems.webxr.sessionReferenceSpaceType`, and the corresponding
+reference space object is available during the XR session as
+`sceneEl.systems['tracked-controls-webxr'].referenceSpace`.
 
 ### requiredFeatures
 

--- a/examples/test/laser-controls/index.html
+++ b/examples/test/laser-controls/index.html
@@ -47,14 +47,15 @@
         }
       });
     </script>
-    <a-scene background="color: #212" antialias="true">
-      <a-entity position="0 3.2 0" camera look-controls wasd-controls></a-entity>
+    <a-scene background="color: #212" antialias="true"
+             webxr="referenceSpaceType: local">
+      <a-entity position="0 1.6 0" camera look-controls wasd-controls></a-entity>
       <a-entity id="leftHand" laser-controls="hand: left" raycaster="objects: [mixin='box']"></a-entity>
       <a-entity id="rightHand" laser-controls="hand: right" raycaster="objects: [mixin='box']" line="color: #118A7E"></a-entity>
 
       <a-light position="0 0.5 1" intensity="0.75"></a-light>
 
-      <a-entity position="0 0 -10">
+      <a-entity position="0 -1.6 -10">
         <a-mixin id="box" geometry="primitive: box" material="color: #FAFAFA" rotation="0 0 -35" scale="0.5 0.5 0.5" intersect-color-change shadow="cast: true; receive: false"></a-mixin>
         <a-entity boxes></a-entity>
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -284,6 +284,8 @@ module.exports.AScene = registerElement('a-scene', {
             if (this.xrSession) {
               this.xrSession.removeEventListener('end', this.exitVRBound);
             }
+            var refspace = this.sceneEl.systems.webxr.sessionReferenceSpaceType;
+            vrManager.setReferenceSpaceType(refspace);
             var xrMode = useAR ? 'immersive-ar' : 'immersive-vr';
             var xrInit = this.sceneEl.systems.webxr.sessionConfiguration;
             navigator.xr.requestSession(xrMode, xrInit).then(

--- a/src/systems/tracked-controls-webxr.js
+++ b/src/systems/tracked-controls-webxr.js
@@ -35,10 +35,10 @@ module.exports.System = registerSystem('tracked-controls-webxr', {
     xrSession.requestReferenceSpace(refspace).then(function (referenceSpace) {
       self.referenceSpace = referenceSpace;
     }).catch(function (err) {
-      console.warn('Failed to get reference space "' + refspace + '": ' + err);
       self.el.sceneEl.systems.webxr.warnIfFeatureNotRequested(
           refspace,
           'tracked-controls-webxr uses reference space "' + refspace + '".');
+      throw err;
     });
   },
 

--- a/src/systems/tracked-controls-webxr.js
+++ b/src/systems/tracked-controls-webxr.js
@@ -31,7 +31,7 @@ module.exports.System = registerSystem('tracked-controls-webxr', {
       }
       return;
     }
-    var refspace = 'local-floor';
+    var refspace = self.el.sceneEl.systems.webxr.sessionReferenceSpaceType;
     xrSession.requestReferenceSpace(refspace).then(function (referenceSpace) {
       self.referenceSpace = referenceSpace;
     }).catch(function (err) {

--- a/src/systems/webxr.js
+++ b/src/systems/webxr.js
@@ -5,7 +5,7 @@ var registerSystem = require('../core/system').registerSystem;
  */
 module.exports.System = registerSystem('webxr', {
   schema: {
-    referenceSpaceType: {type: 'string', default: ['local-floor']},
+    referenceSpaceType: {type: 'string', default: 'local-floor'},
     requiredFeatures: {type: 'array', default: ['local-floor']},
     optionalFeatures: {type: 'array', default: ['bounded-floor']},
     overlayElement: {type: 'selector'}

--- a/src/systems/webxr.js
+++ b/src/systems/webxr.js
@@ -5,6 +5,7 @@ var registerSystem = require('../core/system').registerSystem;
  */
 module.exports.System = registerSystem('webxr', {
   schema: {
+    referenceSpaceType: {type: 'string', default: ['local-floor']},
     requiredFeatures: {type: 'array', default: ['local-floor']},
     optionalFeatures: {type: 'array', default: ['bounded-floor']},
     overlayElement: {type: 'selector'}
@@ -16,6 +17,7 @@ module.exports.System = registerSystem('webxr', {
       requiredFeatures: data.requiredFeatures,
       optionalFeatures: data.optionalFeatures
     };
+    this.sessionReferenceSpaceType = data.referenceSpaceType;
 
     if (data.overlayElement) {
       this.warnIfFeatureNotRequested('dom-overlay');

--- a/src/systems/webxr.js
+++ b/src/systems/webxr.js
@@ -1,5 +1,8 @@
 var registerSystem = require('../core/system').registerSystem;
 
+var utils = require('../utils/');
+var warn = utils.debug('systems:webxr:warn');
+
 /**
  * WebXR session initialization and XR module support.
  */
@@ -42,7 +45,7 @@ module.exports.System = registerSystem('webxr', {
     if (!this.wasFeatureRequested(feature)) {
       var msg = 'Please add the feature "' + feature + '" to a-scene\'s ' +
           'webxr system options in requiredFeatures/optionalFeatures.';
-      console.warn((optIntro ? optIntro + ' ' : '') + msg);
+      warn((optIntro ? optIntro + ' ' : '') + msg);
     }
   }
 });


### PR DESCRIPTION
**Description:**
Support changing the scene reference space to something other than 'local-floor'

**Changes proposed:**
- add schema entry
- use the name in webxr-tracked-controller and in three.js (for the viewer pose)
- update documentation
