### PR TITLE
Update initial camera query (fix #5023)

### DIFF
--- a/examples/test/mixin/index.html
+++ b/examples/test/mixin/index.html
@@ -13,11 +13,13 @@
                  rotation="0 45 0"></a-mixin>
         <a-mixin id="sphere" geometry="primitive: sphere"
                  material="color: blue"></a-mixin>
+        <a-mixin id="camera" camera="active: false"></a-mixin>
       </a-assets>
 
       <a-entity mixin="cube" position="-3.5 1 -4" material="color: yellow"></a-entity>
       <a-entity mixin="cube" position="0 1 -4"></a-entity>
       <a-entity mixin="cube" position="3.5 1 -4"></a-entity>
+      <a-entity mixin="camera"></a-entity>
     </a-scene>
   </body>
 </html>

--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -132,7 +132,7 @@ module.exports.System = registerSystem('camera', {
   disableActiveCamera: function () {
     var cameraEls;
     var newActiveCameraEl;
-    cameraEls = this.sceneEl.querySelectorAll('[camera]');
+    cameraEls = this.sceneEl.querySelectorAll(':not(a-mixin)[camera]');
     newActiveCameraEl = cameraEls[cameraEls.length - 1];
     newActiveCameraEl.setAttribute('camera', 'active', true);
   },
@@ -159,7 +159,7 @@ module.exports.System = registerSystem('camera', {
     // Grab the default camera.
     var defaultCameraWrapper = sceneEl.querySelector('[' + DEFAULT_CAMERA_ATTR + ']');
     var defaultCameraEl = defaultCameraWrapper &&
-                          defaultCameraWrapper.querySelector('[camera]');
+                          defaultCameraWrapper.querySelector(':not(a-mixin)[camera]');
 
     // Remove default camera if new camera is not the default camera.
     if (newCameraEl !== defaultCameraEl) { removeDefaultCamera(sceneEl); }
@@ -175,7 +175,7 @@ module.exports.System = registerSystem('camera', {
     }
 
     // Disable other cameras in the scene
-    cameraEls = sceneEl.querySelectorAll('[camera]');
+    cameraEls = sceneEl.querySelectorAll(':not(a-mixin)[camera]');
     for (i = 0; i < cameraEls.length; i++) {
       cameraEl = cameraEls[i];
       if (!cameraEl.isEntity || newCameraEl === cameraEl) { continue; }

--- a/src/systems/camera.js
+++ b/src/systems/camera.js
@@ -43,7 +43,7 @@ module.exports.System = registerSystem('camera', {
     }
 
     // Search for initial user-defined camera.
-    cameraEls = sceneEl.querySelectorAll('a-camera, [camera]');
+    cameraEls = sceneEl.querySelectorAll('a-camera, :not(a-mixin)[camera]');
 
     // No user cameras, create default one.
     if (!cameraEls.length) {


### PR DESCRIPTION
**Description:** Resolves #5023.

There are additional `[camera]` queries in `camera.js` that may need to be updated too, but for now I only changed the one that fixes the perpetual loading screen from the linked issue (verified in `examples/test/mixin/index.html`)

**Changes proposed:**
- `[camera]` -> `:not(a-mixin)[camera]`