### PR TITLE
Update to stats docs: fixed link to source

### DIFF
--- a/docs/components/stats.md
+++ b/docs/components/stats.md
@@ -3,7 +3,7 @@ title: stats
 type: components
 layout: docs
 parent_section: components
-source_code: src/components/stats.js
+source_code: src/components/scene/stats.js
 ---
 
 [scene]: ../core/scene.md


### PR DESCRIPTION
The stats file has been moved from src/components/stats.js to src/components/scene/stats.js

The documentation hasnt been updated to reflect this change, and clicking the view source button 404's at the moment.

**Description:**

**Changes proposed:**
-
-
-
