### PR TITLE
Remove sphericalEnvMap

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -189,6 +189,8 @@ For example:
 </a-scene>
 ```
 
+Notice: The previously available `sphericalEnvMap` property was removed because support no longer exists in Three.js ([PR](https://github.com/mrdoob/three.js/pull/19517)): we recommend users switch to `envMap` for environment reflections. 
+
 ### `flat`
 
 [basic]: https://threejs.org/docs/#api/materials/MeshBasicMaterial

--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -122,7 +122,6 @@ These properties are available on top of the base material properties.
 | normalTextureOffset           | How the normal texture is offset in the x y direction.                                                                                          | 0 0           |
 | repeat                        | How many times a texture (defined by `src`) repeats in the X and Y direction.                                                                   | 1 1           |
 | roughness                     | How rough the material is from `0` to `1`. A rougher material will scatter reflected light in more directions than a smooth material.           | 0.5           |
-| sphericalEnvMap               | Environment spherical texture for reflections. Can either be a selector to an `<img>`, or an inline URL.                                        | None          |
 | width                         | Width of video (in pixels), if defining a video texture.                                                                                        | 640           |
 | wireframe                     | Whether to render just the geometry edges.                                                                                                      | false         |
 | wireframeLinewidth            | Width in px of the rendered line.                                                                                                               | 2             |
@@ -164,12 +163,9 @@ There are three properties which give the illusion of complex geometry:
 
 #### Environment Maps
 
-The `envMap` and `sphericalEnvMap` properties define what environment
+The `envMap` property defines what environment
 the material reflects. The clarity of the environment reflection depends
 on the `metalness`, and `roughness` properties.
-
-The `sphericalEnvMap` property takes a single spherical mapped
-texture. Of the kind you would assign to a `<a-sky>`.
 
 Unlike textures, the `envMap` property takes a cubemap, six images put together
 to form a cube. The cubemap wraps around the mesh and applied as a texture.

--- a/docs/primitives/a-box.md
+++ b/docs/primitives/a-box.md
@@ -53,7 +53,6 @@ The box primitive creates shapes such as boxes, cubes, or walls.
 | segments-depth                   | geometry.segmentsDepth                 | 1             |
 | segments-height                  | geometry.segmentsHeight                | 1             |
 | segments-width                   | geometry.segmentsWidth                 | 1             |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | width                            | geometry.width                         | 1             |
 | wireframe                        | material.wireframe                     | false         |

--- a/docs/primitives/a-circle.md
+++ b/docs/primitives/a-circle.md
@@ -51,7 +51,6 @@ component with the type set to `circle`.
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
 | segments                         | geometry.segments                      | 32            |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 360           |
 | theta-start                      | geometry.thetaStart                    | 0             |

--- a/docs/primitives/a-cone.md
+++ b/docs/primitives/a-cone.md
@@ -52,7 +52,6 @@ The cone primitive creates a cone shape.
 | roughness                        | material.roughness                     | 0.5           |
 | segments-height                  | geometry.segmentsHeight                | 18            |
 | segments-radial                  | geometry.segmentsRadial                | 36            |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 360           |
 | theta-start                      | geometry.thetaStart                    | 0             |

--- a/docs/primitives/a-cylinder.md
+++ b/docs/primitives/a-cylinder.md
@@ -63,7 +63,6 @@ Also, we can create a tube by making the cylinder open-ended, which removes the 
 | roughness                        | material.roughness                     | 0.5           |
 | segments-height                  | geometry.segmentsHeight                | 18            |
 | segments-radial                  | geometry.segmentsRadial                | 36            |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 360           |
 | theta-start                      | geometry.thetaStart                    | 0             |

--- a/docs/primitives/a-dodecahedron.md
+++ b/docs/primitives/a-dodecahedron.md
@@ -41,7 +41,6 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 | roughness                        | material.roughness                     | 0.5           |
 | segments-height                  | geometry.segmentsHeight                | 18            |
 | segments-radial                  | geometry.segmentsRadial                | 36            |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 360           |
 | theta-start                      | geometry.thetaStart                    | 0             |

--- a/docs/primitives/a-icosahedron.md
+++ b/docs/primitives/a-icosahedron.md
@@ -38,7 +38,6 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 | radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |

--- a/docs/primitives/a-octahedron.md
+++ b/docs/primitives/a-octahedron.md
@@ -38,7 +38,6 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 | radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |

--- a/docs/primitives/a-plane.md
+++ b/docs/primitives/a-plane.md
@@ -53,7 +53,6 @@ component with the type set to `plane`.
 | roughness                        | material.roughness                     | 0.5           |
 | segments-height                  | geometry.segmentsHeight                | 1             |
 | segments-width                   | geometry.segmentsWidth                 | 1             |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | width                            | geometry.width                         | 1             |
 | wireframe                        | material.wireframe                     | false         |

--- a/docs/primitives/a-ring.md
+++ b/docs/primitives/a-ring.md
@@ -50,7 +50,6 @@ The ring primitive creates a ring or disc shape.
 | roughness                        | material.roughness                     | 0.5           |
 | segments-phi                     | geometry.segmentsPhi                   | 10            |
 | segments-theta                   | geometry.segmentsTheta                 | 32            |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 360           |
 | theta-start                      | geometry.thetaStart                    | 0             |

--- a/docs/primitives/a-sphere.md
+++ b/docs/primitives/a-sphere.md
@@ -43,7 +43,6 @@ The sphere primitive creates a spherical or polyhedron shapes. It wraps an entit
 | roughness                        | material.roughness                     | 0.5           |
 | segments-height                  | geometry.segmentsHeight                | 18            |
 | segments-width                   | geometry.segmentsWidth                 | 36            |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 180           |
 | theta-start                      | geometry.thetaStart                    | 0             |

--- a/docs/primitives/a-tetrahedron.md
+++ b/docs/primitives/a-tetrahedron.md
@@ -38,7 +38,6 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 | radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |

--- a/docs/primitives/a-torus-knot.md
+++ b/docs/primitives/a-torus-knot.md
@@ -47,7 +47,6 @@ component with the type set to `torusKnot`.
 | roughness                        | material.roughness                     | 0.5           |
 | segments-radial                  | geometry.segmentsRadial                | 8             |
 | segments-tubular                 | geometry.segmentsTubular               | 100           |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |

--- a/docs/primitives/a-torus.md
+++ b/docs/primitives/a-torus.md
@@ -46,7 +46,6 @@ component with the type set to `torus`.
 | roughness                        | material.roughness                     | 0.5           |
 | segments-radial                  | geometry.segmentsRadial                | 36            |
 | segments-tubular                 | geometry.segmentsTubular               | 32            |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |

--- a/docs/primitives/a-triangle.md
+++ b/docs/primitives/a-triangle.md
@@ -49,7 +49,6 @@ component with the type set to `triangle`.
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | vertex-a                         | geometry.vertexA                       | 0  0.5 0   |
 | vertex-b                         | geometry.vertexB                       | -0.5 -0.5 0   |

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -47,7 +47,6 @@ module.exports.Shader = registerShader('standard', {
     roughnessTextureOffset: {type: 'vec2'},
     roughnessTextureRepeat: {type: 'vec2', default: {x: 1, y: 1}},
 
-    sphericalEnvMap: {type: 'map'},
     src: {type: 'map'},
     width: {default: 512},
     wireframe: {default: false},
@@ -110,27 +109,14 @@ module.exports.Shader = registerShader('standard', {
     var self = this;
     var material = this.material;
     var envMap = data.envMap;
-    var sphericalEnvMap = data.sphericalEnvMap;
 
     // No envMap defined or already loading.
-    if ((!envMap && !sphericalEnvMap) || this.isLoadingEnvMap) {
+    if (!envMap || this.isLoadingEnvMap) {
       material.envMap = null;
       material.needsUpdate = true;
       return;
     }
     this.isLoadingEnvMap = true;
-
-    // if a spherical env map is defined then use it.
-    if (sphericalEnvMap) {
-      this.el.sceneEl.systems.material.loadTexture(sphericalEnvMap, {src: sphericalEnvMap}, function textureLoaded (texture) {
-        self.isLoadingEnvMap = false;
-        texture.mapping = THREE.SphericalReflectionMapping;
-        material.envMap = texture;
-        utils.material.handleTextureEvents(self.el, texture);
-        material.needsUpdate = true;
-      });
-      return;
-    }
 
     // Another material is already loading this texture. Wait on promise.
     if (texturePromises[envMap]) {

--- a/tests/shaders/standard.test.js
+++ b/tests/shaders/standard.test.js
@@ -78,18 +78,6 @@ suite('standard material', function () {
     });
   });
 
-  test('can use spherical env maps', function (done) {
-    var el = this.el;
-    var imageUrl = 'base/tests/assets/test.png';
-    el.setAttribute('material', 'sphericalEnvMap: url(' + imageUrl + ');');
-    assert.ok(el.components.material.shader.isLoadingEnvMap);
-    el.addEventListener('materialtextureloaded', function (evt) {
-      assert.equal(evt.detail.texture.mapping, THREE.SphericalReflectionMapping);
-      assert.equal(el.getObject3D('mesh').material.envMap, evt.detail.texture);
-      done();
-    });
-  });
-
   test('can use cube env maps', function (done) {
     var el = this.el;
     var imageUrl = 'base/tests/assets/test.png';


### PR DESCRIPTION
**Description:**

The `THREE.SphericalReflectionMapping` mapping that `sphericalEnvMap` relies on has been removed in Three.js (https://github.com/mrdoob/three.js/pull/19517) and the library was released without it in r118, so reflections using this feature no longer work in the latest release of A-Frame.

The cited reasons are (and I'm somewhat paraphrasing) that it almost never does what the user expects it to do or is otherwise ill-suited. And that using cube maps or something like https://github.com/colinfizgig/aframe_Components/blob/master/components/camera-cube-env.js, i.e. camera-generated `envMap`s is a better approach for reflections.

There are three options as I see it:
1. Removing `sphericalEnvMap`
2. Reintroducing `THREE.SphericalReflectionMapping` in `super-three`
3. Some sort of translation layer into cube maps

 The PR implements option 1, as the upstream reasons for removal make sense to me, but happy to discuss further!