### PR TITLE
Add info about binding event listeners (docs update)

### DIFF
--- a/docs/introduction/javascript-events-dom-apis.md
+++ b/docs/introduction/javascript-events-dom-apis.md
@@ -502,6 +502,37 @@ entityEl.addEventListener('physicscollided', collisionHandler);
 entityEl.removeEventListener('physicscollided', collisionHandler);
 ```
 
+### Binding Event Listeners
+
+By default, event listeners do not have access to the component's `this`.  Instead, `this` will be bound to `window`, so you won't see errors if you reference `this` inside an event Listener, but you are likely to get unexpected results.
+
+In order for the component's `this` to be accessible inside an event listener, [it must be bound](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this).
+
+There are several ways you can do this:
+
+1. By using an arrow function to define the event listener.  Arrow functions automatically bind `this`.
+
+```entityEl.addEventListener('physicscollided', function (event) {
+entityEl.addEventListener('click', (event) => {
+  console.log(this.el.id);
+});
+```
+
+2. By binding the function as you add the event listener.  You will also need to do the same when [removing the event listener.](#removing-an-event-listener-with-removeeventlistener)
+
+```entityEl.addEventListener('physicscollided', (event) => {
+entityEl.addEventListener('click', this.clickListener.bind(this));
+```
+
+3. By creating another function, which is the bound version of the function.
+
+   ```
+   this.listeners = {
+     clickListener: this.clickListener.bind(this);
+   }
+   entityEl.addEventListener('click', this.listeners.clickListener);
+   ```
+
 ## Caveats
 
 [faq]: ./faq.md#why-is-the-html-not-updating-when-i-check-the-browser-inspector

--- a/docs/introduction/javascript-events-dom-apis.md
+++ b/docs/introduction/javascript-events-dom-apis.md
@@ -504,7 +504,7 @@ entityEl.removeEventListener('physicscollided', collisionHandler);
 
 ### Binding Event Listeners
 
-By default, event listeners do not have access to the component's `this`.  Instead, `this` will be bound to `window`, so you won't see errors if you reference `this` inside an event Listener, but you are likely to get unexpected results.
+By default, [Javascript execution context rules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this) binds `this` to the global context (`window`) for any independent function, meaning that these functions won't have access to the component's `this` by default.
 
 In order for the component's `this` to be accessible inside an event listener, [it must be bound](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this).
 

--- a/docs/introduction/javascript-events-dom-apis.md
+++ b/docs/introduction/javascript-events-dom-apis.md
@@ -518,20 +518,24 @@ entityEl.addEventListener('click', (event) => {
 });
 ```
 
-2. By binding the function as you add the event listener.  You will also need to do the same when [removing the event listener.](#removing-an-event-listener-with-removeeventlistener)
+2. By defining your event listener within the events object of the component (this will also handling adding and removing the listener automatically)
+
+   See the explanation [here](../core/component.html#events).
+
+3. By binding the function as you add the event listener.  You will also need to do the same when [removing the event listener.](#removing-an-event-listener-with-removeeventlistener)
 
 ```entityEl.addEventListener('physicscollided', (event) => {
 entityEl.addEventListener('click', this.clickListener.bind(this));
 ```
 
-3. By creating another function, which is the bound version of the function.
+4. By creating another function, which is the bound version of the function.
 
-   ```
-   this.listeners = {
-     clickListener: this.clickListener.bind(this);
-   }
-   entityEl.addEventListener('click', this.listeners.clickListener);
-   ```
+```
+this.listeners = {
+    clickListener: this.clickListener.bind(this);
+}
+entityEl.addEventListener('click', this.listeners.clickListener);
+```
 
 ## Caveats
 

--- a/docs/introduction/javascript-events-dom-apis.md
+++ b/docs/introduction/javascript-events-dom-apis.md
@@ -523,13 +523,8 @@ this.el.addEventListener('physicscollided', (event) => {
 
    See the explanation [here](../core/component.html#events).
 
-3. By binding the function as you add the event listener.  You will also need to do the same when [removing the event listener.](#removing-an-event-listener-with-removeeventlistener)
 
-```entityEl.addEventListener('physicscollided', (event) => {
-entityEl.addEventListener('click', this.clickListener.bind(this));
-```
-
-4. By creating another function, which is the bound version of the function.
+3. By creating another function, which is the bound version of the function.
 
 ```
 this.listeners = {

--- a/docs/introduction/javascript-events-dom-apis.md
+++ b/docs/introduction/javascript-events-dom-apis.md
@@ -510,13 +510,14 @@ In order for the component's `this` to be accessible inside an event listener, [
 
 There are several ways you can do this:
 
-1. By using an arrow function to define the event listener.  Arrow functions automatically bind `this`.
+1. By using an arrow function to define the event listener.  Arrow functions automatically bind `this`
 
-```entityEl.addEventListener('physicscollided', function (event) {
-entityEl.addEventListener('click', (event) => {
-  console.log(this.el.id);
+```
+this.el.addEventListener('physicscollided', (event) => {
+    console.log(this.el.id);
 });
 ```
+
 
 2. By defining your event listener within the events object of the component (this will also handling adding and removing the listener automatically)
 


### PR DESCRIPTION
**Description:**

I answered a question on A-Frame slack where someone hadn't realized they needed to bind event listeners in order to access this inside them.

I looked for an explanation of this in the docs, but there wasn't one.  I guess I figured this out from examples + generic JS documentation on `this`.  But it's a pretty fundamental to using event listeners in A-Frame, and I think deserves some explanation in the core docs.

**Changes proposed:**

- Added a section to the docs intro to event listeners explaining that `this` is not accessible by default, and how to get access to it.
