### PR TITLE
Implement and rename hmdEnabled to magicWindowTrackingEnabled

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -15,7 +15,7 @@ module.exports.Component = registerComponent('look-controls', {
 
   schema: {
     enabled: {default: true},
-    hmdEnabled: {default: true},
+    magicWindowTrackingEnabled: {default: true},
     pointerLockEnabled: {default: false},
     reverseMouseDrag: {default: false},
     reverseTouchDrag: {default: false},
@@ -51,6 +51,7 @@ module.exports.Component = registerComponent('look-controls', {
 
   setupMagicWindowControls: function () {
     var magicWindowControls;
+    var data = this.data;
 
     // Only on mobile devices and only enabled if DeviceOrientation permission has been granted.
     if (utils.device.isMobile()) {
@@ -58,10 +59,10 @@ module.exports.Component = registerComponent('look-controls', {
       if (typeof DeviceOrientationEvent !== 'undefined' && DeviceOrientationEvent.requestPermission) {
         magicWindowControls.enabled = false;
         if (this.el.sceneEl.components['device-orientation-permission-ui'].permissionGranted) {
-          magicWindowControls.enabled = true;
+          magicWindowControls.enabled = data.magicWindowTrackingEnabled;
         } else {
           this.el.sceneEl.addEventListener('deviceorientationpermissiongranted', function () {
-            magicWindowControls.enabled = true;
+            magicWindowControls.enabled = data.magicWindowTrackingEnabled;
           });
         }
       }
@@ -76,10 +77,15 @@ module.exports.Component = registerComponent('look-controls', {
       this.updateGrabCursor(data.enabled);
     }
 
-    // Reset pitch and yaw if disabling HMD.
-    if (oldData && !data.hmdEnabled && !oldData.hmdEnabled) {
-      this.pitchObject.rotation.set(0, 0, 0);
-      this.yawObject.rotation.set(0, 0, 0);
+    // Reset magic window eulers if tracking is disabled.
+    if (oldData && !data.magicWindowTrackingEnabled && oldData.magicWindowTrackingEnabled) {
+      this.magicWindowAbsoluteEuler.set(0, 0, 0);
+      this.magicWindowDeltaEuler.set(0, 0, 0);
+    }
+
+    // Pass on magic window tracking setting to magicWindowControls.
+    if (this.magicWindowControls) {
+      this.magicWindowControls.enabled = data.magicWindowTrackingEnabled;
     }
 
     if (oldData && !data.pointerLockEnabled !== oldData.pointerLockEnabled) {


### PR DESCRIPTION
**Description:**
This is an implementation of the fix for #4520  

**Changes proposed:**
- Rename `hmdEnabled` to `magicWindowTrackingEnabled`
- Pass through `magicWindowTrackingEnabled` setting to `magicWindowControls.enabled`
- Reset magic window eulers when tracking is disabled. Otherwise you can get stuck looking at the ground. This was also what the original code was aiming to do, since previous versions used `pitchObject` and `yawObject` for gyroscope tracking. But the previous check `oldData && !data.hmdEnabled && !oldData.hmdEnabled` should actually have been more like `oldData && !data.hmdEnabled && oldData.hmdEnabled` in order to catch the transition from enabled to disabled.
