### PR TITLE
Quest 2 controller fixes (fixes issue #5607)

### DIFF
--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -470,7 +470,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 });
 
 /**
- * A-Frame's material component makes a single unified shared material for all meshes.
+ * A-Frame's material component makes a single unified shared material for all child meshes.
  * In order to be able to color individual buttons, we need to give each sub-mesh its own
  * THREE material. Without this, changing the color on any individual button mesh changes
  * the color on every button mesh.

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -172,7 +172,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     this.previousButtonValues = {};
     this.rendererSystem = this.el.sceneEl.systems.renderer;
     this.bindMethods();
-    this.triggerEuler = new THREE.Euler;
+    this.triggerEuler = new THREE.Euler();
   },
 
   addEventListeners: function () {
@@ -275,10 +275,9 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   onButtonChanged: function (evt) {
     // move the button models
-    if (this.isV3) { 
+    if (this.isV3) {
       this.onButtonChangedV3(evt);
-    }
-    else {  
+    } else {
       var button = this.mapping[this.data.hand].buttons[evt.detail.id];
       var buttonMeshes = this.buttonMeshes;
       var analogValue;
@@ -300,7 +299,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     this.el.emit(button + 'changed', evt.detail.state);
   },
 
-  clickButtons: ['xbutton','ybutton','abutton','bbutton','thumbstick'],
+  clickButtons: ['xbutton', 'ybutton', 'abutton', 'bbutton', 'thumbstick'],
   onButtonChangedV3: function (evt) {
     var button = this.mapping[this.data.hand].buttons[evt.detail.id];
     var buttonObjects = this.buttonObjects;
@@ -309,22 +308,19 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
     analogValue = evt.detail.state.value;
     analogValue *= this.data.hand === 'left' ? -1 : 1;
-    
+
     if (button === 'trigger') {
       this.triggerEuler.copy(this.buttonRanges.trigger.min.rotation);
       this.triggerEuler.x += analogValue * this.buttonRanges.trigger.diff.x;
       this.triggerEuler.y += analogValue * this.buttonRanges.trigger.diff.y;
       this.triggerEuler.z += analogValue * this.buttonRanges.trigger.diff.z;
       buttonObjects.trigger.setRotationFromEuler(this.triggerEuler);
-    }
-    else if (button === 'grip') {
+    } else if (button === 'grip') {
       buttonObjects.grip.position.x = buttonObjects.grip.minX + analogValue * 0.004;
+    } else if (this.clickButtons.includes(button)) {
+      buttonObjects[button].position.y = analogValue === 0 ? this.buttonRanges[button].unpressedY : this.buttonRanges[button].pressedY;
     }
-    else if (this.clickButtons.includes(button)) {
-      buttonObjects[button].position.y = analogValue === 0 ? 
-        this.buttonRanges[button].unpressedY : this.buttonRanges[button].pressedY;
-    }
-  },  
+  },
 
   onModelLoaded: function (evt) {
     if (this.isV3) {
@@ -352,7 +348,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       this.multiMeshFix(button);
     }
 
-    this.applyOffset(evt.detail.model)
+    this.applyOffset(evt.detail.model);
 
     this.el.emit('controllermodelready', {
       name: 'oculus-touch-controls',
@@ -360,16 +356,16 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       rayOrigin: this.displayModel[this.data.hand].rayOrigin
     });
   },
-  
-  applyOffset(model) {
+
+  applyOffset (model) {
     model.position.copy(this.displayModel[this.data.hand].modelPivotOffset);
     model.rotation.copy(this.displayModel[this.data.hand].modelPivotRotation);
   },
-  
-  multiMeshFix(button) {
+
+  multiMeshFix (button) {
     if (!this.buttonMeshes[button]) return;
     this.buttonMeshes[button].traverse((node) => {
-      if (node.type != "Mesh") return;
+      if (node.type !== 'Mesh') return;
       let originalMaterial = node.material;
       this.buttonMeshes[button].naturalColor = originalMaterial.color;
       node.material = new THREE.MeshStandardMaterial(); // {color: originalMaterial.color}
@@ -380,37 +376,37 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
           // because A-Frame uses the same single material object for all material nodes, it also uses the
           // same color. This means they use the same color object--we have to break that link. Other links
           // likely also exist, but they don't matter to us, because color is the only one we change.
-          node.material[key] = key !== 'color' ? originalMaterial[key] :  originalMaterial[key].clone();
+          node.material[key] = key !== 'color' ? originalMaterial[key] : originalMaterial[key].clone();
         }
-      })
+      });
       originalMaterial.dispose();
-    })
+    });
   },
 
-  onModelLoadedV3(evt) {
+  onModelLoadedV3 (evt) {
     let controllerObject3D = this.controllerObject3D = evt.detail.model;
-    
+
     if (!this.data.model) { return; }
-    
-    let buttonObjects = this.buttonObjects = {},
-        buttonMeshes = this.buttonMeshes = {},
-        buttonRanges = this.buttonRanges = {};
-    
+
+    let buttonObjects = this.buttonObjects = {};
+    let buttonMeshes = this.buttonMeshes = {};
+    let buttonRanges = this.buttonRanges = {};
+
     buttonMeshes.grip = controllerObject3D.getObjectByName('squeeze');
     buttonObjects.grip = controllerObject3D.getObjectByName('xr_standard_squeeze_pressed_value');
     buttonRanges.grip = {
       min: controllerObject3D.getObjectByName('xr_standard_squeeze_pressed_min'),
-      max: controllerObject3D.getObjectByName('xr_standard_squeeze_pressed_max'),
-    }
+      max: controllerObject3D.getObjectByName('xr_standard_squeeze_pressed_max')
+    };
     buttonObjects.grip.minX = buttonObjects.grip.position.x;
-    
+
     buttonMeshes.thumbstick = controllerObject3D.getObjectByName('thumbstick');
     buttonObjects.thumbstick = controllerObject3D.getObjectByName('xr_standard_thumbstick_pressed_value');
     buttonRanges.thumbstick = {
       min: controllerObject3D.getObjectByName('xr_standard_thumbstick_pressed_min'),
       max: controllerObject3D.getObjectByName('xr_standard_thumbstick_pressed_max'),
-      originalRotation: this.buttonObjects.thumbstick.rotation.clone(),
-    }
+      originalRotation: this.buttonObjects.thumbstick.rotation.clone()
+    };
     buttonRanges.thumbstick.pressedY = buttonObjects.thumbstick.position.y;
     buttonRanges.thumbstick.unpressedY =
       buttonRanges.thumbstick.pressedY + Math.abs(buttonRanges.thumbstick.max.position.y) - Math.abs(buttonRanges.thumbstick.min.position.y);
@@ -419,57 +415,57 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     buttonObjects.trigger = controllerObject3D.getObjectByName('xr_standard_trigger_pressed_value');
     buttonRanges.trigger = {
       min: controllerObject3D.getObjectByName('xr_standard_trigger_pressed_min'),
-      max: controllerObject3D.getObjectByName('xr_standard_trigger_pressed_max'),
-    }
+      max: controllerObject3D.getObjectByName('xr_standard_trigger_pressed_max')
+    };
     buttonRanges.trigger.diff = {
       x: Math.abs(buttonRanges.trigger.max.rotation.x) - Math.abs(buttonRanges.trigger.min.rotation.x),
       y: Math.abs(buttonRanges.trigger.max.rotation.y) - Math.abs(buttonRanges.trigger.min.rotation.y),
-      z: Math.abs(buttonRanges.trigger.max.rotation.z) - Math.abs(buttonRanges.trigger.min.rotation.z),      
-    }
-    
-    let btn1 = this.data.hand === 'left' ? 'x' : 'a',
-        btn2 = this.data.hand === 'left' ? 'y' : 'b' ;
-    
-    buttonMeshes[btn1+"button"] = controllerObject3D.getObjectByName(btn1+'_button');
-    buttonObjects[btn1+"button"] = controllerObject3D.getObjectByName(btn1+'_button_pressed_value');
-    buttonRanges[btn1+"button"] = {
-      min: controllerObject3D.getObjectByName(btn1+'_button_pressed_min'),
-      max: controllerObject3D.getObjectByName(btn1+'_button_pressed_max'),
-    }
+      z: Math.abs(buttonRanges.trigger.max.rotation.z) - Math.abs(buttonRanges.trigger.min.rotation.z)
+    };
 
-    buttonMeshes[btn2+"button"] = controllerObject3D.getObjectByName(btn2+'_button');
-    buttonObjects[btn2+"button"] = controllerObject3D.getObjectByName(btn2+'_button_pressed_value');
-    buttonRanges[btn2+"button"] = {
-      min: controllerObject3D.getObjectByName(btn2+'_button_pressed_min'),
-      max: controllerObject3D.getObjectByName(btn2+'_button_pressed_max'),
-    }    
-    
-    buttonRanges[btn1+"button"].unpressedY = buttonObjects[btn1+"button"].position.y;
-    buttonRanges[btn1+"button"].pressedY = 
-      buttonRanges[btn1+"button"].unpressedY + Math.abs(buttonRanges[btn1+"button"].max.position.y) - Math.abs(buttonRanges[btn1+"button"].min.position.y); 
-    
-    buttonRanges[btn2+"button"].unpressedY = buttonObjects[btn2+"button"].position.y;
-    buttonRanges[btn2+"button"].pressedY = 
-      buttonRanges[btn2+"button"].unpressedY - Math.abs(buttonRanges[btn2+"button"].max.position.y) + Math.abs(buttonRanges[btn2+"button"].min.position.y); 
+    let btn1 = this.data.hand === 'left' ? 'x' : 'a';
+    let btn2 = this.data.hand === 'left' ? 'y' : 'b';
+
+    buttonMeshes[btn1 + 'button'] = controllerObject3D.getObjectByName(btn1 + '_button');
+    buttonObjects[btn1 + 'button'] = controllerObject3D.getObjectByName(btn1 + '_button_pressed_value');
+    buttonRanges[btn1 + 'button'] = {
+      min: controllerObject3D.getObjectByName(btn1 + '_button_pressed_min'),
+      max: controllerObject3D.getObjectByName(btn1 + '_button_pressed_max')
+    };
+
+    buttonMeshes[btn2 + 'button'] = controllerObject3D.getObjectByName(btn2 + '_button');
+    buttonObjects[btn2 + 'button'] = controllerObject3D.getObjectByName(btn2 + '_button_pressed_value');
+    buttonRanges[btn2 + 'button'] = {
+      min: controllerObject3D.getObjectByName(btn2 + '_button_pressed_min'),
+      max: controllerObject3D.getObjectByName(btn2 + '_button_pressed_max')
+    };
+
+    buttonRanges[btn1 + 'button'].unpressedY = buttonObjects[btn1 + 'button'].position.y;
+    buttonRanges[btn1 + 'button'].pressedY =
+      buttonRanges[btn1 + 'button'].unpressedY + Math.abs(buttonRanges[btn1 + 'button'].max.position.y) - Math.abs(buttonRanges[btn1 + 'button'].min.position.y);
+
+    buttonRanges[btn2 + 'button'].unpressedY = buttonObjects[btn2 + 'button'].position.y;
+    buttonRanges[btn2 + 'button'].pressedY =
+      buttonRanges[btn2 + 'button'].unpressedY - Math.abs(buttonRanges[btn2 + 'button'].max.position.y) + Math.abs(buttonRanges[btn2 + 'button'].min.position.y);
   },
-  
+
   onAxisMoved: function (evt) {
     emitIfAxesChanged(this, this.mapping[this.data.hand].axes, evt);
   },
-  
-  onThumbstickMoved: function(evt) {
-    if (!this.isV3 || !this.buttonMeshes || !this.buttonMeshes.thumbstick) {return;}
+
+  onThumbstickMoved: function (evt) {
+    if (!this.isV3 || !this.buttonMeshes || !this.buttonMeshes.thumbstick) { return; }
     for (let axis in evt.detail) {
-      this.buttonObjects.thumbstick.rotation[this.axisMap[axis]] = 
-        this.buttonRanges.thumbstick.originalRotation[this.axisMap[axis]] - 
-        (Math.PI*1/8) *
-        evt.detail[axis] * 
+      this.buttonObjects.thumbstick.rotation[this.axisMap[axis]] =
+        this.buttonRanges.thumbstick.originalRotation[this.axisMap[axis]] -
+        (Math.PI * 1 / 8) *
+        evt.detail[axis] *
         (axis === 'y' || this.data.hand === 'right' ? -1 : 1);
     }
   },
   axisMap: {
     y: 'x',
-    x: 'z',
+    x: 'z'
   },
 
   updateModel: function (buttonName, evtName) {
@@ -481,11 +477,11 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   updateButtonModel: function (buttonName, evtName) {
     var button;
     var color = (evtName === 'up' || evtName === 'touchend') ? this.buttonMeshes[buttonName].naturalColor || this.data.buttonColor : evtName === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
-    
+
     if (this.buttonMeshes && this.buttonMeshes[buttonName]) {
       button = this.buttonMeshes[buttonName];
       button.material.color.set(color);
       this.rendererSystem.applyColorCorrection(button.material.color);
     }
-  },
+  }
 });

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -242,7 +242,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       }
     }
     var modelUrl = this.displayModel[data.hand].modelUrl;
-    this.isV3 = this.displayModel === CONTROLLER_PROPERTIES['oculus-touch-v3'];
+    this.isOculusTouchV3 = this.displayModel === CONTROLLER_PROPERTIES['oculus-touch-v3'];
     this.el.setAttribute('gltf-model', modelUrl);
   },
 
@@ -275,7 +275,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   onButtonChanged: function (evt) {
     // move the button meshes
-    if (this.isV3) {
+    if (this.isOculusTouchV3) {
       this.onButtonChangedV3(evt);
     } else {
       var button = this.mapping[this.data.hand].buttons[evt.detail.id];
@@ -323,8 +323,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onModelLoaded: function (evt) {
-    if (this.isV3) {
-      this.onModelLoadedV3(evt);
+    if (this.isOculusTouchV3) {
+      this.onOculusTouchV3ModelLoaded(evt);
     } else {
       var controllerObject3D = this.controllerObject3D = evt.detail.model;
       var buttonMeshes;
@@ -364,16 +364,17 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   multiMeshFix: function (button) {
     if (!this.buttonMeshes[button]) return;
-    this.buttonMeshes[button].traverse((node) => {
+    var self = this;
+    this.buttonMeshes[button].traverse(function (node) {
       if (node.type !== 'Mesh') return;
       let newMaterial = node.material.clone();
-      this.buttonMeshes[button].naturalColor = node.material.color;
+      self.buttonMeshes[button].naturalColor = node.material.color;
       node.material.dispose();
       node.material = newMaterial;
     });
   },
 
-  onModelLoadedV3: function (evt) {
+  onOculusTouchV3ModelLoaded: function (evt) {
     var controllerObject3D = this.controllerObject3D = evt.detail.model;
 
     if (!this.data.model) { return; }
@@ -446,7 +447,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onThumbstickMoved: function (evt) {
-    if (!this.isV3 || !this.buttonMeshes || !this.buttonMeshes.thumbstick) { return; }
+    if (!this.isOculusTouchV3 || !this.buttonMeshes || !this.buttonMeshes.thumbstick) { return; }
     for (var axis in evt.detail) {
       this.buttonObjects.thumbstick.rotation[this.axisMap[axis]] =
         this.buttonRanges.thumbstick.originalRotation[this.axisMap[axis]] -

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -274,7 +274,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onButtonChanged: function (evt) {
-    // move the button models
+    // move the button meshes
     if (this.isV3) {
       this.onButtonChangedV3(evt);
     } else {
@@ -368,9 +368,9 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       if (node.type !== 'Mesh') return;
       let originalMaterial = node.material;
       this.buttonMeshes[button].naturalColor = originalMaterial.color;
-      node.material = new THREE.MeshStandardMaterial(); // {color: originalMaterial.color}
+      node.material = new THREE.MeshStandardMaterial();
 
-      // preserve details. (not iterable, so we have to use Object.keys.)
+      // preserve details; not iterable, so we have to use Object.keys()
       Object.keys(originalMaterial).forEach(key => {
         if (originalMaterial[key] !== node.material[key]) {
           // because A-Frame uses the same single material object for all material nodes, it also uses the
@@ -458,7 +458,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     for (let axis in evt.detail) {
       this.buttonObjects.thumbstick.rotation[this.axisMap[axis]] =
         this.buttonRanges.thumbstick.originalRotation[this.axisMap[axis]] -
-        (Math.PI * 1 / 8) *
+        (Math.PI / 8) *
         evt.detail[axis] *
         (axis === 'y' || this.data.hand === 'right' ? -1 : 1);
     }
@@ -477,9 +477,10 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   updateButtonModel: function (buttonName, evtName) {
     var button;
     var color = (evtName === 'up' || evtName === 'touchend') ? this.buttonMeshes[buttonName].naturalColor || this.data.buttonColor : evtName === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
+    var buttonMeshes = this.buttonMeshes;
 
-    if (this.buttonMeshes && this.buttonMeshes[buttonName]) {
-      button = this.buttonMeshes[buttonName];
+    if (buttonMeshes && buttonMeshes[buttonName]) {
+      button = buttonMeshes[buttonName];
       button.material.color.set(color);
       this.rendererSystem.applyColorCorrection(button.material.color);
     }

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -153,6 +153,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   mapping: INPUT_MAPPING,
 
   bindMethods: function () {
+    this.onButtonChanged = bind(this.onButtonChanged, this);
+    this.onThumbstickMoved = bind(this.onThumbstickMoved, this);
     this.onModelLoaded = bind(this.onModelLoaded, this);
     this.onControllersUpdate = bind(this.onControllersUpdate, this);
     this.checkIfControllerPresent = bind(this.checkIfControllerPresent, this);
@@ -161,7 +163,6 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   init: function () {
     var self = this;
-    this.onButtonChanged = bind(this.onButtonChanged, this);
     this.onButtonDown = function (evt) { onButtonEvent(evt.detail.id, 'down', self, self.data.hand); };
     this.onButtonUp = function (evt) { onButtonEvent(evt.detail.id, 'up', self, self.data.hand); };
     this.onButtonTouchStart = function (evt) { onButtonEvent(evt.detail.id, 'touchstart', self, self.data.hand); };
@@ -171,6 +172,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     this.previousButtonValues = {};
     this.rendererSystem = this.el.sceneEl.systems.renderer;
     this.bindMethods();
+    this.triggerEuler = new THREE.Euler;
   },
 
   addEventListeners: function () {
@@ -182,6 +184,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     el.addEventListener('touchend', this.onButtonTouchEnd);
     el.addEventListener('axismove', this.onAxisMoved);
     el.addEventListener('model-loaded', this.onModelLoaded);
+    el.addEventListener('thumbstickmoved', this.onThumbstickMoved);
     this.controllerEventsActive = true;
   },
 
@@ -194,6 +197,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     el.removeEventListener('touchend', this.onButtonTouchEnd);
     el.removeEventListener('axismove', this.onAxisMoved);
     el.removeEventListener('model-loaded', this.onModelLoaded);
+    el.removeEventListener('thumbstickmoved', this.onThumbstickMoved);
     this.controllerEventsActive = false;
   },
 
@@ -220,18 +224,17 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     if (!data.model) { return; }
     // Set the controller display model based on the data passed in.
     this.displayModel = CONTROLLER_PROPERTIES[data.controllerType] || CONTROLLER_PROPERTIES[CONTROLLER_DEFAULT];
-    // If the developer is asking for auto-detection, see if the displayName can be retrieved to identify the specific unit.
-    // This only works for WebVR currently.
+    // If the developer is asking for auto-detection, use the retrieved displayName to identify the specific unit.
     if (data.controllerType === 'auto') {
       var trackedControlsSystem = this.el.sceneEl.systems['tracked-controls-webvr'];
-      // WebVR
       if (trackedControlsSystem && trackedControlsSystem.vrDisplay) {
+        // WebVR
         var displayName = trackedControlsSystem.vrDisplay.displayName;
-        // The Oculus Quest uses the updated generation 2 inside-out tracked controllers so update the displayModel.
         if (/^Oculus Quest$/.test(displayName)) {
           this.displayModel = CONTROLLER_PROPERTIES['oculus-touch-v2'];
         }
-      } else { // WebXR
+      } else {
+        // WebXR
         controllerId = CONTROLLER_DEFAULT;
         controllerId = controller.profiles.indexOf('oculus-touch-v2') !== -1 ? 'oculus-touch-v2' : controllerId;
         controllerId = controller.profiles.indexOf('oculus-touch-v3') !== -1 ? 'oculus-touch-v3' : controllerId;
@@ -239,6 +242,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       }
     }
     var modelUrl = this.displayModel[data.hand].modelUrl;
+    this.isV3 = this.displayModel === CONTROLLER_PROPERTIES['oculus-touch-v3'];
     this.el.setAttribute('gltf-model', modelUrl);
   },
 
@@ -270,48 +274,85 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onButtonChanged: function (evt) {
-    var button = this.mapping[this.data.hand].buttons[evt.detail.id];
-    var buttonMeshes = this.buttonMeshes;
-    var analogValue;
-    if (!button) { return; }
+    // move the button models
+    if (this.isV3) { 
+      this.onButtonChangedV3(evt);
+    }
+    else {  
+      var button = this.mapping[this.data.hand].buttons[evt.detail.id];
+      var buttonMeshes = this.buttonMeshes;
+      var analogValue;
+      if (!button) { return; }
 
-    if (button === 'trigger' || button === 'grip') { analogValue = evt.detail.state.value; }
+      if (button === 'trigger' || button === 'grip') { analogValue = evt.detail.state.value; }
 
-    // Update trigger and/or grip meshes, if any.
-    if (buttonMeshes) {
-      if (button === 'trigger' && buttonMeshes.trigger) {
-        buttonMeshes.trigger.rotation.x = this.originalXRotationTrigger - analogValue * (Math.PI / 26);
-      }
-      if (button === 'grip' && buttonMeshes.grip) {
-        buttonMeshes.grip.position.x = this.originalXPositionGrip + (this.data.hand === 'left' ? -1 : 1) * analogValue * 0.004;
+      if (buttonMeshes) {
+        if (button === 'trigger' && buttonMeshes.trigger) {
+          buttonMeshes.trigger.rotation.x = this.originalXRotationTrigger - analogValue * (Math.PI / 26);
+        }
+        if (button === 'grip' && buttonMeshes.grip) {
+          analogValue *= this.data.hand === 'left' ? -1 : 1;
+          buttonMeshes.grip.position.x = this.originalXPositionGrip + analogValue * 0.004;
+        }
       }
     }
-
     // Pass along changed event with button state, using the buttom mapping for convenience.
     this.el.emit(button + 'changed', evt.detail.state);
   },
 
+  clickButtons: ['xbutton','ybutton','abutton','bbutton','thumbstick'],
+  onButtonChangedV3: function (evt) {
+    var button = this.mapping[this.data.hand].buttons[evt.detail.id];
+    var buttonObjects = this.buttonObjects;
+    var analogValue;
+    if (!button) { return; }
+
+    analogValue = evt.detail.state.value;
+    analogValue *= this.data.hand === 'left' ? -1 : 1;
+    
+    if (button === 'trigger') {
+      this.triggerEuler.copy(this.buttonRanges.trigger.min.rotation);
+      this.triggerEuler.x += analogValue * this.buttonRanges.trigger.diff.x;
+      this.triggerEuler.y += analogValue * this.buttonRanges.trigger.diff.y;
+      this.triggerEuler.z += analogValue * this.buttonRanges.trigger.diff.z;
+      buttonObjects.trigger.setRotationFromEuler(this.triggerEuler);
+    }
+    else if (button === 'grip') {
+      buttonObjects.grip.position.x = buttonObjects.grip.minX + analogValue * 0.004;
+    }
+    else if (this.clickButtons.includes(button)) {
+      buttonObjects[button].position.y = analogValue === 0 ? 
+        this.buttonRanges[button].unpressedY : this.buttonRanges[button].pressedY;
+    }
+  },  
+
   onModelLoaded: function (evt) {
-    var controllerObject3D = this.controllerObject3D = evt.detail.model;
-    var buttonMeshes;
+    if (this.isV3) {
+      this.onModelLoadedV3(evt);
+    } else {
+      var controllerObject3D = this.controllerObject3D = evt.detail.model;
+      var buttonMeshes;
 
-    if (!this.data.model) { return; }
+      if (!this.data.model) { return; }
 
-    buttonMeshes = this.buttonMeshes = {};
+      buttonMeshes = this.buttonMeshes = {};
 
-    buttonMeshes.grip = controllerObject3D.getObjectByName('buttonHand');
-    this.originalXPositionGrip = buttonMeshes.grip && buttonMeshes.grip.position.x;
-    buttonMeshes.thumbstick = controllerObject3D.getObjectByName('stick');
-    buttonMeshes.trigger = controllerObject3D.getObjectByName('buttonTrigger');
-    this.originalXRotationTrigger = buttonMeshes.trigger && buttonMeshes.trigger.rotation.x;
-    buttonMeshes.xbutton = controllerObject3D.getObjectByName('buttonX');
-    buttonMeshes.abutton = controllerObject3D.getObjectByName('buttonA');
-    buttonMeshes.ybutton = controllerObject3D.getObjectByName('buttonY');
-    buttonMeshes.bbutton = controllerObject3D.getObjectByName('buttonB');
+      buttonMeshes.grip = controllerObject3D.getObjectByName('buttonHand');
+      this.originalXPositionGrip = buttonMeshes.grip && buttonMeshes.grip.position.x;
+      buttonMeshes.trigger = controllerObject3D.getObjectByName('buttonTrigger');
+      this.originalXRotationTrigger = buttonMeshes.trigger && buttonMeshes.trigger.rotation.x;
+      buttonMeshes.thumbstick = controllerObject3D.getObjectByName('stick');
+      buttonMeshes.xbutton = controllerObject3D.getObjectByName('buttonX');
+      buttonMeshes.abutton = controllerObject3D.getObjectByName('buttonA');
+      buttonMeshes.ybutton = controllerObject3D.getObjectByName('buttonY');
+      buttonMeshes.bbutton = controllerObject3D.getObjectByName('buttonB');
+    }
 
-    // Offset pivot point
-    controllerObject3D.position.copy(this.displayModel[this.data.hand].modelPivotOffset);
-    controllerObject3D.rotation.copy(this.displayModel[this.data.hand].modelPivotRotation);
+    for (let button in this.buttonMeshes) {
+      this.multiMeshFix(button);
+    }
+
+    this.applyOffset(evt.detail.model)
 
     this.el.emit('controllermodelready', {
       name: 'oculus-touch-controls',
@@ -319,25 +360,132 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       rayOrigin: this.displayModel[this.data.hand].rayOrigin
     });
   },
+  
+  applyOffset(model) {
+    model.position.copy(this.displayModel[this.data.hand].modelPivotOffset);
+    model.rotation.copy(this.displayModel[this.data.hand].modelPivotRotation);
+  },
+  
+  multiMeshFix(button) {
+    if (!this.buttonMeshes[button]) return;
+    this.buttonMeshes[button].traverse((node) => {
+      if (node.type != "Mesh") return;
+      let originalMaterial = node.material;
+      this.buttonMeshes[button].naturalColor = originalMaterial.color;
+      node.material = new THREE.MeshStandardMaterial(); // {color: originalMaterial.color}
 
+      // preserve details. (not iterable, so we have to use Object.keys.)
+      Object.keys(originalMaterial).forEach(key => {
+        if (originalMaterial[key] !== node.material[key]) {
+          // because A-Frame uses the same single material object for all material nodes, it also uses the
+          // same color. This means they use the same color object--we have to break that link. Other links
+          // likely also exist, but they don't matter to us, because color is the only one we change.
+          node.material[key] = key !== 'color' ? originalMaterial[key] :  originalMaterial[key].clone();
+        }
+      })
+      originalMaterial.dispose();
+    })
+  },
+
+  onModelLoadedV3(evt) {
+    let controllerObject3D = this.controllerObject3D = evt.detail.model;
+    
+    if (!this.data.model) { return; }
+    
+    let buttonObjects = this.buttonObjects = {},
+        buttonMeshes = this.buttonMeshes = {},
+        buttonRanges = this.buttonRanges = {};
+    
+    buttonMeshes.grip = controllerObject3D.getObjectByName('squeeze');
+    buttonObjects.grip = controllerObject3D.getObjectByName('xr_standard_squeeze_pressed_value');
+    buttonRanges.grip = {
+      min: controllerObject3D.getObjectByName('xr_standard_squeeze_pressed_min'),
+      max: controllerObject3D.getObjectByName('xr_standard_squeeze_pressed_max'),
+    }
+    buttonObjects.grip.minX = buttonObjects.grip.position.x;
+    
+    buttonMeshes.thumbstick = controllerObject3D.getObjectByName('thumbstick');
+    buttonObjects.thumbstick = controllerObject3D.getObjectByName('xr_standard_thumbstick_pressed_value');
+    buttonRanges.thumbstick = {
+      min: controllerObject3D.getObjectByName('xr_standard_thumbstick_pressed_min'),
+      max: controllerObject3D.getObjectByName('xr_standard_thumbstick_pressed_max'),
+      originalRotation: this.buttonObjects.thumbstick.rotation.clone(),
+    }
+    buttonRanges.thumbstick.pressedY = buttonObjects.thumbstick.position.y;
+    buttonRanges.thumbstick.unpressedY =
+      buttonRanges.thumbstick.pressedY + Math.abs(buttonRanges.thumbstick.max.position.y) - Math.abs(buttonRanges.thumbstick.min.position.y);
+
+    buttonMeshes.trigger = controllerObject3D.getObjectByName('trigger');
+    buttonObjects.trigger = controllerObject3D.getObjectByName('xr_standard_trigger_pressed_value');
+    buttonRanges.trigger = {
+      min: controllerObject3D.getObjectByName('xr_standard_trigger_pressed_min'),
+      max: controllerObject3D.getObjectByName('xr_standard_trigger_pressed_max'),
+    }
+    buttonRanges.trigger.diff = {
+      x: Math.abs(buttonRanges.trigger.max.rotation.x) - Math.abs(buttonRanges.trigger.min.rotation.x),
+      y: Math.abs(buttonRanges.trigger.max.rotation.y) - Math.abs(buttonRanges.trigger.min.rotation.y),
+      z: Math.abs(buttonRanges.trigger.max.rotation.z) - Math.abs(buttonRanges.trigger.min.rotation.z),      
+    }
+    
+    let btn1 = this.data.hand === 'left' ? 'x' : 'a',
+        btn2 = this.data.hand === 'left' ? 'y' : 'b' ;
+    
+    buttonMeshes[btn1+"button"] = controllerObject3D.getObjectByName(btn1+'_button');
+    buttonObjects[btn1+"button"] = controllerObject3D.getObjectByName(btn1+'_button_pressed_value');
+    buttonRanges[btn1+"button"] = {
+      min: controllerObject3D.getObjectByName(btn1+'_button_pressed_min'),
+      max: controllerObject3D.getObjectByName(btn1+'_button_pressed_max'),
+    }
+
+    buttonMeshes[btn2+"button"] = controllerObject3D.getObjectByName(btn2+'_button');
+    buttonObjects[btn2+"button"] = controllerObject3D.getObjectByName(btn2+'_button_pressed_value');
+    buttonRanges[btn2+"button"] = {
+      min: controllerObject3D.getObjectByName(btn2+'_button_pressed_min'),
+      max: controllerObject3D.getObjectByName(btn2+'_button_pressed_max'),
+    }    
+    
+    buttonRanges[btn1+"button"].unpressedY = buttonObjects[btn1+"button"].position.y;
+    buttonRanges[btn1+"button"].pressedY = 
+      buttonRanges[btn1+"button"].unpressedY + Math.abs(buttonRanges[btn1+"button"].max.position.y) - Math.abs(buttonRanges[btn1+"button"].min.position.y); 
+    
+    buttonRanges[btn2+"button"].unpressedY = buttonObjects[btn2+"button"].position.y;
+    buttonRanges[btn2+"button"].pressedY = 
+      buttonRanges[btn2+"button"].unpressedY - Math.abs(buttonRanges[btn2+"button"].max.position.y) + Math.abs(buttonRanges[btn2+"button"].min.position.y); 
+  },
+  
   onAxisMoved: function (evt) {
     emitIfAxesChanged(this, this.mapping[this.data.hand].axes, evt);
   },
-
-  updateModel: function (buttonName, evtName) {
-    if (!this.data.model) { return; }
-    this.updateButtonModel(buttonName, evtName);
+  
+  onThumbstickMoved: function(evt) {
+    if (!this.isV3 || !this.buttonMeshes || !this.buttonMeshes.thumbstick) {return;}
+    for (let axis in evt.detail) {
+      this.buttonObjects.thumbstick.rotation[this.axisMap[axis]] = 
+        this.buttonRanges.thumbstick.originalRotation[this.axisMap[axis]] - 
+        (Math.PI*1/8) *
+        evt.detail[axis] * 
+        (axis === 'y' || this.data.hand === 'right' ? -1 : 1);
+    }
+  },
+  axisMap: {
+    y: 'x',
+    x: 'z',
   },
 
-  updateButtonModel: function (buttonName, state) {
+  updateModel: function (buttonName, evtName) {
+    if (this.data.model) {
+      this.updateButtonModel(buttonName, evtName);
+    }
+  },
+
+  updateButtonModel: function (buttonName, evtName) {
     var button;
-    var color = (state === 'up' || state === 'touchend') ? this.data.buttonColor : state === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
-    var buttonMeshes = this.buttonMeshes;
-    if (!this.data.model) { return; }
-    if (buttonMeshes && buttonMeshes[buttonName]) {
-      button = buttonMeshes[buttonName];
+    var color = (evtName === 'up' || evtName === 'touchend') ? this.buttonMeshes[buttonName].naturalColor || this.data.buttonColor : evtName === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
+    
+    if (this.buttonMeshes && this.buttonMeshes[buttonName]) {
+      button = this.buttonMeshes[buttonName];
       button.material.color.set(color);
       this.rendererSystem.applyColorCorrection(button.material.color);
     }
-  }
+  },
 });

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -225,6 +225,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     // Set the controller display model based on the data passed in.
     this.displayModel = CONTROLLER_PROPERTIES[data.controllerType] || CONTROLLER_PROPERTIES[CONTROLLER_DEFAULT];
     // If the developer is asking for auto-detection, use the retrieved displayName to identify the specific unit.
+    // This only works for WebVR currently.
     if (data.controllerType === 'auto') {
       var trackedControlsSystem = this.el.sceneEl.systems['tracked-controls-webvr'];
       // WebVR

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -366,20 +366,10 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     if (!this.buttonMeshes[button]) return;
     this.buttonMeshes[button].traverse((node) => {
       if (node.type !== 'Mesh') return;
-      var originalMaterial = node.material;
-      this.buttonMeshes[button].naturalColor = originalMaterial.color;
-      node.material = new THREE.MeshStandardMaterial();
-
-      // preserve details; not iterable, so we have to use Object.keys()
-      Object.keys(originalMaterial).forEach(key => {
-        if (originalMaterial[key] !== node.material[key]) {
-          // because A-Frame uses the same single material object for all material nodes, it also uses the
-          // same color. This means they use the same color object--we have to break that link. Other links
-          // likely also exist, but they don't matter to us, because color is the only one we change.
-          node.material[key] = key !== 'color' ? originalMaterial[key] : originalMaterial[key].clone();
-        }
-      });
-      originalMaterial.dispose();
+      let newMaterial = node.material.clone();
+      this.buttonMeshes[button].naturalColor = node.material.color;
+      node.material.dispose();
+      node.material = newMaterial;
     });
   },
 

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -344,7 +344,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       buttonMeshes.bbutton = controllerObject3D.getObjectByName('buttonB');
     }
 
-    for (let button in this.buttonMeshes) {
+    for (var button in this.buttonMeshes) {
       this.multiMeshFix(button);
     }
 
@@ -357,16 +357,16 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     });
   },
 
-  applyOffset (model) {
+  applyOffset: function (model) {
     model.position.copy(this.displayModel[this.data.hand].modelPivotOffset);
     model.rotation.copy(this.displayModel[this.data.hand].modelPivotRotation);
   },
 
-  multiMeshFix (button) {
+  multiMeshFix: function (button) {
     if (!this.buttonMeshes[button]) return;
     this.buttonMeshes[button].traverse((node) => {
       if (node.type !== 'Mesh') return;
-      let originalMaterial = node.material;
+      var originalMaterial = node.material;
       this.buttonMeshes[button].naturalColor = originalMaterial.color;
       node.material = new THREE.MeshStandardMaterial();
 
@@ -383,14 +383,14 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     });
   },
 
-  onModelLoadedV3 (evt) {
-    let controllerObject3D = this.controllerObject3D = evt.detail.model;
+  onModelLoadedV3: function (evt) {
+    var controllerObject3D = this.controllerObject3D = evt.detail.model;
 
     if (!this.data.model) { return; }
 
-    let buttonObjects = this.buttonObjects = {};
-    let buttonMeshes = this.buttonMeshes = {};
-    let buttonRanges = this.buttonRanges = {};
+    var buttonObjects = this.buttonObjects = {};
+    var buttonMeshes = this.buttonMeshes = {};
+    var buttonRanges = this.buttonRanges = {};
 
     buttonMeshes.grip = controllerObject3D.getObjectByName('squeeze');
     buttonObjects.grip = controllerObject3D.getObjectByName('xr_standard_squeeze_pressed_value');
@@ -423,30 +423,32 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       z: Math.abs(buttonRanges.trigger.max.rotation.z) - Math.abs(buttonRanges.trigger.min.rotation.z)
     };
 
-    let btn1 = this.data.hand === 'left' ? 'x' : 'a';
-    let btn2 = this.data.hand === 'left' ? 'y' : 'b';
+    var button1 = this.data.hand === 'left' ? 'x' : 'a';
+    var button2 = this.data.hand === 'left' ? 'y' : 'b';
+    var button1id = button1 + 'button';
+    var button2id = button2 + 'button';
 
-    buttonMeshes[btn1 + 'button'] = controllerObject3D.getObjectByName(btn1 + '_button');
-    buttonObjects[btn1 + 'button'] = controllerObject3D.getObjectByName(btn1 + '_button_pressed_value');
-    buttonRanges[btn1 + 'button'] = {
-      min: controllerObject3D.getObjectByName(btn1 + '_button_pressed_min'),
-      max: controllerObject3D.getObjectByName(btn1 + '_button_pressed_max')
+    buttonMeshes[button1id] = controllerObject3D.getObjectByName(button1 + '_button');
+    buttonObjects[button1id] = controllerObject3D.getObjectByName(button1 + '_button_pressed_value');
+    buttonRanges[button1id] = {
+      min: controllerObject3D.getObjectByName(button1 + '_button_pressed_min'),
+      max: controllerObject3D.getObjectByName(button1 + '_button_pressed_max')
     };
 
-    buttonMeshes[btn2 + 'button'] = controllerObject3D.getObjectByName(btn2 + '_button');
-    buttonObjects[btn2 + 'button'] = controllerObject3D.getObjectByName(btn2 + '_button_pressed_value');
-    buttonRanges[btn2 + 'button'] = {
-      min: controllerObject3D.getObjectByName(btn2 + '_button_pressed_min'),
-      max: controllerObject3D.getObjectByName(btn2 + '_button_pressed_max')
+    buttonMeshes[button2id] = controllerObject3D.getObjectByName(button2 + '_button');
+    buttonObjects[button2id] = controllerObject3D.getObjectByName(button2 + '_button_pressed_value');
+    buttonRanges[button2id] = {
+      min: controllerObject3D.getObjectByName(button2 + '_button_pressed_min'),
+      max: controllerObject3D.getObjectByName(button2 + '_button_pressed_max')
     };
 
-    buttonRanges[btn1 + 'button'].unpressedY = buttonObjects[btn1 + 'button'].position.y;
-    buttonRanges[btn1 + 'button'].pressedY =
-      buttonRanges[btn1 + 'button'].unpressedY + Math.abs(buttonRanges[btn1 + 'button'].max.position.y) - Math.abs(buttonRanges[btn1 + 'button'].min.position.y);
+    buttonRanges[button1id].unpressedY = buttonObjects[button1id].position.y;
+    buttonRanges[button1id].pressedY =
+      buttonRanges[button1id].unpressedY + Math.abs(buttonRanges[button1id].max.position.y) - Math.abs(buttonRanges[button1id].min.position.y);
 
-    buttonRanges[btn2 + 'button'].unpressedY = buttonObjects[btn2 + 'button'].position.y;
-    buttonRanges[btn2 + 'button'].pressedY =
-      buttonRanges[btn2 + 'button'].unpressedY - Math.abs(buttonRanges[btn2 + 'button'].max.position.y) + Math.abs(buttonRanges[btn2 + 'button'].min.position.y);
+    buttonRanges[button2id].unpressedY = buttonObjects[button2id].position.y;
+    buttonRanges[button2id].pressedY =
+      buttonRanges[button2id].unpressedY - Math.abs(buttonRanges[button2id].max.position.y) + Math.abs(buttonRanges[button2id].min.position.y);
   },
 
   onAxisMoved: function (evt) {
@@ -455,7 +457,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   onThumbstickMoved: function (evt) {
     if (!this.isV3 || !this.buttonMeshes || !this.buttonMeshes.thumbstick) { return; }
-    for (let axis in evt.detail) {
+    for (var axis in evt.detail) {
       this.buttonObjects.thumbstick.rotation[this.axisMap[axis]] =
         this.buttonRanges.thumbstick.originalRotation[this.axisMap[axis]] -
         (Math.PI / 8) *

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -458,7 +458,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   updateButtonModel: function (buttonName, evtName) {
     // update the button mesh colors
     var button;
-    var color = (evtName === 'up' || evtName === 'touchend') ? this.buttonMeshes[buttonName].naturalColor || this.data.buttonColor : evtName === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
+    var color = (evtName === 'up' || evtName === 'touchend') ? this.buttonMeshes[buttonName].originalColor || this.data.buttonColor : evtName === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
     var buttonMeshes = this.buttonMeshes;
 
     if (buttonMeshes && buttonMeshes[buttonName]) {
@@ -480,7 +480,7 @@ function cloneMaterialToTHREE (object3d) {
   object3d.traverse(function (node) {
     if (node.type !== 'Mesh') return;
     let newMaterial = node.material.clone();
-    object3d.naturalColor = node.material.color;
+    object3d.originalColor = node.material.color;
     node.material.dispose();
     node.material = newMaterial;
   });

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -346,7 +346,9 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     }
 
     for (var button in this.buttonMeshes) {
-      cloneMaterialToTHREE(this.buttonMeshes[button]);
+      if (this.buttonMeshes[button]) {
+        cloneMaterialToTHREE(this.buttonMeshes[button]);
+      }
     }
 
     this.applyOffset(evt.detail.model);
@@ -467,12 +469,12 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   }
 });
 
-/*
-  A-Frame's material component makes a single unified shared material for all meshes.
-  In order to be able to color individual buttons, we need to give each sub-mesh its own
-  THREE material. Without this, changing the color on any individual button mesh changes
-  the color on every button mesh.
-*/
+/**
+ * A-Frame's material component makes a single unified shared material for all meshes.
+ * In order to be able to color individual buttons, we need to give each sub-mesh its own
+ * THREE material. Without this, changing the color on any individual button mesh changes
+ * the color on every button mesh.
+ */
 
 function cloneMaterialToTHREE (object3d) {
   object3d.traverse(function (node) {

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -227,14 +227,13 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     // If the developer is asking for auto-detection, use the retrieved displayName to identify the specific unit.
     if (data.controllerType === 'auto') {
       var trackedControlsSystem = this.el.sceneEl.systems['tracked-controls-webvr'];
+      // WebVR
       if (trackedControlsSystem && trackedControlsSystem.vrDisplay) {
-        // WebVR
         var displayName = trackedControlsSystem.vrDisplay.displayName;
         if (/^Oculus Quest$/.test(displayName)) {
           this.displayModel = CONTROLLER_PROPERTIES['oculus-touch-v2'];
         }
-      } else {
-        // WebXR
+      } else { // WebXR
         controllerId = CONTROLLER_DEFAULT;
         controllerId = controller.profiles.indexOf('oculus-touch-v2') !== -1 ? 'oculus-touch-v2' : controllerId;
         controllerId = controller.profiles.indexOf('oculus-touch-v3') !== -1 ? 'oculus-touch-v3' : controllerId;

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -467,6 +467,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   updateButtonModel: function (buttonName, evtName) {
+    // update the button mesh colors
     var button;
     var color = (evtName === 'up' || evtName === 'touchend') ? this.buttonMeshes[buttonName].naturalColor || this.data.buttonColor : evtName === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
     var buttonMeshes = this.buttonMeshes;

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -346,7 +346,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
     for (var button in this.buttonMeshes) {
       if (this.buttonMeshes[button]) {
-        cloneMeshMaterials(this.buttonMeshes[button]);
+        cloneMeshMaterial(this.buttonMeshes[button]);
       }
     }
 
@@ -472,7 +472,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
  * Some of the controller models share the same material for different parts (buttons, triggers...).
  * In order to change their color independently we have to create separate materials.
  */
-function cloneMeshMaterials (object3d) {
+function cloneMeshMaterial (object3d) {
   object3d.traverse(function (node) {
     if (node.type !== 'Mesh') return;
     let newMaterial = node.material.clone();

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -455,10 +455,10 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     this.updateButtonModel(buttonName, evtName);
   },
 
-  updateButtonModel: function (buttonName, evtName) {
+  updateButtonModel: function (buttonName, state) {
     // update the button mesh colors
     var button;
-    var color = (evtName === 'up' || evtName === 'touchend') ? this.buttonMeshes[buttonName].originalColor || this.data.buttonColor : evtName === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
+    var color = (state === 'up' || state === 'touchend') ? this.buttonMeshes[buttonName].originalColor || this.data.buttonColor : state === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
     var buttonMeshes = this.buttonMeshes;
 
     if (buttonMeshes && buttonMeshes[buttonName]) {

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -347,7 +347,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
     for (var button in this.buttonMeshes) {
       if (this.buttonMeshes[button]) {
-        cloneMaterialToTHREE(this.buttonMeshes[button]);
+        cloneMeshMaterials(this.buttonMeshes[button]);
       }
     }
 
@@ -470,13 +470,10 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 });
 
 /**
- * A-Frame's material component makes a single unified shared material for all child meshes.
- * In order to be able to color individual buttons, we need to give each sub-mesh its own
- * THREE material. Without this, changing the color on any individual button mesh changes
- * the color on every button mesh.
+ * Some of the controller models share the same material for different parts (buttons, triggers...).
+ * In order to change their color independently we have to create separate materials.
  */
-
-function cloneMaterialToTHREE (object3d) {
+function cloneMeshMaterials (object3d) {
   object3d.traverse(function (node) {
     if (node.type !== 'Mesh') return;
     let newMaterial = node.material.clone();


### PR DESCRIPTION
See [issue 5607](https://github.com/aframevr/aframe/issues/5067).

**Features:**
All Oculus controllers:
- fixes bug where all buttons would light up if any button was pressed
- untouched color state is now mesh's original color

Quest 2 controllers:
- all of the above
- correct joystick model movement
- moving a/b/x/y buttons

**Description:**
- moved onButtonChanged to bindMethods
- added onThumbstickMoved to support thumbstick model updates
- added recycled euler for trigger updates, which are performed as a multi-dimensional rotation for v3 controller model
- added thumbstickMoved event listener, and matching handlers
- slight comment cleanup in a few places
- added onButtonChangedV3 and onModelLoadedV3 for handling non-conforming model cleanly while maintaining backwards compatibility unambiguously
- added multiMeshFix to fix issue that all oculus controlers have had, where all buttons light up if any button is pressed
- update to use model default color as button color when not being touched

I've tested all four controller models using the this pre-merge version of the WebXR Emulator Extension: https://github.com/MozillaReality/WebXR-emulator-extension/pull/278

I have run a build with this branch and use that built version of A-Frame that includes this change here:
https://glitch.com/~quest-2-controller-responsive-buttons