### PR TITLE
don't try to use Hit Test in VR

### DIFF
--- a/src/components/scene/ar-hit-test.js
+++ b/src/components/scene/ar-hit-test.js
@@ -270,6 +270,11 @@ module.exports.Component = register('ar-hit-test', {
     }.bind(this));
 
     this.el.sceneEl.renderer.xr.addEventListener('sessionstart', function () {
+      // Don't request Hit Test unless AR (breaks WebXR Emulator)
+      if (!this.el.is('ar-mode')) {
+        return;
+      }
+
       var renderer = this.el.sceneEl.renderer;
       var session = this.session = renderer.xr.getSession();
       this.hasPosedOnce = false;

--- a/src/components/scene/ar-hit-test.js
+++ b/src/components/scene/ar-hit-test.js
@@ -271,9 +271,7 @@ module.exports.Component = register('ar-hit-test', {
 
     this.el.sceneEl.renderer.xr.addEventListener('sessionstart', function () {
       // Don't request Hit Test unless AR (breaks WebXR Emulator)
-      if (!this.el.is('ar-mode')) {
-        return;
-      }
+      if (!this.el.is('ar-mode')) { return; }
 
       var renderer = this.el.sceneEl.renderer;
       var session = this.session = renderer.xr.getSession();


### PR DESCRIPTION
**Description:**

When the AR Hit Test component is used and the user tries to enter VR on a device using the WebXR Emulator it get stuck in a loop.

**Changes proposed:**
- Don't try to start the Hit-Test functionality in a non-ar session
