### PR TITLE
Fix hand tracking example - aframe get by jsdelivr commit hash

### DIFF
--- a/examples/showcase/hand-tracking/index.html
+++ b/examples/showcase/hand-tracking/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Hand Tracking! • A-Frame</title>
     <meta name="description" content="Hand Tracking! • A-Frame">
-    <script src="../../../dist/aframe-master.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@02e3ae714dd29fa6e60a02d720ad9d8c0a8d31d8/dist/aframe-master.min.js"></script>
     <script src="../../js/info-message.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@1.3.0/dist/aframe-environment-component.min.js"></script>
     <script src="pinchable.js"></script>


### PR DESCRIPTION
**Description:**

- For this issue https://github.com/aframevr/aframe/issues/4918
- [Hand Tracking example](https://aframe.io/examples/showcase/handtracking/) has under screenshot's issue
![image](https://user-images.githubusercontent.com/41536271/150678670-2f6c64bd-17ce-45f0-8c9d-788f86c9521c.png)


**Changes proposed:**

- Get from aframe `cdn.jsdelivr.net` by latest commit hash ([#02e3ae714dd29fa6e60a02d720ad9d8c0a8d31d8](https://github.com/aframevr/aframe/commit/02e3ae714dd29fa6e60a02d720ad9d8c0a8d31d8))
![271801782_1115711759266933_737035654452730128_n](https://user-images.githubusercontent.com/41536271/150679294-b8cee466-4bea-4573-b24d-db37e21660e1.jpg)

