### PR TITLE
[docs] remove deprecated setting from look-control docs and fix chang…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ AR, hand tracking, compositor layers, immersive navigation (Quest only), Quest 2
 * Make msdf shader WebGL 2 compliant @arpu
 * Valve Index controller support @zach-capalbo
 * Cordova compatibility @benallfree
-* Change [look-controls](https://aframe.io/docs/1.0.0/components/look-controls.html#sidebar) `hmdEnable` property name to `magicWindowTrackingEnabled` @dmarcos
+* Change [look-controls](https://aframe.io/docs/1.0.0/components/look-controls.html#sidebar) `hmdEnabled` property name to `magicWindowTrackingEnabled` @dmarcos
 * Improve hand tracking pinch gesture accuracy @cesmoak (#4691)
 * Improve error handling when entering immersive mode (#4660) @federico-camonapp @dmarcos
 * Make text of [device permission ui component](https://aframe.io/docs/1.0.0/components/device-orientation-permission-ui.html#sidebar) dialogs configurable @dmarcos

--- a/docs/components/look-controls.md
+++ b/docs/components/look-controls.md
@@ -29,7 +29,6 @@ component](camera.md).
 | Property         | Description                                                      | Default Value |
 |------------------|------------------------------------------------------------------|---------------|
 | enabled          | Whether look controls are enabled.                               | true          |
-| hmdEnabled       | Whether to use VR headset pose in VR mode.                       | true          |
 | reverseMouseDrag | Whether to reverse mouse drag.                                   | false         |
 | reverseTouchDrag | Whether to reverse touch drag.                                   | false         |
 | touchEnabled     | Whether to use touch controls in magic window mode.              | true          |


### PR DESCRIPTION
**Description:**

The property `hmdEnabled` of `look-controls` has been renamed to `magicWindowTrackingEnabled` in #4528 .
The change has been released in [v1.1.0](https://github.com/aframevr/aframe/releases/tag/v1.1.0).

**Changes proposed:**
- Remove obsolete entry from docs
- Fixed typo in changelog
___ 

Note: The release notes in [v1.1.0](https://github.com/aframevr/aframe/releases/tag/v1.1.0)  contain the same typo as the changelog: `hmdEnable` instead of `hmdEnabled`.

It could be useful to update the release notes as well, to enable finding the keyword with "Find in page" features.