### PR TITLE
Fix geometry-merger links

### DIFF
--- a/docs/introduction/best-practices.md
+++ b/docs/introduction/best-practices.md
@@ -65,11 +65,9 @@ purpose of using A-Frame.
 [animation]: ../components/animation.md#direct-values-through-object3d-and-components
 [asm]: ../core/asset-management-system.md
 [hardware]: ./vr-headsets-and-webvr-browsers.md
-[merge]: https://www.npmjs.com/package/aframe-geometry-merger-component
 [stats]: ../components/stats.md
 [pool]: ../components/pool.md
 [background]: ../components/background.md
-[pool]
 [geometrymerger]: https://www.npmjs.com/package/aframe-geometry-merger-component
 
 


### PR DESCRIPTION
Geometry-merger component links were not parsed correctly, because of the extra `[pool]` before the link's definition.
The definition was also duplicated as `[merge]`.

**Description:**
Errors in the genereal Performance sections were fixed by editing the link definitions.

**Changes proposed:**
- Remove one line to fix syntax
- Remove a superfluous line
