### PR TITLE
Update controller property for Oculus Quest

### DIFF
--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -59,14 +59,14 @@ var CONTROLLER_PROPERTIES = {
   'oculus-touch-v2': {
     left: {
       modelUrl: TOUCH_GEN2_CONTROLLER_MODEL_BASE_URL + 'gen2-left.gltf',
-      rayOrigin: {origin: {x: -0.01, y: 0, z: -0.02}, direction: {x: 0, y: -0.5, z: -1}},
-      modelPivotOffset: new THREE.Vector3(0, 0, 0),
+      rayOrigin: {origin: {x: 0, y: 0, z: 0}, direction: {x: 0, y: 0, z: -1}},
+      modelPivotOffset: new THREE.Vector3(0.01, 0.005, 0.03),
       modelPivotRotation: new THREE.Euler(0, 0, 0)
     },
     right: {
       modelUrl: TOUCH_GEN2_CONTROLLER_MODEL_BASE_URL + 'gen2-right.gltf',
-      rayOrigin: {origin: {x: 0.01, y: 0, z: -0.02}, direction: {x: 0, y: -0.5, z: -1}},
-      modelPivotOffset: new THREE.Vector3(0, 0, 0),
+      rayOrigin: {origin: {x: 0, y: 0, z: 0}, direction: {x: 0, y: 0, z: -1}},
+      modelPivotOffset: new THREE.Vector3(-0.01, 0.005, 0.03),
       modelPivotRotation: new THREE.Euler(0, 0, 0)
     }
   }


### PR DESCRIPTION
**Description:**

The ray direction of oculus quest controller in the WebXR session is wrong. So adjusted direction and position.
The direction within WebVR API may will be broken, but the latest Oculus Browser no longer supports the WebVR.

**Changes proposed:**
-
-
-
