### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/introduction/best-practices.md
+++ b/docs/introduction/best-practices.md
@@ -64,7 +64,7 @@ purpose of using A-Frame.
 
 [animation]: ../components/animation.md#direct-values-through-object3d-and-components
 [asm]: ../core/asset-management-system.md
-[hardware]: ./vr-headsets-and-webvr-browsers.md
+[hardware]: ./vr-headsets-and-webxr-browsers.md
 [stats]: ../components/stats.md
 [pool]: ../components/pool.md
 [background]: ../components/background.md


### PR DESCRIPTION
Fix broken link in docs

https://aframe.io/docs/1.3.0/introduction/vr-headsets-and-webvr-browsers.html replaced with https://aframe.io/docs/1.3.0/introduction/vr-headsets-and-webxr-browsers.html (web**v**r replaced with web**x**r)