### PR TITLE
Warning on html-and-primitives.md

### DIFF
--- a/docs/introduction/html-and-primitives.md
+++ b/docs/introduction/html-and-primitives.md
@@ -124,10 +124,10 @@ components.
 
 Let's attach community physics components to primitives. We include the source
 for [Don McCurdy's
-`aframe-physics-system`](https://github.com/donmccurdy/aframe-physics-system) and attach
+`aframe-physics-system`](https://github.com/n5ro/aframe-physics-system) and attach
 the physics components via HTML attributes:
 
-> :warning: **If you are using A-Frame 1.2.0**: [`aframe-physics-system`](https://github.com/donmccurdy/aframe-physics-system) may not work as expected with the latest version of A-Frame. Updates on the functionality of this physics system can be found on [this GitHub issue](https://github.com/n5ro/aframe-physics-system/issues/187).
+> :warning: **If you are using A-Frame 1.2.0 or later**: [`aframe-physics-system`](https://github.com/donmccurdy/aframe-physics-system) and you're having issues make sure you're no longer using the now deprecated THREE.Geometry. More info on [this GitHub issue](https://github.com/n5ro/aframe-physics-system/issues/187).
 
 ```html
 <html>

--- a/docs/introduction/html-and-primitives.md
+++ b/docs/introduction/html-and-primitives.md
@@ -127,6 +127,8 @@ for [Don McCurdy's
 `aframe-physics-system`](https://github.com/donmccurdy/aframe-physics-system) and attach
 the physics components via HTML attributes:
 
+> :warning: **If you are using A-Frame 1.2.0**: [`aframe-physics-system`](https://github.com/donmccurdy/aframe-physics-system) may not work as expected with the latest version of A-Frame. Updates on the functionality of this physics system can be found on [this GitHub issue](https://github.com/n5ro/aframe-physics-system/issues/187).
+
 ```html
 <html>
   <head>


### PR DESCRIPTION
aframe-physics-system does not work and has not worked with the newer version(s) of A-Frame for the past few months. Don McCurdy warned that they would stop maintaining frame-physics-system in [this blog post](https://www.donmccurdy.com/2020/09/06/projects-up-for-adoption/). Developers using this physics system are well aware of this bug and no official solution has been created yet. Possible solutions are being discussed [here](https://github.com/n5ro/aframe-physics-system/issues/187) but since it has been unusable for quite a while now, I think it would be reasonable to warn people that it may not work properly.