### PR TITLE
Fix GearVR controller detection with WebXR

### DIFF
--- a/src/components/daydream-controls.js
+++ b/src/components/daydream-controls.js
@@ -18,6 +18,39 @@ var GAMEPAD_ID_WEBVR = 'Daydream Controller';
 var GAMEPAD_ID_PREFIX = isWebXRAvailable ? GAMEPAD_ID_WEBXR : GAMEPAD_ID_WEBVR;
 
 /**
+ * Button indices:
+ * 0 - trackpad
+ * 1 - menu (never dispatched on this layer)
+ * 2 - system (never dispatched on this layer)
+ *
+ * Axis:
+ * 0 - trackpad x
+ * 1 - trackpad y
+ */
+var INPUT_MAPPING_WEBVR = {
+  axes: {trackpad: [0, 1]},
+  buttons: ['trackpad', 'menu', 'system']
+};
+
+/**
+ * Button indices:
+ * 0 - none
+ * 1 - none
+ * 2 - touchpad
+ *
+ * Axis:
+ * 0 - touchpad x
+ * 1 - touchpad y
+ * Reference: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/google/google-daydream.json
+ */
+var INPUT_MAPPING_WEBXR = {
+  axes: {touchpad: [0, 1]},
+  buttons: ['none', 'none', 'touchpad', 'menu', 'system']
+};
+
+var INPUT_MAPPING = isWebXRAvailable ? INPUT_MAPPING_WEBXR : INPUT_MAPPING_WEBVR;
+
+/**
  * Daydream controls.
  * Interface with Daydream controller and map Gamepad events to
  * controller buttons: trackpad, menu, system
@@ -34,16 +67,7 @@ module.exports.Component = registerComponent('daydream-controls', {
     armModel: {default: true}
   },
 
-  /**
-   * Button IDs:
-   * 0 - trackpad
-   * 1 - menu (never dispatched on this layer)
-   * 2 - system (never dispatched on this layer)
-   */
-  mapping: {
-    axes: {trackpad: [0, 1]},
-    buttons: ['trackpad', 'menu', 'system']
-  },
+  mapping: INPUT_MAPPING,
 
   bindMethods: function () {
     this.onModelLoaded = bind(this.onModelLoaded, this);
@@ -90,7 +114,8 @@ module.exports.Component = registerComponent('daydream-controls', {
   },
 
   checkIfControllerPresent: function () {
-    checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX, {hand: this.data.hand});
+    checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX,
+      this.data.hand ? {hand: this.data.hand} : {});
   },
 
   play: function () {
@@ -110,6 +135,7 @@ module.exports.Component = registerComponent('daydream-controls', {
       armModel: data.armModel,
       hand: data.hand,
       idPrefix: GAMEPAD_ID_PREFIX,
+      id: GAMEPAD_ID_PREFIX,
       orientationOffset: data.orientationOffset
     });
     if (!this.data.model) { return; }
@@ -139,6 +165,7 @@ module.exports.Component = registerComponent('daydream-controls', {
     buttonMeshes.menu = controllerObject3D.getObjectByName('AppButton_AppButton_Cylinder.004');
     buttonMeshes.system = controllerObject3D.getObjectByName('HomeButton_HomeButton_Cylinder.005');
     buttonMeshes.trackpad = controllerObject3D.getObjectByName('TouchPad_TouchPad_Cylinder.003');
+    buttonMeshes.touchpad = controllerObject3D.getObjectByName('TouchPad_TouchPad_Cylinder.003');
     // Offset pivot point.
     controllerObject3D.position.set(0, 0, -0.04);
   },

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -67,11 +67,6 @@ module.exports.Component = registerComponent('gearvr-controls', {
     armModel: {default: true}
   },
 
-  /**
-   * Button IDs:
-   * 0 - trackpad
-   * 1 - trigger
-   */
   mapping: INPUT_MAPPING,
 
   bindMethods: function () {

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -171,6 +171,7 @@ module.exports.Component = registerComponent('gearvr-controls', {
     buttonMeshes = this.buttonMeshes = {};
     buttonMeshes.trigger = controllerObject3D.children[2];
     buttonMeshes.trackpad = controllerObject3D.children[1];
+    buttonMeshes.touchpad = controllerObject3D.children[1];
   },
 
   onButtonChanged: function (evt) {

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -44,14 +44,8 @@ var INPUT_MAPPING_WEBVR = {
  * Reference: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/oculus/oculus-go.json
  */
 var INPUT_MAPPING_WEBXR = {
-  left: {
-    axes: {touchpad: [0, 1]},
-    buttons: ['trigger', 'none', 'touchpad', 'menu']
-  },
-  right: {
-    axes: {touchpad: [0, 1]},
-    buttons: ['trigger', 'none', 'touchpad', 'menu']
-  }
+  axes: {touchpad: [0, 1]},
+  buttons: ['trigger', 'none', 'touchpad', 'menu']
 };
 
 var INPUT_MAPPING = isWebXRAvailable ? INPUT_MAPPING_WEBXR : INPUT_MAPPING_WEBVR;

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -41,11 +41,11 @@ var INPUT_MAPPING_WEBVR = {
  * Axis:
  * 0 - touchpad x
  * 1 - touchpad y
- * Reference: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/oculus/oculus-go.json
+ * Reference: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/samsung/samsung-gearvr.json
  */
 var INPUT_MAPPING_WEBXR = {
   axes: {touchpad: [0, 1]},
-  buttons: ['trigger', 'none', 'touchpad', 'menu']
+  buttons: ['trigger', 'none', 'touchpad', 'none', 'menu']
 };
 
 var INPUT_MAPPING = isWebXRAvailable ? INPUT_MAPPING_WEBXR : INPUT_MAPPING_WEBVR;

--- a/src/components/oculus-go-controls.js
+++ b/src/components/oculus-go-controls.js
@@ -166,6 +166,7 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     buttonMeshes = this.buttonMeshes = {};
     buttonMeshes.trigger = controllerObject3D.getObjectByName('oculus_go_button_trigger');
     buttonMeshes.trackpad = controllerObject3D.getObjectByName('oculus_go_touchpad');
+    buttonMeshes.touchpad = controllerObject3D.getObjectByName('oculus_go_touchpad');
   },
 
   onButtonChanged: function (evt) {

--- a/src/components/oculus-go-controls.js
+++ b/src/components/oculus-go-controls.js
@@ -64,11 +64,6 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     armModel: {default: true}
   },
 
-  /**
-   * Button IDs:
-   * 0 - trackpad
-   * 1 - trigger
-   */
   mapping: INPUT_MAPPING,
 
   bindMethods: function () {

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -162,7 +162,7 @@ function findMatchingControllerWebXR (controllers, idPrefix, handedness, index, 
   for (i = 0; i < controllers.length; i++) {
     controller = controllers[i];
     profiles = controller.profiles;
-    if (profiles.length === 0) { return; }
+    if (profiles.length === 0) { continue; }
     if (iterateProfiles) {
       for (j = 0; j < profiles.length; j++) {
         controllerMatch = profiles[j].startsWith(idPrefix);

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -162,14 +162,13 @@ function findMatchingControllerWebXR (controllers, idPrefix, handedness, index, 
   for (i = 0; i < controllers.length; i++) {
     controller = controllers[i];
     profiles = controller.profiles;
-    if (profiles.length === 0) { continue; }
     if (iterateProfiles) {
       for (j = 0; j < profiles.length; j++) {
         controllerMatch = profiles[j].startsWith(idPrefix);
         if (controllerMatch) { break; }
       }
     } else {
-      controllerMatch = profiles[0].startsWith(idPrefix);
+      controllerMatch = profiles.length > 0 && profiles[0].startsWith(idPrefix);
     }
     if (!controllerMatch) { continue; }
     // Vive controllers are assigned handedness at runtime and it might not be always available.


### PR DESCRIPTION
**Description:**

GearVR controller is not detected with WebXR on Oculus Browser 8.1.5.203450095 based on Chromium 79.0.3945.126

**Changes proposed:**
![Capture d’écran de 2020-04-07 14-40-22](https://user-images.githubusercontent.com/112249/78674089-5d830b80-78e3-11ea-8a05-6ce5b4bb3b34.png)

The issue is in src/utils/tracked-controls.js findMatchingControllerWebXR.
We need to continue iterating over controllers instead of returning if the first controller didn't match. 
