### PR TITLE
Explain pitfalls with using setAttribute to trigger animations.

### DIFF
--- a/docs/components/animation.md
+++ b/docs/components/animation.md
@@ -114,24 +114,7 @@ Accessed as `el.components.animation.<MEMBER>`.
 
 ### Controlling Animations using setAttribute
 
-Like any A-Frame component, the animation component can be configured from JavaScript by calling setAttribute() on an element.
-
-The second parameter can either be a string, or an object, detailing the properties to set.
-
-For example, either:
-
-```
-el.setAttribute('animation', 'property: rotation; from 0 0 0; to 0 180 0; dur: 1000');
-```
-
-or:
-
-```
-el.setAttribute('animation', {'property': 'rotation',
-                              'from': {'x' : 0, 'y' : 0, 'z': 0},
-                              'to': {'x' : 0, 'y' : 180, 'z': 0},
-                              'dur': 1000});
-```
+Like any A-Frame component, the animation component can be configured from JavaScript by calling [setAttribute()]( https://aframe.io/docs/1.2.0/introduction/javascript-events-dom-apis.html#updating-a-component-with-setattribute) on an element.
 
 By default, the animation will begin playing immediately (autoplay is true by default).
 
@@ -139,10 +122,12 @@ However, care should be taken when using the interface in this way.  If a finite
 
 This is because A-Frame sees the second request as a duplicate request for configuration already applied to the element, and so the second request never reaches the animation component.
 
-To ensure an animation is played, you can do either of the following:
+A better approach is to control the start of an animation using events (see next section)
 
-- explicitly remove any previous animation attribute using removeAttribute(), prior to calling setAttribute();
-- or start the animation using an event, rather than using autoplay (see the next section)
+- On initialization, configure all the animations that may be required on the object, with a custom event configured to start the animation.
+- When you want to start a specific animation, do so by using emit() rather than setAttribute().
+
+This gives more robust control of the animation (avoiding problems where you request the same animation twice in a row), and also reduces the overheads involved in setting up animation config, since it only needs to be done once.
 
 ## Animating on Events
 
@@ -161,6 +146,26 @@ We can use the `startEvents` property to animate upon events:
 [eventsglitch]: https://glitch.com/edit/#!/aframe-animation-events?path=index.html:1:0
 
 [Remix the Animating on Events Glitch][eventsglitch].
+
+
+
+To start an animation by explicitly emitting an event, you can do the following:
+
+```
+el.emit(`start-anim-001`, null, false);
+```
+
+The "false" parameter ensures the event won't bubble up to parents, so that you can target the animation at just one particular element.  Full documentation [here](https://aframe.io/docs/1.2.0/core/entity.html#emit-name-detail-bubbles).
+
+This assumes that an animation has already been configured to respond to that custom start event, for example like this:
+
+```
+el.setAttribute(animation__001, {'property': position,
+                                 'to': {x: 1, y: 1: z: 1},                                 
+                                 'startEvents': 'start-anim-001');
+```
+
+(configuring startEvents on the animation automatically disables autoplay).
 
 ## Animating Different Types of Values
 

--- a/docs/components/animation.md
+++ b/docs/components/animation.md
@@ -64,8 +64,8 @@ different types of values.
 | startEvents   | Comma-separated list of events to listen to trigger a restart and play. Animation will not autoplay if specified. `startEvents` will **restart** the animation, use `pauseEvents` to resume it. If there are other animation components on the entity animating the same property, those animations will be automatically paused to not conflict. | null          |                         |
 | pauseEvents   | Comma-separated list of events to listen to trigger pause. Can be resumed with `resumeEvents`.                                                                                                                                                                                                                                                    | null          |                         |
 | resumeEvents  | Comma-separated list of events to listen to trigger resume after pausing.                                                                                                                                                                                                                                                                         | null          |                         |
-| autoplay      | Whether or not the animation should `autoplay`. Should be specified if the animation is defined for the [`animation-timeline` component][animationtimeline].                                                                                                                                                                                      | null          |                         |
-| enabled       | If disabled, animation will stop and startEvents will not trigger animation start.                                                                                                                                                                                                                                                                                                                        | true          |
+| autoplay      | Whether or not the animation should `autoplay`. Should be specified if the animation is defined for the [`animation-timeline` component][animationtimeline].                                                                                                                                                                                      | true      |                         |
+| enabled       | If disabled, animation will stop and startEvents will not trigger animation start.                                                                                                                                                                                                                                                                                                                        | true          ||
 
 ### Multiple Animations
 
@@ -111,6 +111,38 @@ Accessed as `el.components.animation.<MEMBER>`.
 |-----------|----------------------------|
 | animation | anime.js object.           |
 | config    | Config passed to anime.js. |
+
+### Controlling Animations using setAttribute
+
+Like any A-Frame component, the animation component can be configured from JavaScript by calling setAttribute() on an element.
+
+The second parameter can either be a string, or an object, detailing the properties to set.
+
+For example, either:
+
+```
+el.setAttribute('animation', 'property: rotation; from 0 0 0; to 0 180 0; dur: 1000');
+```
+
+or:
+
+```
+el.setAttribute('animation', {'property': 'rotation',
+                              'from': {'x' : 0, 'y' : 0, 'z': 0},
+                              'to': {'x' : 0, 'y' : 180, 'z': 0},
+                              'dur': 1000});
+```
+
+By default, the animation will begin playing immediately (autoplay is true by default).
+
+However, care should be taken when using the interface in this way.  If a finite (i.e. non-looping) animation is requested twice in a row, with identical parameters, the second animation will not play, and neither will it generate an animationcomplete event.
+
+This is because A-Frame sees the second request as a duplicate request for configuration already applied to the element, and so the second request never reaches the animation component.
+
+To ensure an animation is played, you can do either of the following:
+
+- explicitly remove any previous animation attribute using removeAttribute(), prior to calling setAttribute();
+- or start the animation using an event, rather than using autoplay (see the next section)
 
 ## Animating on Events
 


### PR DESCRIPTION
**Description:**

As detailed (at some length) in this issue...
https://github.com/aframevr/aframe/issues/4810


**Changes proposed:**

Updates to animation documentation, to:
- correct default value for autoplay (docs are currently plain wrong here)
- to offer some examples of how animations can be started using setAttribute method calls, and highlight the potential pitfall with duplicate animations that can occur here.
 
