### PR TITLE
[docs] Update a-ring.md

### DIFF
--- a/docs/primitives/a-ring.md
+++ b/docs/primitives/a-ring.md
@@ -6,7 +6,7 @@ parent_section: primitives
 source_code: src/extras/primitives/primitives/meshPrimitives.js
 ---
 
-The ring primitive creates a ring or disc shape.
+The ring primitive creates a ring or disc shape using the [geometry component] with type set to `ring`.
 
 ## Example
 
@@ -57,3 +57,5 @@ The ring primitive creates a ring or disc shape.
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+  
+[geometry component]: ../components/geometry.md/#ring


### PR DESCRIPTION
**Description:**
I noticed that the definitions in many of the primitives pages were not described in a similar way and sometimes there was not a definition. I also noticed that the link would not take you directly to the geometry.

Here, I updated a-ring.

**Changes proposed:**
- I standardized the text for the primitive to match the formatting style of other primitives and to match the definition given in the geometry component page. 

- I also changed the geometry component page link to the anchor link in the geometry component page.