### PR TITLE
Add alphaMap to Standard material schema.

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -100,6 +100,9 @@ These properties are available on top of the base material properties.
 
 | Property                      | Description                                                                                                                                     | Default Value |
 |-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| alphaMap                      | Alpha map. Controls the opacity of the mesh. Can either be a selector to an `<img>`, or an inline URL.  Requires `transparent=true`. | None
+| alphaTextureRepeat            | How many times the alpha texture repeats in the X and Y direction               | 1 1 
+| alphaTextureOffset            | How the displacement texture is offset in the x y direction                     | 0 0
 | ambientOcclusionMap           | Ambient occlusion map. Used to add shadows to the mesh. Can either be a selector to an `<img>`, or an inline URL. Requires 2nd set of UVs (see below). | None          |
 | ambientOcclusionMapIntensity  | The intensity of the ambient occlusion map, a number between 0 and 1.                                                                           | 1             |
 | ambientOcclusionTextureRepeat | How many times the ambient occlusion texture repeats in the X and Y direction.                                                                  | 1 1           |

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -41,6 +41,10 @@ module.exports.Shader = registerShader('standard', {
     normalTextureOffset: {type: 'vec2'},
     normalTextureRepeat: {type: 'vec2', default: {x: 1, y: 1}},
 
+    alphaMap: {type: 'map'},
+    alphaTextureOffset: {type: 'vec2'},
+    alphaTextureRepeat: {type: 'vec2', default: {x: 1, y: 1}},
+
     offset: {type: 'vec2', default: {x: 0, y: 0}},
     repeat: {type: 'vec2', default: {x: 1, y: 1}},
 
@@ -74,6 +78,7 @@ module.exports.Shader = registerShader('standard', {
     if (data.ambientOcclusionMap) { utils.material.updateDistortionMap('ambientOcclusion', this, data); }
     if (data.metalnessMap) { utils.material.updateDistortionMap('metalness', this, data); }
     if (data.roughnessMap) { utils.material.updateDistortionMap('roughness', this, data); }
+    if (data.alphaMap) { utils.material.updateDistortionMap('alpha', this, data); }
     this.updateEnvMap(data);
   },
 
@@ -85,6 +90,7 @@ module.exports.Shader = registerShader('standard', {
     if (data.ambientOcclusionMap) { utils.material.updateDistortionMap('ambientOcclusion', this, data); }
     if (data.metalnessMap) { utils.material.updateDistortionMap('metalness', this, data); }
     if (data.roughnessMap) { utils.material.updateDistortionMap('roughness', this, data); }
+    if (data.alphaMap) { utils.material.updateDistortionMap('alpha', this, data); }
     this.updateEnvMap(data);
   },
 


### PR DESCRIPTION
**Description:**

Adds `alphaMap`, `alphaTextureOffset`, and `alphaTextureRepeat` to Standard Material schema.  This is already supported by Super-Three

**Changes proposed:**
- Add `alphaMap`, `alphaTextureOffset`, and `alphaTextureRepeat` to Standard Material schema.  
- Update Material#Standard docs to match