### PR TITLE
Fix reflection component removal

### DIFF
--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -32,6 +32,7 @@ module.exports.Component = register('reflection', {
     this.cubeCamera = new THREE.CubeCamera(0.1, 1000, this.cubeRenderTarget);
     this.lightingEstimationTexture = (new THREE.WebGLCubeRenderTarget(16)).texture;
     this.needsVREnvironmentUpdate = true;
+    this.probeLight = null;
 
     // Update WebXR to support light-estimation
     var webxrData = this.el.getAttribute('webxr');
@@ -142,7 +143,7 @@ module.exports.Component = register('reflection', {
       this.needsVREnvironmentUpdate = false;
       this.cubeCamera.position.set(0, 1.6, 0);
       this.cubeCamera.update(renderer, scene);
-      this.el.object3D.environment = this.cubeRenderTarget.texture;
+      scene.environment = this.cubeRenderTarget.texture;
     }
 
     if (this.needsLightProbeUpdate && frame) {
@@ -155,6 +156,9 @@ module.exports.Component = register('reflection', {
 
   remove: function () {
     this.el.object3D.environment = null;
-    this.removeChild(this.probeLight);
+    if (this.probeLight) {
+      this.el.removeChild(this.probeLight);
+      this.probeLight = null;
+    }
   }
 });

--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -32,7 +32,6 @@ module.exports.Component = register('reflection', {
     this.cubeCamera = new THREE.CubeCamera(0.1, 1000, this.cubeRenderTarget);
     this.lightingEstimationTexture = (new THREE.WebGLCubeRenderTarget(16)).texture;
     this.needsVREnvironmentUpdate = true;
-    this.probeLight = null;
 
     // Update WebXR to support light-estimation
     var webxrData = this.el.getAttribute('webxr');
@@ -158,7 +157,6 @@ module.exports.Component = register('reflection', {
     this.el.object3D.environment = null;
     if (this.probeLight) {
       this.el.removeChild(this.probeLight);
-      this.probeLight = null;
     }
   }
 });

--- a/tests/components/scene/reflection.test.js
+++ b/tests/components/scene/reflection.test.js
@@ -1,0 +1,22 @@
+/* global assert, setup, suite, test */
+
+suite('reflection', function () {
+  setup(function (done) {
+    var el = this.sceneEl = document.createElement('a-scene');
+    document.body.appendChild(el);
+    const directionalLight = document.createElement('a-entity');
+    directionalLight.setAttribute('light', {color: '#FFF', intensity: 0.6, castShadow: true});
+    directionalLight.setAttribute('position', {x: -0.5, y: 1, z: 1});
+    directionalLight.setAttribute('id', 'dirlight');
+    el.appendChild(directionalLight);
+    el.addEventListener('loaded', function () { done(); });
+  });
+
+  test('set environment on the scene', function () {
+    var sceneEl = this.sceneEl;
+    assert.isNull(sceneEl.object3D.environment);
+    sceneEl.setAttribute('reflection', {directionalLight: '#dirlight'});
+    assert.isNotNull(sceneEl.object3D.environment);
+    assert.isNull(sceneEl.components.reflection.probeLight);
+  });
+});

--- a/tests/components/scene/reflection.test.js
+++ b/tests/components/scene/reflection.test.js
@@ -17,6 +17,5 @@ suite('reflection', function () {
     assert.isNull(sceneEl.object3D.environment);
     sceneEl.setAttribute('reflection', {directionalLight: '#dirlight'});
     assert.isNotNull(sceneEl.object3D.environment);
-    assert.isNull(sceneEl.components.reflection.probeLight);
   });
 });


### PR DESCRIPTION
**Description:**

We get a `Uncaught TypeError: this.removeChild is not a function` error when removing the scene if we had the reflection component on it and we didn't enter vr mode.

**Changes proposed:**
- Be sure `this.probeLight` exists before trying to remove it, also use `this.el.removeChild` instead of non existing `this.removeChild`
- Add a test that doesn't fail on this error