### PR TITLE
Fix triggerchanged event not firing from touch v3

### DIFF
--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -309,14 +309,14 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onButtonChanged: function (evt) {
+    var button = this.mapping[this.data.hand].buttons[evt.detail.id];
+    if (!button) { return; }
     // move the button meshes
     if (this.isOculusTouchV3) {
-      this.onButtonChangedV3(evt);
+      this.onButtonChangedV3(button, evt);
     } else {
-      var button = this.mapping[this.data.hand].buttons[evt.detail.id];
       var buttonMeshes = this.buttonMeshes;
       var analogValue;
-      if (!button) { return; }
 
       if (button === 'trigger' || button === 'grip') { analogValue = evt.detail.state.value; }
 
@@ -335,11 +335,9 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   clickButtons: ['xbutton', 'ybutton', 'abutton', 'bbutton', 'thumbstick'],
-  onButtonChangedV3: function (evt) {
-    var button = this.mapping[this.data.hand].buttons[evt.detail.id];
+  onButtonChangedV3: function (button, evt) {
     var buttonObjects = this.buttonObjects;
     var analogValue;
-    if (!button) { return; }
 
     analogValue = evt.detail.state.value;
     analogValue *= this.data.hand === 'left' ? -1 : 1;

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -313,7 +313,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     if (!button) { return; }
     // move the button meshes
     if (this.isOculusTouchV3) {
-      this.onButtonChangedV3(button, evt);
+      this.onButtonChangedV3(evt);
     } else {
       var buttonMeshes = this.buttonMeshes;
       var analogValue;
@@ -335,7 +335,8 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   clickButtons: ['xbutton', 'ybutton', 'abutton', 'bbutton', 'thumbstick'],
-  onButtonChangedV3: function (button, evt) {
+  onButtonChangedV3: function (evt) {
+    var button = this.mapping[this.data.hand].buttons[evt.detail.id];
     var buttonObjects = this.buttonObjects;
     var analogValue;
 


### PR DESCRIPTION
**Description:**

I found that the `triggerchanged` event was not firing with the current A-Frame master build, as `button` was undefined in `onButtonChanged` if the V3 code path was taken.

**Changes proposed:**
- Since the assignment to `button` is identical in both functions, it can be moved out and passed along to the V3 function when necessary. This puts it back in scope to be referenced for the event emit.
