### PR TITLE
Fix an issue that click event fired twice in WebXR session (#4494)

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -319,6 +319,7 @@ module.exports.Component = registerComponent('cursor', {
   },
 
   onEnterVR: function () {
+    if (this.data.rayOrigin === 'mouse') { this.clearCurrentIntersection(true); }
     var xrSession = this.el.sceneEl.xrSession;
     var self = this;
     if (!xrSession) { return; }

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -319,7 +319,7 @@ module.exports.Component = registerComponent('cursor', {
   },
 
   onEnterVR: function () {
-    if (this.data.rayOrigin === 'mouse') { this.clearCurrentIntersection(true); }
+    this.clearCurrentIntersection(true);
     var xrSession = this.el.sceneEl.xrSession;
     var self = this;
     if (!xrSession) { return; }


### PR DESCRIPTION
**Description:**
When entering VR , clear intersection of cursor component for mouse to prevent unintended click events in WebXR. Because the raycaster will never be updated in VR.

**Changes proposed:**
- Fix issue https://github.com/aframevr/aframe/issues/4494
