### PR TITLE
Make MouseEvent and TouchEvent available on cursor events

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,7 +12,7 @@
     "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
     "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
     "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
-    "indent"        : 4,        // {int} Number of spaces to use for indentation
+    "indent"        : 2,        // {int} Number of spaces to use for indentation
     "latedef"       : false,    // true: Require variables/functions to be defined before being used
     "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
     "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`

--- a/.jshintrc
+++ b/.jshintrc
@@ -12,7 +12,7 @@
     "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
     "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
     "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
-    "indent"        : 2,        // {int} Number of spaces to use for indentation
+    "indent"        : 4,        // {int} Number of spaces to use for indentation
     "latedef"       : false,    // true: Require variables/functions to be defined before being used
     "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
     "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`

--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -105,7 +105,11 @@ component, [the raycaster component][raycaster].
 | mouseleave    | Emitted on both cursor and intersected entity (if any) when cursor no longer intersects with previously intersected entity. |
 | mouseup       | Emitted on both cursor and intersected entity (if any) on mouseup on the canvas element.                                    |
 
-### Intersection Data
+### Event Data
+
+Additional detail is included in the `detail` object on the event as follows:
+
+#### intersection
 
 Relevant events will contain in the event detail `intersection`, which will
 contain `{distance, point, face, faceIndex, indices, object}` about specific
