### PR TITLE
iOS15 ios orientation blank bug

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -14,12 +14,13 @@ var initPostMessageAPI = require('./postMessage');
 
 var bind = utils.bind;
 var isIOS = utils.device.isIOS();
+var isIOS15 = utils.device.isIOS15();
 var isMobile = utils.device.isMobile();
 var isWebXRAvailable = utils.device.isWebXRAvailable;
 var registerElement = re.registerElement;
 var warn = utils.debug('core:a-scene:warn');
 
-if (isIOS) { require('../../utils/ios-orientationchange-blank-bug'); }
+if (isIOS && !isIOS15) { require('../../utils/ios-orientationchange-blank-bug'); }
 
 /**
  * Scene element, holds all entities.

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ require('./core/a-mixin');
 require('./extras/components/');
 require('./extras/primitives/');
 
-console.log('A-Frame Version: 1.3.0 (Date 2022-03-14, Commit #d780484d)');
+console.log('A-Frame Version: 1.3.0 (Date 2022-03-18, Commit #cafb63db)');
 console.log('THREE Version (https://github.com/supermedium/three.js):',
             pkg.dependencies['super-three']);
 console.log('WebVR Polyfill Version:', pkg.dependencies['webvr-polyfill']);

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ require('./core/a-mixin');
 require('./extras/components/');
 require('./extras/primitives/');
 
-console.log('A-Frame Version: 1.3.0 (Date 2022-03-18, Commit #cafb63db)');
+console.log('A-Frame Version: 1.3.0 (Date 2022-03-14, Commit #d780484d)');
 console.log('THREE Version (https://github.com/supermedium/three.js):',
             pkg.dependencies['super-three']);
 console.log('WebVR Polyfill Version:', pkg.dependencies['webvr-polyfill']);

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -140,7 +140,7 @@ function isIOS15 () {
     var parsedVersion = [
       parseInt(v[1], 10),
       parseInt(v[2], 10),
-      parseInt(v[3] || 0, 10),
+      parseInt(v[3] || 0, 10)
     ];
     _isIOS15 = parsedVersion[0] >= 15;
   }

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -129,6 +129,25 @@ function isIOS () {
 }
 module.exports.isIOS = isIOS;
 
+/*
+* Checks if device is running on iOS 15 or greater
+* @return {Boolean}
+*/
+function isIOS15 () {
+  var _isIOS15 = false;
+  if (isIOS()) {
+    var v = window.navigator.appVersion.match(/OS (\d+)_(\d+)_?(\d+)?/);
+    var parsedVersion = [
+      parseInt(v[1], 10),
+      parseInt(v[2], 10),
+      parseInt(v[3] || 0, 10),
+    ];
+    _isIOS15 = parsedVersion[0] >= 15;
+  }
+  return _isIOS15;
+}
+module.exports.isIOS15 = isIOS15;
+
 function isMobileDeviceRequestingDesktopSite () {
   return !isMobile() && !isMobileVR() && window.orientation !== undefined;
 }

--- a/src/utils/ios-orientationchange-blank-bug.js
+++ b/src/utils/ios-orientationchange-blank-bug.js
@@ -1,4 +1,4 @@
-// Safari regression introduced in iOS 12 and remains in iOS 13.
+// Safari regression introduced in iOS 12 and remains in iOS 13. This fix causes issues in iOS 15.
 // https://stackoverflow.com/questions/62717621/white-space-at-page-bottom-after-device-rotation-in-ios-safari
 window.addEventListener('orientationchange', function () {
   document.documentElement.style.height = `initial`;


### PR DESCRIPTION
**Description:**
This is causing issues for me on ios15 on safari.  The scene disappears from view - goes black.  I'll try and recreate the issue in a codepen or something.  If anything it doesn't seem to be needed anymore for iOS15(at least 15.4) no white space. There seems to be a different issue on other aframe examples where the camera points straight down on orientation change

**Changes proposed:**
- check for ios15 before adding the listener

with aframe 1.3.0
https://codepen.io/lmiller152/pen/WNdGYOP

1.3.0 with my ios check
https://codepen.io/lmiller152/pen/ExogJgw

@dmarcos  I did a little more digging and found it was a styles issue using `embedded` on `a-scene` with wrappers.  Probably more user error with our setup - but strange the issue only happens on iOS15/safari.  