### PR TITLE
bump teleport controls reference to 0.3.x in minecraft doc

### DIFF
--- a/docs/guides/building-a-minecraft-demo.md
+++ b/docs/guides/building-a-minecraft-demo.md
@@ -394,7 +394,7 @@ component on the controller on the entity:
 
 ```html
 <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
-<script src="https://unpkg.com/aframe-teleport-controls@0.2.x/dist/aframe-teleport-controls.min.js"></script>
+<script src="https://unpkg.com/aframe-teleport-controls@0.3.x/dist/aframe-teleport-controls.min.js"></script>
 
 <!-- ... -->
 


### PR DESCRIPTION
**Description:**
bump teleport controls reference to 0.3.x in minecraft doc

**Changes proposed:**
- change 0.2.x to 0.3.x
