### PR TITLE
Allow directional lights to automatically follow shadows

### DIFF
--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -94,10 +94,10 @@ creating a child entity it targets. For example, pointing down its -Z axis:
 Directional lights are the most efficient type for adding realtime shadows to a scene. You can use shadows like so:
 
 ```html
-<a-light type="directional" light="castShadow:true;" position="1 1 1" intensity="0.5" shdadow-camera-auto="#objects"></a-light>
+<a-light type="directional" light="castShadow:true;" position="1 1 1" intensity="0.5" shdadow-camera-automatic="#objects"></a-light>
 ```
 
-The `shdadow-camera-auto` configuration maps to `light.shadowCameraAuto` which tells the light to automatically update the shadow camera to be the minimum size and position to encompass the target elements. 
+The `shdadow-camera-automatic` configuration maps to `light.shadowCameraAutomatic` which tells the light to automatically update the shadow camera to be the minimum size and position to encompass the target elements. 
 
 ### Hemisphere
 
@@ -191,21 +191,21 @@ is very helpful to **[use the A-Frame Inspector to configure shadows][inspector]
 Light types that support shadows (`point`, `spot`, and `directional`) include
 additional properties:
 
-| Property            | Light type      | Description                                                                                                                                | Default Value |
-|---------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| castShadow          |                 | Whether this light casts shadows on the scene.                                                                                             | false         |
-| shadowBias          |                 | Offset depth when deciding whether a surface is in shadow. Tiny adjustments here (in the order of +/-0.0001) may reduce artifacts in shadows. | 0             |
-| shadowCameraAuto    | `directional`   | Automatically configure the Bottom, Top, Left, Right and Near of a directional light's shadow map, from an element                         |               |
-| shadowCameraBottom  | `directional`   | Bottom plane of shadow camera frustum.                                                                                                     | -5            |
-| shadowCameraFar     |                 | Far plane of shadow camera frustum.                                                                                                        | 500           |
-| shadowCameraFov     | `point`, `spot` | Shadow camera's FOV.                                                                                                                       | 50            |
-| shadowCameraLeft    | `directional`   | Left plane of shadow camera frustum.                                                                                                       | -5            |
-| shadowCameraNear    |                 | Near plane of shadow camera frustum.                                                                                                       | 0.5           |
-| shadowCameraRight   | `directional`   | Right plane of shadow camera frustum.                                                                                                      | 5             |
-| shadowCameraTop     | `directional`   | Top plane of shadow camera frustum.                                                                                                        | 5             |
-| shadowCameraVisible |                 | Displays a visual aid showing the shadow camera's position and frustum. This is the light's view of the scene, used to project shadows.    | false         |
-| shadowMapHeight     |                 | Shadow map's vertical resolution. Larger shadow maps display more crisp shadows, at the cost of performance.                               | 512           |
-| shadowMapWidth      |                 | Shadow map's horizontal resolution.                                                                                                        | 512           |
+| Property              | Light type      | Description                                                                                                                                | Default Value |
+|-----------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| castShadow            |                 | Whether this light casts shadows on the scene.                                                                                             | false         |
+| shadowBias            |                 | Offset depth when deciding whether a surface is in shadow. Tiny adjustments here (in the order of +/-0.0001) may reduce artifacts in shadows. | 0             |
+| shadowCameraAutomatic | `directional`   | Automatically configure the Bottom, Top, Left, Right and Near of a directional light's shadow map, from an element                         |               |
+| shadowCameraBottom    | `directional`   | Bottom plane of shadow camera frustum.                                                                                                     | -5            |
+| shadowCameraFar       |                 | Far plane of shadow camera frustum.                                                                                                        | 500           |
+| shadowCameraFov       | `point`, `spot` | Shadow camera's FOV.                                                                                                                       | 50            |
+| shadowCameraLeft      | `directional`   | Left plane of shadow camera frustum.                                                                                                       | -5            |
+| shadowCameraNear      |                 | Near plane of shadow camera frustum.                                                                                                       | 0.5           |
+| shadowCameraRight     | `directional`   | Right plane of shadow camera frustum.                                                                                                      | 5             |
+| shadowCameraTop       | `directional`   | Top plane of shadow camera frustum.                                                                                                        | 5             |
+| shadowCameraVisible   |                 | Displays a visual aid showing the shadow camera's position and frustum. This is the light's view of the scene, used to project shadows.    | false         |
+| shadowMapHeight       |                 | Shadow map's vertical resolution. Larger shadow maps display more crisp shadows, at the cost of performance.                               | 512           |
+| shadowMapWidth        |                 | Shadow map's horizontal resolution.                                                                                                        | 512           |
 
 ### Adding Real-Time Shadows
 

