### PR TITLE
[docs] Update a-circle.md

### DIFF
--- a/docs/primitives/a-circle.md
+++ b/docs/primitives/a-circle.md
@@ -6,8 +6,7 @@ parent_section: primitives
 source_code: src/extras/primitives/primitives/meshPrimitives.js
 ---
 
-The circle primitive creates circles surfaces using the [geometry][geometry]
-component with the type set to `circle`.
+The circle primitive creates a flat two-dimensional circle using the [geometry component] with type set to `circle`.
 
 ## Example
 
@@ -67,4 +66,4 @@ To make a circle parallel to the ground, rotate it around the X-axis:
 <a-circle rotation="-90 0 0"></a-circle>
 ```
 
-[geometry]: ../components/geometry.md
+[geometry component]: ../components/geometry.md/#circle


### PR DESCRIPTION
**Description:**
I noticed that the definitions in many of the primitives pages were not described in a similar way and sometimes there was not a definition. I also noticed that the link would not take you directly to the geometry.

Here, I updated a-circle.

**Changes proposed:**
- I standardized the text for the primitive to match the formatting style of other primitives and to match the definition given in the geometry component page. 

- I also changed the geometry component page link to the anchor link in the geometry component page.