### PR TITLE
Easier Contributions

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: npm install
+    command: npm run start
+ports: 
+  - port: 9000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
   <a href="https://npmjs.com/package/aframe">
     <img src="https://img.shields.io/npm/l/aframe.svg?style=flat-square" alt="License"></a>
   </a>
+  <a href="https://gitpod.io/from-referrer/">
+    <img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code"/>
+  </a>
 </p>
 
 <div align="center">
@@ -189,6 +192,16 @@ npm start  # Start the local development server.
 ```
 
 And open in your browser **[http://localhost:9000](http://localhost:9000)**.
+
+## Online one-click setup
+
+You can use Gitpod(an Online Open Source VS Code like IDE which is free for Open Source) for developing online. With a single click it will start a workspace and automatically:
+
+- clone the `aframe` repo.
+- install the dependencies via `npm start`.
+- start the local development server.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ### Generating Builds
 


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects. 

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone the `aframe` repo.
- install the dependencies via `npm start`.
- start the local development server.

This way anyone interested in contributing can start straight away without any friction.

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95646814-92b42480-0ae5-11eb-92ad-11ae6a12f318.png)

You can give it a try on my fork of the repo via the following link:
 
https://gitpod.io/#https://github.com/nisarhassan12/aframe

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)

Please let me know if there is anything that can be improved. I would like to help.