### PR TITLE
really run all tests and fix broken tests

### DIFF
--- a/src/components/text.js
+++ b/src/components/text.js
@@ -220,6 +220,10 @@ module.exports.Component = registerComponent('text', {
       }).then(function (image) {
         // Make mesh visible and apply font image as texture.
         var texture = self.texture;
+        // The component may have been removed at this point and texture will
+        // be null. This happens mainly while executing the tests,
+        // in this case we just return.
+        if (!texture) return;
         texture.image = image;
         texture.needsUpdate = true;
         textures[data.font] = texture;

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -59,7 +59,7 @@ module.exports = registerElement('a-assets', {
         }
 
         // Trigger loaded for scene to start rendering.
-        Promise.all(loaded).then(bind(this.load, this));
+        Promise.allSettled(loaded).then(bind(this.load, this));
 
         // Timeout to start loading anyways.
         timeout = parseInt(this.getAttribute('timeout'), 10) || 3000;

--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -52,6 +52,21 @@ setup(function () {
   };
 });
 
+// Ensure that uncaught exceptions between tests result in the tests failing.
+// This works around an issue with mocha / karma-mocha, see
+// https://github.com/karma-runner/karma-mocha/issues/227
+var pendingError = null;
+var pendingErrorNotice = null;
+
+window.addEventListener('error', event => {
+  pendingError = event.error;
+  pendingErrorNotice = 'An uncaught exception was thrown between tests';
+});
+window.addEventListener('unhandledrejection', event => {
+  pendingError = event.reason;
+  pendingErrorNotice = 'An uncaught promise rejection occurred between tests';
+});
+
 teardown(function (done) {
   // Clean up any attached elements.
   var attachedEls = ['canvas', 'a-assets', 'a-scene'];
@@ -67,4 +82,9 @@ teardown(function (done) {
   setTimeout(function () {
     done();
   });
+
+  if (pendingError) {
+    console.error(pendingErrorNotice);
+    throw pendingError;
+  }
 });

--- a/tests/components/daydream-controls.test.js
+++ b/tests/components/daydream-controls.test.js
@@ -5,7 +5,7 @@ suite('daydream-controls', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
     el.setAttribute('daydream-controls', 'hand: right'); // to ensure index = 0
-    el.addEventListener('loaded', function () {
+    var callback = function () {
       var component = el.components['daydream-controls'];
       component.controllersWhenPresent = [{
         id: 'Daydream Controller',
@@ -17,7 +17,9 @@ suite('daydream-controls', function () {
       }];
       el.parentEl.renderer.xr.getStandingMatrix = function () {};
       done();
-    });
+    };
+    if (el.hasLoaded) { callback(); }
+    el.addEventListener('loaded', callback);
   });
 
   suite('checkIfControllerPresent', function () {

--- a/tests/components/gearvr-controls.test.js
+++ b/tests/components/gearvr-controls.test.js
@@ -5,7 +5,7 @@ suite('gearvr-controls', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
     el.setAttribute('gearvr-controls', 'hand: right');  // To ensure index is 0.
-    el.addEventListener('loaded', function () {
+    var callback = function () {
       var component = el.components['gearvr-controls'];
       component.controllersWhenPresent = [{
         id: 'Gear VR Controller',
@@ -20,7 +20,9 @@ suite('gearvr-controls', function () {
       }];
       el.parentEl.renderer.xr.getStandingMatrix = function () {};
       done();
-    });
+    };
+    if (el.hasLoaded) { callback(); }
+    el.addEventListener('loaded', callback);
   });
 
   suite('checkIfControllerPresent', function () {

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -12,6 +12,7 @@ suite('geometry', function () {
   setup(function (done) {
     el = helpers.entityFactory();
     el.setAttribute('geometry', 'buffer: false; primitive: box;');
+    if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {
       done();
     });

--- a/tests/components/gltf-model.test.js
+++ b/tests/components/gltf-model.test.js
@@ -13,7 +13,9 @@ suite('gltf-model', function () {
     asset.setAttribute('src', SRC);
     el = this.el = entityFactory({assets: [asset]});
     if (el.hasLoaded) { done(); }
-    el.addEventListener('loaded', function () { done(); });
+    el.addEventListener('loaded', function () {
+      done();
+    });
   });
 
   test('can load', function (done) {

--- a/tests/components/light.test.js
+++ b/tests/components/light.test.js
@@ -6,6 +6,7 @@ suite('light', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
     el.setAttribute('light', '');
+    if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {
       done();
     });

--- a/tests/components/obj-model.test.js
+++ b/tests/components/obj-model.test.js
@@ -15,7 +15,9 @@ suite('obj-model', function () {
     objAsset.setAttribute('src', OBJ);
     el = this.el = entityFactory({assets: [mtlAsset, objAsset]});
     if (el.hasLoaded) { done(); }
-    el.addEventListener('loaded', function () { done(); });
+    el.addEventListener('loaded', function () {
+      done();
+    });
   });
 
   test('can load .OBJ only', function (done) {

--- a/tests/components/oculus-go-controls.test.js
+++ b/tests/components/oculus-go-controls.test.js
@@ -5,7 +5,7 @@ suite('oculus-go-controls', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
     el.setAttribute('oculus-go-controls', 'hand: right');  // To ensure index is 0.
-    el.addEventListener('loaded', function () {
+    var callback = function () {
       var component = el.components['oculus-go-controls'];
       // Initially no controllers are present
       component.controllers = [];
@@ -23,7 +23,9 @@ suite('oculus-go-controls', function () {
       }];
       el.parentEl.renderer.xr.getStandingMatrix = function () {};
       done();
-    });
+    };
+    if (el.hasLoaded) { callback(); }
+    el.addEventListener('loaded', callback);
   });
 
   suite('checkIfControllerPresent', function () {

--- a/tests/components/oculus-touch-controls.test.js
+++ b/tests/components/oculus-touch-controls.test.js
@@ -8,7 +8,7 @@ suite('oculus-touch-controls', function () {
   setup(function (done) {
     el = this.el = entityFactory();
     el.setAttribute('oculus-touch-controls', '');
-    el.addEventListener('loaded', function () {
+    var callback = function () {
       component = el.components['oculus-touch-controls'];
       // Initially no controllers are present
       component.controllers = [];
@@ -20,7 +20,9 @@ suite('oculus-touch-controls', function () {
         pose: {}
       }];
       done();
-    });
+    };
+    if (el.hasLoaded) { callback(); }
+    el.addEventListener('loaded', callback);
   });
 
   suite('checkIfControllerPresent', function () {

--- a/tests/components/position.test.js
+++ b/tests/components/position.test.js
@@ -5,6 +5,7 @@ suite('position', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
     el.setAttribute('position', '');
+    if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {
       done();
     });

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -310,7 +310,7 @@ suite('raycaster', function () {
           assert.notEqual(component.clearedIntersectedEls.indexOf(targetEl), -1);
           raycasterEl.removeEventListener('raycaster-intersection-cleared', cb);
           done();
-        });
+        }, {once: true});
         component.tock();
       });
       component.tock();
@@ -324,24 +324,24 @@ suite('raycaster', function () {
         targetEl.addEventListener('raycaster-intersected-cleared', function (evt) {
           assert.equal(evt.detail.el, raycasterEl);
           done();
-        });
+        }, {once: true});
         component.tock();
       });
       component.tock();
     });
 
-    test.skip('clears intersections when disabled', function (done) {
+    test('clears intersections when disabled', function (done) {
       targetEl.addEventListener('raycaster-intersected', function () {
         targetEl.addEventListener('raycaster-intersected-cleared', function () {
           done();
-        });
+        }, {once: true});
         assert.equal(component.intersectedEls.length, 2);
         assert.equal(component.clearedIntersectedEls.length, 0);
         el.setAttribute('raycaster', 'enabled', false);
         assert.equal(component.intersectedEls.length, 0);
         assert.equal(component.intersections.length, 0);
         assert.equal(component.clearedIntersectedEls.length, 2);
-      });
+      }, {once: true});
       component.tock();
     });
 
@@ -349,7 +349,7 @@ suite('raycaster', function () {
       targetEl.addEventListener('raycaster-intersected', function () {
         el.addEventListener('raycaster-intersection-cleared', function () {
           done();
-        });
+        }, {once: true});
         el.setAttribute('raycaster', 'enabled', false);
       });
       component.tock();

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -330,7 +330,7 @@ suite('raycaster', function () {
       component.tock();
     });
 
-    test('clears intersections when disabled', function (done) {
+    test.skip('clears intersections when disabled', function (done) {
       targetEl.addEventListener('raycaster-intersected', function () {
         targetEl.addEventListener('raycaster-intersected-cleared', function () {
           done();

--- a/tests/components/rotation.test.js
+++ b/tests/components/rotation.test.js
@@ -6,6 +6,7 @@ suite('rotation', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
     el.setAttribute('rotation', '');
+    if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {
       done();
     });

--- a/tests/components/scale.test.js
+++ b/tests/components/scale.test.js
@@ -5,6 +5,7 @@ suite('scale', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
     el.setAttribute('scale', '');
+    if (el.hasLoaded) { done(); }
     el.addEventListener('loaded', function () {
       done();
     });

--- a/tests/components/scene/vr-mode-ui.test.js
+++ b/tests/components/scene/vr-mode-ui.test.js
@@ -34,7 +34,10 @@ suite('vr-mode-ui', function () {
   test('hides on enter VR', function () {
     var scene = this.el;
     // mock camera
-    scene.camera = {el: {object3D: {}}};
+    scene.camera = {
+      el: {object3D: {}},
+      updateProjectionMatrix: function () {}
+    };
     scene.enterVR();
     UI_CLASSES.forEach(function (uiClass) {
       assert.ok(scene.querySelector(uiClass).className.indexOf('a-hidden'));

--- a/tests/components/shadow.test.js
+++ b/tests/components/shadow.test.js
@@ -17,11 +17,11 @@ suite('shadow component', function () {
       });
       el.setAttribute('shadow', {});
       mesh = new THREE.Mesh(
-        new THREE.Sphere(2),
+        new THREE.SphereGeometry(2),
         new THREE.MeshBasicMaterial({color: 0xffff00})
       );
       meshWithMaterialArray = new THREE.Mesh(
-        new THREE.Sphere(2),
+        new THREE.SphereGeometry(2),
         [new THREE.MeshBasicMaterial({color: 0xffff00}),
           new THREE.MeshBasicMaterial({color: 0xffff00})]
       );

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -1,13 +1,13 @@
 /* global assert, process, setup, suite, test */
-const entityFactory = require('../helpers').entityFactory;
+var elFactory = require('../helpers').elFactory;
 
 suite('tracked-controls', function () {
   var el;
 
   setup(function (done) {
-    el = entityFactory();
-    setTimeout(() => {
-      el.sceneEl.addEventListener('loaded', function () { done(); });
+    elFactory().then(_el => {
+      el = _el;
+      done();
     });
   });
 

--- a/tests/components/visible.test.js
+++ b/tests/components/visible.test.js
@@ -1,30 +1,29 @@
 /* global assert, process, setup, suite, test */
-var entityFactory = require('../helpers').entityFactory;
+var elFactory = require('../helpers').elFactory;
 
 suite('visible', function () {
+  var el;
+
   setup(function (done) {
-    var el = this.el = entityFactory();
-    el.setAttribute('visible', '');
-    el.addEventListener('loaded', function () {
+    elFactory().then(_el => {
+      el = _el;
+      el.setAttribute('visible', '');
       done();
     });
   });
 
   suite('update', function () {
     test('treats empty as true', function () {
-      var el = this.el;
       el.setAttribute('visible', '');
       assert.ok(el.object3D.visible);
     });
 
     test('can set to visible', function () {
-      var el = this.el;
       el.setAttribute('visible', true);
       assert.ok(el.object3D.visible);
     });
 
     test('can set to not visible', function () {
-      var el = this.el;
       el.setAttribute('visible', false);
       assert.notOk(el.object3D.visible);
     });

--- a/tests/components/windows-motion-controls.test.js
+++ b/tests/components/windows-motion-controls.test.js
@@ -20,12 +20,14 @@ suite('windows-motion-controls', function () {
   setup(function (done) {
     el = this.el = entityFactory();
     el.setAttribute('windows-motion-controls', '');
-    el.addEventListener('loaded', function () {
+    var callback = function () {
       component = el.components['windows-motion-controls'];
       // Stub so we don't actually make calls to load the meshes from the remote CDN in every test.
       component.loadModel = function () { };
       done();
-    });
+    };
+    if (el.hasLoaded) { callback(); }
+    el.addEventListener('loaded', callback);
   });
 
   suite('checkIfControllerPresent', function () {

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -106,15 +106,21 @@ suite('a-assets', function () {
   });
 
   test.skip('calls load when timing out', function (done) {
+    // We can't really test a timeout now since we changed from
+    // Promise.all to Promise.allSettled in a-assets.js
+    // The cdnIsDown.png file that doesn't exist will just give an error
+    // but still loads the scene.
+    // We need a way to simulate a hanging request for this test...
     var el = this.el;
     var scene = this.scene;
     var img = document.createElement('img');
 
     el.setAttribute('timeout', 50);
-    img.setAttribute('src', '');
+    img.setAttribute('src', 'cdnIsDown.png');
     el.appendChild(img);
 
     el.addEventListener('timeout', function () {
+      // This timeout listener is now never executed.
       el.addEventListener('loaded', function () {
         assert.ok(el.hasLoaded);
         done();
@@ -125,7 +131,7 @@ suite('a-assets', function () {
   });
 
   suite('fixUpMediaElement', function () {
-    test.skip('recreates media elements with crossorigin if necessary', function (done) {
+    test('recreates media elements with crossorigin if necessary', function (done) {
       var el = this.el;
       var scene = this.scene;
       var img = document.createElement('img');
@@ -162,7 +168,7 @@ suite('a-assets', function () {
       document.body.appendChild(scene);
     });
 
-    test.skip('does not recreate media element if not crossorigin', function (done) {
+    test('does not recreate media element if not crossorigin', function (done) {
       var el = this.el;
       var scene = this.scene;
       var img = document.createElement('img');
@@ -182,7 +188,7 @@ suite('a-assets', function () {
       document.body.appendChild(scene);
     });
 
-    test.skip('does not recreate media element if crossorigin already set', function (done) {
+    test('does not recreate media element if crossorigin already set', function (done) {
       var el = this.el;
       var scene = this.scene;
       var img = document.createElement('img');
@@ -241,11 +247,15 @@ suite('a-asset-item', function () {
     document.body.appendChild(this.sceneEl);
   });
 
-  test.skip('emits error event', function (done) {
+  test('emits error event', function (done) {
     var assetItem = document.createElement('a-asset-item');
     assetItem.setAttribute('src', 'doesntexist');
     assetItem.addEventListener('error', function (evt) {
       assert.ok(evt.detail.xhr !== undefined);
+      // ATTENTION! This evt.stopPropagation() is very important. Without it
+      // the test will pass but will silently reduces the number of
+      // tests run from 1121 to 559!
+      evt.stopPropagation();
       done();
     });
     this.assetsEl.appendChild(assetItem);

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -9,7 +9,7 @@ var XHR_SRC = '/base/tests/assets/dummy/dummy.txt';
 var XHR_SRC_GLTF = '/base/tests/assets/dummy/dummy.gltf';
 var XHR_SRC_GLB = '/base/tests/assets/dummy/dummy.glb';
 
-suite.skip('a-assets', function () {
+suite('a-assets', function () {
   setup(function () {
     var el = this.el = document.createElement('a-assets');
     var scene = this.scene = document.createElement('a-scene');
@@ -105,7 +105,7 @@ suite.skip('a-assets', function () {
     document.body.appendChild(scene);
   });
 
-  test('calls load when timing out', function (done) {
+  test.skip('calls load when timing out', function (done) {
     var el = this.el;
     var scene = this.scene;
     var img = document.createElement('img');
@@ -125,7 +125,7 @@ suite.skip('a-assets', function () {
   });
 
   suite('fixUpMediaElement', function () {
-    test('recreates media elements with crossorigin if necessary', function (done) {
+    test.skip('recreates media elements with crossorigin if necessary', function (done) {
       var el = this.el;
       var scene = this.scene;
       var img = document.createElement('img');
@@ -162,7 +162,7 @@ suite.skip('a-assets', function () {
       document.body.appendChild(scene);
     });
 
-    test('does not recreate media element if not crossorigin', function (done) {
+    test.skip('does not recreate media element if not crossorigin', function (done) {
       var el = this.el;
       var scene = this.scene;
       var img = document.createElement('img');
@@ -182,7 +182,7 @@ suite.skip('a-assets', function () {
       document.body.appendChild(scene);
     });
 
-    test('does not recreate media element if crossorigin already set', function (done) {
+    test.skip('does not recreate media element if crossorigin already set', function (done) {
       var el = this.el;
       var scene = this.scene;
       var img = document.createElement('img');
@@ -221,7 +221,7 @@ suite.skip('a-assets', function () {
   });
 });
 
-suite.skip('a-asset-item', function () {
+suite('a-asset-item', function () {
   setup(function () {
     var el = this.assetsEl = document.createElement('a-assets');
     var scene = this.sceneEl = document.createElement('a-scene');
@@ -241,7 +241,7 @@ suite.skip('a-asset-item', function () {
     document.body.appendChild(this.sceneEl);
   });
 
-  test('emits error event', function (done) {
+  test.skip('emits error event', function (done) {
     var assetItem = document.createElement('a-asset-item');
     assetItem.setAttribute('src', 'doesntexist');
     assetItem.addEventListener('error', function (evt) {

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -9,7 +9,7 @@ var XHR_SRC = '/base/tests/assets/dummy/dummy.txt';
 var XHR_SRC_GLTF = '/base/tests/assets/dummy/dummy.gltf';
 var XHR_SRC_GLB = '/base/tests/assets/dummy/dummy.glb';
 
-suite('a-assets', function () {
+suite.skip('a-assets', function () {
   setup(function () {
     var el = this.el = document.createElement('a-assets');
     var scene = this.scene = document.createElement('a-scene');
@@ -221,7 +221,7 @@ suite('a-assets', function () {
   });
 });
 
-suite('a-asset-item', function () {
+suite.skip('a-asset-item', function () {
   setup(function () {
     var el = this.assetsEl = document.createElement('a-assets');
     var scene = this.sceneEl = document.createElement('a-scene');

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -966,18 +966,30 @@ suite('a-entity', function () {
     });
 
     test('initializes defined dependency component with HTML', function (done) {
+      var count = 0;
       delete components.root;
       registerComponent('root', {
-        dependencies: ['dependency']
+        dependencies: ['dependency'],
+        init: function () {
+          count++;
+          if (count === 2) {
+            delete components.root;
+            delete components.dependency;
+            done();
+          }
+        }
       });
 
       registerComponent('dependency', {
         schema: {foo: {type: 'string'}},
         init: function () {
           assert.equal(this.data.foo, 'bar');
-          delete components.root;
-          delete components.dependency;
-          done();
+          count++;
+          if (count === 2) {
+            delete components.root;
+            delete components.dependency;
+            done();
+          }
         }
       });
 
@@ -985,14 +997,18 @@ suite('a-entity', function () {
     });
 
     test('initializes defined dependency component with null data w/ HTML', function (done) {
+      var count = 0;
       delete components.root;
       registerComponent('root', {
         dependencies: ['dependency'],
         init: function () {
           assert.equal(this.el.components.dependency.data.foo, 'bar');
-          delete components.root;
-          delete components.dependency;
-          done();
+          count++;
+          if (count === 2) {
+            delete components.root;
+            delete components.dependency;
+            done();
+          }
         }
       });
 
@@ -1000,6 +1016,12 @@ suite('a-entity', function () {
         schema: {foo: {default: 'bar'}},
         init: function () {
           assert.equal(this.data.foo, 'bar');
+          count++;
+          if (count === 2) {
+            delete components.root;
+            delete components.dependency;
+            done();
+          }
         }
       });
 

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -1138,7 +1138,7 @@ suite('a-entity', function () {
 
       box.setAttribute('geometry', {primitive: 'box'});
       component = box.components.geometry;
-      removeSpy = this.sinon.replace(component, 'remove', () => {});
+      removeSpy = this.sinon.replace(component, 'remove', this.sinon.fake(() => {}));
 
       box.removeComponent('geometry');
       assert.notOk(removeSpy.called);

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -783,7 +783,9 @@ suite('Component', function () {
       components.dummy = undefined;
       var el = this.el = entityFactory();
       if (el.hasLoaded) { done(); }
-      el.addEventListener('loaded', function () { done(); });
+      el.addEventListener('loaded', function () {
+        done();
+      });
     });
 
     test('init is called once if the init routine sets the component', function () {
@@ -808,7 +810,9 @@ suite('Component', function () {
       components.dummy = undefined;
       var el = this.el = entityFactory();
       if (el.hasLoaded) { done(); }
-      el.addEventListener('loaded', function () { done(); });
+      el.addEventListener('loaded', function () {
+        done();
+      });
     });
 
     test('not called if component data does not change', function () {

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -498,7 +498,7 @@ suite('a-scene (without renderer)', function () {
       var event;
       var requestPointerLockSpy;
 
-      requestPointerLockSpy = this.sinon.spy(sceneEl.canvas, 'requestPointerLock');
+      requestPointerLockSpy = this.sinon.replace(sceneEl.canvas, 'requestPointerLock', sinon.fake(() => {}));
       event = new CustomEvent('vrdisplaypointerrestricted');
 
       sceneEl.addEventListener('loaded', () => {
@@ -519,7 +519,7 @@ suite('a-scene (without renderer)', function () {
 
       event = new CustomEvent('vrdisplaypointerunrestricted');
 
-      this.sinon.stub(sceneEl, 'getPointerLockElement', function () {
+      this.sinon.replace(sceneEl, 'getPointerLockElement', function () {
         return sceneEl.canvas;
       });
 
@@ -541,7 +541,7 @@ suite('a-scene (without renderer)', function () {
 
       event = new CustomEvent('vrdisplaypointerunrestricted');
 
-      this.sinon.stub(sceneEl, 'getPointerLockElement', function () {
+      this.sinon.replace(sceneEl, 'getPointerLockElement', function () {
         // Mock that pointerlock is taken by the page itself,
         // independently of the a-scene handler for vrdisplaypointerrestricted event
         return document.createElement('canvas');
@@ -562,10 +562,10 @@ suite('a-scene (without renderer)', function () {
       var requestPointerLockSpy;
 
       exitPointerLockSpy = this.sinon.spy(document, 'exitPointerLock');
-      requestPointerLockSpy = this.sinon.spy(sceneEl.canvas, 'requestPointerLock');
+      requestPointerLockSpy = this.sinon.replace(sceneEl.canvas, 'requestPointerLock', sinon.fake(() => {}));
       event = new CustomEvent('vrdisplaypointerrestricted');
 
-      this.sinon.stub(sceneEl, 'getPointerLockElement', function () {
+      this.sinon.replace(sceneEl, 'getPointerLockElement', function () {
         // Mock that pointerlock is taken by the page itself,
         // independently of the a-scene handler for vrdisplaypointerrestricted event
         return document.createElement('canvas');

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -1,4 +1,4 @@
-/* global AFRAME, assert, CustomEvent, process, sinon, setup, suite, teardown, test, THREE */
+/* global AFRAME, assert, CustomEvent, process, screen, sinon, setup, suite, teardown, test, THREE */
 var AScene = require('core/scene/a-scene').AScene;
 var components = require('core/component').components;
 var scenes = require('core/scene/scenes');
@@ -188,9 +188,12 @@ suite('a-scene (without renderer)', function () {
     });
 
     test('calls requestPresent on mobile', function (done) {
+      // Fake the lock method otherwise we get "screen.orientation.lock() is not available on this device."
+      this.sinon.stub(screen.orientation, 'lock');
       var sceneEl = this.el;
       sceneEl.isMobile = true;
       sceneEl.enterVR().then(function () {
+        assert.ok(screen.orientation.lock.called);
         assert.ok(sceneEl.renderer.xr.enabled);
         done();
       });
@@ -302,6 +305,7 @@ suite('a-scene (without renderer)', function () {
     });
 
     test('calls exitPresent on mobile', function (done) {
+      this.sinon.stub(screen.orientation, 'lock');
       var sceneEl = this.el;
       sceneEl.isMobile = true;
       sceneEl.exitVR().then(function () {

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -319,6 +319,7 @@ suite('a-scene (without renderer)', function () {
       sceneEl.renderer.xr.enabled = true;
       sceneEl.isMobile = false;
       this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(false);
+      this.sinon.stub(sceneEl.canvas, 'requestFullscreen');
       sceneEl.exitVR().then(function () {
         assert.ok(sceneEl.renderer.xr.enabled);
         done();

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -273,6 +273,7 @@ suite('a-scene (without renderer)', function () {
           dispose: function () {}
         },
         dispose: function () {},
+        getContext: function () { return undefined; },
         setAnimationLoop: function () {},
         setPixelRatio: function () {},
         setSize: function () {},

--- a/tests/core/shader.test.js
+++ b/tests/core/shader.test.js
@@ -9,11 +9,8 @@ suite('shader', function () {
 
   setup(function (done) {
     el = entityFactory();
-    if (el.hasLoaded) {
-      done();
-    } else {
-      el.addEventListener('loaded', function () { done(); });
-    }
+    if (el.hasLoaded) { done(); }
+    el.addEventListener('loaded', function () { done(); });
   });
 
   teardown(function () {
@@ -107,11 +104,10 @@ suite('shader data binding', function () {
     updateSpy = this.sinon.spy(shader.prototype, 'update');
 
     el = entityFactory();
-    if (el.hasLoaded) {
+    if (el.hasLoaded) { done(); }
+    el.addEventListener('loaded', function () {
       done();
-    } else {
-      el.addEventListener('loaded', function () { done(); });
-    }
+    });
   });
 
   teardown(function () {

--- a/tests/extras/primitives/primitives/a-obj-model.test.js
+++ b/tests/extras/primitives/primitives/a-obj-model.test.js
@@ -13,19 +13,21 @@ suite('a-obj-model', function () {
     });
   });
 
-  test('can set obj-model.mtl', function () {
+  test('can set obj-model.mtl', function (done) {
     var el = this.objModelEl;
-    el.setAttribute('mtl', 'mymtl.mtl');
+    el.setAttribute('obj-model', 'mtl', 'mymtl.mtl');
     process.nextTick(function () {
-      assert.equal(el.getAttribute('obj-model').mtl, 'url(mymtl.mtl)');
+      assert.equal(el.getAttribute('obj-model').mtl, 'mymtl.mtl');
+      done();
     });
   });
 
-  test('can set obj-model.obj', function () {
+  test('can set obj-model.obj', function (done) {
     var el = this.objModelEl;
-    el.setAttribute('obj', 'myobj.obj');
+    el.setAttribute('obj-model', 'obj', 'myobj.obj');
     process.nextTick(function () {
-      assert.equal(el.getAttribute('obj-model').mtl, 'url(myobj.obj)');
+      assert.equal(el.getAttribute('obj-model').obj, 'myobj.obj');
+      done();
     });
   });
 });

--- a/tests/extras/primitives/primitives/a-torus.test.js
+++ b/tests/extras/primitives/primitives/a-torus.test.js
@@ -21,7 +21,7 @@ suite('a-torus', function () {
     assert.equal(this.torusEl.getAttribute('geometry').primitive, 'torus');
   });
 
-  test('can set torus properties', function () {
+  test('can set torus properties', function (done) {
     var geometry;
     var torusEl = this.torusEl;
     torusEl.setAttribute('segments-tubular', '100');
@@ -34,6 +34,7 @@ suite('a-torus', function () {
       assert.equal(geometry.segmentsTubular, 100);
       assert.equal(geometry.radius, 2);
       assert.equal(geometry.radiusTubular, 0.1);
+      done();
     });
   });
 });

--- a/tests/extras/primitives/primitives/meshPrimitives.test.js
+++ b/tests/extras/primitives/primitives/meshPrimitives.test.js
@@ -43,8 +43,8 @@ suite('meshPrimitives', function () {
         assert.equal(el.getAttribute('material').color, 'red');
         assert.equal(el.getAttribute('material').side, 'back');
         assert.equal(el.getAttribute('geometry').depth, 5);
+        done();
       });
-      done();
     });
   });
 

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -18,14 +18,13 @@ if (process.env.TEST_FILE) {
 } else {
 // This global pattern produces some test failures
 //  FILES.push('tests/**/*.test.js');
-// Using those patterns will change the tests execution order and all tests
-// pass...
-  FILES.push('tests/components/**/*.test.js');
-  FILES.push('tests/core/**/*.test.js');
-  FILES.push('tests/extras/**/*.test.js');
-  FILES.push('tests/shaders/**/*.test.js');
-  FILES.push('tests/systems/**/*.test.js');
-  FILES.push('tests/utils/**/*.test.js');
+// Using a pattern for each folder will change the tests execution order and
+// all tests pass...
+  var excluded_folders = ['assets', 'coverage', 'node'];
+  glob.sync('tests/*/').forEach(function (dirname) {
+    if (excluded_folders.indexOf(dirname) !== -1) return;
+    FILES.push(dirname + '**/*.test.js');
+  });
 }
 
 // add 'src' to be able to resolve require('utils/tracked-controls') for

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -16,9 +16,12 @@ if (process.env.TEST_FILE) {
     }
   });
 } else {
-  glob.sync('tests/**/*.test.js').forEach(function (filename) {
-    FILES.push(filename);
-  });
+  FILES.push('tests/components/**/*.test.js');
+  FILES.push('tests/core/**/*.test.js');
+  FILES.push('tests/extras/**/*.test.js');
+  FILES.push('tests/shaders/**/*.test.js');
+  FILES.push('tests/systems/**/*.test.js');
+  FILES.push('tests/utils/**/*.test.js');
 }
 
 // add 'src' to be able to resolve require('utils/tracked-controls') for

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -45,7 +45,7 @@ var karmaConf = {
   },
   client: {
     captureConsole: true,
-    mocha: {ui: 'tdd'}
+    mocha: {ui: 'tdd', timeout: 3000}
   },
   envPreprocessor: [
     'TEST_ENV'

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -16,6 +16,10 @@ if (process.env.TEST_FILE) {
     }
   });
 } else {
+// This global pattern produces some test failures
+//  FILES.push('tests/**/*.test.js');
+// Using those patterns will change the tests execution order and all tests
+// pass...
   FILES.push('tests/components/**/*.test.js');
   FILES.push('tests/core/**/*.test.js');
   FILES.push('tests/extras/**/*.test.js');

--- a/tests/systems/camera.test.js
+++ b/tests/systems/camera.test.js
@@ -147,7 +147,7 @@ suite('camera system', function () {
           assert.ok(cameraEl.getAttribute('camera').active);
           assert.ok(cameraSystem.setActiveCamera.calledOnce);
           assert.equal(cameraSystem.activeCameraEl, cameraEl);
-          cameraSystem.setActiveCamera.reset();
+          cameraSystem.setActiveCamera.resetHistory();
           done();
         });
       });
@@ -175,7 +175,7 @@ suite('camera system', function () {
           assert.ok(cameraEl.getAttribute('camera').active);
           assert.ok(cameraSystem.setActiveCamera.calledOnce);
           assert.equal(cameraSystem.activeCameraEl, cameraEl);
-          cameraSystem.setActiveCamera.reset();
+          cameraSystem.setActiveCamera.resetHistory();
           done();
         });
       });

--- a/tests/systems/camera.test.js
+++ b/tests/systems/camera.test.js
@@ -2,6 +2,8 @@
 var constants = require('constants/');
 var entityFactory = require('../helpers').entityFactory;
 
+var IMG_SRC = '/base/tests/assets/test.png';
+
 suite('camera system', function () {
   var sceneEl;
 
@@ -30,14 +32,14 @@ suite('camera system', function () {
 
   test('uses defined camera if defined', function (done) {
     var assetsEl;
-    var imgEl;  // Image that will never load.
+    var imgEl;
     var cameraEl;
     var sceneEl;
 
     // Create assets.
     assetsEl = document.createElement('a-assets');
     imgEl = document.createElement('img');
-    imgEl.setAttribute('src', 'neverloadlalala5.gif');
+    imgEl.setAttribute('src', IMG_SRC);
     assetsEl.appendChild(imgEl);
 
     // Create scene.


### PR DESCRIPTION
I'm still not sure how karma file pattern works to find the tests but
`npm run test:chrome`
was running actually only the tests from the tests/components/ directory.
This was the equivalent of 
`TEST_FILE=components npm run test:chrome`
355 tests

With the changes, specifying each directory, it finds all the tests now:
`npm run test:chrome`
511 tests, 2 skipped

I fixed the broken tests.