### PR TITLE
Update geometry docs custom example from THREE.Geometry to THREE.BufferGeometry

### DIFF
--- a/docs/components/geometry.md
+++ b/docs/components/geometry.md
@@ -346,17 +346,16 @@ AFRAME.registerGeometry('example', {
   },
 
   init: function (data) {
-    var geometry = new THREE.Geometry();
-    geometry.vertices = data.vertices.map(function (vertex) {
-        var points = vertex.split(' ').map(function(x){return parseInt(x);});
-        return new THREE.Vector3(points[0], points[1], points[2]);
-    });
-    geometry.computeBoundingBox();
-    geometry.faces.push(new THREE.Face3(0, 1, 2));
-    geometry.mergeVertices();
-    geometry.computeFaceNormals();
-    geometry.computeVertexNormals();
-    this.geometry = geometry;
+    var geometry = new THREE.BufferGeometry();
+     const pointsArray = new Array();
+     data.vertices.map(function (vertex) {
+     var points = vertex.split(' ').map(function(x){return parseInt(x);});
+     pointsArray.push(new THREE.Vector3(points[0], points[1], points[2]));
+     });
+     geometry.setFromPoints(pointsArray);
+     geometry.computeBoundingBox();
+     geometry.computeVertexNormals();
+     this.geometry = geometry;
   }
 });
 ```


### PR DESCRIPTION
Example given for component no longer works > v1.1.0 as THREE.Geometry depreciated

**Description:**
Update to use BufferGeometry and setFromPoints

**Changes proposed:**
Change from
```
AFRAME.registerGeometry('example', {
  schema: {
    vertices: {
      default: ['-10 10 0', '-10 -10 0', '10 -10 0'],
    }
  },

  init: function (data) {
    var geometry = new THREE.Geometry();
    geometry.vertices = data.vertices.map(function (vertex) {
        var points = vertex.split(' ').map(function(x){return parseInt(x);});
        return new THREE.Vector3(points[0], points[1], points[2]);
    });
    geometry.computeBoundingBox();
    geometry.faces.push(new THREE.Face3(0, 1, 2));
    geometry.mergeVertices();
    geometry.computeFaceNormals();
    geometry.computeVertexNormals();
    this.geometry = geometry;
  }
});
```
To
```
AFRAME.registerGeometry('example', {
    schema: {
        vertices: {
        default: ['-10 10 0', '-10 -10 0', '10 -10 0'],
        }
    },
    init: function (data) {
        var geometry = new THREE.BufferGeometry();
        const pointsArray = new Array();
        data.vertices.map(function (vertex) {
        var points = vertex.split(' ').map(function(x){return parseInt(x);});
        pointsArray.push(new THREE.Vector3(points[0], points[1], points[2]));
        });
        geometry.setFromPoints(pointsArray);
        geometry.computeBoundingBox();
        geometry.computeVertexNormals();
        this.geometry = geometry;
    }
});
```