@@ -116,6 +120,37 @@ this.el.addEventListener('click', function (evt) {
   console.log(evt.detail.intersection.point);
 });
 ```
+
+#### intersectedEl
+
+Events emitted on the cursor entity also include event detail `intersectedEl`, which provides a reference to the intersected entity.
+
+#### originalEvent
+
+Where the trigger for a cursor event is a [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) or [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent), event detail `originalEvent` provides a reference to that event.
+
+These events provide a wealth of additional detail about the event, as detailed in the APIs linked above.  Among other things, they indicate:
+
+- which mouse button was used
+- information about the state of the mouse buttons, and relevant keys shuch as Shift, Ctrl etc. at the time of the mouse event.
+- the screen co-ordinates where the event occured.
+
+This information can be used by applications to handle cursor events differently, depending on this information (e.g. different handling of left click & right click).
+
+For example:
+
+```
+this.el.addEventListener('click', function (evt) {
+  if (!evt.detail.originalEvent || evt.detail.originalEvent.button === 0) {
+    console.log("left button clicked");
+  
+  } else if (evt.detail.originalEvent.button === 2) {
+    console.log("right button clicked"); 
+  }
+});
+```
+
+Event detail `originalEvent` is not always present.  It is not present on `mousenter`, `mouseleave` and `fusing` events, and it is not present on a `click` event that has been triggered by a fuse timeout rather than a mouse click or touch event.
 
 ## States
 

--- a/docs/components/cursor.md
+++ b/docs/components/cursor.md
@@ -125,14 +125,14 @@ this.el.addEventListener('click', function (evt) {
 
 Events emitted on the cursor entity also include event detail `intersectedEl`, which provides a reference to the intersected entity.
 
-#### originalEvent
+#### mouseEvent and touchEvent
 
-Where the trigger for a cursor event is a [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) or [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent), event detail `originalEvent` provides a reference to that event.
+Where the trigger for a cursor event is a [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) or [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent), event detail `mouseEvent` or `touchEvent` provides a reference to that event.
 
-These events provide a wealth of additional detail about the event, as detailed in the APIs linked above.  Among other things, they indicate:
+These events provide a wealth of additional detail about the event, as detailed in the APIs linked above.  Among other things, they can indicate:
 
 - which mouse button was used
-- information about the state of the mouse buttons, and relevant keys shuch as Shift, Ctrl etc. at the time of the mouse event.
+- information about the state of the mouse buttons (or multi-touch for touch events), and relevant keys shuch as Shift, Ctrl etc. at the time of the mouse or touch event.
 - the screen co-ordinates where the event occured.
 
 This information can be used by applications to handle cursor events differently, depending on this information (e.g. different handling of left click & right click).
@@ -141,16 +141,16 @@ For example:
 
 ```
 this.el.addEventListener('click', function (evt) {
-  if (!evt.detail.originalEvent || evt.detail.originalEvent.button === 0) {
-    console.log("left button clicked");
+  if (!evt.detail.mouseEvent || evt.detail.mouseEvent.button === 0) {
+    console.log("left button clicked (or touch event / no information)");
   
-  } else if (evt.detail.originalEvent.button === 2) {
+  } else if (evt.detail.mouseEvent.button === 2) {
     console.log("right button clicked"); 
   }
 });
 ```
 
-Event detail `originalEvent` is not always present.  It is not present on `mousenter`, `mouseleave` and `fusing` events, and it is not present on a `click` event that has been triggered by a fuse timeout rather than a mouse click or touch event.
+At most one of  `mouseEvent` or `touchEvent` will be present on a cursor event, and sometimes neither will.  Neither will be present on `mousenter`, `mouseleave` and `fusing` events, nor on a `click` event that has been triggered by a fuse timeout rather than a mouse click or touch event.
 
 ## States
 

--- a/examples/test/cursor/click-color-change.js
+++ b/examples/test/cursor/click-color-change.js
@@ -13,7 +13,7 @@ AFRAME.registerComponent('click-color-change', {
   },
 
   click (event) {
-    const mouseEvent = event.detail.originalEvent;
+    const mouseEvent = event.detail.mouseEvent;
 
     if (!mouseEvent) return;
 

--- a/examples/test/cursor/click-color-change.js
+++ b/examples/test/cursor/click-color-change.js
@@ -1,0 +1,31 @@
+/* global AFRAME, THREE */
+
+AFRAME.registerComponent('click-color-change', {
+
+  init () {
+    this.el.addEventListener('click', this.click.bind(this));
+    this.r = 0;
+    this.g = 0;
+    this.b = 0;
+
+    // disable right-click context menu
+    window.addEventListener('contextmenu', event => event.preventDefault());
+  },
+
+  click (event) {
+    const mouseEvent = event.detail.originalEvent;
+
+    if (!mouseEvent) return;
+
+    if (mouseEvent.button === 0) {
+      this.r = 1 - this.r;
+    } else if (mouseEvent.button === 1) {
+      this.g = 1 - this.g;
+    } else if (mouseEvent.button === 2) {
+      this.b = 1 - this.b;
+    }
+
+    const color = new THREE.Color(this.r, this.g, this.b);
+    this.el.setAttribute('color', `#${color.getHexString()}`);
+  }
+});

--- a/examples/test/cursor/mouse-events.html
+++ b/examples/test/cursor/mouse-events.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Cursor</title>
+    <meta name="description" content="Cursor - A-Frame">
+    <script src="../../../dist/aframe-master.js"></script>
+    <script src="./click-color-change.js"></script>
+  </head>
+  <body>
+    <div style='position: absolute; left: 30%; top: 10%; z-index: 1'>
+        <p>Example to show differential handling of different mouse buttons on cursor events.</p>
+        <p>Click on cube to change color:
+            <ul>
+                <li>Left button to toggle red</li>
+                <li>Middle button to toggle green</li>
+                <li>Right button to toggle blue</li>
+            </ul>
+        </p>
+    </div>
+    <a-scene background="color: #FBE0D8">
+      
+      <a-entity id="mouseCursor" cursor="rayOrigin: mouse" raycaster="objects: .intersectable"></a-entity>
+
+      <a-entity position="0 1 -3">
+        <a-box color="black"
+               click-color-change
+               class="intersectable">
+        </a-box>
+      </a-entity>
+    </a-scene>
+  </body>
+</html>

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -301,7 +301,7 @@ module.exports.Component = registerComponent('cursor', {
       }
     }
 
