### PR TITLE
Reflection refactor 

### DIFF
--- a/docs/components/background.md
+++ b/docs/components/background.md
@@ -13,30 +13,12 @@ frustum culling issues when `a-sky` is further than the far plane of the
 camera. There are no unexpected occlusions either with far objects that might
 be behind of the sphere geometry of `a-sky`.
 
-The background component can also generate a default environment cube map for all
-materials, this is useful in case you find GLB models end up too dark or reflective
-materials don't look right because they are not reflecting the environment this
-will provide a default reflective environment.
-
-## Scene Lighting and Lighting Estimation
-
-The background component will ensure that an environment map is generated from your surroundings using WebXR
-Lighting estimation in Augmented Reality if it is available.
-
-It will also create lights to match the lighting of the real world. So you should turn off any scene lights when the user enters AR using the `hide-on-enter-ar` component.
-
-These lights are a `directional` and a `probe` light. If your scene makes use of shadows
-from a directional light you can provide this as the `directionalLight` property and it
-will control that light instead of making it's own one. Once the user leaves AR this
-light may have a different color, intensity and position than when they entered AR as it has been
-altered by the lighting estimation.
-
 ## Example
 
 The example below sets the background color to red and use lighting estimation for AR.
 
 ```html
-<a-scene webxr="optionalFeatures: light-estimation;" background="color: red"></a-scene>
+<a-scene background="color: red"></a-scene>
 ```
 
 ## Properties
@@ -45,5 +27,3 @@ The example below sets the background color to red and use lighting estimation f
 |----------------------------|-----------------------------------------------------------|-----------------|
 | color                      | Color of the scene background.                            | black           |
 | transparent                | Background is transparent. The color property is ignored. | false           |
-| generateEnvironment        | Whether to generate a default environment.                | true            |
-| directionalLight           | Use an existing light for the AR lighting                 | null            |

--- a/docs/components/reflection.md
+++ b/docs/components/reflection.md
@@ -7,10 +7,12 @@ source_code: src/components/reflection.js
 examples: []
 ---
 
-The reflection component can also generate a default environment cube map for all
+The reflection component generates a default environment cube map for all
 materials, this is useful in case you find GLB models end up too dark or reflective
 materials don't look right because they are not reflecting the environment this
 will provide a default reflective environment.
