### PR TITLE
Add Reverb G2 Support

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -211,6 +211,7 @@ module.exports.Component = registerComponent('hand-controls', {
         el.setAttribute('vive-controls', controlConfiguration);
         el.setAttribute('oculus-touch-controls', controlConfiguration);
         el.setAttribute('windows-motion-controls', controlConfiguration);
+        el.setAttribute('hp-mixed-reality-controls', controlConfiguration);
       });
     }
   },

--- a/src/components/hp-mixed-reality-controls.js
+++ b/src/components/hp-mixed-reality-controls.js
@@ -13,7 +13,7 @@ var GAMEPAD_ID_PREFIX = 'hp';
 var GAMEPAD_ID_SUFFIX = '-mixed-reality';
 var GAMEPAD_ID_COMPOSITE = GAMEPAD_ID_PREFIX + GAMEPAD_ID_SUFFIX;
 
-var HP_MIXEDL_REALITY_MODEL_GLB_BASE_URL = 'https://cdn.aframe.io/controllers/hp-mixed-reality/';
+var HP_MIXEDL_REALITY_MODEL_GLB_BASE_URL = 'https://cdn.aframe.io/controllers/hp/mixed-reality/';
 
 /**
  * Button IDs:
@@ -57,10 +57,10 @@ module.exports.Component = registerComponent('hp-mixed-reality-controls', {
     this.controllerPresent = false;
     this.lastControllerCheck = 0;
     this.onButtonChanged = bind(this.onButtonChanged, this);
-    this.onButtonDown = function (evt) { onButtonEvent(evt.detail.id, 'down', self); };
-    this.onButtonUp = function (evt) { onButtonEvent(evt.detail.id, 'up', self); };
-    this.onButtonTouchEnd = function (evt) { onButtonEvent(evt.detail.id, 'touchend', self); };
-    this.onButtonTouchStart = function (evt) { onButtonEvent(evt.detail.id, 'touchstart', self); };
+    this.onButtonDown = function (evt) { onButtonEvent(evt.detail.id, 'down', self, self.data.hand); };
+    this.onButtonUp = function (evt) { onButtonEvent(evt.detail.id, 'up', self, self.data.hand); };
+    this.onButtonTouchEnd = function (evt) { onButtonEvent(evt.detail.id, 'touchend', self, self.data.hand); };
+    this.onButtonTouchStart = function (evt) { onButtonEvent(evt.detail.id, 'touchstart', self, self.data.hand); };
     this.previousButtonValues = {};
     this.rendererSystem = this.el.sceneEl.systems.renderer;
 
@@ -167,11 +167,7 @@ module.exports.Component = registerComponent('hp-mixed-reality-controls', {
     this.el.emit(button + 'changed', evt.detail.state);
   },
 
-  onModelLoaded: function (evt) {
-    var controllerObject3D = evt.detail.model;
-    // our glb scale is too large.
-    controllerObject3D.scale.set(0.01, 0.01, 0.01);
-  },
+  onModelLoaded: function (evt) {},
 
   onAxisMoved: function (evt) {
     emitIfAxesChanged(this, this.mapping.axes, evt);

--- a/src/components/hp-mixed-reality-controls.js
+++ b/src/components/hp-mixed-reality-controls.js
@@ -1,0 +1,184 @@
+var bind = require('../utils/bind');
+var registerComponent = require('../core/component').registerComponent;
+
+var trackedControlsUtils = require('../utils/tracked-controls');
+var checkControllerPresentAndSetup = trackedControlsUtils.checkControllerPresentAndSetup;
+var emitIfAxesChanged = trackedControlsUtils.emitIfAxesChanged;
+var onButtonEvent = trackedControlsUtils.onButtonEvent;
+
+// See Profiles Registry:
+// https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/registry
+// TODO: Add a more robust system for deriving gamepad name.
+var GAMEPAD_ID_PREFIX = 'hp';
+var GAMEPAD_ID_SUFFIX = '-mixed-reality';
+var GAMEPAD_ID_COMPOSITE = GAMEPAD_ID_PREFIX + GAMEPAD_ID_SUFFIX;
+
+var HP_MIXEDL_REALITY_MODEL_GLB_BASE_URL = 'https://cdn.aframe.io/controllers/hp-mixed-reality/';
+
+/**
+ * Button IDs:
+ * 0 - trigger
+ * 1 - grip
+ * 2 - touchpad
+ * 3 - menu (never dispatched on this layer)
+ *
+ * Axis:
+ * 0 - touchpad x axis
+ * 1 - touchpad y axis
+ */
+var INPUT_MAPPING_WEBXR = {
+  left: {
+    axes: {touchpad: [2, 3]},
+    buttons: ['trigger', 'grip', 'none', 'thumbstick', 'xbutton', 'ybutton']
+  },
+  right: {
+    axes: {touchpad: [2, 3]},
+    buttons: ['trigger', 'grip', 'none', 'thumbstick', 'abutton', 'bbutton']
+  }
+};
+
+/**
+ * Magic Leap Controls
+ * Interface with Magic Leap control and map Gamepad events to controller
+ * buttons: trigger, grip, touchpad, and menu.
+ * Load a controller model.
+ */
+module.exports.Component = registerComponent('hp-mixed-reality-controls', {
+  schema: {
+    hand: {default: 'none'},
+    model: {default: true},
+    orientationOffset: {type: 'vec3'}
+  },
+
+  mapping: INPUT_MAPPING_WEBXR,
+
+  init: function () {
+    var self = this;
+    this.controllerPresent = false;
+    this.lastControllerCheck = 0;
+    this.onButtonChanged = bind(this.onButtonChanged, this);
+    this.onButtonDown = function (evt) { onButtonEvent(evt.detail.id, 'down', self); };
+    this.onButtonUp = function (evt) { onButtonEvent(evt.detail.id, 'up', self); };
+    this.onButtonTouchEnd = function (evt) { onButtonEvent(evt.detail.id, 'touchend', self); };
+    this.onButtonTouchStart = function (evt) { onButtonEvent(evt.detail.id, 'touchstart', self); };
+    this.previousButtonValues = {};
+    this.rendererSystem = this.el.sceneEl.systems.renderer;
+
+    this.bindMethods();
+  },
+
+  update: function () {
+    var data = this.data;
+    this.controllerIndex = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
+  },
+
+  play: function () {
+    this.checkIfControllerPresent();
+    this.addControllersUpdateListener();
+  },
+
+  pause: function () {
+    this.removeEventListeners();
+    this.removeControllersUpdateListener();
+  },
+
+  bindMethods: function () {
+    this.onModelLoaded = bind(this.onModelLoaded, this);
+    this.onControllersUpdate = bind(this.onControllersUpdate, this);
+    this.checkIfControllerPresent = bind(this.checkIfControllerPresent, this);
+    this.removeControllersUpdateListener = bind(this.removeControllersUpdateListener, this);
+    this.onAxisMoved = bind(this.onAxisMoved, this);
+  },
+
+  addEventListeners: function () {
+    var el = this.el;
+    el.addEventListener('buttonchanged', this.onButtonChanged);
+    el.addEventListener('buttondown', this.onButtonDown);
+    el.addEventListener('buttonup', this.onButtonUp);
+    el.addEventListener('touchstart', this.onButtonTouchStart);
+    el.addEventListener('touchend', this.onButtonTouchEnd);
+    el.addEventListener('axismove', this.onAxisMoved);
+    el.addEventListener('model-loaded', this.onModelLoaded);
+    this.controllerEventsActive = true;
+  },
+
+  removeEventListeners: function () {
+    var el = this.el;
+    el.removeEventListener('buttonchanged', this.onButtonChanged);
+    el.removeEventListener('buttondown', this.onButtonDown);
+    el.removeEventListener('buttonup', this.onButtonUp);
+    el.removeEventListener('touchstart', this.onButtonTouchStart);
+    el.removeEventListener('touchend', this.onButtonTouchEnd);
+    el.removeEventListener('axismove', this.onAxisMoved);
+    el.removeEventListener('model-loaded', this.onModelLoaded);
+    this.controllerEventsActive = false;
+  },
+
+  checkIfControllerPresent: function () {
+    var data = this.data;
+    checkControllerPresentAndSetup(this, GAMEPAD_ID_COMPOSITE,
+                                   {index: this.controllerIndex, hand: data.hand});
+  },
+
+  injectTrackedControls: function () {
+    var el = this.el;
+    var data = this.data;
+
+    el.setAttribute('tracked-controls', {
+      // TODO: verify expected behavior between reserved prefixes.
+      idPrefix: GAMEPAD_ID_COMPOSITE,
+      hand: data.hand,
+      controller: this.controllerIndex,
+      orientationOffset: data.orientationOffset
+    });
+
+    // Load model.
+    if (!this.data.model) { return; }
+    this.el.setAttribute('gltf-model', HP_MIXEDL_REALITY_MODEL_GLB_BASE_URL + this.data.hand + '.glb');
+  },
+
+  addControllersUpdateListener: function () {
+    this.el.sceneEl.addEventListener('controllersupdated', this.onControllersUpdate, false);
+  },
+
+  removeControllersUpdateListener: function () {
+    this.el.sceneEl.removeEventListener('controllersupdated', this.onControllersUpdate, false);
+  },
+
+  onControllersUpdate: function () {
+    // Note that due to gamepadconnected event propagation issues, we don't rely on events.
+    this.checkIfControllerPresent();
+  },
+
+  /**
+   * Rotate the trigger button based on how hard the trigger is pressed.
+   */
+  onButtonChanged: function (evt) {
+    var button = this.mapping[this.data.hand].buttons[evt.detail.id];
+    var analogValue;
+
+    if (!button) { return; }
+    if (button === 'trigger') {
+      analogValue = evt.detail.state.value;
+      console.log('analog value of trigger press: ' + analogValue);
+    }
+
+    // Pass along changed event with button state, using button mapping for convenience.
+    this.el.emit(button + 'changed', evt.detail.state);
+  },
+
+  onModelLoaded: function (evt) {
+    var controllerObject3D = evt.detail.model;
+    // our glb scale is too large.
+    controllerObject3D.scale.set(0.01, 0.01, 0.01);
+  },
+
+  onAxisMoved: function (evt) {
+    emitIfAxesChanged(this, this.mapping.axes, evt);
+  },
+
+  updateModel: function (buttonName, evtName) {},
+
+  setButtonColor: function (buttonName, color) {}
+
+});

