### PR TITLE
Improve pinching accuracy (fixes #4689)

### DIFF
--- a/docs/components/hand-tracking-controls.md
+++ b/docs/components/hand-tracking-controls.md
@@ -25,7 +25,8 @@ Use `hand-tracking-controls` to integrate [hand tracked input][webxrhandinput] i
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | modelColor          | Color of hand material.                                                                | white         |
 | modelStyle           | Mesh representing the hand or dots matching the joints        | mesh
-
+| startPinchDistance    | Maximum distance between tip of thumb and index finger before a pinch gesture is started. | 0.015 |
+| endPinchDistance    | Minimum distance between tip of thumb and index finger before a pinch gesture is ended. | 0.03 |
 
 ## Events
 

--- a/docs/components/hand-tracking-controls.md
+++ b/docs/components/hand-tracking-controls.md
@@ -25,8 +25,6 @@ Use `hand-tracking-controls` to integrate [hand tracked input][webxrhandinput] i
 | hand                 | The hand that will be tracked (i.e., right, left). | left                 |
 | modelColor          | Color of hand material.                                                                | white         |
 | modelStyle           | Mesh representing the hand or dots matching the joints        | mesh
-| startPinchDistance    | Maximum distance between tip of thumb and index finger before a pinch gesture is started. | 0.015 |
-| endPinchDistance    | Minimum distance between tip of thumb and index finger before a pinch gesture is ended. | 0.03 |
 
 ## Events
 

--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -221,20 +221,20 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
 
       if (distance < this.data.startPinchDistance && this.isPinched === false) {
         this.isPinched = true;
-        this.pinchEventDetail.position.copy(indexTipPose.transform.position);
+        this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, 0.5);
         this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchstarted', this.pinchEventDetail);
       }
 
       if (distance > this.data.endPinchDistance && this.isPinched === true) {
         this.isPinched = false;
-        this.pinchEventDetail.position.copy(indexTipPose.transform.position);
+        this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, 0.5);
         this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchended', this.pinchEventDetail);
       }
 
       if (this.isPinched) {
-        this.pinchEventDetail.position.copy(indexTipPose.transform.position);
+        this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, 0.5);
         this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchmoved', this.pinchEventDetail);
       }

--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -43,6 +43,10 @@ var BONE_MAPPING = [
   'pinky_null'
 ];
 
+var PINCH_START_DISTANCE = 0.015;
+var PINCH_END_DISTANCE = 0.03;
+var PINCH_POSITION_INTERPOLATION = 0.5;
+
 /**
  * Controls for hand tracking
  */
@@ -217,22 +221,22 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
 
       var distance = indexTipPosition.distanceTo(thumbTipPosition);
 
-      if (distance < 0.015 && this.isPinched === false) {
+      if (distance < PINCH_START_DISTANCE && this.isPinched === false) {
         this.isPinched = true;
-        this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, 0.5);
+        this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, PINCH_POSITION_INTERPOLATION);
         this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchstarted', this.pinchEventDetail);
       }
 
-      if (distance > 0.03 && this.isPinched === true) {
+      if (distance > PINCH_END_DISTANCE && this.isPinched === true) {
         this.isPinched = false;
-        this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, 0.5);
+        this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, PINCH_POSITION_INTERPOLATION);
         this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchended', this.pinchEventDetail);
       }
 
       if (this.isPinched) {
-        this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, 0.5);
+        this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, PINCH_POSITION_INTERPOLATION);
         this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchmoved', this.pinchEventDetail);
       }