+
+![Left hand side has objects with no reflection, the objects on the right reflect the environment](https://user-images.githubusercontent.com/4225330/151032019-1f14a079-604a-4c5f-b377-ea30a4e2b098.png)
 
 ## Scene Lighting and Lighting Estimation
 

--- a/docs/components/reflection.md
+++ b/docs/components/reflection.md
@@ -1,0 +1,39 @@
+---
+title: reflection
+type: components
+layout: docs
+parent_section: components
+source_code: src/components/reflection.js
+examples: []
+---
+
+The reflection component can also generate a default environment cube map for all
+materials, this is useful in case you find GLB models end up too dark or reflective
+materials don't look right because they are not reflecting the environment this
+will provide a default reflective environment.
+
+## Scene Lighting and Lighting Estimation
+
+The reflection component will generate an environment map from your surroundings using WebXR
+Lighting estimation in Augmented Reality if it is available.
+
+During this it will also take control of your scene's main directional light to ensure it's direction and color matches that of the rest of the environemnt. This works really well for your scene's shadows.
+It will also create a probe light to match the lighting of the real world.
+So you should turn off any additional global scene lights, such as other directional lights, hemisphere lights or ambient lights, when the user enters AR. You can do this with the `hide-on-enter-ar` component.
+
+Once the user leaves AR this light may have a different color, intensity and position than when they entered AR as it has been altered by the lighting estimation.
+
+## Example
+
+The example below sets the reflection color to red and use lighting estimation for AR.
+
+```html
+<a-scene reflection="directionalLight:a-light#dirlight;"></a-scene>
+	<a-light id="dirlight" intensity="1" light="castShadow:true;type:directional" position="1 1 1"></a-light>
+```
+
+## Properties
+
+| Property                   | Description                                               | Default Value   |
+|----------------------------|-----------------------------------------------------------|-----------------|
+| directionalLight           | Light to control during WebXR Lighting Estimation         |                 |

--- a/examples/boilerplate/webxr-ar-lighting/index.html
+++ b/examples/boilerplate/webxr-ar-lighting/index.html
@@ -16,7 +16,7 @@
 <body>
 	<a-scene
 		webxr="overlayElement:#dom-overlay;"
-		reflection
+		reflection="directionalLight:#dirlight;"
 		ar-hit-test="target:#table;"
 		shadow="type: pcfsoft">
 		<a-assets>

--- a/examples/boilerplate/webxr-ar-lighting/index.html
+++ b/examples/boilerplate/webxr-ar-lighting/index.html
@@ -16,7 +16,7 @@
 <body>
 	<a-scene
 		webxr="overlayElement:#dom-overlay;"
-		reflection="directionalLight:#dirlight;"
+		reflection
 		ar-hit-test="target:#table;"
 		shadow="type: pcfsoft">
 		<a-assets>

--- a/examples/boilerplate/webxr-ar-lighting/index.html
+++ b/examples/boilerplate/webxr-ar-lighting/index.html
@@ -16,7 +16,7 @@
 <body>
 	<a-scene
 		webxr="overlayElement:#dom-overlay;"
-		background="directionalLight:#dirlight;"
+		reflection="directionalLight:#dirlight;"
 		ar-hit-test="target:#table;"
 		shadow="type: pcfsoft">
 		<a-assets>
@@ -45,7 +45,7 @@
 					material="roughness: 0.1; metalness: 0.2;"></a-cylinder>
 				<a-box position="-1 0.5 1" rotation="0 45 0" color="#4CC3D9" material="roughness: 0.1; metalness: 0.2;">
 				</a-box>
-				<a-sphere position="0 1.25 -1" radius="1.25" color="#FFFFFF" material="roughness: 0; metalness: 0;">
+				<a-sphere position="0 1.25 -1" radius="1.25" color="#cccccc" material="roughness:0.5; metalness:0.1;">
 				</a-sphere>
 				<a-torus-knot position="0 3 0" material="metalness: 1; roughness: 0.17"
 					geometry="radius: 0.45; radiusTubular: 0.09"

--- a/examples/boilerplate/webxr-ar-lighting/index.html
+++ b/examples/boilerplate/webxr-ar-lighting/index.html
@@ -16,6 +16,7 @@
 <body>
 	<a-scene
 		webxr="overlayElement:#dom-overlay;"
+    background="color:skyblue;"
 		reflection="directionalLight:#dirlight;"
 		ar-hit-test="target:#table;"
 		shadow="type: pcfsoft">

--- a/examples/boilerplate/webxr-ar-lighting/index.html
+++ b/examples/boilerplate/webxr-ar-lighting/index.html
@@ -16,7 +16,7 @@
 <body>
 	<a-scene
 		webxr="overlayElement:#dom-overlay;"
-    background="color:skyblue;"
+		background="color:skyblue;"
 		reflection="directionalLight:#dirlight;"
 		ar-hit-test="target:#table;"
 		shadow="type: pcfsoft">

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "present": "0.0.6",
     "promise-polyfill": "^3.1.0",
     "super-animejs": "^3.1.0",
-    "super-three": "^0.136.0",
+    "super-three": "^0.136.1",
     "three-bmfont-text": "dmarcos/three-bmfont-text#21d017046216e318362c48abd1a48bddfb6e0733",
     "webvr-polyfill": "^0.10.12"
   },

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -47,6 +47,7 @@ require('./scene/inspector');
 require('./scene/fog');
 require('./scene/keyboard-shortcuts');
 require('./scene/pool');
+require('./scene/reflection');
 require('./scene/screenshot');
 require('./scene/stats');
 require('./scene/vr-mode-ui');

--- a/src/components/scene/background.js
+++ b/src/components/scene/background.js
@@ -1,144 +1,13 @@
-/* global THREE, XRWebGLBinding */
+/* global THREE */
 var register = require('../../core/component').registerComponent;
 var COMPONENTS = require('../../core/component').components;