--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -195,7 +195,7 @@ additional properties:
 |---------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | castShadow          |                 | Whether this light casts shadows on the scene.                                                                                             | false         |
 | shadowBias          |                 | Offset depth when deciding whether a surface is in shadow. Tiny adjustments here (in the order of +/-0.0001) may reduce artifacts in shadows. | 0             |
-| shadowCameraAuto    | `directional`   | Automatically configure the Bottom, Top, Left, Right, Near and Far of a directional light's shadow map, from an element                    |               |
+| shadowCameraAuto    | `directional`   | Automatically configure the Bottom, Top, Left, Right and Near of a directional light's shadow map, from an element                         |               |
 | shadowCameraBottom  | `directional`   | Bottom plane of shadow camera frustum.                                                                                                     | -5            |
 | shadowCameraFar     |                 | Far plane of shadow camera frustum.                                                                                                        | 500           |
 | shadowCameraFov     | `point`, `spot` | Shadow camera's FOV.                                                                                                                       | 50            |

--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -91,7 +91,13 @@ creating a child entity it targets. For example, pointing down its -Z axis:
 </a-light>
 ```
 
-Directional lights are the most efficient type for adding realtime shadows to a scene.
+Directional lights are the most efficient type for adding realtime shadows to a scene. You can use shadows like so:
+
+```html
+<a-light type="directional" light="castShadow:true;" position="1 1 1" intensity="0.5" shdadow-camera-auto="#objects"></a-light>
+```
+
+The `shdadow-camera-auto` configuration maps to `light.shadowCameraAuto` which tells the light to automatically update the shadow camera to be the minimum size and position to encompass the target elements. 
 
 ### Hemisphere
 
@@ -189,6 +195,7 @@ additional properties:
 |---------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | castShadow          |                 | Whether this light casts shadows on the scene.                                                                                             | false         |
 | shadowBias          |                 | Offset depth when deciding whether a surface is in shadow. Tiny adjustments here (in the order of +/-0.0001) may reduce artifacts in shadows. | 0             |
+| shadowCameraAuto    | `directional`   | Automatically configure the Bottom, Top, Left, Right, Near and Far of a directional light's shadow map, from an element                    |               |
 | shadowCameraBottom  | `directional`   | Bottom plane of shadow camera frustum.                                                                                                     | -5            |
 | shadowCameraFar     |                 | Far plane of shadow camera frustum.                                                                                                        | 500           |
 | shadowCameraFov     | `point`, `spot` | Shadow camera's FOV.                                                                                                                       | 50            |

--- a/examples/boilerplate/ar-hello-world/index.html
+++ b/examples/boilerplate/ar-hello-world/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Hello, World! • A-Frame</title>
-    <meta name="description" content="Hello, World! • A-Frame">
+    <title>Hello, AR World! • A-Frame</title>
+    <meta name="description" content="Hello, AR World! • A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
     <script>
       AFRAME.registerComponent('follow-shadow', {

--- a/examples/boilerplate/ar-hello-world/index.html
+++ b/examples/boilerplate/ar-hello-world/index.html
@@ -23,8 +23,9 @@
       reflection="directionalLight:a-light[type=directional]"
       ar-hit-test="target:#objects;"
       renderer="physicallyCorrectLights:true;colorManagement:true;exposure:1;toneMapping:ACESFilmic;"
+      shadow="type:pcfsoft"
     >
-      <a-light type="directional" light="castShadow:true;" position="1 1 1" intensity="0.5" auto-shadow-cam="#objects"></a-light>
+      <a-light type="directional" light="castShadow:true;" position="1 1 1" intensity="0.5" shadow-camera-auto="#objects"></a-light>
       <a-camera position="0 0.4 0" wasd-controls="acceleration:10;"></a-camera>
       <a-entity id="objects" scale="0.2 0.2 0.2" position="0 0 -1" shadow>
         <a-box position="-1 0.5 1" rotation="0 45 0" color="#4CC3D9"></a-box>

--- a/examples/boilerplate/ar-hello-world/index.html
+++ b/examples/boilerplate/ar-hello-world/index.html
@@ -25,7 +25,7 @@
       renderer="physicallyCorrectLights:true;colorManagement:true;exposure:1;toneMapping:ACESFilmic;"
       shadow="type:pcfsoft"
     >
-      <a-light type="directional" light="castShadow:true;" position="1 1 1" intensity="0.5" shadow-camera-auto="#objects"></a-light>
+      <a-light type="directional" light="castShadow:true;" position="1 1 1" intensity="0.5" shadow-camera-automatic="#objects"></a-light>
       <a-camera position="0 0.4 0" wasd-controls="acceleration:10;"></a-camera>
       <a-entity id="objects" scale="0.2 0.2 0.2" position="0 0 -1" shadow>
         <a-box position="-1 0.5 1" rotation="0 45 0" color="#4CC3D9"></a-box>

--- a/examples/boilerplate/ar-hello-world/index.html
+++ b/examples/boilerplate/ar-hello-world/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Hello, World! • A-Frame</title>
+    <meta name="description" content="Hello, World! • A-Frame">
+    <script src="../../../dist/aframe-master.js"></script>
+    <script>
+      AFRAME.registerComponent('follow-shadow', {
+        schema: {type: 'selector'},
+        init() {this.el.object3D.renderOrder = -1;},
+        tick() { 
+          if (this.data) {
+            this.el.object3D.position.copy(this.data.object3D.position); 
+            this.el.object3D.position.y-=0.001; // stop z-fighting
+          }
+        }
+      });
+    </script>
+  </head>
+  <body>
+    <a-scene
+      reflection="directionalLight:a-light[type=directional]"
+      ar-hit-test="target:#objects;"
+      renderer="physicallyCorrectLights:true;colorManagement:true;exposure:1;toneMapping:ACESFilmic;"
+    >
+      <a-light type="directional" light="castShadow:true;" position="1 1 1" intensity="0.5" auto-shadow-cam="#objects"></a-light>
+      <a-camera position="0 0.4 0" wasd-controls="acceleration:10;"></a-camera>
+      <a-entity id="objects" scale="0.2 0.2 0.2" position="0 0 -1" shadow>
+        <a-box position="-1 0.5 1" rotation="0 45 0" color="#4CC3D9"></a-box>
+        <a-sphere position="0 1.25 -1" radius="1.25" color="#EF2D5E"></a-sphere>
+        <a-cylinder position="1 0.75 1" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
+      </a-entity>
+      <a-plane follow-shadow="#objects" material="shader:shadow" shadow="cast:false;" rotation="-90 0 0" width="2" height="2"></a-plane>
+      <a-sky color="#ECECEC" hide-on-enter-ar></a-sky>
+    </a-scene>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -148,6 +148,7 @@
       <li><a href="showcase/spheres-and-fog/">Spheres and Fog</a></li>
       <li><a href="showcase/wikipedia/">Wikipedia</a></li>
       <li><a href="boilerplate/hello-world/">Hello World</a></li>
+      <li><a href="boilerplate/ar-hello-world/">AR Hello World</a></li>
       <li><a href="boilerplate/panorama/">360&deg; Image</a></li>
       <li><a href="boilerplate/360-video/">360&deg; Video</a></li>
       <li><a href="boilerplate/3d-model/">3D Model (glTF)</a></li>

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -59,7 +59,7 @@ module.exports.Component = registerComponent('light', {
     shadowCameraBottom: {default: -5, if: {castShadow: true}},
     shadowCameraLeft: {default: -5, if: {castShadow: true}},
     shadowCameraVisible: {default: false, if: {castShadow: true}},
-    shadowCameraAuto: {default: '', if: {type: ['directional']}},
+    shadowCameraAutomatic: {default: '', if: {type: ['directional']}},
     shadowMapHeight: {default: 512, if: {castShadow: true}},
     shadowMapWidth: {default: 512, if: {castShadow: true}},
     shadowRadius: {default: 1, if: {castShadow: true}}
@@ -151,11 +151,11 @@ module.exports.Component = registerComponent('light', {
             }
             break;
 
-          case 'shadowCameraAuto':
-            if (data.shadowCameraAuto) {
-              self.shadowCameraAutoEls = Array.from(document.querySelectorAll(data.shadowCameraAuto));
+          case 'shadowCameraAutomatic':
+            if (data.shadowCameraAutomatic) {
+              self.shadowCameraAutomaticEls = Array.from(document.querySelectorAll(data.shadowCameraAutomatic));
             } else {
-              self.shadowCameraAutoEls = [];
+              self.shadowCameraAutomaticEls = [];
             }
             break;
 
@@ -185,7 +185,7 @@ module.exports.Component = registerComponent('light', {
         this.data.type === 'directional' &&
         this.light.shadow &&
         this.light.shadow.camera instanceof THREE.OrthographicCamera &&
-        this.shadowCameraAutoEls.length
+        this.shadowCameraAutomaticEls.length
       ) {
         var camera = this.light.shadow.camera;
         camera.getWorldDirection(normal);
@@ -198,7 +198,7 @@ module.exports.Component = registerComponent('light', {
         camera.right = -100000;
         camera.top = -100000;
         camera.bottom = 100000;
-        this.shadowCameraAutoEls.forEach(function (el) {
+        this.shadowCameraAutomaticEls.forEach(function (el) {
           bbox.setFromObject(el.object3D);
           bbox.getBoundingSphere(sphere);
           var distanceToPlane = distanceOfPointFromPlane(cameraWorldPosition, normal, sphere.center);
@@ -239,10 +239,10 @@ module.exports.Component = registerComponent('light', {
         el.getObject3D('light-target').position.set(0, 0, -1);
       }
 
-      if (data.shadowCameraAuto) {
-        this.shadowCameraAutoEls = Array.from(document.querySelectorAll(data.shadowCameraAuto));
+      if (data.shadowCameraAutomatic) {
+        this.shadowCameraAutomaticEls = Array.from(document.querySelectorAll(data.shadowCameraAutomatic));
       } else {
-        this.shadowCameraAutoEls = [];
+        this.shadowCameraAutomaticEls = [];
       }
     }
   },

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -129,7 +129,7 @@ module.exports.Component = registerComponent('light', {
           }
 
           case 'envMap':
-            this.updateProbeMap(data, light);
+            self.updateProbeMap(data, light);
             break;
 
           case 'castShadow':
@@ -151,16 +151,20 @@ module.exports.Component = registerComponent('light', {
             }
             break;
 
+          case 'shadowCameraAuto':
+            if (data.shadowCameraAuto) {
+              self.shadowCameraAutoEls = Array.from(document.querySelectorAll(data.shadowCameraAuto));
+            } else {
+              self.shadowCameraAutoEls = [];
+            }
+            break;
+
           default: {
             light[key] = value;
           }
         }
       });
       return;
-    }
-
-    if (data.shadowCameraAutoTarget) {
-      this.shadowCameraAutoTargetEls = Array.from(document.querySelectorAll(data.shadowCameraAutoTarget));
     }
 
     // No light yet or light type has changed. Create and add light.
@@ -181,7 +185,7 @@ module.exports.Component = registerComponent('light', {
         this.data.type === 'directional' &&
         this.light.shadow &&
         this.light.shadow.camera instanceof THREE.OrthographicCamera &&
-        this.shadowCameraAutoTargetEls.length
+        this.shadowCameraAutoEls.length
       ) {
         var camera = this.light.shadow.camera;
         camera.getWorldDirection(normal);
@@ -194,7 +198,7 @@ module.exports.Component = registerComponent('light', {
         camera.right = -100000;
         camera.top = -100000;
         camera.bottom = 100000;
-        this.shadowCameraAutoTargetEls.forEach(function (el) {
+        this.shadowCameraAutoEls.forEach(function (el) {
           bbox.setFromObject(el.object3D);
           bbox.getBoundingSphere(sphere);
           var distanceToPlane = distanceOfPointFromPlane(cameraWorldPosition, normal, sphere.center);
@@ -233,6 +237,12 @@ module.exports.Component = registerComponent('light', {
       if (data.type === 'spot') {
         el.setObject3D('light-target', this.defaultTarget);
         el.getObject3D('light-target').position.set(0, 0, -1);
+      }
+
+      if (data.shadowCameraAuto) {
+        this.shadowCameraAutoEls = Array.from(document.querySelectorAll(data.shadowCameraAuto));
+      } else {
+        this.shadowCameraAutoEls = [];
       }
     }
   },

--- a/src/extras/primitives/primitives/a-light.js
+++ b/src/extras/primitives/primitives/a-light.js
@@ -15,6 +15,7 @@ registerPrimitive('a-light', {
     penumbra: 'light.penumbra',
     type: 'light.type',
     target: 'light.target',
-    envmap: 'light.envMap'
+    envmap: 'light.envMap',
+    'shadow-camera-auto': 'light.shadowCameraAuto'
   }
 });

--- a/src/extras/primitives/primitives/a-light.js
+++ b/src/extras/primitives/primitives/a-light.js
@@ -16,6 +16,6 @@ registerPrimitive('a-light', {
     type: 'light.type',
     target: 'light.target',
     envmap: 'light.envMap',
-    'shadow-camera-auto': 'light.shadowCameraAuto'
+    'shadow-camera-automatic': 'light.shadowCameraAutomatic'
   }
 });

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -18,16 +18,16 @@
  * @param {THREE.Vector3} positionOnPlane any point on the plane.
  * @param {THREE.Vector3} planeNormal the normal of the plane
  * @param {THREE.Vector3} pointToTest point to test
- * @param {THREE.Vector3} out where to store the result.
+ * @param {THREE.Vector3} resultPoint where to store the result.
  * @returns
  */
- function nearestPointInPlane (positionOnPlane, planeNormal, pointToTest, out) {
+ function nearestPointInPlane (positionOnPlane, planeNormal, pointToTest, resultPoint) {
    var t = distanceOfPointFromPlane(positionOnPlane, planeNormal, pointToTest);
   // closest point on the plane
-   out.copy(planeNormal);
-   out.multiplyScalar(t);
-   out.add(pointToTest);
-   return out;
+   resultPoint.copy(planeNormal);
+   resultPoint.multiplyScalar(t);
+   resultPoint.add(pointToTest);
+   return resultPoint;
  }
 
  module.exports.distanceOfPointFromPlane = distanceOfPointFromPlane;

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -1,0 +1,34 @@
+/**
+ * Find the disatance from a plane defined by a point on the plane and the normal of the plane to any point.
+ * @param {THREE.Vector3} positionOnPlane any point on the plane.
+ * @param {THREE.Vector3} planeNormal the normal of the plane
+ * @param {THREE.Vector3} p1 point to test
+ * @returns Number
+ */
+ function distanceOfPointFromPlane (positionOnPlane, planeNormal, p1) {
+  // the d value in the plane equation a*x + b*y + c*z=d
+   var d = planeNormal.dot(positionOnPlane);
+
+  // distance of point from plane
+   return (d - planeNormal.dot(p1)) / planeNormal.length();
+ }
+
+/**
+ * Find the point on a plane that lies closest to
+ * @param {THREE.Vector3} positionOnPlane any point on the plane.
+ * @param {THREE.Vector3} planeNormal the normal of the plane
+ * @param {THREE.Vector3} p1 point to test
+ * @param {THREE.Vector3} out where to store the result.
+ * @returns
+ */
+ function nearestPointInPlane (positionOnPlane, planeNormal, p1, out) {
+   var t = distanceOfPointFromPlane(positionOnPlane, planeNormal, p1);
+  // closest point on the plane
+   out.copy(planeNormal);
+   out.multiplyScalar(t);
+   out.add(p1);
+   return out;
+ }
+
+ module.exports.distanceOfPointFromPlane = distanceOfPointFromPlane;
+ module.exports.nearestPointInPlane = nearestPointInPlane;

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -2,31 +2,31 @@
  * Find the disatance from a plane defined by a point on the plane and the normal of the plane to any point.
  * @param {THREE.Vector3} positionOnPlane any point on the plane.
  * @param {THREE.Vector3} planeNormal the normal of the plane
- * @param {THREE.Vector3} p1 point to test
+ * @param {THREE.Vector3} pointToTest point to test
  * @returns Number
  */
- function distanceOfPointFromPlane (positionOnPlane, planeNormal, p1) {
+ function distanceOfPointFromPlane (positionOnPlane, planeNormal, pointToTest) {
   // the d value in the plane equation a*x + b*y + c*z=d
    var d = planeNormal.dot(positionOnPlane);
 
   // distance of point from plane
-   return (d - planeNormal.dot(p1)) / planeNormal.length();
+   return (d - planeNormal.dot(pointToTest)) / planeNormal.length();
  }
 
 /**
  * Find the point on a plane that lies closest to
  * @param {THREE.Vector3} positionOnPlane any point on the plane.
  * @param {THREE.Vector3} planeNormal the normal of the plane
- * @param {THREE.Vector3} p1 point to test
+ * @param {THREE.Vector3} pointToTest point to test
  * @param {THREE.Vector3} out where to store the result.
  * @returns
  */
- function nearestPointInPlane (positionOnPlane, planeNormal, p1, out) {
-   var t = distanceOfPointFromPlane(positionOnPlane, planeNormal, p1);
+ function nearestPointInPlane (positionOnPlane, planeNormal, pointToTest, out) {
+   var t = distanceOfPointFromPlane(positionOnPlane, planeNormal, pointToTest);
   // closest point on the plane
    out.copy(planeNormal);
    out.multiplyScalar(t);
-   out.add(p1);
+   out.add(pointToTest);
    return out;
  }
 


### PR DESCRIPTION
**Description:**

To make AR look believable it really helps to have tone mapping and have shadows that show on the real floor.

Unfortunately when you place an AR object it's easy to leave the region covered by the shadow map. This PR adds the ability to
allow the light's shadow map to automatically follow a particular 3D model to ensure it always has a good shadow.

**Changes proposed:**
- Add a new AR example based on the hello world
- Add `shadowCamAutoTarget` to light for Directional lights and `auto-shadow-cam` to `<a-light>`

![image](https://user-images.githubusercontent.com/4225330/158992353-54ad7565-495b-4aea-b55b-f195ad74c33d.png)
In the image above both Torus Knots are pure white but the one on the left has `toneMapped:false` to still displays brightly.

There is a link to the live demo so you can see how the AR looks: https://ada-aframe-test.glitch.me/

The example included in this relies on #5029 
