### PR TITLE
Update the TEXT component shader to conform GLSL 3

### DIFF
--- a/src/shaders/msdf.js
+++ b/src/shaders/msdf.js
@@ -16,11 +16,12 @@ module.exports.Shader = registerShader('msdf', {
   raw: true,
 
   vertexShader: [
-    'attribute vec2 uv;',
-    'attribute vec3 position;',
+    '#version 300 es',
+    'in vec2 uv;',
+    'in vec3 position;',
     'uniform mat4 projectionMatrix;',
     'uniform mat4 modelViewMatrix;',
-    'varying vec2 vUV;',
+    'out vec2 vUV;',
     'void main(void) {',
     '  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);',
     '  vUV = uv;',
@@ -28,17 +29,15 @@ module.exports.Shader = registerShader('msdf', {
   ].join('\n'),
 
   fragmentShader: [
-    '#ifdef GL_OES_standard_derivatives',
-    '#extension GL_OES_standard_derivatives: enable',
-    '#endif',
-
+    '#version 300 es',
     'precision highp float;',
     'uniform bool negate;',
     'uniform float alphaTest;',
     'uniform float opacity;',
     'uniform sampler2D map;',
     'uniform vec3 color;',
-    'varying vec2 vUV;',
+    'in vec2 vUV;',
+    'out vec4 fragColor;',
 
     'float median(float r, float g, float b) {',
     '  return max(min(r, g), min(max(r, g), b));',
@@ -49,7 +48,7 @@ module.exports.Shader = registerShader('msdf', {
     '#define MODIFIED_ALPHATEST (0.02 * isBigEnough / BIG_ENOUGH)',
 
     'void main() {',
-    '  vec3 sampleColor = texture2D(map, vUV).rgb;',
+    '  vec3 sampleColor = texture(map, vUV).rgb;',
     '  if (negate) { sampleColor = 1.0 - sampleColor; }',
 
     '  float sigDist = median(sampleColor.r, sampleColor.g, sampleColor.b) - 0.5;',
@@ -68,7 +67,7 @@ module.exports.Shader = registerShader('msdf', {
 
     '  // Do modified alpha test.',
     '  if (alpha < alphaTest * MODIFIED_ALPHATEST) { discard; return; }',
-    '  gl_FragColor = vec4(color.xyz, alpha * opacity);',
+    '  fragColor = vec4(color.xyz, alpha * opacity);',
     '}'
   ].join('\n')
 });


### PR DESCRIPTION
**Description:**

The latest update of A-Frame to THREE r118 uses 'webgl2' context by default. That breaks the TEXT component, as it's shader should be updated to GLSL 3  #version 300 es.

