### PR TITLE
Changing permissions modal style to allow bigger messages

### DIFF
--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -308,34 +308,31 @@ a-scene audio {
 }
 
 .a-modal {
-  position: absolute;
+  display: flex; 
   background: rgba(0, 0, 0, 0.60);
   background-size: 50% 50%;
-  bottom: 0;
   font-size: 14px;
   font-weight: 600;
-  left: 0;
   line-height: 20px;
-  right: 0;
-  position: fixed;
-  top: 0;
   z-index: 9999999;
+  height: 100%; 
+  width: 100%; 
+  justify-content: center;
+  align-items: center;
 }
 
 .a-dialog {
   position: relative;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  display: flex; 
+  flex-direction: column;
   z-index: 199995;
-  width: 300px;
-  height: 200px;
   background-size: contain;
   background-color: white;
   font-family: sans-serif, monospace;
   font-size: 20px;
   border-radius: 3px;
   padding: 6px;
+  width:300px; 
 }
 
 .a-dialog-text-container {
@@ -359,7 +356,7 @@ a-scene audio {
   display: inline-flex;
   align-self: flex-end;
   width: 100%;
-  height: 30%;
+  height: 60px; 
 }
 
 .a-dialog-button {


### PR DESCRIPTION
**Description:**
Changing the permission modal to allow users to add bigger messages. 

Today, width and height are hardcoded, which creates a strange effect when the message is too long. 
![before-pc-alert-dialog](https://user-images.githubusercontent.com/26838971/109623129-1e822800-7b3d-11eb-82cd-9ccb665524a2.PNG)

**Changes proposed:**
- Making dialogs flex
- Keeping today's dialog width and button height, the modal will only change height depending on the content size

I actually don't know how you would like to handle too long messages (maybe with a text overflow?, or let the user test the message size?). I'll leave this decision up to you. 

Here is a screenshot with the changes : 
![pc-alert-dialog](https://user-images.githubusercontent.com/26838971/109623412-6a34d180-7b3d-11eb-87d9-acaf9aca9357.PNG)

You can also test the changes [with this glitch](https://aframe-modal-update.glitch.me/) 
