### PR TITLE
Update a-box.md

### DIFF
--- a/docs/primitives/a-box.md
+++ b/docs/primitives/a-box.md
@@ -9,7 +9,7 @@ section_order: 5
 source_code: src/extras/primitives/primitives/meshPrimitives.js
 ---
 
-The box primitive creates shapes such as boxes, cubes, or walls.
+The box primitive creates a quadrilateral using the [geometry component] with type set to `box`.
 
 ## Example
 
@@ -58,3 +58,5 @@ The box primitive creates shapes such as boxes, cubes, or walls.
 | width                            | geometry.width                         | 1             |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+  
+[geometry component]: ../components/geometry.md/#box


### PR DESCRIPTION
**Description:**
I noticed that the definitions in many of the primitives pages were not described in a similar way and sometimes there was not a definition. I also noticed that the link would not take you directly to the geometry.

Here, I updated a-box.

**Changes proposed:**
- I standardized the text for the primitive to match the formatting style of other primitives and to match the definition given in the geometry component page. 

- I also changed the geometry component page link to the anchor link in the geometry component page.
