### PR TITLE
[Docs] Fixed broken links on text components

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -49,13 +49,13 @@ See more examples to see configuration of alignments, anchors, baselines,
 scaling, and auto-sizing.
 
 [exampletext]: https://aframe.io/aframe/examples/test/text/index.html
-[codetext]: https://aframe.io/aframe/examples/test/text/index.html
+[codetext]: https://github.com/aframevr/aframe/blob/master/examples/test/text/index.html
 [exampleanchors]: https://aframe.io/aframe/examples/test/text/anchors.html
-[codeanchors]: https://aframe.io/aframe/examples/test/text/anchors.html
-[examplescenarios]: https://aframe.io/aframe/examples/test/textt/scenarios.html
-[codescenarios]: https://aframe.io/aframe/examples/test/text/scenarios.html
+[codeanchors]: https://github.com/aframevr/aframe/blob/master/examples/test/text/anchors.html
+[examplescenarios]: https://aframe.io/aframe/examples/test/text/scenarios.html
+[codescenarios]: https://github.com/aframevr/aframe/blob/master/examples/test/text/scenarios.html
 [examplesizes]: https://aframe.io/aframe/examples/test/text/sizes.html
-[codesizes]: https://aframe.io/aframe/examples/test/text/sizes.html
+[codesizes]: https://github.com/aframevr/aframe/blob/master/examples/test/text/sizes.html
 
 - [Text Example][exampletext] ([code][codetext])
 - [Text Anchors][exampleanchors] ([code][codeanchors])

--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -48,14 +48,14 @@ configuration.
 See more examples to see configuration of alignments, anchors, baselines,
 scaling, and auto-sizing.
 
-[exampletext]: https://aframevr.github.io/aframe/examples/test/text/index.html
-[codetext]: https://github.com/aframevr/aframe/blob/master/examples/test/text/index.html
-[exampleanchors]: https://aframevr.github.io/aframe/examples/test/text/anchors.html
-[codeanchors]: https://github.com/aframevr/aframe/blob/master/examples/test/text/anchors.html
-[examplescenarios]: https://aframevr.github.io/aframe/examples/test/text/scenarios.html
-[codescenarios]: https://github.com/aframevr/aframe/blob/master/examples/test/text/scenarios.html
-[examplesizes]: https://aframevr.github.io/aframe/examples/test/text/sizes.html
-[codesizes]: https://github.com/aframevr/aframe/blob/master/examples/test/text/sizes.html
+[exampletext]: https://aframe.io/aframe/examples/test/text/index.html
+[codetext]: https://aframe.io/aframe/examples/test/text/index.html
+[exampleanchors]: https://aframe.io/aframe/examples/test/text/anchors.html
+[codeanchors]: https://aframe.io/aframe/examples/test/text/anchors.html
+[examplescenarios]: https://aframe.io/aframe/examples/test/textt/scenarios.html
+[codescenarios]: https://aframe.io/aframe/examples/test/text/scenarios.html
+[examplesizes]: https://aframe.io/aframe/examples/test/text/sizes.html
+[codesizes]: https://aframe.io/aframe/examples/test/text/sizes.html
 
 - [Text Example][exampletext] ([code][codetext])
 - [Text Anchors][exampleanchors] ([code][codeanchors])


### PR DESCRIPTION
**Description:** On the text component documentation it looks like about 1/3 of the examples 404. It seems like they reference a no longer existing git repo.

**Changes proposed:**
- Update links to valid locations for examples



