### PR TITLE
Possible fix for 4973

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -387,9 +387,13 @@ var proto = Object.create(ANode.prototype, {
 
       // Wait for component to initialize.
       if (!component.initialized) {
+        component.pendingRemoval = true;
         this.addEventListener('componentinitialized', function tryRemoveLater (evt) {
           if (evt.detail.name !== name) { return; }
-          this.removeComponent(name, destroy);
+          if (component.pendingRemoval) {
+            this.removeComponent(name, destroy);
+            component.pendingRemoval = false;
+          }
           this.removeEventListener('componentinitialized', tryRemoveLater);
         });
         return;
@@ -486,8 +490,16 @@ var proto = Object.create(ANode.prototype, {
           this.removeComponent(attr, true);
           return;
         }
-        // Component already initialized. Update component.
+        // Component initialization already started. Update component.
         component.updateProperties(attrValue, clobber);
+
+        // Component has been initialized, but is pending removal
+        if (component.pendingRemoval) {
+          // This new update should cancel any pending removal, and reinstate the attribute
+          // (which will have been removed, synchronously, when the component removal was initiated)
+          window.HTMLElement.prototype.setAttribute.call(this, attr, '');
+          component.pendingRemoval = false;
+        }
         return;
       }
 


### PR DESCRIPTION
**Description:**

A fix for https://github.com/aframevr/aframe/issues/4973.

In brief...
- if called before an entity is created, removeAttribute() completes asynchronously.
- this leaves a window in which a subsequent call to setAttribute() has no effect - it gets overwritten by the async completion of removeAttribute()
- the fix handles this window.

**Changes proposed:**
- An additional state flag on the component to track the "pending removal" state of a component that occurs when removeAttrbute() completes asynchronously.  Only go through with removal if this flag is still set.
- If setAttribute() is called before removeAttribute() completes...
-- clear this flag (so that the removal is cancelled)
-- recreate the component's corresponding attribute in the DOM (since this will have been removed asynchronously by removeAttribute().

As per #4973 there is a sample glitch that I have used to verify the fix here:
https://glitch.com/edit/#!/modifying-attributes-after-creation?path=index.html%3A1%3A0

Not sure whether this can be incorporated into A-Frame as an additional test case?