### PR TITLE
[docs] Add Oculus Quest 2 to Headsets list

### DIFF
--- a/docs/introduction/vr-headsets-and-webvr-browsers.md
+++ b/docs/introduction/vr-headsets-and-webvr-browsers.md
@@ -50,6 +50,7 @@ are constrained to looking around and wiggling the controller.
 [Oculus Go]: https://www.oculus.com/go
 [Vive Focus]: https://enterprise.vive.com/us/vivefocus/
 [Oculus Quest]: https://www.oculus.com/quest
+[Oculus Quest 2]: https://www.oculus.com/quest-2/
 
 | Headset                 | Platform   | Positional Tracking | Controllers        | Controller Positional Tracking |
 |-------------------------|------------|---------------------|--------------------|--------------------------------|
@@ -61,6 +62,7 @@ are constrained to looking around and wiggling the controller.
 | [Oculus Go]             | Standalone | :x:                 | :white_check_mark: | :x:                            |
 | [Vive Focus]            | Standalone | :x:                 | :white_check_mark: | :x:                            |
 | [Oculus Quest]            | Standalone | :white_check_mark:  | :white_check_mark: | :white_check_mark:             |
+| [Oculus Quest 2]            | Standalone | :white_check_mark:  | :white_check_mark: | :white_check_mark:             |
 
 ## What is WebVR?
 

--- a/docs/introduction/vr-headsets-and-webvr-browsers.md
+++ b/docs/introduction/vr-headsets-and-webvr-browsers.md
@@ -43,14 +43,11 @@ are constrained to looking around and wiggling the controller.
 ### What Are Some Current Headsets?
 
 [HTC Vive]: https://www.vive.com/
-[Oculus Rift]: https://www.oculus.com/rift/
+[Oculus headsets]: https://www.oculus.com
 [Google Daydream]: https://vr.google.com/daydream/
 [Samsung GearVR]: http://www.samsung.com/global/galaxy/gear-vr/
 [Windows Mixed Reality]: https://developer.microsoft.com/en-us/windows/mixed-reality/
-[Oculus Go]: https://www.oculus.com/go
 [Vive Focus]: https://enterprise.vive.com/us/vivefocus/
-[Oculus Quest]: https://www.oculus.com/quest
-[Oculus Quest 2]: https://www.oculus.com/quest-2/
 
 | Headset                 | Platform   | Positional Tracking | Controllers        | Controller Positional Tracking |
 |-------------------------|------------|---------------------|--------------------|--------------------------------|


### PR DESCRIPTION
**Description:**
The new Oculus Quest 2 isn't on the [What Are Some Current Headsets?](https://aframe.io/docs/1.0.0/introduction/vr-headsets-and-webvr-browsers.html#what-are-some-current-headsets) list.

**Changes proposed:**
- Add the Oculus Quest 2 to the list
- Since [Oculus Quest is no longer available](https://www.oculus.com/quest/), should we remove it from the list? 🤔 