### PR TITLE
[docs] Update a-plane.md

### DIFF
--- a/docs/primitives/a-plane.md
+++ b/docs/primitives/a-plane.md
@@ -8,8 +8,7 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 
 [geometry]: ../components/geometry.md
 
-The plane primitive creates flat surfaces using the [geometry][geometry]
-component with the type set to `plane`.
+The plane primitive creates a flat surface using the [geometry component] with type set to `plane`.
 
 ## Example
 
@@ -67,3 +66,5 @@ rotate it around the X-axis:
 ```html
 <a-plane rotation="-90 0 0"></a-plane>
 ```
+
+[geometry component]: ../components/geometry.md/#plane


### PR DESCRIPTION
**Description:**
I noticed that the definitions in many of the primitives pages were not described in a similar way and sometimes there was not a definition. I also noticed that the link would not take you directly to the geometry.

Here, I updated a-plane.

**Changes proposed:**
- I standardized the text for the primitive to match the formatting style of other primitives and to match the definition given in the geometry component page. 

- I also changed the geometry component page link to the anchor link in the geometry component page.