### PR TITLE
Distortion map texture properties

### DIFF
--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -2,6 +2,7 @@ var registerSystem = require('../core/system').registerSystem;
 var THREE = require('../lib/three');
 var utils = require('../utils/');
 var isHLS = require('../utils/material').isHLS;
+var setTextureProperties = require('../utils/material').setTextureProperties;
 
 var bind = utils.bind;
 var debug = utils.debug;
@@ -314,37 +315,6 @@ function loadImageTexture (src, data) {
               xhr.statusText);
       }
     );
-  }
-}
-
-/**
- * Set texture properties such as repeat and offset.
- *
- * @param {object} data - With keys like `repeat`.
- */
-function setTextureProperties (texture, data) {
-  var offset = data.offset || {x: 0, y: 0};
-  var repeat = data.repeat || {x: 1, y: 1};
-  var npot = data.npot || false;
-
-  // To support NPOT textures, wrap must be ClampToEdge (not Repeat),
-  // and filters must not use mipmaps (i.e. Nearest or Linear).
-  if (npot) {
-    texture.wrapS = THREE.ClampToEdgeWrapping;
-    texture.wrapT = THREE.ClampToEdgeWrapping;
-    texture.magFilter = THREE.LinearFilter;
-    texture.minFilter = THREE.LinearFilter;
-  }
-
-  // Don't bother setting repeat if it is 1/1. Power-of-two is required to repeat.
-  if (repeat.x !== 1 || repeat.y !== 1) {
-    texture.wrapS = THREE.RepeatWrapping;
-    texture.wrapT = THREE.RepeatWrapping;
-    texture.repeat.set(repeat.x, repeat.y);
-  }
-  // Don't bother setting offset if it is 0/0.
-  if (offset.x !== 0 || offset.y !== 0) {
-    texture.offset.set(offset.x, offset.y);
   }
 }
 

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -10,6 +10,36 @@ var COLOR_MAPS = new Set([
 ]);
 
 /**
+ * Set texture properties such as repeat and offset.
+ *
+ * @param {object} data - With keys like `repeat`.
+*/
+module.exports.setTextureProperties = function (texture, data) {
+  var offset = data.offset || {x: 0, y: 0};
+  var repeat = data.repeat || {x: 1, y: 1};
+  var npot = data.npot || false;
+  // To support NPOT textures, wrap must be ClampToEdge (not Repeat),
+  // and filters must not use mipmaps (i.e. Nearest or Linear).
+  if (npot) {
+    texture.wrapS = THREE.ClampToEdgeWrapping;
+    texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearFilter;
+  }
+
+  // Don't bother setting repeat if it is 1/1. Power-of-two is required to repeat.
+  if (repeat.x !== 1 || repeat.y !== 1) {
+    texture.wrapS = THREE.RepeatWrapping;
+    texture.wrapT = THREE.RepeatWrapping;
+    texture.repeat.set(repeat.x, repeat.y);
+  }
+  // Don't bother setting offset if it is 0/0.
+  if (offset.x !== 0 || offset.y !== 0) {
+    texture.offset.set(offset.x, offset.y);
+  }
+};
+
+/**
  * Update `material` texture property (usually but not always `map`)
  * from `data` property (usually but not always `src`)
  *
@@ -117,6 +147,9 @@ module.exports.updateDistortionMap = function (longType, shader, data) {
     material[slot] = texture;
     if (texture && COLOR_MAPS.has(slot)) {
       rendererSystem.applyColorCorrection(texture);
+    }
+    if (texture) {
+      module.exports.setTextureProperties(texture, data);
     }
     material.needsUpdate = true;
     handleTextureEvents(el, texture);

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -14,7 +14,7 @@ var COLOR_MAPS = new Set([
  *
  * @param {object} data - With keys like `repeat`.
 */
-module.exports.setTextureProperties = function (texture, data) {
+function setTextureProperties (texture, data) {
   var offset = data.offset || {x: 0, y: 0};
   var repeat = data.repeat || {x: 1, y: 1};
   var npot = data.npot || false;
@@ -37,7 +37,8 @@ module.exports.setTextureProperties = function (texture, data) {
   if (offset.x !== 0 || offset.y !== 0) {
     texture.offset.set(offset.x, offset.y);
   }
-};
+}
+module.exports.setTextureProperties = setTextureProperties;
 
 /**
  * Update `material` texture property (usually but not always `map`)
@@ -149,7 +150,7 @@ module.exports.updateDistortionMap = function (longType, shader, data) {
       rendererSystem.applyColorCorrection(texture);
     }
     if (texture) {
-      module.exports.setTextureProperties(texture, data);
+      setTextureProperties(texture, data);
     }
     material.needsUpdate = true;
     handleTextureEvents(el, texture);


### PR DESCRIPTION
**Description:**

Distortion maps were using the default Wrapping so that when a normal map and a map were provided and there was repeating 
the texture would end up cut off e.g.:

![image](https://user-images.githubusercontent.com/4225330/134164524-ae2b22cf-d31e-4c71-849c-daee40511796.png)

**Changes proposed:**
- Move the material's setTextureProperties out of the system and into the utils
- use it to set the properties on the distortion maps too

![image](https://user-images.githubusercontent.com/4225330/134164988-f78daf8c-9100-4422-8ce7-6bb0c1458ad5.png)
