### PR TITLE
Bug fixes for WebXR layers:

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -60,6 +60,8 @@ module.exports.Component = registerComponent('layer', {
 
     this.visibilityChanged = false;
     if (!this.layer) { return; }
+    if (type !== 'monocubemap' && type !== 'stereocubemap') { return; }
+
     if (!src.complete) {
       this.pendingCubeMapUpdate = true;
     } else {
@@ -72,7 +74,7 @@ module.exports.Component = registerComponent('layer', {
       this.loadingScreen = false;
     }
 
-    if (this.layer.layout === 'mono') {
+    if (type === 'monocubemap') {
       glayer = xrGLFactory.getSubImage(this.layer, frame);
       this.loadCubeMapImage(glayer.colorTexture, src, 0);
     } else {

--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -53,7 +53,6 @@ module.exports.Component = registerComponent('layer', {
   },
 
   loadCubeMapImages: function () {
-    var type = this.data.type;
     var glayer;
     var xrGLFactory = this.xrGLFactory;
     var frame = this.el.sceneEl.frame;
@@ -73,7 +72,7 @@ module.exports.Component = registerComponent('layer', {
       this.loadingScreen = false;
     }
 
-    if (type === 'monocubemap') {
+    if (this.layer.layout === 'mono') {
       glayer = xrGLFactory.getSubImage(this.layer, frame);
       this.loadCubeMapImage(glayer.colorTexture, src, 0);
     } else {
@@ -245,6 +244,7 @@ module.exports.Component = registerComponent('layer', {
       height: this.data.height / 2 || this.texture.image.height / 1000,
       width: this.data.width / 2 || this.texture.image.width / 1000
     });
+    this.initLoadingScreenImages();
     sceneEl.renderer.xr.addLayer(this.layer);
   },
 
@@ -359,7 +359,7 @@ module.exports.Component = registerComponent('layer', {
       warn('The layer component requires WebXR and the layers API enabled');
       return;
     }
-    xrSession.requestReferenceSpace('local').then(this.onRequestedReferenceSpace);
+    xrSession.requestReferenceSpace('local-floor').then(this.onRequestedReferenceSpace);
     this.needsRedraw = true;
     this.layerEnabled = true;
     if (this.quadPanelEl) {


### PR DESCRIPTION
Request "local-floor" reference space to match three.js default.
Init loading screen images for quad layer
Check mono layout instead of monocubemap to ensure we ask for the proper subimage type.