### PR TITLE
New throttle function for the componentchanged event. 

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -72,7 +72,7 @@ var Component = module.exports.Component = function (el, attrValue, id) {
   }
 
   // Last value passed to updateProperties.
-  this.throttledEmitComponentChanged = utils.throttle(function emitChange () {
+  this.throttledEmitComponentChanged = utils.throttleComponentChanged(function emitChange () {
     el.emit('componentchanged', self.evtDetail, false);
   }, 200);
   this.updateProperties(attrValue);


### PR DESCRIPTION
One extra call might be issued at the end of the last interval to broadcast the last state of the component after a burst of component changes (fix #4972)