--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -50,7 +50,9 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
   schema: {
     hand: {default: 'right', oneOf: ['left', 'right']},
     modelStyle: {default: 'mesh', oneOf: ['dots', 'mesh']},
-    modelColor: {default: 'white'}
+    modelColor: {default: 'white'},
+    startPinchDistance: {default: 0.015},
+    endPinchDistance: {default: 0.03}
   },
 
   bindMethods: function () {
@@ -217,14 +219,14 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
 
       var distance = indexTipPosition.distanceTo(thumbTipPosition);
 
-      if (distance < 0.01 && this.isPinched === false) {
+      if (distance < this.data.startPinchDistance && this.isPinched === false) {
         this.isPinched = true;
         this.pinchEventDetail.position.copy(indexTipPose.transform.position);
         this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchstarted', this.pinchEventDetail);
       }
 
-      if (distance > 0.03 && this.isPinched === true) {
+      if (distance > this.data.endPinchDistance && this.isPinched === true) {
         this.isPinched = false;
         this.pinchEventDetail.position.copy(indexTipPose.transform.position);
         this.pinchEventDetail.position.y += 1.5;

--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -50,9 +50,7 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
   schema: {
     hand: {default: 'right', oneOf: ['left', 'right']},
     modelStyle: {default: 'mesh', oneOf: ['dots', 'mesh']},
-    modelColor: {default: 'white'},
-    startPinchDistance: {default: 0.015},
-    endPinchDistance: {default: 0.03}
+    modelColor: {default: 'white'}
   },
 
   bindMethods: function () {
@@ -219,14 +217,14 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
 
       var distance = indexTipPosition.distanceTo(thumbTipPosition);
 
-      if (distance < this.data.startPinchDistance && this.isPinched === false) {
+      if (distance < 0.015 && this.isPinched === false) {
         this.isPinched = true;
         this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, 0.5);
         this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchstarted', this.pinchEventDetail);
       }
 
-      if (distance > this.data.endPinchDistance && this.isPinched === true) {
+      if (distance > 0.03 && this.isPinched === true) {
         this.isPinched = false;
         this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, 0.5);
         this.pinchEventDetail.position.y += 1.5;

--- a/tests/components/hand-tracking-controls.test.js
+++ b/tests/components/hand-tracking-controls.test.js
@@ -8,6 +8,8 @@ suite('tracked-controls-webxr', function () {
   var standingMatrix = new THREE.Matrix4();
   var index = {transform: {position: {x: 0, y: 0, z: 0}}};
   var thumb = {transform: {position: {x: 0, y: 0, z: 0}}};
+  var indexPosition = new THREE.Vector3();
+  var thumbPosition = new THREE.Vector3();
 
   setup(function (done) {
     standingMatrix.identity();
@@ -53,6 +55,13 @@ suite('tracked-controls-webxr', function () {
       el.components['hand-tracking-controls'].checkIfControllerPresent();
       el.components['hand-tracking-controls'].detectPinch();
       assert.equal(emitSpy.getCalls()[0].args[0], 'pinchstarted');
+      indexPosition.copy(index.transform.position);
+      indexPosition.y += 1.5;
+      thumbPosition.copy(thumb.transform.position);
+      thumbPosition.y += 1.5;
+      const indexThumbDistance = indexPosition.distanceTo(thumbPosition);
+      assert.isAtMost(emitSpy.getCalls()[0].args[1].position.distanceTo(indexPosition), indexThumbDistance);
+      assert.isAtMost(emitSpy.getCalls()[0].args[1].position.distanceTo(thumbPosition), indexThumbDistance);
     });
 
     test('pinchended', function () {
@@ -61,8 +70,16 @@ suite('tracked-controls-webxr', function () {
       el.components['hand-tracking-controls'].checkIfControllerPresent();
       el.components['hand-tracking-controls'].isPinched = true;
       thumb.transform.position.z = 10;
+      thumbPosition.copy(thumb.transform.position);
       el.components['hand-tracking-controls'].detectPinch();
       assert.equal(emitSpy.getCalls()[0].args[0], 'pinchended');
+      indexPosition.copy(index.transform.position);
+      indexPosition.y += 1.5;
+      thumbPosition.copy(thumb.transform.position);
+      thumbPosition.y += 1.5;
+      const indexThumbDistance = indexPosition.distanceTo(thumbPosition);
+      assert.isAtMost(emitSpy.getCalls()[0].args[1].position.distanceTo(indexPosition), indexThumbDistance);
+      assert.isAtMost(emitSpy.getCalls()[0].args[1].position.distanceTo(thumbPosition), indexThumbDistance);
     });
   });
 });


### PR DESCRIPTION
**Description:** As discussed in #4689, this PR improves pinching accuracy by 1) adjusting the distance between thumb and index finger needed to start the gesture, and by 2) moving the position pinch events report to the halfway point between the thumb and index finger.

**Changes proposed:**
- The min distance between thumb and index fingertips to start a pinch gesture is changed to be `0.015`.
- Two new properties are exposed on `hand-tracking-controls`: `startPinchDistance`, which defaults to `0.015` and `endPinchDistance`, which defaults to `0.03`.
- The `position` property for `pinchstarted`, `pinchmoved`, and `pinchended` events is moved to the halfway point between thumb and index fingertips.
- Checks are added to tests to sanity-check the pinch event position.
