### PR TITLE
[docs] Update a-cone.md

### DIFF
--- a/docs/primitives/a-cone.md
+++ b/docs/primitives/a-cone.md
@@ -6,7 +6,7 @@ parent_section: primitives
 source_code: src/extras/primitives/primitives/meshPrimitives.js
 ---
 
-The cone primitive creates a cone shape.
+The cone primitive creates a cone using the [geometry component] with type set to `cone`.
 
 ## Example
 
@@ -59,3 +59,5 @@ The cone primitive creates a cone shape.
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+  
+[geometry component]: ../components/geometry.md/#cone


### PR DESCRIPTION
**Description:**
I noticed that the definitions in many of the primitives pages were not described in a similar way and sometimes there was not a definition. I also noticed that the link would not take you directly to the geometry.

Here, I updated a-cone.

**Changes proposed:**
- I standardized the text for the primitive to match the formatting style of other primitives and to match the definition given in the geometry component page. 

- I also changed the geometry component page link to the anchor link in the geometry component page.