### PR TITLE
Samsung tablets were not recognized as tablets; updated user agent st…

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -120,7 +120,7 @@ module.exports.isMobile = isMobile;
  */
 function isTablet (mockUserAgent) {
   var userAgent = mockUserAgent || window.navigator.userAgent;
-  return /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
+  return /ipad|Nexus (7|9)|xoom|sch-i800|SamsungBrowser|sm-[a-z]+[a-z0-9]+|playbook|tablet|kindle/i.test(userAgent);
 }
 module.exports.isTablet = isTablet;
 

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -8,6 +8,15 @@ suite('isTablet', function () {
     assert.ok(device.isTablet(nexus7));
     assert.ok(device.isTablet(nexus9));
   });
+
+  test('is true for Samsung tablets (eg Galaxy Tab 7)', function () {
+    const galaxyTab7Chrome = 'Mozilla/5.0 (Linux; Android 11; SM-T970) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Safari/537.36';
+    const galaxTab7SamsungBrowser = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Safari/537.36';
+
+    assert.ok(device.isTablet(galaxyTab7Chrome));
+    assert.ok(device.isTablet(galaxTab7SamsungBrowser));
+  });
+
 });
 
 suite('environment', function () {


### PR DESCRIPTION
**Description:**

Samsung tablets (at least the Galaxy Tab S7+) were being mis-identified as desktop browsers, thus displaying a user dialog to switch viewing modes. This is the same dialog seen in #4798 (see below). This PR includes Samsung-specific checks that are not addressed by  #4803

<img width="355" alt="Screen Shot 2021-09-28 at 4 17 42 PM" src="https://user-images.githubusercontent.com/87674287/135178281-367215af-fb07-4f2c-94f2-4e6dd104be93.png">



**Changes proposed:**

- Update the `isTablet` regular expression to include user agent matching for Chrome and Samsung Browser on the Galaxy tablet
- Added relevant unit tests for Galaxy tablets
