### PR TITLE
Fix a typo in javascript-events-dom-apis.md

### DIFF
--- a/docs/introduction/javascript-events-dom-apis.md
+++ b/docs/introduction/javascript-events-dom-apis.md
@@ -218,7 +218,7 @@ modify the object directly:
 ```js
 // <a-entity geometry="primitive: sphere; radius: 2"></a-entity>
 el.getAttribute('geometry');
-// >> {"primitive": "sphere", "radius: 2", ...}
+// >> {"primitive": "sphere", "radius": 2, ...}
 ```
 
 ### Retrieving `position` and `scale`


### PR DESCRIPTION
**Description:**

Fix a typo `"radius: 2"` to `"radius": 2`
