### PR TITLE
Fixes dynamically created a-scene attributes

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -550,7 +550,12 @@ module.exports.AScene = registerElement('a-scene', {
           system.updateProperties(value);
           return;
         }
-        AEntity.prototype.setAttribute.call(this, attr, value, componentPropValue);
+        if (this.systemNames.length) {
+          AEntity.prototype.setAttribute.call(this, attr, value, componentPropValue);
+        } else {
+          // system registration isn't completed yet, so just set as a regular node
+          ANode.prototype.setAttribute.call(this, attr, value);
+        }
       }
     },
 

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -596,6 +596,19 @@ suite('a-scene (without renderer)', function () {
       assert.equal(sceneEl.getAttribute('test'), 'system');
     });
 
+    test('can setAttribute on dynamically created scene', function () {
+      AFRAME.registerComponent('test', {schema: {default: 'component'}});
+      AFRAME.registerSystem('test', {schema: {default: 'system'}});
+
+      var sceneEl = document.createElement('a-scene');
+
+      sceneEl.setAttribute('test', 'manual');
+      assert.equal(sceneEl.getAttribute('test'), 'manual');
+
+      sceneEl.initSystem('test');
+      assert.equal(sceneEl.getAttribute('test'), 'manual');
+    });
+
     test('does not initialize component on setAttribute', function (done) {
       var sceneEl = document.createElement('a-scene');
       var stub = sinon.stub();


### PR DESCRIPTION
**Description:**
document.createElement("a-scene").setAttribute doesn't work
correctly when there is already a registered system and component
with the same name.


**Changes proposed:**
- Call the `ANode` implementation if there are no `systemNames` yet.