### PR TITLE
Add reference to google hosted draco decoder URL

### DIFF
--- a/docs/components/gltf-model.md
+++ b/docs/components/gltf-model.md
@@ -152,6 +152,8 @@ All files are available from the three.js repository, under
 automatically choose whether to use a WASM or JavaScript decoder, so both should
 be included.
 
+A Google-hosted version of the Draco decoder libraries saves you from needing to include these libraries in your own project: set `https://www.gstatic.com/draco/v1/decoders/` as the value for `dracoDecoderPath`.
+
 ## More Resources
 
 [sketchfab]: https://sketchfab.com/models?features=downloadable&sort_by=-likeCount


### PR DESCRIPTION
In gltf-model doc add a reference to hosted draco decoder libraries from google

**Description:**

As a new user it's annoying to include these draco decoder files in my project and I wouldn't have done so had I known this value accepted remote locations and there exists a Google hosted CDN version.

**Changes proposed:**
-
-
-
