### PR TITLE
Improve pinching for moving objects (fixes #4690)

### DIFF
--- a/docs/components/hand-tracking-controls.md
+++ b/docs/components/hand-tracking-controls.md
@@ -30,9 +30,23 @@ Use `hand-tracking-controls` to integrate [hand tracked input][webxrhandinput] i
 
 | Event Name    | Description                                                    |
 | ----------    | -----------                                                    |
-| pinchstarted  | The pinch gesture has started. World coordinates passed as event detail.                                 |
-| pinchended    | The pinch gesture has ended. World coordinates passed as event detail.                                    |
-| pinchmoved    | The hand moved while making the pinch gesture. Useful for interactions that track the hand while the gesture is engaged. World coordinates passed as event detail.                  |
+| pinchstarted  | The pinch gesture has started. World coordinates and wrist orientation passed as event detail.                                 |
+| pinchended    | The pinch gesture has ended. World coordinates and wrist orientation passed as event detail.                                    |
+
+## Members
+
+Accessed as `el.components['hand-tracking-controls'].<MEMBER>`.
+
+| Member    | Description                                                                           |
+|-----------|---------------------------------------------------------------------------------------|
+| pinchWorldPosition    | The position of the active pinch gesture  |
+| wristWorldOrientation | The orientation of the wrist  |
+
+## States
+
+| State Name  | Description                                                                           |
+|-------------|---------------------------------------------------------------------------------------|
+| pinched | Set while the pinch gesture is active  |
 
 ## Assets
 

--- a/tests/components/hand-tracking-controls.test.js
+++ b/tests/components/hand-tracking-controls.test.js
@@ -8,8 +8,10 @@ suite('tracked-controls-webxr', function () {
   var standingMatrix = new THREE.Matrix4();
   var index = {transform: {position: {x: 0, y: 0, z: 0}}};
   var thumb = {transform: {position: {x: 0, y: 0, z: 0}}};
+  var wrist = {transform: {orientation: {x: 0, y: 0, z: 0, w: 1}}};
   var indexPosition = new THREE.Vector3();
   var thumbPosition = new THREE.Vector3();
+  var wristOrientation = new THREE.Quaternion();
 
   setup(function (done) {
     standingMatrix.identity();
@@ -18,7 +20,8 @@ suite('tracked-controls-webxr', function () {
       el.sceneEl.addEventListener('loaded', function () {
         window.XRHand = {
           INDEX_PHALANX_TIP: 0,
-          THUMB_PHALANX_TIP: 1
+          THUMB_PHALANX_TIP: 1,
+          WRIST: 2
         };
         el.sceneEl.hasWebXR = true;
         el.sceneEl.frame = {
@@ -30,7 +33,7 @@ suite('tracked-controls-webxr', function () {
         controller = {
           handedness: 'left',
           profiles: ['oculus-hand'],
-          hand: [index, thumb]
+          hand: [index, thumb, wrist]
         };
         system.controllers = [controller];
         el.setAttribute('hand-tracking-controls', {hand: 'left'});
@@ -54,32 +57,57 @@ suite('tracked-controls-webxr', function () {
       el.setAttribute('hand-tracking-controls', {hand: 'left'});
       el.components['hand-tracking-controls'].checkIfControllerPresent();
       el.components['hand-tracking-controls'].detectPinch();
-      assert.equal(emitSpy.getCalls()[0].args[0], 'pinchstarted');
+      assert.equal(emitSpy.getCalls()[0].args[0], 'stateadded');
+      assert.equal(emitSpy.getCalls()[1].args[0], 'pinchstarted');
       indexPosition.copy(index.transform.position);
       indexPosition.y += 1.5;
       thumbPosition.copy(thumb.transform.position);
       thumbPosition.y += 1.5;
       const indexThumbDistance = indexPosition.distanceTo(thumbPosition);
-      assert.isAtMost(emitSpy.getCalls()[0].args[1].position.distanceTo(indexPosition), indexThumbDistance);
-      assert.isAtMost(emitSpy.getCalls()[0].args[1].position.distanceTo(thumbPosition), indexThumbDistance);
+      assert.isAtMost(emitSpy.getCalls()[1].args[1].position.distanceTo(indexPosition), indexThumbDistance);
+      assert.isAtMost(emitSpy.getCalls()[1].args[1].position.distanceTo(thumbPosition), indexThumbDistance);
+      wristOrientation.copy(wrist.transform.orientation);
+      assert.isTrue(emitSpy.getCalls()[1].args[1].orientation.equals(wristOrientation));
+      assert.isTrue(el.is('pinched'));
     });
 
     test('pinchended', function () {
-      const emitSpy = sinon.spy(el, 'emit');
       el.setAttribute('hand-tracking-controls', {hand: 'left'});
       el.components['hand-tracking-controls'].checkIfControllerPresent();
-      el.components['hand-tracking-controls'].isPinched = true;
+      el.addState('pinched');
+      const emitSpy = sinon.spy(el, 'emit');
       thumb.transform.position.z = 10;
       thumbPosition.copy(thumb.transform.position);
       el.components['hand-tracking-controls'].detectPinch();
-      assert.equal(emitSpy.getCalls()[0].args[0], 'pinchended');
+      assert.equal(emitSpy.getCalls()[0].args[0], 'stateremoved');
+      assert.equal(emitSpy.getCalls()[1].args[0], 'pinchended');
       indexPosition.copy(index.transform.position);
       indexPosition.y += 1.5;
       thumbPosition.copy(thumb.transform.position);
       thumbPosition.y += 1.5;
       const indexThumbDistance = indexPosition.distanceTo(thumbPosition);
-      assert.isAtMost(emitSpy.getCalls()[0].args[1].position.distanceTo(indexPosition), indexThumbDistance);
-      assert.isAtMost(emitSpy.getCalls()[0].args[1].position.distanceTo(thumbPosition), indexThumbDistance);
+      assert.isAtMost(emitSpy.getCalls()[1].args[1].position.distanceTo(indexPosition), indexThumbDistance);
+      assert.isAtMost(emitSpy.getCalls()[1].args[1].position.distanceTo(thumbPosition), indexThumbDistance);
+      wristOrientation.copy(wrist.transform.orientation);
+      assert.isTrue(emitSpy.getCalls()[1].args[1].orientation.equals(wristOrientation));
+      assert.isFalse(el.is('pinched'));
+    });
+  });
+
+  suite('pinched state', function () {
+    test('stays set while pinching', function () {
+      el.setAttribute('hand-tracking-controls', { hand: 'left' });
+      el.components['hand-tracking-controls'].checkIfControllerPresent();
+      thumb.transform.position.z = 0.0;
+      assert.isFalse(el.is('pinched'));
+      el.components['hand-tracking-controls'].detectPinch();
+      assert.isTrue(el.is('pinched'));
+      thumb.transform.position.z = 0.01;
+      el.components['hand-tracking-controls'].detectPinch();
+      assert.isTrue(el.is('pinched'));
+      thumb.transform.position.z = 0.1;
+      el.components['hand-tracking-controls'].detectPinch();
+      assert.isFalse(el.is('pinched'));
     });
   });
 });


### PR DESCRIPTION
**Description:** As discussed in #4690, this change improves pinching for use in moving objects. Specifically, it adds a wrist orientation that can be used to track hand rotation over the course of a pinch gesture, allowing a grabbed object to be rotated appropriately. In addition, for improved performance, the `pinchmoved` event is removed in favor of a `pinched` state and two new members are added to the component that mirror the properties of the `pinchstarted` and `pinchended` events.

Note that since the only additional joint tracked is the wrist, I deferred adding a property to turn on and off joint tracking. Happy to add if that is preferred. If adding, would like clarity if it would be for all pinch-related joints or just the wrist. If it is for all pinch-related joints, suggest the property is a flag like `pinchTracking` or `gestureTracking` instead of `jointPositionCalculation` or similar.

Also, was hung up on `pinched` vs `pinching` for the new state, but went with `pinched` as it is the name of the previous flag member the component used internally. Also happy to change if desired.

**Changes proposed:**
- Remove `pinchmoved` event
- Add `pinched` state
- Add wrist orientation tracking; this is exposed on the `pinchstarted` and `pinchended` events as `orientation` and on the component as a `wristWorldOrientation` member
- Add `pinchWorldPosition` member to the component, which is the same as `position` on the `pinchstarted` and `pinchended` event details
- Update tests
- Add documentation
