### PR TITLE
PlaneBufferGeometry was renamed to PlaneGeometry in threejs r144

### DIFF
--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -71,7 +71,7 @@ module.exports.Component = registerComponent('screenshot', {
         side: THREE.DoubleSide
       });
       self.quad = new THREE.Mesh(
-        new THREE.PlaneBufferGeometry(1, 1),
+        new THREE.PlaneGeometry(1, 1),
         self.material
       );
       self.quad.visible = false;


### PR DESCRIPTION
**Description:**

`PlaneBufferGeometry` was renamed to `PlaneGeometry` a while ago but in threejs r144 they added a warning
"THREE.PlaneBufferGeometry has been renamed to THREE.PlaneGeometry.", see https://github.com/mrdoob/three.js/commit/5acd8ce2cfb7fc29b4fde9775e46041ace9bc055

**Changes proposed:**
- use `PlaneGeometry` instead of `PlaneBufferGeometry` to avoid a warning

I did a search in aframe code for other XYZBufferGeometry, this is the only instance I could find.
