### PR TITLE
Add ability to use grip instead of targetRay space

### DIFF
--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -50,6 +50,7 @@ so using idPrefix for Vive / OpenVR controllers is recommended.
 | headElement       | Head element for arm model if needed (if not active camera).                             |                  |
 | hand              | Which hand to use, if arm model is needed.  (left negates X)                             | right            |
 | orientationOffset | Offset to apply to model orientation.                                                    | x: 0, y: 0, z: 0 |
+| space             | Specifies whether to use targetRayspace or gripSpace to determine controller pose.       | targetRaySpace   |
 
 ## Events
 

--- a/src/components/tracked-controls-webxr.js
+++ b/src/components/tracked-controls-webxr.js
@@ -17,7 +17,7 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
     handTrackingEnabled: {default: false},
     index: {type: 'int', default: -1},
     iterateControllerProfiles: {default: false},
-    space: {type: 'string', oneOf: ['targetRaySpace, gripSpace'], default: 'targetRaySpace'}
+    space: {type: 'string', oneOf: ['targetRaySpace', 'gripSpace'], default: 'targetRaySpace'}
   },
 
   init: function () {

--- a/src/components/tracked-controls-webxr.js
+++ b/src/components/tracked-controls-webxr.js
@@ -16,7 +16,8 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
     hand: {type: 'string', default: ''},
     handTrackingEnabled: {default: false},
     index: {type: 'int', default: -1},
-    iterateControllerProfiles: {default: false}
+    iterateControllerProfiles: {default: false},
+    space: {type: 'string', oneOf: ['targetRaySpace, gripSpace'], default: 'targetRaySpace'}
   },
 
   init: function () {
@@ -75,7 +76,7 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
     var frame = sceneEl.frame;
     if (!controller || !sceneEl.frame || !this.system.referenceSpace) { return; }
     if (!controller.hand) {
-      this.pose = frame.getPose(controller.targetRaySpace, this.system.referenceSpace);
+      this.pose = frame.getPose(controller[this.data.space], this.system.referenceSpace);
       this.updatePose();
       this.updateButtons();
     }

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -22,7 +22,8 @@ module.exports.Component = registerComponent('tracked-controls', {
     // Arm model parameters when not 6DoF.
     armModel: {default: false},
     headElement: {type: 'selector'},
-    iterateControllerProfiles: {default: false}
+    iterateControllerProfiles: {default: false},
+    space: {type: 'string', oneOf: ['targetRaySpace, gripSpace'], default: 'targetRaySpace'}
   },
 
   update: function () {
@@ -34,7 +35,8 @@ module.exports.Component = registerComponent('tracked-controls', {
         hand: data.hand,
         index: data.controller,
         iterateControllerProfiles: data.iterateControllerProfiles,
-        handTrackingEnabled: data.handTrackingEnabled
+        handTrackingEnabled: data.handTrackingEnabled,
+        space: data.space
       });
     } else {
       el.setAttribute('tracked-controls-webvr', data);

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -23,7 +23,7 @@ module.exports.Component = registerComponent('tracked-controls', {
     armModel: {default: false},
     headElement: {type: 'selector'},
     iterateControllerProfiles: {default: false},
-    space: {type: 'string', oneOf: ['targetRaySpace, gripSpace'], default: 'targetRaySpace'}
+    space: {type: 'string', oneOf: ['targetRaySpace', 'gripSpace'], default: 'targetRaySpace'}
   },
 
   update: function () {


### PR DESCRIPTION
**Description:**
`tracked-controls-webxr` currently uses `targetRaySpace` to report controller pose with no option to change it. This PR adds the ability to specify `gripSpace` over `targetRaySpace`, while still keeping `targetRaySpace` as the default.

**Changes proposed:**
- Adds a `space` property on both `tracked-controls` and `tracked-controls-webxr` to allow the user to specify `gripSpace` over `targetRaySpace`.
