### PR TITLE
Remove Google Blocks (poly) from FAQ

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -194,7 +194,6 @@ For 360&deg; images, search for [equirectangular images on Flickr][flickr].
 
 For 3D models, check out:
 
-- [Google Blocks](https://vr.google.com/objects)
 - [Sketchfab](https://sketchfab.com)
 - [Clara.io](http://clara.io)
 - [Archive3D](http://archive3d.net)


### PR DESCRIPTION
**Description:**

Google Poly was shut down on June 30, 2021, so it is no longer a viable option for getting 3D models. See https://support.google.com/poly/answer/10192635 for details.

**Changes proposed:**
- Remove the link from the FAQ
