### PR TITLE
Documentation: Text Component - replace auto reference by 0 for geometry auto-scaling

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -233,7 +233,7 @@ geometry component's `width`, do not specify a `width` for the text component:
 
 ```html
 <a-entity
-  geometry="primitive: plane; width: 4; height: auto"
+  geometry="primitive: plane; width: 4; height: 0"
   material="color: blue"
   text="value: This text will be 4 units wide."></a-entity>
 ```
@@ -241,14 +241,14 @@ geometry component's `width`, do not specify a `width` for the text component:
 #### Scaling Geometry to Fit Text
 
 To have the geometry automatically scale with the text, set the geometry
-component's `width` and `height` properties to `auto`, and set the text
+component's `width` and `height` properties to `0` (to be understood as automatically), and set the text
 component's `width` as desired. In this example, the plane's `width` will be
 set to 4 units, and its `height` will be set to match the actual height of the
 text:
 
 ```html
 <a-entity
-  geometry="primitive: plane; height: auto; width: auto"
+  geometry="primitive: plane; height: 0; width: 0"
   material="color: blue"
   text="width: 4; value: This text will be 4 units wide."></a-entity>
 ```


### PR DESCRIPTION
as per https://github.com/aframevr/aframe/issues/2837 'auto' is not acceptable value for geometry width/height.
For the time being '0' can be used for having the auto-scaling behavior.

**Description:**

**Changes proposed:**
-
-
-