--- a/src/components/hp-mixed-reality-controls.js
+++ b/src/components/hp-mixed-reality-controls.js
@@ -10,9 +10,7 @@ var onButtonEvent = trackedControlsUtils.onButtonEvent;
 // See Profiles Registry:
 // https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/registry
 // TODO: Add a more robust system for deriving gamepad name.
-var GAMEPAD_ID_PREFIX = 'hp';
-var GAMEPAD_ID_SUFFIX = '-mixed-reality';
-var GAMEPAD_ID_COMPOSITE = GAMEPAD_ID_PREFIX + GAMEPAD_ID_SUFFIX;
+var GAMEPAD_ID = 'hp-mixed-reality';
 
 var HP_MIXEDL_REALITY_MODEL_GLB_BASE_URL = 'https://cdn.aframe.io/controllers/hp/mixed-reality/';
 
@@ -117,7 +115,7 @@ module.exports.Component = registerComponent('hp-mixed-reality-controls', {
 
   checkIfControllerPresent: function () {
     var data = this.data;
-    checkControllerPresentAndSetup(this, GAMEPAD_ID_COMPOSITE,
+    checkControllerPresentAndSetup(this, GAMEPAD_ID,
                                    {index: this.controllerIndex, hand: data.hand});
   },
 
@@ -127,7 +125,7 @@ module.exports.Component = registerComponent('hp-mixed-reality-controls', {
 
     el.setAttribute('tracked-controls', {
       // TODO: verify expected behavior between reserved prefixes.
-      idPrefix: GAMEPAD_ID_COMPOSITE,
+      idPrefix: GAMEPAD_ID,
       hand: data.hand,
       controller: this.controllerIndex,
       orientationOffset: data.orientationOffset
@@ -182,10 +180,5 @@ module.exports.Component = registerComponent('hp-mixed-reality-controls', {
 
   onAxisMoved: function (evt) {
     emitIfAxesChanged(this, this.mapping.axes, evt);
-  },
-
-  updateModel: function (buttonName, evtName) {},
-
-  setButtonColor: function (buttonName, color) {}
-
+  }
 });

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,6 +8,7 @@ require('./generic-tracked-controller-controls');
 require('./gltf-model');
 require('./hand-tracking-controls');
 require('./hand-controls');
+require('./hp-mixed-reality-controls');
 require('./layer');
 require('./laser-controls');
 require('./light');

--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -18,6 +18,7 @@ registerComponent('laser-controls', {
     // Set all controller models.
     el.setAttribute('daydream-controls', controlsConfiguration);
     el.setAttribute('gearvr-controls', controlsConfiguration);
+    el.setAttribute('hp-mixed-reality-controls', controlsConfiguration);
     el.setAttribute('magicleap-controls', controlsConfiguration);
     el.setAttribute('oculus-go-controls', controlsConfiguration);
     el.setAttribute('oculus-touch-controls', controlsConfiguration);
@@ -84,6 +85,11 @@ registerComponent('laser-controls', {
 
     'generic-tracked-controller-controls': {
       cursor: {downEvents: ['triggerdown'], upEvents: ['triggerup']}
+    },
+
+    'hp-mixed-reality-controls': {
+      cursor: {downEvents: ['triggerdown'], upEvents: ['triggerup']},
+      raycaster: {origin: {x: 0, y: 0, z: 0}}
     },
 
     'magicleap-controls': {


### PR DESCRIPTION
**Description:**

Adds the Reverb G2 controller as a supported controller

From https://github.com/aframevr/aframe/pull/4823#issuecomment-799624075

- [X]  Copy magicleap-controls and rename to hp-mixed-reality-controls
- [X]  Replace controller id with hp-mixed-reality as indicated in webxr profile
- [X]  Point URL to appropriate model. Take models from the repo and submit to the A-Frame assets repo. Model scale adjustment might be necessary. I think we need to account for handennes. See oculus touch support for an example
    - Pending review: https://github.com/aframevr/assets/pull/39
- [x] Map buttons and axes according to the profile

Additional Changes Needed: 
- [x] Add to necessary tracked control locations to be auto-configured (laser controls, etc)
- [x] Adjust copy-pasted code for handedness
- [x] Adjust model offset and rotation to match physical orientation

