### PR TITLE
Properly dispose renderer to stop the animation loop

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -214,7 +214,7 @@ module.exports.AScene = registerElement('a-scene', {
         window.removeEventListener('vrdisplaypointerrestricted', this.pointerRestrictedBound);
         window.removeEventListener('vrdisplaypointerunrestricted', this.pointerUnrestrictedBound);
         window.removeEventListener('sessionend', this.resize);
-        this.renderer.xr.dispose();
+        this.renderer.dispose();
       }
     },
 

--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -41,6 +41,7 @@ setup(function () {
       dispose: function () {},
       enabled: false
     },
+    dispose: function () {},
     getContext: function () { return undefined; },
     setAnimationLoop: function () {},
     setSize: function () {},

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -146,6 +146,7 @@ suite('a-scene (without renderer)', function () {
           setPoseTarget: function () {},
           dispose: function () {}
         },
+        dispose: function () {},
         getContext: function () { return undefined; },
         setAnimationLoop: function () {},
         setPixelRatio: function () {},
@@ -271,6 +272,7 @@ suite('a-scene (without renderer)', function () {
           setPoseTarget: function () {},
           dispose: function () {}
         },
+        dispose: function () {},
         setAnimationLoop: function () {},
         setPixelRatio: function () {},
         setSize: function () {},
@@ -445,6 +447,7 @@ suite('a-scene (without renderer)', function () {
           setDevice: function () {},
           dispose: function () {}
         },
+        dispose: function () {},
         setAnimationLoop: function () {},
         setSize: setSizeSpy,
         render: function () {}


### PR DESCRIPTION
**Description:**
In aframe 1.3.0 and master (three r141), when you are removing the a-scene from the DOM, it disposes the WebXRManager/WebVRManager (`renderer.xr`) on `detachedCallback` but not the renderer itself (WebGLRenderer), so it doesn't stop properly the animation loop and it continues executing some tick methods.
You can test with `document.body.removeChild(AFRAME.scenes[0])`
Before the PR:
![Capture d’écran du 2022-09-10 17-42-52](https://user-images.githubusercontent.com/112249/189492806-df4bac5f-b958-4e53-b931-001bf9d5ed0a.png)

After the PR:
![Capture d’écran du 2022-09-10 18-33-41](https://user-images.githubusercontent.com/112249/189492878-20ee9cbf-3914-4f66-b5dc-8dd4855e3e33.png)

This is known issue since a long time, see https://github.com/aframevr/aframe/issues/3146#issuecomment-335682180 and https://stackoverflow.com/questions/54930875/aframejs-how-to-completely-destroy-a-scene and I also documented it in https://aframe.wiki/en/memory

**Changes proposed:**
- This PR properly call `renderer.dispose()` that execute `renderer.xr.dispose()` and `animation.stop()` and also dispose other things, see https://github.com/supermedium/three.js/blob/super-r141/src/renderers/WebGLRenderer.js#L592-L621

Properly disposing the renderer in `detachedCallback` seems right because in `attachedCallback` that is calling `this.setupRenderer()` we're creating a new WebGLRenderer always.
But note that [detaching or reattaching the scene is not a supported use case](https://github.com/aframevr/aframe/issues/3146#issuecomment-335660380), it gives currently an error before and after this PR anyway on the `/examples/boilerplate/3d-model/` example where I tested that and I'm no gonna investigate that.

```
scene=AFRAME.scenes[0]
document.body.removeChild(scene)
document.body.appendChild(scene)
core:a-entity:warn Tried to remove `Object3D` of type:  mesh which was not defined.
2
browser.js:111 core:a-node:error Failure loading node:   TypeError: Cannot read properties of undefined (reading 'constructor')
    at extendProperties (component.js:736:1)
    at NewComponent.callUpdateHandler (component.js:416:1)
    at NewComponent.updateProperties (component.js:300:1)
    at HTMLElement.value (a-entity.js:490:1)
    at HTMLElement.value (a-entity.js:456:1)
    at entityLoadCallback (a-entity.js:249:1)
    at emitLoaded (a-node.js:127:1)
browser.js:111 components:gltf-model:warn Unexpected token '<', "<!DOCTYPE "... is not valid JSON 
```
