### PR TITLE
Fix bad link in documentation

### DIFF
--- a/docs/components/gltf-model.md
+++ b/docs/components/gltf-model.md
@@ -120,10 +120,10 @@ glTF file size may be reduced using [Draco][draco] or [Meshopt][meshopt] compres
 
 To optimize an existing glTF model, use tools such as:
 
-- [Blender][blender]: Draco compression
-- [glTF-Pipeline][gltf-pipeline]: Draco compression
-- [glTF-Transform][gltf-transform]: Draco or Meshopt compression
-- [gltfpack][gltfpack]: Meshopt compression
+- [Blender][blender] for Draco compression
+- [glTF-Pipeline][gltf-pipeline] for Draco compression
+- [glTF-Transform][gltf-transform] for Draco or Meshopt compression
+- [gltfpack][gltfpack] for Meshopt compression
 
 You'll also need to load a decoder library by configuring scene properties as explained below.
 

--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -299,7 +299,7 @@ including:
 
 ## Which headsets, browsers, devices, and platforms does A-Frame support?
 
-[deviceplatform]: ./vr-headsets-and-webvr-browsers.md
+[deviceplatform]: ./vr-headsets-and-webxr-browsers.md
 
 Most of them. Read *[VR Headsets and WebVR Browsers][deviceplatform]* for more
 information.


### PR DESCRIPTION
`npm run test:docs` didn't work anymore because the referenceRegex regexp wrongly matching `[Blender][blender]: Draco compression` when searching for `[blender]: https://www.blender.org/` type of reference. Instead of trying to modify the regexp, I just changed the doc to avoid the colon.
With that fixed, the script found a bad link caused by the renaming of webvr to webxr of the `vr-headsets-and-webxr-browsers.md` file.