### PR TITLE
Updated hand-control to emit events that are consistent with the documentation (fixes aframevr#4883)

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -29,8 +29,10 @@ var ANIMATIONS = {
 // Map animation to public events for the API.
 var EVENTS = {};
 EVENTS[ANIMATIONS.fist] = 'grip';
-EVENTS[ANIMATIONS.thumbUp] = 'pistol';
+EVENTS[ANIMATIONS.thumbUp] = 'thumb';
 EVENTS[ANIMATIONS.point] = 'pointing';
+EVENTS[ANIMATIONS.pointThumb] = 'pistol';
+EVENTS[ANIMATIONS.hold] = 'point';
 
 /**
  * Hand controls component that abstracts 6DoF controls:
@@ -394,16 +396,16 @@ module.exports.Component = registerComponent('hand-controls', {
  * @param {string} gesture
  * @param {boolean} active
  */
-function getGestureEventName (gesture, active) {
+ function getGestureEventName (gesture, active) {
   var eventName;
 
   if (!gesture) { return; }
 
   eventName = EVENTS[gesture];
   if (eventName === 'grip') {
-    return eventName + (active ? 'close' : 'open');
+    return eventName + (active ? 'down' : 'up');
   }
-  if (eventName === 'point') {
+  if (eventName === 'point' || eventName === 'thumb') {
     return eventName + (active ? 'up' : 'down');
   }
   if (eventName === 'pointing' || eventName === 'pistol') {


### PR DESCRIPTION
**Description:** Changes the EVENTS object and getGestureEventName function to emit events that are consistent with the documentation found at https://aframe.io/docs/1.2.0/components/hand-controls.html#events. Previously, the only events emitted were gripclose, gripopen, pistolstart, pistolend, pointingstart, and pointingend. Additionally, pistolstart and pistolend were emitted when thumbup and thumbdown should have been emitted. See aframevr#4883 for more detail.

**Changes proposed:**
- Have the pistol events be emitted with the pointThumb animation.
- Have the thumb events be emitted with the thumbUp animation.
- Have the point events be emitted with the hold animation.
- Change the suffixes for the grip events to down/up.
- Add up/down as the suffixes for the thumb events
