### PR TITLE
fix hit-test error handling

### DIFF
--- a/src/components/scene/ar-hit-test.js
+++ b/src/components/scene/ar-hit-test.js
@@ -68,24 +68,30 @@ function HitTest (renderer, hitTestSourceDetails) {
 HitTest.prototype.previousFrameAnchors = new Set();
 HitTest.prototype.anchorToObject3D = new Map();
 
+function warnAboutHitTest (e) {
+  console.warn(e.message);
+  console.warn('Cannot requestHitTestSource Are you missing: webxr="optionalFeatures: hit-test;" from <a-scene>?');
+}
+
 HitTest.prototype.sessionStart = function sessionStart (hitTestSourceDetails) {
   this.session = this.renderer.xr.getSession();
-  try {
-    if (hitTestSourceDetails.space) {
-      this.session.requestHitTestSource(hitTestSourceDetails)
-      .then(function (xrHitTestSource) {
-        this.xrHitTestSource = xrHitTestSource;
-      }.bind(this));
-    } else if (hitTestSourceDetails.profile) {
-      this.session.requestHitTestSourceForTransientInput(hitTestSourceDetails)
-      .then(function (xrHitTestSource) {
-        this.xrHitTestSource = xrHitTestSource;
-        this.transient = true;
-      }.bind(this));
-    }
-  } catch (e) {
-    console.warn(e.message);
-    console.warn('Cannot requestHitTestSource Are you missing: webxr="optionalFeatures: hit-test;" from <a-scene>?');
+  if (!('requestHitTestSource' in this.session)) {
+    warnAboutHitTest({message: 'No requestHitTestSource on the session.'});
+    return;
+  }
+  if (hitTestSourceDetails.space) {
+    this.session.requestHitTestSource(hitTestSourceDetails)
+    .then(function (xrHitTestSource) {
+      this.xrHitTestSource = xrHitTestSource;
+    }.bind(this))
+    .catch(warnAboutHitTest);
+  } else if (hitTestSourceDetails.profile) {
+    this.session.requestHitTestSourceForTransientInput(hitTestSourceDetails)
+    .then(function (xrHitTestSource) {
+      this.xrHitTestSource = xrHitTestSource;
+      this.transient = true;
+    }.bind(this))
+    .catch(warnAboutHitTest);
   }
 };
 


### PR DESCRIPTION
**Description:**

The current version of Edge on Hololens doesn't support hit-test which revealed some issues with the error handling in ar-hit-test

This was a hangover from when it was ported from modern JS to ES5. 

