### PR TITLE
Removed the mongoose web server option

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -57,8 +57,6 @@ files are properly served. Options of local servers include:
 
 - Running `npm i -g five-server@latest && five-server --port=8000` in a terminal
   in the same directory as your HTML file.
-- Downloading the [Mongoose](https://www.cesanta.com/products/binary) application
-  and opening it from the same directory as your HTML file.
 - Running `python -m SimpleHTTPServer` (or `python -m http.server` for Python 3)
   in a terminal in the same directory as your HTML file.
 


### PR DESCRIPTION
**Description:**
I removed the mongoose web server option because the link is dead and it looks like they are not releasing the binary version anymore.

**Changes proposed:**
- Removal of the mongoose web server option.

