### PR TITLE
Asset property type needs to parse attrValue when updating

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -356,6 +356,11 @@ Component.prototype = {
       if (this.isObjectBased) {
         parseProperty(attrValue, this.schema);
       }
+      // Assets need parsing otherwise #asset-id will not be converted in url for this.data (ex gltf-model)
+      if (this.schema.parse.name === 'assetParse') {
+        this.data = parseProperty(attrValue, this.schema);
+        return;
+      }
       // Single-property (already parsed).
       this.data = attrValue;
       return;


### PR DESCRIPTION
Only in components with single-property schema, asset is not parsed when updating (for example gltf-model)
So #asset-id will not be converted in url necessary for this.data.

Maybe instead of doing this in propertyTypes we should add the possibility to force a parse, like:
`function registerPropertyType (type, defaultValue, parse, stringify, parseRequired)`
so it becomes
`registerPropertyType('model', '', assetParse, undefined, true);`
and then in the code commited above instead of checking the parse function name, we check
`if (this.schema.parseRequired)`

**Description:**

**Changes proposed:**
- add parse of attrValue for singleProperty schema for type: asset when updating component
-
-
