### PR TITLE
Clear velocity on previous WS / AD axis when changed to a new value

### DIFF
--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -33,6 +33,8 @@ module.exports.Component = registerComponent('wasd-controls', {
     // To keep track of the pressed keys.
     this.keys = {};
     this.easing = 1.1;
+	this.lastWSAxis = wsAxis;
+	this.lastADAxis = adAxis;
 
     this.velocity = new THREE.Vector3();
 
@@ -90,6 +92,16 @@ module.exports.Component = registerComponent('wasd-controls', {
 
     adAxis = data.adAxis;
     wsAxis = data.wsAxis;
+	
+	// If a control axis was changed, reset its old velocity
+	if (adAxis != this.lastADAxis) {
+		velocity[this.lastADAxis] = 0;		
+		this.lastADAxis = adAxis;
+	}
+	if (wsAxis != this.lastWSAxis) {
+		velocity[this.lastWSAxis] = 0;
+		this.lastWSAxis = wsAxis;
+	}
 
     // If FPS too low, reset velocity.
     if (delta > MAX_DELTA) {
@@ -97,6 +109,8 @@ module.exports.Component = registerComponent('wasd-controls', {
       velocity[wsAxis] = 0;
       return;
     }
+	
+
 
     // https://gamedev.stackexchange.com/questions/151383/frame-rate-independant-movement-with-acceleration
     var scaledEasing = Math.pow(1 / this.easing, delta * 60);

--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -33,8 +33,8 @@ module.exports.Component = registerComponent('wasd-controls', {
     // To keep track of the pressed keys.
     this.keys = {};
     this.easing = 1.1;
-	this.lastWSAxis = wsAxis;
-	this.lastADAxis = adAxis;
+	this.lastWSAxis = this.data.wsAxis;
+	this.lastADAxis = this.data.adAxis;
 
     this.velocity = new THREE.Vector3();
 
@@ -109,8 +109,6 @@ module.exports.Component = registerComponent('wasd-controls', {
       velocity[wsAxis] = 0;
       return;
     }
-	
-
 
     // https://gamedev.stackexchange.com/questions/151383/frame-rate-independant-movement-with-acceleration
     var scaledEasing = Math.pow(1 / this.easing, delta * 60);

--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -33,8 +33,6 @@ module.exports.Component = registerComponent('wasd-controls', {
     // To keep track of the pressed keys.
     this.keys = {};
     this.easing = 1.1;
-	this.lastWSAxis = this.data.wsAxis;
-	this.lastADAxis = this.data.adAxis;
 
     this.velocity = new THREE.Vector3();
 
@@ -65,6 +63,15 @@ module.exports.Component = registerComponent('wasd-controls', {
     // Get movement vector and translate position.
     el.object3D.position.add(this.getMovementVector(delta));
   },
+  
+  update: function (oldData) {
+    
+    // If a control axis was changed, reset its old axis' velocity
+	if (oldData.adAxis !== this.data.adAxis) 
+		{ this.velocity[oldData.adAxis] = 0; }
+	if (oldData.wsAxis !== this.data.wsAxis) 
+		{ this.velocity[oldData.wsAxis] = 0; }
+  },
 
   remove: function () {
     this.removeKeyEventListeners();
@@ -92,16 +99,6 @@ module.exports.Component = registerComponent('wasd-controls', {
 
     adAxis = data.adAxis;
     wsAxis = data.wsAxis;
-	
-	// If a control axis was changed, reset its old velocity
-	if (adAxis != this.lastADAxis) {
-		velocity[this.lastADAxis] = 0;		
-		this.lastADAxis = adAxis;
-	}
-	if (wsAxis != this.lastWSAxis) {
-		velocity[this.lastWSAxis] = 0;
-		this.lastWSAxis = wsAxis;
-	}
 
     // If FPS too low, reset velocity.
     if (delta > MAX_DELTA) {

--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -65,12 +65,9 @@ module.exports.Component = registerComponent('wasd-controls', {
   },
   
   update: function (oldData) {
-    
-    // If a control axis was changed, reset its old axis' velocity
-	if (oldData.adAxis !== this.data.adAxis) 
-		{ this.velocity[oldData.adAxis] = 0; }
-	if (oldData.wsAxis !== this.data.wsAxis) 
-		{ this.velocity[oldData.wsAxis] = 0; }
+    // Reset velocity if axis have changed.
+    if (oldData.adAxis !== this.data.adAxis) { this.velocity[oldData.adAxis] = 0; }
+    if (oldData.wsAxis !== this.data.wsAxis) { this.velocity[oldData.wsAxis] = 0; }
   },
 
   remove: function () {


### PR DESCRIPTION
In 1.3.0, if the WS or AD axes is changed during runtime, the old velocity associated with the last axis 'sticks' to the entity, resulting in often unwanted, constant movement. This change clears that velocity when the WS or AD axes are adjusted to a new value.

The script now monitors if the WS or AD axis is dynamically changed (via previous value variable) and clears the velocity value associated with its previous axis when a change occurs during an update. The nature of this stop is not smoothed, however... leaving that resolution to the future.