-
-// source: view-source:https://storage.googleapis.com/chromium-webxr-test/r886480/proposals/lighting-estimation.html
-function updateLights (estimate, probeLight, directionalLight, directionalLightPosition) {
-  var intensityScalar =
-  Math.max(1.0,
-    Math.max(estimate.primaryLightIntensity.x,
-      Math.max(estimate.primaryLightIntensity.y,
-        estimate.primaryLightIntensity.z)));
-
-  probeLight.sh.fromArray(estimate.sphericalHarmonicsCoefficients);
-  probeLight.intensity = 1;
-
-  directionalLight.color.setRGB(
-    estimate.primaryLightIntensity.x / intensityScalar,
-    estimate.primaryLightIntensity.y / intensityScalar,
-    estimate.primaryLightIntensity.z / intensityScalar);
-
-  directionalLight.intensity = intensityScalar;
-  directionalLightPosition.copy(estimate.primaryLightDirection);
-}
 
 module.exports.Component = register('background', {
   schema: {
     color: { type: 'color', default: 'black' },
-    transparent: { default: false },
-    generateEnvironment: { default: false },
-    directionalLight: { type: 'selector' }
-  },
-  init: function () {
-    var self = this;
-
-    this.pmremGenerator = new THREE.PMREMGenerator(this.el.renderer);
-    this.pmremGenerator.compileCubemapShader();
-    this.cubeRenderTarget = new THREE.WebGLCubeRenderTarget(256, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter });
-    this.lightProbeTarget = new THREE.WebGLCubeRenderTarget(16, { format: THREE.RGBFormat, generateMipmaps: false });
-    this.cubeCamera = new THREE.CubeCamera(0.1, 1000, this.cubeRenderTarget);
-    this.needsEnvironmentUpdate = false;
-    this.timeSinceUpdate = 0;
-
-    // Update WebXR to support light-estimation
-    var webxrData = this.el.getAttribute('webxr');
-    var optionalFeaturesArray = webxrData.optionalFeatures;
-    if (!optionalFeaturesArray.includes('light-estimation')) {
-      optionalFeaturesArray.push('light-estimation');
-      this.el.setAttribute('webxr', webxrData);
-    }
-
-    this.el.sceneEl.addEventListener('enter-vr', function () {
-      var renderer = self.el.renderer;
-      var session = renderer.xr.getSession();
-      if (
-        session.requestLightProbe && self.el.sceneEl.is('ar-mode')
-      ) {
-        self.startLightProbe();
-      }
-    });
-
-    this.el.sceneEl.addEventListener('exit-vr', function () {
-      self.stopLightProbe();
-    });
-  },
-  stopLightProbe: function () {
-    var data = this.data;
-    var scene = this.el.sceneEl.object3D;
-    this.xrLightProbe = null;
-
-    this.probeLight.components.light.light.intensity = 0;
-    if (this.ownDirectionalLight) {
-      this.ownDirectionalLight.components.light.light.intensity = 0;
-    }
-
-    if (data.generateEnvironment) {
-      this.needsEnvironmentUpdate = true;
-    } else {
-      scene.environment = null;
-    }
-  },
-  setupLightsForLightingEstimation: function () {
-    // Make a directionalLight if required
-    if (this.data.directionalLight) {
-      this.directionalLight = this.data.directionalLight;
-    } else {
-      var directionalLight = this.ownDirectionalLight || document.createElement('a-light');
-      directionalLight.setAttribute('type', 'directional');
-      directionalLight.setAttribute('intensity', 0);
-      this.el.appendChild(directionalLight);
-      this.directionalLight = directionalLight;
-      this.ownDirectionalLight = directionalLight;
-    }
-
-    if (!this.probeLight) {
-      var probeLight = document.createElement('a-light');
-      probeLight.setAttribute('type', 'probe');
-      probeLight.setAttribute('intensity', 0);
-      this.el.appendChild(probeLight);
-      this.probeLight = probeLight;
-    }
-  },
-  startLightProbe: function () {
-    var data = this.data;
-    var scene = this.el.sceneEl.object3D;
-
-    if (data.generateEnvironment) {
-      this.needsLightProbeUpdate = true;
-      this.needsEnvironmentUpdate = true;
-    } else {
-      scene.environment = null;
-    }
-  },
-  setupLightProbe: function () {
-    var scene = this.el.object3D;
-    var renderer = this.el.renderer;
-    var xrSession = renderer.xr.getSession();
-    var self = this;
-    var gl = renderer.getContext();
-
-    this.setupLightsForLightingEstimation();
-
-    this.glBinding = new XRWebGLBinding(xrSession, gl);
-    gl.getExtension('EXT_sRGB');
-    gl.getExtension('OES_texture_half_float');
-
-    xrSession.requestLightProbe()
-      .then(function (lightProbe) {
-        scene.environment = self.lightProbeTarget.texture;
-
-        self.xrLightProbe = lightProbe;
-        lightProbe.addEventListener('reflectionchange', function onReflectionChanged () {
-          self.needsEnvironmentUpdate = true;
-        });
-      })
-      .catch(function (err) {
-        console.warn('Lighting estimation not supported: ' + err.message);
-        console.warn('Are you missing: webxr="optionalFeatures: light-estimation;" from <a-scene>?');
-      });
+    transparent: { default: false }
   },
   update: function () {
-    var scene = this.el.sceneEl.object3D;
     var data = this.data;
     var object3D = this.el.object3D;
 
@@ -147,69 +16,6 @@ module.exports.Component = register('background', {
     } else {
       object3D.background = new THREE.Color(data.color);
     }
-
-    if (data.generateEnvironment) {
-      this.needsEnvironmentUpdate = true;
-    } else {
-      scene.environment = null;
-    }
-  },
-
-  updateXRCubeMap: function () {
-    // Update Cube Map, cubeMap maybe some unavailable on some hardware
-    var renderer = this.el.renderer;
-    var cubeMap = this.glBinding.getReflectionCubeMap(this.xrLightProbe);
-    if (cubeMap) {
-      var rendererProps = renderer.properties.get(this.lightProbeTarget.texture);
-      rendererProps.__webglTexture = cubeMap;
-    }
-  },
-
-  tick: function () {
-    var scene = this.el.object3D;
-    var renderer = this.el.renderer;
-    var frame = this.el.sceneEl.frame;
-
-    if (frame && this.xrLightProbe) {
-      // light estimate may not yet be available, it takes a few frames to start working
-      var estimate = frame.getLightEstimate(this.xrLightProbe);
-
-      if (estimate) {
-        updateLights(
-          estimate,
-          this.probeLight.components.light.light,
-          this.directionalLight.components.light.light,
-          this.directionalLight.object3D.position
-        );
-      }
-    }
-
-    if (!this.needsEnvironmentUpdate) {
-      return;
-    }
-
-    if (this.needsLightProbeUpdate) {
-      // wait until the XR Session has started before trying to make
-      // the light probe
-      if (!frame) {
-        return;
-      }
-      this.needsLightProbeUpdate = false;
-      this.setupLightProbe();
-    }
-
-    if (this.xrLightProbe) {
-      this.updateXRCubeMap();
-    } else {
-      this.cubeCamera.position.set(0, 1.6, 0);
-      scene.environment = null;
-      this.cubeCamera.update(renderer, scene);
-      scene.environment = this.pmremGenerator.fromCubemap(
-        this.cubeRenderTarget.texture
-      ).texture;
-    }
-
-    this.needsEnvironmentUpdate = false;
   },
 
   remove: function () {
@@ -219,7 +25,6 @@ module.exports.Component = register('background', {
       object3D.background = null;
       return;
     }
-    this.pmremGenerator.dispose();
     object3D.background = COMPONENTS[this.name].schema.color.default;
   }
 });

--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -147,6 +147,7 @@ module.exports.Component = register('reflection', {
     if (cubeMap) {
       var rendererProps = renderer.properties.get(this.cubeRenderTarget.texture);
       rendererProps.__webglTexture = cubeMap;
+      this.cubeRenderTarget.texture.needsPMREMUpdate = true;
     }
   },
   tick: function () {

--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -23,47 +23,6 @@ function updateLights (estimate, probeLight, directionalLight, directionalLightP
   }
 }
 
-function makeDebugOctogon () {
-  var geometry = new THREE.OctahedronBufferGeometry(0.5, 2);
-  var material = new THREE.ShaderMaterial({
-    side: THREE.BackSide,
-    blending: THREE.NormalBlending,
-    toneMapped: false,
-    uniforms: {
-      cubemap: {
-        type: 't',
-        value: undefined
-      }
-    },
-    vertexShader: `
-varying vec3 vWorldPosition;
-
-void main() {
-  //vec4 worldPosition = modelMatrix * vec4(position, 1.0);
-  vec4 worldPosition = vec4(position, 1.0);
-  vWorldPosition = vec3(worldPosition.z, worldPosition.y, worldPosition.x);
-
-  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-}
-    `,
-    fragmentShader: `
-uniform samplerCube cubemap;
-varying vec3 vWorldPosition;
-
-void main(){
-  vec3 normalizedVWorldPosition = normalize(vWorldPosition);
-  vec3 outcolor = textureCube(cubemap, normalizedVWorldPosition).rgb;
-
-  gl_FragColor = vec4(outcolor, 1.0);
-}
-    `
-  });
-
-  // mesh
-  var skyOcto = new THREE.Mesh(geometry, material);
-  return skyOcto;
-}
-
 module.exports.Component = register('reflection', {
   schema: {
     directionalLight: { type: 'selector' }
@@ -95,10 +54,6 @@ module.exports.Component = register('reflection', {
     this.el.addEventListener('exit-vr', function () {
       self.stopLightProbe();
     });
-
-    this.debugMesh = makeDebugOctogon();
-    this.debugMesh.position.set(0, 2, -2);
-    this.el.object3D.add(this.debugMesh);
 
     this.el.object3D.environment = this.cubeRenderTarget.texture;
   },
@@ -173,7 +128,6 @@ module.exports.Component = register('reflection', {
       this.needsVREnvironmentUpdate = false;
       this.cubeCamera.position.set(0, 1.6, 0);
       this.cubeCamera.update(renderer, scene);
-      this.debugMesh.material.uniforms.cubemap.value = this.cubeRenderTarget.texture;
     }
 
     if (this.needsLightProbeUpdate && frame) {

--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -66,8 +66,7 @@ void main(){
 
 module.exports.Component = register('reflection', {
   schema: {
-    directionalLight: { type: 'selector' },
-    debug: false
+    directionalLight: { type: 'selector' }
   },
   init: function () {
     var self = this;

--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -1,0 +1,151 @@
+/* global THREE, XRWebGLBinding */
+var register = require('../../core/component').registerComponent;
+var COMPONENTS = require('../../core/component').components;
+
+// source: view-source:https://storage.googleapis.com/chromium-webxr-test/r886480/proposals/lighting-estimation.html
+function updateLights (estimate, probeLight, directionalLight, directionalLightPosition) {
+  var intensityScalar =
+    Math.max(1.0,
+      Math.max(estimate.primaryLightIntensity.x,
+        Math.max(estimate.primaryLightIntensity.y,
+          estimate.primaryLightIntensity.z)));
+
+  probeLight.sh.fromArray(estimate.sphericalHarmonicsCoefficients);
+  probeLight.intensity = 1;
+
+  directionalLight.color.setRGB(
+    estimate.primaryLightIntensity.x / intensityScalar,
+    estimate.primaryLightIntensity.y / intensityScalar,
+    estimate.primaryLightIntensity.z / intensityScalar);
+
+  directionalLight.intensity = intensityScalar;
+  directionalLightPosition.copy(estimate.primaryLightDirection);
+}
+
+module.exports.Component = register('reflection', {
+  schema: {
+    directionalLight: { type: 'selector' }
+  },
+  init: function () {
+    var self = this;
+    this.cubeRenderTarget = new THREE.WebGLCubeRenderTarget(256, { generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter });
+    this.lightProbeTarget = new THREE.WebGLCubeRenderTarget(16, { generateMipmaps: false });
+    this.cubeCamera = new THREE.CubeCamera(0.1, 1000, this.cubeRenderTarget);
+    this.needsVREnvironmentUpdate = true;
+    this.timeSinceUpdate = 0;
+    this.updateXRCubeMap = this.updateXRCubeMap.bind(this);
+
+    // Update WebXR to support light-estimation
+    var webxrData = this.el.getAttribute('webxr');
+    var optionalFeaturesArray = webxrData.optionalFeatures;
+    if (!optionalFeaturesArray.includes('light-estimation')) {
+      optionalFeaturesArray.push('light-estimation');
+      this.el.setAttribute('webxr', webxrData);
+    }
+
+    this.el.sceneEl.addEventListener('enter-vr', function () {
+      var renderer = self.el.renderer;
+      var session = renderer.xr.getSession();
+      if (
+        session.requestLightProbe && self.el.sceneEl.is('ar-mode')
+      ) {
+        self.startLightProbe();
+      }
+    });
+
+    this.el.sceneEl.addEventListener('exit-vr', function () {
+      self.stopLightProbe();
+    });
+  },
+  stopLightProbe: function () {
+    this.xrLightProbe = null;
+    this.probeLight.components.light.light.intensity = 0;
+    this.needsVREnvironmentUpdate = true;
+  },
+  startLightProbe: function () {
+    this.needsLightProbeUpdate = true;
+  },
+  setupLightProbe: function () {
+    var renderer = this.el.renderer;
+    var xrSession = renderer.xr.getSession();
+    var self = this;
+    var gl = renderer.getContext();
+
+    if (!this.probeLight) {
+      var probeLight = document.createElement('a-light');
+      probeLight.setAttribute('type', 'probe');
+      probeLight.setAttribute('intensity', 0);
+      this.el.appendChild(probeLight);
+      this.probeLight = probeLight;
+    }
+
+    this.glBinding = new XRWebGLBinding(xrSession, gl);
+    gl.getExtension('EXT_sRGB');
+    gl.getExtension('OES_texture_half_float');
+
+    xrSession.requestLightProbe()
+      .then(function (lightProbe) {
+        self.xrLightProbe = lightProbe;
+        lightProbe.addEventListener('reflectionchange', self.updateXRCubeMap);
+      })
+      .catch(function (err) {
+        console.warn('Lighting estimation not supported: ' + err.message);
+        console.warn('Are you missing: webxr="optionalFeatures: light-estimation;" from <a-scene>?');
+      });
+  },
+  updateXRCubeMap: function () {
+    // Update Cube Map, cubeMap maybe some unavailable on some hardware
+    var scene = this.el.object3D;
+    var renderer = this.el.renderer;
+    var cubeMap = this.glBinding.getReflectionCubeMap(this.xrLightProbe);
+    if (cubeMap) {
+      var rendererProps = renderer.properties.get(this.lightProbeTarget.texture);
+      rendererProps.__webglTexture = cubeMap;
+      scene.environment = this.lightProbeTarget.texture;
+    }
+  },
+  tick: function () {
+    var scene = this.el.object3D;
+    var renderer = this.el.renderer;
+    var frame = this.el.sceneEl.frame;
+
+    if (frame && this.xrLightProbe) {
+      // light estimate may not yet be available, it takes a few frames to start working
+      var estimate = frame.getLightEstimate(this.xrLightProbe);
+
+      if (estimate) {
+        updateLights(
+          estimate,
+          this.probeLight.components.light.light,
+          this.data.directionalLight.components.light.light,
+          this.data.directionalLight.object3D.position
+        );
+      }
+    }
+
+    if (this.needsVREnvironmentUpdate) {
+      this.needsVREnvironmentUpdate = false;
+      this.cubeCamera.position.set(0, 1.6, 0);
+      scene.environment = null;
+      this.cubeCamera.update(renderer, scene);
+      scene.environment = this.cubeRenderTarget.texture;
+    }
+
+    if (this.needsLightProbeUpdate && frame) {
+      // wait until the XR Session has started before trying to make
+      // the light probe
+      this.setupLightProbe();
+      this.needsLightProbeUpdate = false;
+    }
+  },
+
+  remove: function () {
+    var data = this.data;
+    var object3D = this.el.object3D;
+    if (data.transparent) {
+      object3D.background = null;
+      return;
+    }
+    object3D.background = COMPONENTS[this.name].schema.color.default;
+  }
+});


### PR DESCRIPTION
**Description:**

This brings out the environment generation from background into it's own file/component so that developers can turn on reflection as needed by adding the reflection component to <a-scene>.

**Changes proposed:**
- Remove environment map functionality from `background`
- Create new environment map component
- Fix lighting estimation from the new version three (can't get working yet)
