### PR TITLE
Fix minor typo in best-practices doc

### DIFF
--- a/docs/introduction/best-practices.md
+++ b/docs/introduction/best-practices.md
@@ -106,7 +106,7 @@ an A-Frame scene:
 - Use the **[background component][background]** instead of `a-sky` to define a
   solid color as the scene background. This prevents the creation of
   unnecessary geometry.
-- Update `position`, `rotation`, `scale`, and `visible` using at the three.js
+- Update `position`, `rotation`, `scale`, and `visible` at the three.js
   level (`el.object3D.position`, `el.object3D.rotation`, `el.object3D.scale`,
   `el.object3D.visible`) to avoid overhead on `.setAttribute`.
 - If you need to create, remove and re-create many entities of the same type,


### PR DESCRIPTION
**Description:**

There was a minor typo in the wording of how to adjust certain properties at the three.js level.

**Changes proposed:**
- Fix the typo
