### PR TITLE
update cursor.js to support ortho raycaster; fixes #4935

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -221,8 +221,16 @@ module.exports.Component = registerComponent('cursor', {
       mouse.x = (left / bounds.width) * 2 - 1;
       mouse.y = -(top / bounds.height) * 2 + 1;
 
-      origin.setFromMatrixPosition(camera.matrixWorld);
-      direction.set(mouse.x, mouse.y, 0.5).unproject(camera).sub(origin).normalize();
+      if (camera && camera.isPerspectiveCamera) {
+        origin.setFromMatrixPosition(camera.matrixWorld);
+        direction.set(mouse.x, mouse.y, 0.5).unproject(camera).sub(origin).normalize();
+      } else if (camera && camera.isOrthographicCamera) {
+        origin.set(mouse.x, mouse.y, (camera.near + camera.far) / (camera.near - camera.far)).unproject(camera); // set origin in plane of camera
+        direction.set(0, 0, -1).transformDirection(camera.matrixWorld);
+      } else {
+        console.error('AFRAME.Raycaster: Unsupported camera type: ' + camera.type);
+      }
+
       this.el.setAttribute('raycaster', rayCasterConfig);
       if (evt.type === 'touchmove') { evt.preventDefault(); }
     };


### PR DESCRIPTION
**Description:**
Copies raycaster origin logic from three.js to account for ortho camera in addition to perspective

**Changes proposed:**
- See https://github.com/aframevr/aframe/issues/4935 for more info
