### PR TITLE
Allow animating vec3 object3D raw position

### DIFF
--- a/docs/components/animation.md
+++ b/docs/components/animation.md
@@ -53,7 +53,7 @@ different types of values.
 | isRawProperty | Flag to animate an arbitrary object property outside of A-Frame components for better performance. If set to true, for example, we can set `property` to like `components.material.material.opacity`. If `property` starts with `components` or `object3D`, this will be inferred to `true`.                                                      | false         |                         |
 | from          | Initial value at start of animation. If not specified, the current property value of the entity will be used (will be sampled on each animation start). It is best to specify a `from` value when possible for stability.                                                                                                                         | null          |                         |
 | to            | Target value at end of animation.                                                                                                                                                                                                                                                                                                                 | null          |                         |
-| type          | Right now only supports `color` for tweening `isRawProperty` color XYZ/RGB vector  values.                                                                                                                                                                                                                                                        | ''            |                         |
+| type          | Right now only supports `color` or `position`. `color` is used for tweening `isRawProperty` color XYZ/RGB vector values and `position` is used for tweening `isRawProperty` position vec3.                                                                                                                                                                                                                                                        | ''            |                         |
 | delay         | How long (milliseconds) to wait before starting.                                                                                                                                                                                                                                                                                                  | 0             |                         |
 | dir           | Which dir to go from `from` to `to`.                                                                                                                                                                                                                                                                                                              | normal        | alternate, reverse      |
 | dur           | How long (milliseconds) each cycle of the animation is.                                                                                                                                                                                                                                                                                           | 1000          |                         |
@@ -211,6 +211,10 @@ frame, we can animate the opacity value directly with `property:
 components.material.material.opacity`. We use a dot-delimited path to walk the
 object tree to find the value we want to animate, and the animation process
 under the hood reduces down to changing a number.
+
+We can animate three.js full vec3 position directly at once, but we'll need to specify `type:
+position`. We can do
+`property: object3D.position; type: position; to: 1 1 1;`.
 
 #### Direct Color Values
 

--- a/tests/components/animation.test.js
+++ b/tests/components/animation.test.js
@@ -104,6 +104,27 @@ suite('animation', function () {
   });
 
   suite('direct object3D value animation', () => {
+    test('can animate object3D vec3 position directly', function () {
+      el.setAttribute('animation', {
+        property: 'object3D.position',
+        dur: 1000,
+        from: '1 1 1',
+        to: '0 0 0',
+        type: 'position'
+      });
+      component.tick(0, 1);
+      assert.equal(el.object3D.position.x, 1);
+      assert.equal(el.object3D.position.y, 1);
+      assert.equal(el.object3D.position.z, 1);
+      component.tick(0, 500);
+      assert.ok(el.object3D.position.x > 0);
+      assert.ok(el.object3D.position.x < 1);
+      component.tick(0, 500);
+      assert.equal(el.object3D.position.x, 0);
+      assert.equal(el.object3D.position.y, 0);
+      assert.equal(el.object3D.position.z, 0);
+    });
+
     test('can animate object3D value directly', function () {
       el.setAttribute('animation', {
         property: 'object3D.position.x',


### PR DESCRIPTION
**Description:**
Allow animating vec3 position directly on Object3D at once.
Currently we can animate object3D position axis using `property: object3D.position.z` but not the complete vec3 at once.
The goal is to be able to animate the vec3 position directly through object3D without using `setAttributes`.
The current alternative to animate position directly through object3D is to perform 3 animations which has important performance issue.

**Changes proposed:**
- Adding `type: position` similar to raw color animation detection
- In that case animate directly vec3 `object3d.position`
- Tests + documentation update

Feedback welcome
