### PR TITLE
device-orientation-permisson-ui: Don't emit "granted" event until permissions are actually granted.

### DIFF
--- a/src/components/scene/device-orientation-permission-ui.js
+++ b/src/components/scene/device-orientation-permission-ui.js
@@ -52,7 +52,10 @@ module.exports.Component = registerComponent('device-orientation-permission-ui',
     this.onDeviceMotionDialogAllowClicked = bind(this.onDeviceMotionDialogAllowClicked, this);
     this.onDeviceMotionDialogDenyClicked = bind(this.onDeviceMotionDialogDenyClicked, this);
     // Show dialog only if permission has not yet been granted.
-    DeviceOrientationEvent.requestPermission().catch(function () {
+    DeviceOrientationEvent.requestPermission().then(function () {
+      self.el.emit('deviceorientationpermissiongranted');
+      self.permissionGranted = true;
+    }).catch(function () {
       self.devicePermissionDialogEl = createPermissionDialog(
         self.data.denyButtonText,
         self.data.allowButtonText,
@@ -60,9 +63,6 @@ module.exports.Component = registerComponent('device-orientation-permission-ui',
         self.onDeviceMotionDialogAllowClicked,
         self.onDeviceMotionDialogDenyClicked);
       self.el.appendChild(self.devicePermissionDialogEl);
-    }).then(function () {
-      self.el.emit('deviceorientationpermissiongranted');
-      self.permissionGranted = true;
     });
   },
 

--- a/tests/components/scene/device-motion-permission-ui.test.js
+++ b/tests/components/scene/device-motion-permission-ui.test.js
@@ -11,7 +11,15 @@ suite('device-orientation-permission-ui', function () {
       window.DeviceOrientationEvent = {
         requestPermission: function () { return Promise.reject(); }
       };
-      el.addEventListener('loaded', function () { done(); });
+      el.addEventListener('deviceorientationpermissiongranted', function () {
+        assert.fail('Received permissions granted too soon.');
+      });
+      el.addEventListener('deviceorientationpermissionrejected', function () {
+        assert.fail('Received permissions rejected too soon.');
+      });
+      el.addEventListener('loaded', function () {
+        done();
+      });
     });
 
     test('appends permission dialog', function (done) {

--- a/tests/components/scene/device-motion-permission-ui.test.js
+++ b/tests/components/scene/device-motion-permission-ui.test.js
@@ -12,10 +12,10 @@ suite('device-orientation-permission-ui', function () {
         requestPermission: function () { return Promise.reject(); }
       };
       el.addEventListener('deviceorientationpermissiongranted', function () {
-        assert.fail('Received permissions granted too soon.');
+        assert.fail('Received permissiongranted too soon.');
       });
       el.addEventListener('deviceorientationpermissionrejected', function () {
-        assert.fail('Received permissions rejected too soon.');
+        assert.fail('Received permissionrejected too soon.');
       });
       el.addEventListener('loaded', function () {
         done();


### PR DESCRIPTION
**Description:**

See https://github.com/aframevr/aframe/issues/5078

**Changes proposed:**

Code is currently structured as:

```
requestPermission.catch(<create dialog>).then(<mark permissions enabled>)
```

This is flawed, because when the `catch` branch is executed, the `then` branch then gets executed immediately as well.

The fix is to restructure the code as follows:
```
requestPermission.then(<mark permissions enabled>).catch(<create dialog>)
```

I've also made a small UT fix to check for the non-emission of events at this stage in the process.  This change made the script fail without the fix, and it succeeds with the fix in place.

UTs for this component could benefit from some significant extensions, but I'm not sure how soon I'd find time for that, and I didn't want to hold up making this fix available.  So I've only implemented this minimal update to the UT alongside this change.


