### PR TITLE
docs: removed deprecated content.

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -720,7 +720,8 @@ AFRAME.registerComponent('custom-material', {
   },
 
   init: function () {
-    this.material = this.el.getOrCreateObject3D('mesh').material = new THREE.ShaderMaterial({
+    this.el.addEventListener("loaded", e => { // when using gltf models use "model-loaded" instead
+      this.material = this.el.getObject3D('mesh').material = new THREE.ShaderMaterial({
       // ...
     });
   },

--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -723,6 +723,7 @@ AFRAME.registerComponent('custom-material', {
     this.el.addEventListener("loaded", e => { // when using gltf models use "model-loaded" instead
       this.material = this.el.getObject3D('mesh').material = new THREE.ShaderMaterial({
       // ...
+      });
     });
   },
 

--- a/docs/introduction/developing-with-threejs.md
+++ b/docs/introduction/developing-with-threejs.md
@@ -162,12 +162,6 @@ reference to the A-Frame entity from the three.js object via `.el`:
 entityEl.getObject3D('light').el;  // entityEl
 ```
 
-There's also a `.getOrCreateObject3D(name, constructor)` method for creating
-and setting an `Object3D` if one has not been set with the name. This is
-commonly used in the case of `THREE.Mesh` when both the geometry and material
-components need to get or create a mesh. Whichever component gets initialized
-first creates the mesh, then the other component gets the mesh.
-
 ### Removing an `Object3D` From an Entity
 
 To remove an `Object3D` from an entity, and consequently the three.js scene, we


### PR DESCRIPTION
`getOrCreateObject3D(name, constructor)` has been deprecated in https://github.com/aframevr/aframe/pull/3222/files.

**Changes proposed:**
- `developing-with-threejs.md`: Paragraph outdated and not required therefore removal proposed.
- `material.md`: Example updated to comply with current standard.
