### PR TITLE
Encoding should match scene's color management settings

### DIFF
--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -85,7 +85,7 @@ module.exports.Component = registerComponent('screenshot', {
 
   getRenderTarget: function (width, height) {
     return new THREE.WebGLRenderTarget(width, height, {
-      encoding: THREE.sRGBEncoding,
+      encoding: this.el.sceneEl.renderer.outputEncoding,
       minFilter: THREE.LinearFilter,
       magFilter: THREE.LinearFilter,
       wrapS: THREE.ClampToEdgeWrapping,

--- a/tests/components/scene/screenshot.test.js
+++ b/tests/components/scene/screenshot.test.js
@@ -1,26 +1,58 @@
-/* global assert, setup, suite, test */
+/* global THREE, assert, setup, suite, test */
 suite('screenshot', function () {
   var component;
   var sceneEl;
 
+  function checkRenderTarget (renderTarget, encoding) {
+    const texture = renderTarget.texture;
+    assert.equal(texture.encoding, encoding);
+    assert.equal(texture.minFilter, THREE.LinearFilter);
+    assert.equal(texture.magFilter, THREE.LinearFilter);
+    assert.equal(texture.wrapS, THREE.ClampToEdgeWrapping);
+    assert.equal(texture.wrapT, THREE.ClampToEdgeWrapping);
+    assert.equal(texture.format, THREE.RGBAFormat);
+    assert.equal(texture.type, THREE.UnsignedByteType);
+  }
+
   setup(function (done) {
     sceneEl = document.createElement('a-scene');
+    done();
+    // rest of scene setup has to be done inside the scripts to allow for
+    // variation of colorManagement parameter, which can only be set on screen creation.
+  });
+
+  test('capture is called when key shortcut is pressed', function () {
     sceneEl.addEventListener('loaded', () => {
       component = sceneEl.components.screenshot;
-      done();
+      var captureStub = this.sinon.stub(component, 'capture');
+      // Must call onKeyDown method directly because Chrome doesn't provide a reliable method
+      // for KeyboardEvent.
+      component.onKeyDown({
+        keyCode: 83,
+        altKey: true,
+        ctrlKey: true
+      });
+      assert.ok(captureStub.called);
     });
     document.body.appendChild(sceneEl);
   });
 
-  test('capture is called when key shortcut is pressed', function () {
-    var captureStub = this.sinon.stub(component, 'capture');
-    // Must call onKeyDown method directly because Chrome doesn't provide a reliable method
-    // for KeyboardEvent.
-    component.onKeyDown({
-      keyCode: 83,
-      altKey: true,
-      ctrlKey: true
+  test('capture renders screenshot correctly (w/o Color Management)', function () {
+    sceneEl.addEventListener('loaded', () => {
+      component = sceneEl.components.screenshot;
+      const renderTarget = component.getRenderTarget();
+      checkRenderTarget(renderTarget, THREE.LinearEncoding);
     });
-    assert.ok(captureStub.called);
+    document.body.appendChild(sceneEl);
+  });
+
+  test('capture renders screenshot correctly (w/ Color Management)', function () {
+    sceneEl.setAttribute('renderer', 'colorManagement: true');
+    sceneEl.addEventListener('loaded', () => {
+      component = sceneEl.components.screenshot;
+      const renderTarget = component.getRenderTarget();
+      checkRenderTarget(renderTarget, THREE.sRGBEncoding);
+    });
+    document.body.appendChild(sceneEl);
   });
 });


### PR DESCRIPTION
**Description:**

Fix for #5014


**Changes proposed:**
- encoding setting for screenshot is read from renderer, rather than assuming sRGB or Linear
- unit tests to check interaction between colorManagement setting on scene, and encoding used in screenshots.

