### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/components/daydream-controls.md
+++ b/docs/components/daydream-controls.md
@@ -19,7 +19,7 @@ enable both `WebVR` and `Gamepad Extensions` experiments in `chrome://flags`
 and relaunch the browser.
 
 Then, open your web app, enter VR mode and place the phone inside the headset.
-It can occassionally take a few seconds before the controller can be used.
+It can occasionally take a few seconds before the controller can be used.
 
 ## Example
 

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -13,7 +13,7 @@ examples: []
 
 The link component connects between experiences and allows for traversing between VR web pages. When activated via an event, the link component sends the user to a different page, just like a normal web page redirect. To maintain VR across pages, the following conditions must apply:
 
-- Your browser implements the WebXR [in-VR navigation proposal][invrproposal]. Notice that is not yet part of the standard. Support is experimental, varies accross browsers and it might require enabling manually in settings.
+- Your browser implements the WebXR [in-VR navigation proposal][invrproposal]. Notice that is not yet part of the standard. Support is experimental, varies across browsers and it might require enabling manually in settings.
 
 [sessiongranted]: https://github.com/immersive-web/navigation#api-proposal
 

--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -288,7 +288,7 @@ a video element, then the texture will loop and autoplay by default. To specify
 otherwise, create a video element in the asset management system, and pass a
 selector for the `id` attribute (e.g., `#my-video`):
 
-Video autoplay policies are getting more and more strict and rules might vary accross browsers. Mandatory user gesture is now commonly enforced. For maximum compatibility, you can offer a button that the user can click to start [video playback][startplayback]. [Simple sample code][videotestcode] can be found in the docs. Pay particular attention to the [play-on-click component][videoplaycomponent]
+Video autoplay policies are getting more and more strict and rules might vary across browsers. Mandatory user gesture is now commonly enforced. For maximum compatibility, you can offer a button that the user can click to start [video playback][startplayback]. [Simple sample code][videotestcode] can be found in the docs. Pay particular attention to the [play-on-click component][videoplaycomponent]
 
 ```html
 <a-scene>

--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -85,7 +85,7 @@ the same domain (directory) as your application.
 If you are trying to load a video, make sure the browser supports the video
 (i.e., encoding, framerate, size).
 
-Video autoplay policies are getting more and more strict and rules might vary accross browsers. Mandatory user gesture is now commonly enforced. For maximum compatibility, you can offer a button that the user can click to start [video playback][startplayback]. [Simple sample code][videotestcode] can be found in the docs. Pay particular attention to the [play-on-click component][videoplaycomponent]
+Video autoplay policies are getting more and more strict and rules might vary across browsers. Mandatory user gesture is now commonly enforced. For maximum compatibility, you can offer a button that the user can click to start [video playback][startplayback]. [Simple sample code][videotestcode] can be found in the docs. Pay particular attention to the [play-on-click component][videoplaycomponent]
 
 Read the [*Hosting and Publishing* guide](./hosting-and-publishing.md) for more
 information.

--- a/examples/showcase/comicbook/message.html
+++ b/examples/showcase/comicbook/message.html
@@ -1,4 +1,4 @@
-<p>This example relies on <a href="https://immersive-web.github.io/layers/">WebXR layers API</a>. Browser support is experimental and might vary accross vendors.</a></p>
+<p>This example relies on <a href="https://immersive-web.github.io/layers/">WebXR layers API</a>. Browser support is experimental and might vary across vendors.</a></p>
 
 <p>
 <strong>Panning:</strong> Thumbstick</br>

--- a/examples/showcase/hand-tracking/message.html
+++ b/examples/showcase/hand-tracking/message.html
@@ -1,1 +1,1 @@
-<p> Hand tracking  relies on an <a href="https://www.w3.org/TR/webxr-hand-input-1/">API proposal</a> and is not yet part of the WebXR standard. Browser support is experimental, it might vary accross vendors and it might require enabling the feature manually in settings.</p>
+<p> Hand tracking  relies on an <a href="https://www.w3.org/TR/webxr-hand-input-1/">API proposal</a> and is not yet part of the WebXR standard. Browser support is experimental, it might vary across vendors and it might require enabling the feature manually in settings.</p>

--- a/examples/showcase/link-traversal/message.html
+++ b/examples/showcase/link-traversal/message.html
@@ -1,1 +1,1 @@
-<p> Immersive navigation relies on an <a href="https://github.com/immersive-web/navigation">API proposal</a> and is not yet part of the WebXR standard. Browser support is experimental, it might vary accross vendors and it might require enabling the feature manually in settings.</p>
+<p> Immersive navigation relies on an <a href="https://github.com/immersive-web/navigation">API proposal</a> and is not yet part of the WebXR standard. Browser support is experimental, it might vary across vendors and it might require enabling the feature manually in settings.</p>

--- a/examples/showcase/model-viewer/message.html
+++ b/examples/showcase/model-viewer/message.html
@@ -1,4 +1,4 @@
-<p> AR mode relies on the <a href="https://www.w3.org/TR/webxr-ar-module-1/">WebXR Augmented Reality Module</a> proposal. Browser support is experimental and might vary accross vendors.</p>
+<p> AR mode relies on the <a href="https://www.w3.org/TR/webxr-ar-module-1/">WebXR Augmented Reality Module</a> proposal. Browser support is experimental and might vary across vendors.</p>
 
 <p>
 <strong>Desktop:</strong> Mouse drag (rotate), Mouse wheel (zoom)<br>


### PR DESCRIPTION
**Description:**

Fix typo in docs

**Changes proposed:**
- `docs/components/daydream-controls.md` line 22: `occassionally` to `occasionally`
- `docs/components/link.md` line 16: `accross` to `across`
- `docs/components/material.md` line 291: `accross` to `across`
- `docs/introduction/faq.md` line 88: `accross` to `across`
- `examples/showcase/comicbook/message.html` line 1: `accross` to `across`
- `examples/showcase/hand-tracking/message.html` line 1: `accross` to `across`
- `examples/showcase/link-traversal/message.html` line 1: `accross` to `across`
- `examples/showcase/model-viewer/message.html` line 1: `accross` to `across`