### PR TITLE
Alow HP Reverb G2 Controllers to show up as Oculus Touch

### DIFF
--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -199,7 +199,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   checkIfControllerPresent: function () {
     checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX, {
-      hand: this.data.hand
+      hand: this.data.hand,
+      iterateControllerProfiles: true
     });
   },
 

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -22,7 +22,7 @@ module.exports.Component = registerComponent('tracked-controls', {
     // Arm model parameters when not 6DoF.
     armModel: {default: false},
     headElement: {type: 'selector'},
-    iterateControllerProfiles: {default: false}
+    iterateControllerProfiles: {default: true}
   },
 
   update: function () {


### PR DESCRIPTION
Allow iterating when setting up oculus-touch controllers. Allows ReverbG2 controllers to be found as Oculus touch controllers.

**Description:**

On Windows Chrome desktop, HP Reverb G2 controllers do not appear in experiences utilizing `tracked-controls` or derived components. 

The input source profiles supplied by Chrome are: "hp-mixed-reality", "oculus-touch", "generic-trigger-squeeze"

**Changes proposed:**
- Set `iterateControllerProfiles` to true by default in `tracked-controls` to allow for secondary profiles to be found at all
- Pass `iterateControllerProfiles` to `checkControllerPresentAndSetup` in `oculus-touch-controls` to allow HP Reverb G2 controllers to by initialized by their secondary profile.

I've tested these changes using the following workaround pasted into the developer console on several A-Frame experiences, including the "tracked controls showcase":

```
document.querySelectorAll('*[hand-controls]').forEach(el => {
    el.setAttribute('tracked-controls', 'iterateControllerProfiles', true); 
    AFRAME.utils.trackedControls.checkControllerPresentAndSetup(el.components['oculus-touch-controls'], 'oculus-touch', 
        {hand: el.getAttribute('hand-controls').hand, iterateControllerProfiles: true})
})
```
