### PR TITLE
Use background to set the default environment map

### DIFF
--- a/docs/components/background.md
+++ b/docs/components/background.md
@@ -13,6 +13,10 @@ frustum culling issues when `a-sky` is further than the far plane of the
 camera. There are no unexpected occlusions either with far objects that might
 be behind of the sphere geometry of `a-sky`.
 
+The background component can also generate a default envrionment cube map for all
+materials, if you find GLB models end up too dark or reflective materials don't
+reflect the environment this will provide a default reflective environment.
+
 ## Example
 
 The example below sets the background color to red.
@@ -23,7 +27,8 @@ The example below sets the background color to red.
 
 ## Properties
 
-| Property    | Description                                               | Default Value |
-|-------------|-----------------------------------------------------------|---------------|
-| color       | Color of the scene background.                            | black         |
-| transparent | Background is transparent. The color property is ignored. | false         |
+| Property            | Description                                               | Default Value |
+|---------------------|-----------------------------------------------------------|---------------|
+| color               | Color of the scene background.                            | black         |
+| transparent         | Background is transparent. The color property is ignored. | false         |
+| generateEnvironment | Whether to generate a default environment                 | true          |

--- a/docs/components/background.md
+++ b/docs/components/background.md
@@ -13,7 +13,7 @@ frustum culling issues when `a-sky` is further than the far plane of the
 camera. There are no unexpected occlusions either with far objects that might
 be behind of the sphere geometry of `a-sky`.
 
-The background component can also generate a default envrionment cube map for all
+The background component can also generate a default environment cube map for all
 materials, if you find GLB models end up too dark or reflective materials don't
 reflect the environment this will provide a default reflective environment.
 

--- a/src/components/scene/background.js
+++ b/src/components/scene/background.js
@@ -9,10 +9,8 @@ module.exports.Component = register('background', {
     generateEnvironment: {default: true}
   },
   init: function () {
-    var cubeRenderTarget = new THREE.WebGLCubeRenderTarget(128, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter });
-    var cubeCamera = new THREE.CubeCamera(1, 100000, cubeRenderTarget);
-    this.cubeRenderTarget = cubeRenderTarget;
-    this.cubeCamera = cubeCamera;
+    this.cubeRenderTarget = new THREE.WebGLCubeRenderTarget(128, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter });
+    this.cubeCamera = new THREE.CubeCamera(1, 100000, this.cubeRenderTarget);
     this.needsEnvironmentUpdate = true;
   },
   update: function () {

--- a/src/components/scene/background.js
+++ b/src/components/scene/background.js
@@ -25,6 +25,11 @@ module.exports.Component = register('background', {
       object3D.background = new THREE.Color(data.color);
     }
 
+    if (scene.environment && scene.environment !== this.cubeRenderTarget.texture) {
+      console.warn('Background will not overide predefined environment maps');
+      return;
+    }
+
     if (data.generateEnvironment) {
       scene.environment = this.cubeRenderTarget.texture;
     } else {
@@ -50,6 +55,9 @@ module.exports.Component = register('background', {
     if (data.transparent) {
       object3D.background = null;
       return;
+    }
+    if (object3D.environment === this.cubeRenderTarget.texture) {
+      object3D.environment = null;
     }
     object3D.background = COMPONENTS[this.name].schema.color.default;
   }

--- a/src/components/scene/background.js
+++ b/src/components/scene/background.js
@@ -8,33 +8,35 @@ module.exports.Component = register('background', {
     transparent: {default: false},
     generateEnvironment: {default: true}
   },
+  init: function () {
+    var cubeRenderTarget = new THREE.WebGLCubeRenderTarget(128, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter });
+    var cubeCamera = new THREE.CubeCamera(1, 100000, cubeRenderTarget);
+    this.cubeRenderTarget = cubeRenderTarget;
+    this.cubeCamera = cubeCamera;
+    this.needsEnvironmentUpdate = true;
+  },
   update: function () {
+    var scene = this.el.sceneEl.object3D;
     var data = this.data;
     var object3D = this.el.object3D;
     if (data.transparent) {
       object3D.background = null;
-      return;
+    } else {
+      object3D.background = new THREE.Color(data.color);
     }
-    object3D.background = new THREE.Color(data.color);
 
     if (data.generateEnvironment) {
-      const scene = this.el.sceneEl.object3D;
-      const cubeRenderTarget = new THREE.WebGLCubeRenderTarget(128, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter });
-      const cubeCamera = new THREE.CubeCamera(1, 100000, cubeRenderTarget);
-      this.cubeCamera = cubeCamera;
-      this.needsEnvironmentUpdate = true;
-      scene.environment = cubeRenderTarget.texture;
-      this.el.sceneEl.addEventListener('loaded', function () {
-        this.needsEnvironmentUpdate = true;
-      });
+      scene.environment = this.cubeRenderTarget.texture;
+    } else {
+      scene.environment = null;
     }
   },
 
-  tick () {
+  tick: function () {
     if (!this.needsEnvironmentUpdate) return;
-    const scene = this.el.object3D;
-    const renderer = this.el.renderer;
-    const camera = this.el.camera;
+    var scene = this.el.object3D;
+    var renderer = this.el.renderer;
+    var camera = this.el.camera;
 
     this.el.object3D.add(this.cubeCamera);
     this.cubeCamera.position.copy(camera.position);

--- a/src/components/scene/background.js
+++ b/src/components/scene/background.js
@@ -31,7 +31,7 @@ module.exports.Component = register('background', {
   },
 
   tick () {
-    if (!this.data.auto && !this.needsEnvironmentUpdate) return;
+    if (!this.needsEnvironmentUpdate) return;
     const scene = this.el.object3D;
     const renderer = this.el.renderer;
     const camera = this.el.camera;


### PR DESCRIPTION
**Description:**

Adds behavior to `background` to allow it to set the environment property on the scene element.

It automatically generates an environment map as a cube texture which can be overridden by setting the environment map on a per element basis. 

## No background:
![image](https://user-images.githubusercontent.com/4225330/108059868-0810a280-704e-11eb-9b5e-2a0f1bbb6e37.png)

## Background is hotpink, no skybox
![image](https://user-images.githubusercontent.com/4225330/108059926-1c549f80-704e-11eb-9bb6-9ea163e67937.png)

## Background is still hot pink but with an image skybox
![image](https://user-images.githubusercontent.com/4225330/108059974-2c6c7f00-704e-11eb-956f-66d2812154e5.png)

