### PR TITLE
Added an example and clarified color format

### DIFF
--- a/docs/components/background.md
+++ b/docs/components/background.md
@@ -4,7 +4,9 @@ type: components
 layout: docs
 parent_section: components
 source_code: src/components/background.js
-examples: []
+examples: 
+ - title: Setting up a scene 
+   src: https://glitch.com/~a-frame-background-scene
 ---
 
 The background component sets a basic color background of a scene that is more
@@ -12,6 +14,9 @@ performant than `a-sky` since geometry is not created. There are no undesired
 frustum culling issues when `a-sky` is further than the far plane of the
 camera. There are no unexpected occlusions either with far objects that might
 be behind of the sphere geometry of `a-sky`.
+
+Background supports the HTML color codes format, as well as the rgb(r,g,b), 
+hsl(h,s%,l%) and regular #hex notation. 
 
 ## Example
 


### PR DESCRIPTION
Added a bit context about the format of the color supported. Also wired a simple example self-explanatory for tests

**Description:**
Added clarity over the range of formats supported for the colors

**Changes proposed:**
- Explain clearly what formats are supported for colors for the background of the scene tag
- Added a simple example running the code for self-explanatory purposes
-
