### PR TITLE
Added a template repo for gTLF in React.js apps

### DIFF
--- a/docs/components/gltf-model.md
+++ b/docs/components/gltf-model.md
@@ -168,6 +168,7 @@ various exporters and converters converters are available:
 - [FBX &rarr; glTF][fbx-converter]
 - [COLLADA &rarr; glTF][collada-converter]
 - [glTF Workflow for A Saturday Night](https://blog.mozvr.com/a-saturday-night-gltf-workflow/)
+- [gTLF in React; Based on Google POLY API](https://github.com/rand0mC0d3r/poly-a-frame-viewer)
 
 [spec]: https://github.com/KhronosGroup/glTF
 


### PR DESCRIPTION
**Description:**
Added a link to a sample React.JS project that shows how to load correctly a gTLF file from the Google Poly API. The project is simple and self explanatory and can be plugged with any other API or locally loaded resource

**Changes proposed:**
- Adding a link to a template like project for React developers to load simply a gTLF file along with it's assets
- Reffered project is self explanatory and is modern and simple for newbies coming from a WebDevelopment towards a 3d/xr world

**Why Google Poly**
- Because loading assets from a server is a default business scenario path and handling render cycles in a declarative A-Frame is currently not covered in a simple reproducible way.
