### PR TITLE
Make Listening for Events section inclusive of custom controllers

### DIFF
--- a/docs/introduction/interactions-and-controllers.md
+++ b/docs/introduction/interactions-and-controllers.md
@@ -501,13 +501,10 @@ A-Blast][a-blast].
 
 ## Listening for Controller Events
 
-The events emitted by the A-Frame and vendor specific controllers (e.g Quest,
-Index...) build on the base level events emitted by the
-[tracked-controls component]((#tracked-controls-component)) to the specific
-events of each controller. To handle these events, we look for the event name
-in the controller component's documentation pages at the event tables, then
-register event handlers how we want. Here are the events emitted by A-Frame's
-controller components:
+To handle controller events, we look for the event name in the controller
+component's documentation pages in the event tables, then register event
+handlers how we want. Here are the events emitted by A-Frame's controller
+components:
 
 - [daydream-controls events](../components/daydream-controls.md#events)
 - [gearvr-controls events](../components/gearvr-controls.md#events)
@@ -535,6 +532,10 @@ Then attach the component:
 ```html
 <a-entity oculus-touch-controls x-button-listener></a-entity>
 ```
+
+See [creating custom controllers](#creating-custom-controllers) for more
+details on how events are defined by building abstractions on the base level
+events emitted by the [tracked-controls component]((#tracked-controls-component)).
 
 ## Adding Laser Interactions for Controllers
 

--- a/docs/introduction/interactions-and-controllers.md
+++ b/docs/introduction/interactions-and-controllers.md
@@ -501,14 +501,13 @@ A-Blast][a-blast].
 
 ## Listening for Controller Events
 
-Controllers may have many buttons, many axes, and may emit many events. The
-events defined by the controller, themselves built off of the basic events provided
-by the [tracked-controls component]((#tracked-controls-component)), provide the API
-contract through which the controller adds semantic actions to the component it
-belongs to. To handle events, we look for the event name in the controller
-component's documentation pages at the event tables, then register event handlers
-how we want. The event handlers work the same for custom controllers. Here are the
-events emitted by A-Frame's controller components:
+The events emitted by the A-Frame and vendor specific controllers (e.g Quest,
+Index...) build on the base level events emitted by the
+[tracked-controls component]((#tracked-controls-component)) to the specific
+events of each controller. To handle these events, we look for the event name
+in the controller component's documentation pages at the event tables, then
+register event handlers how we want. Here are the events emitted by A-Frame's
+controller components:
 
 - [daydream-controls events](../components/daydream-controls.md#events)
 - [gearvr-controls events](../components/gearvr-controls.md#events)

--- a/docs/introduction/interactions-and-controllers.md
+++ b/docs/introduction/interactions-and-controllers.md
@@ -499,14 +499,16 @@ For advanced examples on real applications, see the [paint-controls component
 for A-Painter][a-painter] or the [shoot-controls component for
 A-Blast][a-blast].
 
-## Listening for Button and Axis Events
+## Listening for Controller Events
 
-Controllers have many buttons and emit many events. For each button, every time
-a button is pressed down, released, or for some cases, even touched. And for
-each axis (e.g., trackpad, thumbstick), an event is emitted every time it is
-touched. To handle buttons, look for the event name in the respective
-controller component documentation pages at the event tables, then register
-event handlers how we want:
+Controllers may have many buttons, many axes, and may emit many events. The
+events defined by the controller, themselves built off of the basic events provided
+by the [tracked-controls component]((#tracked-controls-component)), provide the API
+contract through which the controller adds semantic actions to the component it
+belongs to. To handle events, we look for the event name in the controller
+component's documentation pages at the event tables, then register event handlers
+how we want. The event handlers work the same for custom controllers. Here are the
+events emitted by A-Frame's controller components:
 
 - [daydream-controls events](../components/daydream-controls.md#events)
 - [gearvr-controls events](../components/gearvr-controls.md#events)


### PR DESCRIPTION
**Description:**
As I understand, this section is really about listening for controller events, which won't necessarily be for buttons and axes. On an initial read through the docs, I had just read about creating custom controllers, so felt it may be more clear to make this section inclusive of the custom controllers just covered. Open to any suggested edits, I believe my statements are backed up from what I've seen so far but am generally unfamiliar with the library so need to be checked!

At a minimum, I'd like to fix up the "For each button, every time a button is pressed down, released, or for some cases, even touched." sentence fragment!

**Changes proposed:**
- Make section about listening to controller events, not specific to A-Frame controllers
- Link tracked-controls-component instead of relisting events