### PR TITLE
Add the phong shader to allow performant materials

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -147,6 +147,30 @@ For example, for a tree bark material, as an estimation, we might set:
 </a-entity>
 ```
 
+#### Phong-Based Shading
+
+Phong shading is an inexpensive shader model which whilst less realistic than the
+standard material is better than flat shading.
+
+To use it set the shader to phong in the material:
+
+```html
+<a-torus-knot position="0 3 0" material="shader:phong; reflectivity: 0.9; shininess: 30;"
+  geometry="radius: 0.45; radiusTubular: 0.09">
+</a-torus-knot>
+```
+
+It has the following properties you can use:
+
+|  Name          | Description                                                                   | Default |
+|----------------|-------------------------------------------------------------------------------|---------|
+|specular        | This defines how shiny the material is and the color of its shine.            | #111111 |
+|shininess       | How shiny the specular highlight is; a higher value gives a sharper highlight | 30      |
+|transparent     | Whether the material is transparent                                           | false   |
+|combine         | How the environment map mixes with the material. "mix", "add" or "multiply"   | "mix"   |
+|reflectivity    | How much the environment map affects the surface                              | 0.9     |
+|refract         | Whether the defined envMap should refract                                     | false   |
+|refractionRatio | 1/refractive index of the material                                            | 0.98    |
 #### Distortion Maps
 
 There are three properties which give the illusion of complex geometry:

--- a/examples/boilerplate/webxr-ar-lighting/index.html
+++ b/examples/boilerplate/webxr-ar-lighting/index.html
@@ -48,7 +48,7 @@
 				</a-box>
 				<a-sphere position="0 1.25 -1" radius="1.25" color="#cccccc" material="roughness:0.5; metalness:0.1;">
 				</a-sphere>
-				<a-torus-knot position="0 3 0" material="metalness: 1; roughness: 0.17"
+				<a-torus-knot position="0 3 0" material="shader:phong; reflectivity: 0.9; shininess: 100;"
 					geometry="radius: 0.45; radiusTubular: 0.09"
 					animation__rotate="easing: linear; from: 0 0 0; loop: true; property: rotation; to: 0 0 360; dur: 3000;">
 				</a-torus-knot>

--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -57,6 +57,7 @@ module.exports.Component = registerComponent('layer', {
     var xrGLFactory = this.xrGLFactory;
     var frame = this.el.sceneEl.frame;
     var src = this.data.src;
+    var type = this.data.type;
 
     this.visibilityChanged = false;
     if (!this.layer) { return; }

--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -138,9 +138,11 @@ module.exports.Component = register('reflection', {
     }
 
     if (this.needsVREnvironmentUpdate) {
+      scene.environment = null;
       this.needsVREnvironmentUpdate = false;
       this.cubeCamera.position.set(0, 1.6, 0);
       this.cubeCamera.update(renderer, scene);
+      this.el.object3D.environment = this.cubeRenderTarget.texture;
     }
 
     if (this.needsLightProbeUpdate && frame) {

--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -1,5 +1,6 @@
 require('./flat');
 require('./standard');
+require('./phong');
 require('./sdf');
 require('./msdf');
 require('./ios10hls');


### PR DESCRIPTION
**Description:**

Add the THREE.js Phong material to let developers use a more perfomant material for large non-flat objects.

**Changes proposed:**
- Fixes an issue in `layers.js` that was preventing it from being merged
- Fixes a bug in reflection.js where there was a circular texture dependency
- Phong material code based on standard material but tweaked for phong parameters
- Phong envMap defaults to a getter to the scene.environment because phong materials don't automatically use the scene.environment
