### PR TITLE
[docs] Update a-tetrahedron.md

### DIFF
--- a/docs/primitives/a-tetrahedron.md
+++ b/docs/primitives/a-tetrahedron.md
@@ -6,6 +6,8 @@ parent_section: primitives
 source_code: src/extras/primitives/primitives/meshPrimitives.js
 ---
 
+The tetrahedron primitive creates a polygon with four triangular faces using the [geometry component] with type set to `tetrahedron`.
+  
 ## Example
 
 ```html
@@ -43,3 +45,5 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+  
+[geometry component]: ../components/geometry.md/#tetrahedron


### PR DESCRIPTION
**Description:**
I noticed that the definitions in many of the primitives pages were not described in a similar way and sometimes there was not a definition. I also noticed that the link would not take you directly to the geometry.

Here, I updated a-tetrahedron.

**Changes proposed:**
- I standardized the text for the primitive to match the formatting style of other primitives and to match the definition given in the geometry component page. 

- I also changed the geometry component page link to the anchor link in the geometry component page.