-    this.twoWayEmit(EVENTS.MOUSEDOWN);
+    this.twoWayEmit(EVENTS.MOUSEDOWN, evt);
     this.cursorDownEl = this.intersectedEl;
   },
 
@@ -318,7 +318,7 @@ module.exports.Component = registerComponent('cursor', {
     this.isCursorDown = false;
 
     var data = this.data;
-    this.twoWayEmit(EVENTS.MOUSEUP);
+    this.twoWayEmit(EVENTS.MOUSEUP, evt);
 
     if (this.reenableARHitTest === true) {
       this.el.sceneEl.setAttribute('ar-hit-test', 'enabled', true);
@@ -334,7 +334,7 @@ module.exports.Component = registerComponent('cursor', {
 
     if ((!data.fuse || data.rayOrigin === 'mouse' || data.rayOrigin === 'xrselect') &&
         this.intersectedEl && this.cursorDownEl === this.intersectedEl) {
-      this.twoWayEmit(EVENTS.CLICK);
+      this.twoWayEmit(EVENTS.CLICK, evt);
     }
 
     // if the current xr input stops selecting then make the ray caster point somewhere else
@@ -475,7 +475,7 @@ module.exports.Component = registerComponent('cursor', {
   /**
    * Helper to emit on both the cursor and the intersected entity (if exists).
    */
-  twoWayEmit: function (evtName) {
+  twoWayEmit: function (evtName, originalEvent) {
     var el = this.el;
     var intersectedEl = this.intersectedEl;
     var intersection;
@@ -483,11 +483,17 @@ module.exports.Component = registerComponent('cursor', {
     intersection = this.el.components.raycaster.getIntersection(intersectedEl);
     this.eventDetail.intersectedEl = intersectedEl;
     this.eventDetail.intersection = intersection;
+    if (originalEvent) {
+      this.eventDetail.originalEvent = originalEvent;
+    }
     el.emit(evtName, this.eventDetail);
 
     if (!intersectedEl) { return; }
 
     this.intersectedEventDetail.intersection = intersection;
+    if (originalEvent) {
+      this.intersectedEventDetail.originalEvent = originalEvent;
+    }
     intersectedEl.emit(evtName, this.intersectedEventDetail);
   }
 });

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -1,4 +1,4 @@
-/* global THREE */
+/* global THREE, MouseEvent, TouchEvent */
 var registerComponent = require('../core/component').registerComponent;
 var utils = require('../utils/');
 
@@ -480,20 +480,24 @@ module.exports.Component = registerComponent('cursor', {
     var intersectedEl = this.intersectedEl;
     var intersection;
 
+    function addOriginalEvent (detail, evt) {
+      if (originalEvent instanceof MouseEvent) {
+        detail.mouseEvent = originalEvent;
+      } else if (originalEvent instanceof TouchEvent) {
+        detail.touchEvent = originalEvent;
+      }
+    }
+
     intersection = this.el.components.raycaster.getIntersection(intersectedEl);
     this.eventDetail.intersectedEl = intersectedEl;
     this.eventDetail.intersection = intersection;
-    if (originalEvent) {
-      this.eventDetail.originalEvent = originalEvent;
-    }
+    addOriginalEvent(this.eventDetail, originalEvent);
     el.emit(evtName, this.eventDetail);
 
     if (!intersectedEl) { return; }
 
     this.intersectedEventDetail.intersection = intersection;
-    if (originalEvent) {
-      this.intersectedEventDetail.originalEvent = originalEvent;
-    }
+    addOriginalEvent(this.intersectedEventDetail, originalEvent);
     intersectedEl.emit(evtName, this.intersectedEventDetail);
   }
 });

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test, CustomEvent, MouseEvent */
+/* global assert, process, setup, suite, test, CustomEvent, MouseEvent, TouchEvent */
 var entityFactory = require('../helpers').entityFactory;
 var once = require('../helpers').once;
 
@@ -475,13 +475,13 @@ suite('cursor', function () {
     });
   });
 
-  suite('cursor event detail contains original events', function () {
+  suite('cursor event detail contains original mouse & touch events', function () {
     test('original mousedown event', function (done) {
       component.intersection = intersection;
       component.intersectedEl = intersectedEl;
       const mouseDown = new MouseEvent('mousedown');
       once(el, 'mousedown', function (e) {
-        assert.equal(e.detail.originalEvent, mouseDown);
+        assert.equal(e.detail.mouseEvent, mouseDown);
         done();
       });
       component.onCursorDown(mouseDown);
@@ -492,7 +492,7 @@ suite('cursor', function () {
       component.intersectedEl = intersectedEl;
       const mouseUp = new MouseEvent('mouseup');
       once(el, 'mouseup', function (e) {
-        assert.equal(e.detail.originalEvent, mouseUp);
+        assert.equal(e.detail.mouseEvent, mouseUp);
         done();
       });
       component.isCursorDown = true;
@@ -505,11 +505,47 @@ suite('cursor', function () {
       component.cursorDownEl = intersectedEl;
       const mouseUp = new MouseEvent('mouseup');
       once(el, 'click', function (e) {
-        assert.equal(e.detail.originalEvent, mouseUp);
+        assert.equal(e.detail.mouseEvent, mouseUp);
         done();
       });
       component.isCursorDown = true;
       component.onCursorUp(mouseUp);
+    });
+
+    test('original touchstart event', function (done) {
+      component.intersection = intersection;
+      component.intersectedEl = intersectedEl;
+      const touchStart = new TouchEvent('touchstart');
+      once(el, 'mousedown', function (e) {
+        assert.equal(e.detail.touchEvent, touchStart);
+        done();
+      });
+      component.onCursorDown(touchStart);
+    });
+
+    test('original touchend event', function (done) {
+      component.intersection = intersection;
+      component.intersectedEl = intersectedEl;
+      const touchEnd = new TouchEvent('touchend');
+      once(el, 'mouseup', function (e) {
+        assert.equal(e.detail.touchEvent, touchEnd);
+        done();
+      });
+      component.isCursorDown = true;
+      component.onCursorUp(touchEnd);
+    });
+
+    test('original touchend event on click', function (done) {
+      component.intersection = intersection;
+      component.intersectedEl = intersectedEl;
+      component.cursorDownEl = intersectedEl;
+      const touchEnd = new TouchEvent('touchend');
+      once(el, 'click', function (e) {
+        assert.equal(e.detail.touchEvent, touchEnd);
+        done();
+      });
+      component.isCursorDown = true;
+      component.onCursorUp(touchEnd);
     });
   });
 });

--- a/tests/components/cursor.test.js
+++ b/tests/components/cursor.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test, CustomEvent */
+/* global assert, process, setup, suite, test, CustomEvent, MouseEvent */
 var entityFactory = require('../helpers').entityFactory;
 var once = require('../helpers').once;
 
@@ -472,6 +472,44 @@ suite('cursor', function () {
       assert.isFalse(cursorEmitSpy.calledWith('mouseup'));
       el.sceneEl.canvas.dispatchEvent(upEvt);
       assert.isTrue(cursorEmitSpy.calledWith('mouseup'));
+    });
+  });
+
+  suite('cursor event detail contains original events', function () {
+    test('original mousedown event', function (done) {
+      component.intersection = intersection;
+      component.intersectedEl = intersectedEl;
+      const mouseDown = new MouseEvent('mousedown');
+      once(el, 'mousedown', function (e) {
+        assert.equal(e.detail.originalEvent, mouseDown);
+        done();
+      });
+      component.onCursorDown(mouseDown);
+    });
+
+    test('original mouseup event', function (done) {
+      component.intersection = intersection;
+      component.intersectedEl = intersectedEl;
+      const mouseUp = new MouseEvent('mouseup');
+      once(el, 'mouseup', function (e) {
+        assert.equal(e.detail.originalEvent, mouseUp);
+        done();
+      });
+      component.isCursorDown = true;
+      component.onCursorUp(mouseUp);
+    });
+
+    test('original mouseup event on click', function (done) {
+      component.intersection = intersection;
+      component.intersectedEl = intersectedEl;
+      component.cursorDownEl = intersectedEl;
+      const mouseUp = new MouseEvent('mouseup');
+      once(el, 'click', function (e) {
+        assert.equal(e.detail.originalEvent, mouseUp);
+        done();
+      });
+      component.isCursorDown = true;
+      component.onCursorUp(mouseUp);
     });
   });
 });


### PR DESCRIPTION
**Description:**

When using cursor on desktop, it can be complicated to distinguish between left clicks & right clicks.  This is because the cursor events for click, mouseup and mousedown have much less information than the MouseEvent and TouchEvents.

This issue has been raised previously here (in 2018), but was closed without any changes being made.
https://github.com/aframevr/aframe/issues/3833

Recent discussion on the A-Frame discord channel with @dmarcos led to a proposed solution to this problem, which this PR implements (full discussion pasted below for reference)

**Changes proposed:**

- When a MouseEvent or TouchEvent is the immediate cause of a cursor event (mousedown, mouseup or click), include a reference to the MouseEvent or TouchEvent object in event.detail as event.detail.originalEvent
- Unit tests for this change
- Documentation updates
- A simple example (at /examples/test/cursor/mouse-events.html) that changes color of a block based on left, right & middle button clicks.

** Full discussion from discord **

> diarmid — 08/04/2022
> I'd love cursor events triggered by the mouse to include data telling me what mouse button was pressed (left, middle or right).  For desktop apps it's pretty common to have different mouse buttons do different functions.
> 
> This has been requested before (back in 2018), and various offers of PRs made to make this extension, but offers have been rejected on the basis that "it's not needed".
> 
> https://github.com/aframevr/aframe/issues/3833
> 
> @dmarcos Would you feel any differently about this today?  I'd be happy to do a PR for this, just to add data about which mouse button was pressed to the click, mouseup & mousedown events generated by cursor.  I agree with the analysis in the issue that this can be handled in the application, but would be far simpler to be able to use cursor events directly.
> 
> dmarcos — 08/04/2022
> I always worry abstracting away DOM APIs too much. Prefer people to use the standard APIs as much as possible. Once you commit to abstraction things get complex and hard to maintain very quickly 
> an example that people can copy and paste might be more appropriate. can add to the docs
> what do you think?
> fan of copy pasta in general. reusable code without hiding the details
> if simple is easy to adapt and tweak
> a high level abstract API makes you more dependent of maintainers
> 
> diarmid — 08/04/2022
> That makes sense, but the cursor component already has an API that generates custom events (click, mouseup, mousedown), which are missing some important detail vs. what's on the DOM APIs for the equivalent events.
> 
> These events do provide a number of conveniences over the standard DOM events (e.g. you can listen for them on a specific target object), so I'd not be in favour of deprecating them.
> 
> What about including a reference to the original MouseEvent in the cursor's CustomEvent?  That would seem to avoid the maintainability concerns, and allow people to use the standard API to get whatever additional info they might want about the mouse event that triggered the cursor event.
> My problem with a copy-paste example, is that it still leaves us with 2 completely different patterns for handling cursor events - one way if you care about differentiating left click from right click, another way if you don't.  And people will develop apps that handle left & right click indiscriminately, and then decide later that they want to handle them differently and have to rewrite a bunch of code from one pattern into another.
> 
> No matter how good the sample code is, that's still a pain to have to deal with.  The basic way of handling cursor events should ideally be easily extensible to more advanced use cases without having to do substantial rewrites.
> 
> dmarcos — 08/05/2022
> yeah passing the mousevent might be simple enough. thanks for the convo
> 
> diarmid — 08/05/2022
> Ok, if you'd consider that change, I'll have a go at a PR some time next week.

