### PR TITLE
hand-controls: also emit the raw gesture event

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -338,6 +338,9 @@ module.exports.Component = registerComponent('hand-controls', {
     // Emit event for current gesture now active.
     eventName = getGestureEventName(gesture, true);
     if (eventName) { el.emit(eventName); }
+
+    // Emit the raw gesture+lastGesture event
+    el.emit('gesture', {'gesture': gesture, 'lastGesture': lastGesture});
   },
 
   /**


### PR DESCRIPTION
In my use case, I have created a custom component that is just a pair of hands that receive their position and gesture from a network backend. My need is that of mirroring whatever gesture has been emitted by a hand-control enabled entity, send it through the network and let my avatar's "remote hands" play the gesture to my peers.

I could immagine though, that other people might find useful to handle any kind of supported gesture, and in the code I have realized there is sometimes the need to know from which gesture we come from, therefore I have also added the lastGesture in the event payload.

All the best