### PR TITLE
Disable XR when rendering reticle because the XR cameras ignore the layers property

### DIFF
--- a/src/components/scene/ar-hit-test.js
+++ b/src/components/scene/ar-hit-test.js
@@ -383,7 +383,7 @@ module.exports.Component = register('ar-hit-test', {
     var tempImageData;
     var renderer = this.el.sceneEl.renderer;
     var oldRenderTarget, oldBackground;
-    var isXR = renderer.xr.enabled;
+    var isXREnabled = renderer.xr.enabled;
     this.bboxMesh.material.map = this.canvasTexture;
     this.bboxMesh.material.needsUpdate = true;
     this.orthoCam.rotation.set(-Math.PI / 2, 0, -Math.PI / 2);
@@ -407,7 +407,7 @@ module.exports.Component = register('ar-hit-test', {
     renderer.render(this.el.object3D, this.orthoCam);
     this.el.object3D.background = oldBackground;
     this.el.object3D.overrideMaterial = null;
-    renderer.xr.enabled = isXR;
+    renderer.xr.enabled = isXREnabled;
     renderer.setRenderTarget(oldRenderTarget);
     renderer.readRenderTargetPixels(this.textureTarget, 0, 0, 512, 512, this.imageDataArray);
 

--- a/src/components/scene/ar-hit-test.js
+++ b/src/components/scene/ar-hit-test.js
@@ -383,6 +383,7 @@ module.exports.Component = register('ar-hit-test', {
     var tempImageData;
     var renderer = this.el.sceneEl.renderer;
     var oldRenderTarget, oldBackground;
+    var isXR = renderer.xr.enabled;
     this.bboxMesh.material.map = this.canvasTexture;
     this.bboxMesh.material.needsUpdate = true;
     this.orthoCam.rotation.set(-Math.PI / 2, 0, -Math.PI / 2);
@@ -399,12 +400,14 @@ module.exports.Component = register('ar-hit-test', {
 
     oldRenderTarget = renderer.getRenderTarget();
     renderer.setRenderTarget(this.textureTarget);
+    renderer.xr.enabled = false;
     oldBackground = this.el.object3D.background;
     this.el.object3D.overrideMaterial = this.basicMaterial;
     this.el.object3D.background = null;
     renderer.render(this.el.object3D, this.orthoCam);
     this.el.object3D.background = oldBackground;
     this.el.object3D.overrideMaterial = null;
+    renderer.xr.enabled = isXR;
     renderer.setRenderTarget(oldRenderTarget);
     renderer.readRenderTargetPixels(this.textureTarget, 0, 0, 512, 512, this.imageDataArray);
 


### PR DESCRIPTION
This fixes a bug where when the reticle tries to update in XR it includes unexpected objects because it is using the XR camera not the specified camera. The XR camera ignores layers.
