### PR TITLE
XR Cursor

### DIFF
--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -88,7 +88,7 @@ AFRAME.registerComponent('cursor-listener', {
 | fuse               | Whether cursor is fuse-based.                                                                                                                      | false on desktop, true on mobile |
 | fuseTimeout        | How long to wait (in milliseconds) before triggering a fuse-based click event.                                                                     | 1500                             |
 | mouseCursorStylesEnabled | Whether to show pointer cursor in `rayOrigin: mouse` mode when hovering over entity.                                                               | true                             |
-| rayOrigin          | Where the intersection ray is cast from (i.e.,entity or mouse). `rayOrigin: mouse` is extremely useful for VR development on a mouse and keyboard. | entity
+| rayOrigin          | Where the intersection ray is cast from (i.e. xrselect ,entity or mouse). `rayOrigin: mouse` is extremely useful for VR development on a mouse and keyboard. | entity
 | upEvents           | Array of additional events on the entity to *listen* to for triggering `mouseup` (e.g., `trackpadup` for daydream-controls).                       | []                               |
 
 To further customize the cursor component, we configure the cursor's dependency
@@ -183,3 +183,16 @@ pick up event with the `begin` attribute:
 
 To play with an example of a cursor with visual feedback, check out the [Cursor
 with Visual Feedback example on CodePen][cursor-codepen].
+
+## XR Select Cursor
+
+When an XR `"selectstart"` event happens the raycaster picks an element based upon it's current location.
+This works for handheld AR, and headmounted VR and AR. This works well with the mouse `rayOrigin` too.
+
+```html
+<a-scene
+  cursor__mouse="rayOrigin: mouse"
+  cursor__xrselect="rayOrigin: xrselect"
+  raycaster="objects:#objects *;"
+>
+```

--- a/src/components/scene/ar-hit-test.js
+++ b/src/components/scene/ar-hit-test.js
@@ -366,6 +366,11 @@ module.exports.Component = register('ar-hit-test', {
     this.makeBBox();
   },
   update: function () {
+    // If it is disabled it's cleaned up
+    if (this.data.enabled === false) {
+      this.hitTest = null;
+      this.bboxMesh.visible = false;
+    }
     if (this.data.target) {
       if (this.data.target.object3D) {
         this.data.target.addEventListener('model-loaded', this.update);


### PR DESCRIPTION
**Description:**

Allows the cursor component to be used with generic XR inputs without needing to be specifically attached to anything.

In particular this lets it work screen based AR

**Changes proposed:**
- Add an xrselect rayOrigin which sets the origin to the targetRaySpace where select events happen
- Fix mouse constant fusing on mobile
- built on top of #5064 

Demo:
https://www.youtube.com/watch?v=j1SNRmsgfOo
