### PR TITLE
Replace live-server by five-server

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -55,12 +55,12 @@ editors. Both support remixing or forking:
 For the options below, we should develop projects using a local server so that
 files are properly served. Options of local servers include:
 
+- Running `npm i -g five-server@latest && five-server --port=8000` in a terminal
+  in the same directory as your HTML file.
 - Downloading the [Mongoose](https://www.cesanta.com/products/binary) application
   and opening it from the same directory as your HTML file.
 - Running `python -m SimpleHTTPServer` (or `python -m http.server` for Python 3)
   in a terminal in the same directory as your HTML file.
-- Running `npm install -g live-server && live-server` in a terminal in the same
-  directory as your HTML file.
 
 Once we are running our server, we can open our project in the browser using
 the local URL and port which the server is running on (e.g.,


### PR DESCRIPTION
**Description:**

Replaced [Live Server](https://www.npmjs.com/package/live-server) by [Five Server](https://www.npmjs.com/package/five-server) on the [Installation page](https://aframe.io/docs/1.2.0/introduction/installation.html).

**Motivation:**

Five Server is a fork of Live Server with updated dependencies and fixed vulnerabilities.
In addition, it provides features like instant update, highlight and remote logging.
