### PR TITLE
Fix blank scene after link navigation

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -378,7 +378,6 @@ module.exports.AScene = registerElement('a-scene', {
             requestFullscreen(self.canvas);
           }
 
-          self.renderer.setAnimationLoop(self.render);
           self.resize();
           if (resolve) { resolve(); }
         }


### PR DESCRIPTION
The scene would sometimes fail to load after link navigation. If you enter
vr before the scene has loaded, it starts the render loop early, which can
cause an exception if the camera has not been injected yet.

Fixes #4964