### PR TITLE
Add suppport for Meta Quest Touch Pro controllers (fix #5138)

### DIFF
--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -218,7 +218,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   checkIfControllerPresent: function () {
     checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX, {
-      hand: this.data.hand
+      hand: this.data.hand,
+      iterateControllerProfiles: true
     });
   },
 
@@ -252,10 +253,9 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       } else { // WebXR
         controllerId = CONTROLLER_DEFAULT;
         var controllersPropertiesIds = Object.keys(CONTROLLER_PROPERTIES);
-        for (var i = 0; i < controllersPropertiesIds.length; i++) {
-          var controllerPropertyId = controllersPropertiesIds[i];
-          if (controller.profiles.indexOf(controllerPropertyId)) {
-            controllerId = controllerPropertyId;
+        for (var i = 0; i < controller.profiles.length; i++) {
+          if (controllersPropertiesIds.indexOf(controller.profiles[i]) !== -1) {
+            controllerId = controller.profiles[i];
             break;
           }
         }

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -276,7 +276,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
       id: id,
       hand: data.hand,
       orientationOffset: data.orientationOffset,
-      handTrackingEnabled: false
+      handTrackingEnabled: false,
+      iterateControllerProfiles: true
     });
     this.loadModel(controller);
   },

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -17,6 +17,7 @@ var GAMEPAD_ID_PREFIX = isWebXRAvailable ? GAMEPAD_ID_WEBXR : GAMEPAD_ID_WEBVR;
 
 // First generation model URL.
 var TOUCH_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/oculus/oculus-touch-controller-';
+var META_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/meta/';
 
 var OCULUS_TOUCH_WEBVR = {
   left: {
@@ -79,6 +80,20 @@ var CONTROLLER_PROPERTIES = {
       rayOrigin: {origin: {x: -0.015, y: 0.005, z: 0}, direction: {x: 0, y: 0, z: -1}},
       modelPivotOffset: new THREE.Vector3(-0.01, -0.01, 0.05),
       modelPivotRotation: new THREE.Euler(Math.PI / 4, 0, 0)
+    }
+  },
+  'meta-quest-touch-pro': {
+    left: {
+      modelUrl: META_CONTROLLER_MODEL_BASE_URL + 'quest-touch-pro-left.glb',
+      rayOrigin: {origin: {x: 0.015, y: 0.005, z: 0}, direction: {x: 0, y: 0, z: -1}},
+      modelPivotOffset: new THREE.Vector3(0, 0, 0),
+      modelPivotRotation: new THREE.Euler(0, 0, 0)
+    },
+    right: {
+      modelUrl: META_CONTROLLER_MODEL_BASE_URL + 'quest-touch-pro-right.glb',
+      rayOrigin: {origin: {x: -0.015, y: 0.005, z: 0}, direction: {x: 0, y: 0, z: -1}},
+      modelPivotOffset: new THREE.Vector3(0, 0, 0),
+      modelPivotRotation: new THREE.Euler(0, 0, 0)
     }
   }
 };

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -251,8 +251,14 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
         }
       } else { // WebXR
         controllerId = CONTROLLER_DEFAULT;
-        controllerId = controller.profiles.indexOf('oculus-touch-v2') !== -1 ? 'oculus-touch-v2' : controllerId;
-        controllerId = controller.profiles.indexOf('oculus-touch-v3') !== -1 ? 'oculus-touch-v3' : controllerId;
+        var controllersPropertiesIds = Object.keys(CONTROLLER_PROPERTIES);
+        for (var i = 0; i < controllersPropertiesIds.length; i++) {
+          var controllerPropertyId = controllersPropertiesIds[i];
+          if (controller.profiles.indexOf(controllerPropertyId)) {
+            controllerId = controllerPropertyId;
+            break;
+          }
+        }
         this.displayModel = CONTROLLER_PROPERTIES[controllerId];
       }
     }


### PR DESCRIPTION
I noticed there's not a button mapping profile on the [webxr repository](https://github.com/immersive-web/webxr-input-profiles/tree/main/packages/registry/profiles/oculus). I'm assuming the mapping is the same as the previous touch controllers.

To test you can use the example below:

`npm start` and load `http://localhost:9000/showcase/ui/`

I haven't look at the model but if parts are separated we could also animate / highlight the buttons, trigger when pressed in a separate PR.

@cabanier Let me know if it works for you. Thanks so much for testing and congrats on the Quest Pro release. It looks awesome.