### PR TITLE
Map touchpad events to trackpad events on Oculus Go

### DIFF
--- a/docs/components/oculus-go-controls.md
+++ b/docs/components/oculus-go-controls.md
@@ -42,15 +42,26 @@ and/or pressed buttons (trackpad, trigger).
 
 | Event Name         | Description           |
 | ----------         | -----------           |
-| trackpadchanged    | Trackpad changed.     |
-| trackpaddown       | Trackpad pressed.     |
-| trackpadup         | Trackpad released.    |
-| trackpadtouchstart | Trackpad touched.     |
-| trackpadtouchend   | Trackpad not touched. |
-| trackpadmoved      | Trackpad moved.       |
+| touchpadchanged    | Touchpad changed.     |
+| touchpaddown       | Touchpad pressed.     |
+| touchpadup         | Touchpad released.    |
+| touchpadtouchstart | Touchpad touched.     |
+| touchpadtouchend   | Touchpad not touched. |
+| touchpadmoved      | Touchpad moved.       |
 | triggerchanged     | Trigger changed.      |
 | triggerdown        | Trigger pressed.      |
 | triggerup          | Trigger released.     |
+
+### Legacy WebVR Browsers
+
+Legacy (WebVR-based) Oculus Go browsers use the older 'trackpadXXXX' event names, rather than the
+[WebXR nomenclature](https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/assets/profiles)
+'touchpadXXXX'. If you want to support both event types, then you can listen for both flavors of event names.
+
+```.js
+el.addEventListener('touchpadchanged', yourHandler);
+el.addEventListener('trackpadchanged', yourHandler);
+```
 
 ## Assets
 

--- a/src/components/oculus-go-controls.js
+++ b/src/components/oculus-go-controls.js
@@ -39,6 +39,8 @@ var INPUT_MAPPING_WEBVR = {
  * 0 - touchpad x
  * 1 - touchpad y
  * Reference: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/oculus/oculus-go.json
+ *
+ * We map touchpad* events to trackpad*, for backwards compatibility.
  */
 var INPUT_MAPPING_WEBXR = {
   axes: {touchpad: [0, 1]},
@@ -77,6 +79,9 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     this.checkIfControllerPresent = bind(this.checkIfControllerPresent, this);
     this.removeControllersUpdateListener = bind(this.removeControllersUpdateListener, this);
     this.onAxisMoved = bind(this.onAxisMoved, this);
+    if (isWebXRAvailable) {
+      this.mapTouchpadToTrackpad = bind(this.mapTouchpadToTrackpad, this);
+    }
   },
 
   init: function () {
@@ -101,6 +106,14 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     el.addEventListener('touchend', this.onButtonTouchEnd);
     el.addEventListener('model-loaded', this.onModelLoaded);
     el.addEventListener('axismove', this.onAxisMoved);
+    if (isWebXRAvailable) {
+      el.addEventListener('touchpadchanged', this.mapTouchpadToTrackpad);
+      el.addEventListener('touchpaddown', this.mapTouchpadToTrackpad);
+      el.addEventListener('touchpadup', this.mapTouchpadToTrackpad);
+      el.addEventListener('touchpadtouchstart', this.mapTouchpadToTrackpad);
+      el.addEventListener('touchpadtouchend', this.mapTouchpadToTrackpad);
+      el.addEventListener('touchpadmoved', this.mapTouchpadToTrackpad);
+    }
     this.controllerEventsActive = true;
   },
 
@@ -113,6 +126,14 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     el.removeEventListener('touchend', this.onButtonTouchEnd);
     el.removeEventListener('model-loaded', this.onModelLoaded);
     el.removeEventListener('axismove', this.onAxisMoved);
+    if (isWebXRAvailable) {
+      el.removeEventListener('touchpadchanged', this.mapTouchpadToTrackpad);
+      el.removeEventListener('touchpaddown', this.mapTouchpadToTrackpad);
+      el.removeEventListener('touchpadup', this.mapTouchpadToTrackpad);
+      el.removeEventListener('touchpadtouchstart', this.mapTouchpadToTrackpad);
+      el.removeEventListener('touchpadtouchend', this.mapTouchpadToTrackpad);
+      el.removeEventListener('touchpadmoved', this.mapTouchpadToTrackpad);
+    }
     this.controllerEventsActive = false;
   },
 
@@ -202,5 +223,9 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     button = buttonMeshes[buttonName];
     button.material.color.set(color);
     this.rendererSystem.applyColorCorrection(button.material.color);
+  },
+  // Backwards compatibility: also issue trackpad events
+  mapTouchpadToTrackpad: function (evt) {
+    this.el.emit(evt.type.replace('touchpad', 'trackpad'), evt.detail);
   }
 });


### PR DESCRIPTION
- I've tested this on Oculus browser and Firefox, which covers both with and without WebXR.

**Description:**
Maps all touchpad events to trackpad events when using WebXR.

