### PR TITLE
Fix docs 'window.THREE' -> 'AFRAME.THREE'

### DIFF
--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -54,7 +54,7 @@ be left maintaining a wide array of flags.
 
 The component lives within a Browserify/Webpack context so you'll need to
 replace the `require` statements with A-Frame globals (e.g.,
-`AFRAME.registerComponent`, `window.THREE`), and get rid of the `module.exports`.
+`AFRAME.registerComponent`, `AFRAME.THREE`), and get rid of the `module.exports`.
 
 ## Caveats
 


### PR DESCRIPTION
**Description:**

The doc ask to use `window.THREE` but I think it should be `AFRAME.THREE`

**Changes proposed:**

- Replace `window.THREE` by `AFRAME.THREE` in the doc
