### PR TITLE
[docs] Update a-sphere.md

### DIFF
--- a/docs/primitives/a-sphere.md
+++ b/docs/primitives/a-sphere.md
@@ -6,7 +6,7 @@ parent_section: primitives
 source_code: src/extras/primitives/primitives/meshPrimitives.js
 ---
 
-The sphere primitive creates a spherical or polyhedron shapes. It wraps an entity that prescribes the [geometry component](../components/geometry.md) with its geometric primitive set to `sphere`.
+The sphere primitive creates a sphere, polyhedron shape or an abstract shape using the [geometry component] with type set to `sphere`.
 
 ## Example
 
@@ -50,3 +50,5 @@ The sphere primitive creates a spherical or polyhedron shapes. It wraps an entit
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+  
+[geometry component]: ../components/geometry.md/#sphere


### PR DESCRIPTION
**Description:**
I noticed that the definitions in many of the primitives pages were not described in a similar way and sometimes there was not a definition. I also noticed that the link would not take you directly to the geometry.

Here, I updated a-sphere.

**Changes proposed:**
- I standardized the text for the primitive to match the formatting style of other primitives and to match the definition given in the geometry component page. 

- I also changed the geometry component page link to the anchor link in the geometry component page.