### PR TITLE
Remove quest 2 controller offsets

### DIFF
--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -72,14 +72,14 @@ var CONTROLLER_PROPERTIES = {
     left: {
       modelUrl: TOUCH_CONTROLLER_MODEL_BASE_URL + 'v3-left.glb',
       rayOrigin: {origin: {x: 0.015, y: 0.005, z: 0}, direction: {x: 0, y: 0, z: -1}},
-      modelPivotOffset: new THREE.Vector3(0.01, -0.01, 0.05),
-      modelPivotRotation: new THREE.Euler(Math.PI / 4, 0, 0)
+      modelPivotOffset: new THREE.Vector3(0, 0, 0),
+      modelPivotRotation: new THREE.Euler(0, 0, 0)
     },
     right: {
       modelUrl: TOUCH_CONTROLLER_MODEL_BASE_URL + 'v3-right.glb',
       rayOrigin: {origin: {x: -0.015, y: 0.005, z: 0}, direction: {x: 0, y: 0, z: -1}},
-      modelPivotOffset: new THREE.Vector3(-0.01, -0.01, 0.05),
-      modelPivotRotation: new THREE.Euler(Math.PI / 4, 0, 0)
+      modelPivotOffset: new THREE.Vector3(0, 0, 0),
+      modelPivotRotation: new THREE.Euler(0, 0, 0)
     }
   },
   'meta-quest-touch-pro': {

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -71,13 +71,19 @@ var CONTROLLER_PROPERTIES = {
   'oculus-touch-v3': {
     left: {
       modelUrl: TOUCH_CONTROLLER_MODEL_BASE_URL + 'v3-left.glb',
-      rayOrigin: {origin: {x: 0.015, y: 0.005, z: 0}, direction: {x: 0, y: 0, z: -1}},
+      rayOrigin: {
+        origin: {x: 0.0065, y: -0.0186, z: -0.05},
+        direction: {x: 0.12394785839500175, y: -0.5944043672340157, z: -0.7945567170519814}
+      },
       modelPivotOffset: new THREE.Vector3(0, 0, 0),
       modelPivotRotation: new THREE.Euler(0, 0, 0)
     },
     right: {
       modelUrl: TOUCH_CONTROLLER_MODEL_BASE_URL + 'v3-right.glb',
-      rayOrigin: {origin: {x: -0.015, y: 0.005, z: 0}, direction: {x: 0, y: 0, z: -1}},
+      rayOrigin: {
+        origin: {x: -0.0065, y: -0.0186, z: -0.05},
+        direction: {x: -0.12394785839500175, y: -0.5944043672340157, z: -0.7945567170519814}
+      },
       modelPivotOffset: new THREE.Vector3(0, 0, 0),
       modelPivotRotation: new THREE.Euler(0, 0, 0)
     }
@@ -85,13 +91,19 @@ var CONTROLLER_PROPERTIES = {
   'meta-quest-touch-pro': {
     left: {
       modelUrl: META_CONTROLLER_MODEL_BASE_URL + 'quest-touch-pro-left.glb',
-      rayOrigin: {origin: {x: 0.015, y: 0.005, z: 0}, direction: {x: 0, y: 0, z: -1}},
+      rayOrigin: {
+        origin: {x: 0.0065, y: -0.0186, z: -0.05},
+        direction: {x: 0.12394785839500175, y: -0.5944043672340157, z: -0.7945567170519814}
+      },
       modelPivotOffset: new THREE.Vector3(0, 0, 0),
       modelPivotRotation: new THREE.Euler(0, 0, 0)
     },
     right: {
       modelUrl: META_CONTROLLER_MODEL_BASE_URL + 'quest-touch-pro-right.glb',
-      rayOrigin: {origin: {x: -0.015, y: 0.005, z: 0}, direction: {x: 0, y: 0, z: -1}},
+      rayOrigin: {
+        origin: {x: -0.0065, y: -0.0186, z: -0.05},
+        direction: {x: -0.12394785839500175, y: -0.5944043672340157, z: -0.7945567170519814}
+      },
       modelPivotOffset: new THREE.Vector3(0, 0, 0),
       modelPivotRotation: new THREE.Euler(0, 0, 0)
     }


### PR DESCRIPTION
Remove quest 2 controller offsets now that the controller are directly getting transform data from gripSpace instead of targetRaySpace. (based on https://github.com/aframevr/aframe/commit/88e8db12deeb501bfaeb03fe015284197a1942e2) @dmarcos 

https://user-images.githubusercontent.com/11973041/197260871-c63d0ce4-bb6c-4ec1-a038-48c7e44fc757.mp4

We will still need to address the ray orientation problem separately