### PR TITLE
Fix confliction of generic-tracked-controller-controls and other tracked-controllers (#4496)

### DIFF
--- a/src/components/generic-tracked-controller-controls.js
+++ b/src/components/generic-tracked-controller-controls.js
@@ -92,6 +92,10 @@ module.exports.Component = registerComponent('generic-tracked-controller-control
   },
 
   checkIfControllerPresent: function () {
+    // Do nothing if tracked-controls already set.
+    // Generic controls have the lowest precedence.
+    var trackedControl = this.el.components['tracked-controls'];
+    if (trackedControl && trackedControl.data.idPrefix !== GAMEPAD_ID_PREFIX) { return; }
     var data = this.data;
     var hand = data.hand ? data.hand : undefined;
     checkControllerPresentAndSetup(
@@ -112,9 +116,6 @@ module.exports.Component = registerComponent('generic-tracked-controller-control
   injectTrackedControls: function () {
     var el = this.el;
     var data = this.data;
-    // Do nothing if tracked-controls already set.
-    // Generic controls have the lowest precedence.
-    if (this.el.components['tracked-controls']) { return; }
     el.setAttribute('tracked-controls', {
       hand: data.hand,
       idPrefix: GAMEPAD_ID_PREFIX,

--- a/src/components/generic-tracked-controller-controls.js
+++ b/src/components/generic-tracked-controller-controls.js
@@ -92,10 +92,10 @@ module.exports.Component = registerComponent('generic-tracked-controller-control
   },
 
   checkIfControllerPresent: function () {
-    // Do nothing if tracked-controls already set.
+    // Do nothing if another tracked-controls already set.
     // Generic controls have the lowest precedence.
-    var trackedControl = this.el.components['tracked-controls'];
-    if (trackedControl && trackedControl.data.idPrefix !== GAMEPAD_ID_PREFIX) { return; }
+    var trackedControls = this.el.getAttribute('tracked-controls');
+    if (trackedControls && trackedControls.idPrefix !== GAMEPAD_ID_PREFIX) { return; }
     var data = this.data;
     var hand = data.hand ? data.hand : undefined;
     checkControllerPresentAndSetup(


### PR DESCRIPTION
**Description:**

The mousedown event fires twice because `generic-tracked-controller-controls` and another tracked controls are enabled at the same time.
Since `component.addEventListeners()` is called in `checkControllerPresentAndSetup()`, check if other `tracked-controls` exists before calling.

**Changes proposed:**
- issue https://github.com/aframevr/aframe/issues/4496
