### PR TITLE
fix typo "wheter" -> "whether"

### DIFF
--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -35,7 +35,7 @@ component](camera.md).
 | touchEnabled     | Whether to use touch controls in magic window mode.              | true          |
 | mouseEnabled     | Whether to use mouse to move the camera in 2D mode.              | true          |
 | pointerLockEnabled | Whether to hide the cursor using the [Pointer Lock API][pointer-lock-api]. | false |
-| magicWindowTrackingEnabled | Wheter gyroscope camera tracking is enabled on mobile devices. | true |
+| magicWindowTrackingEnabled | Whether gyroscope camera tracking is enabled on mobile devices. | true |
 
 ## Customizing look-controls
 


### PR DESCRIPTION
**Description:**

There is a typo on the word `wheter` which should be spelled `whether`

**Changes proposed:**

- Changed `wheter` to `whether`
