### PR TITLE
Fix selectstart/selectend listeners never registered

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -319,7 +319,7 @@ module.exports.Component = registerComponent('cursor', {
   },
 
   onEnterVR: function () {
-    var xrSession = this.el.xrSession;
+    var xrSession = this.el.sceneEl.xrSession;
     var self = this;
     if (!xrSession) { return; }
     WEBXR_EVENTS.DOWN.forEach(function (downEvent) {


### PR DESCRIPTION
I just tested it in Chrome canary in AR mode. The listeners are never registered because xrSession is undefined. In my case `this.el` is some `<a-entity cursor="fuse:false" raycaster="objects: .clickable">` as a child of `<a-camera>`, not the scene. Did you mean to write ` var xrSession = this.el.sceneEl.xrSession;` @dmarcos in #4407 ? With this change the listeners are registered and the raycaster/cursor works in AR mode.