### PR TITLE
[docs] Update a-torus-knot.md

### DIFF
--- a/docs/primitives/a-torus-knot.md
+++ b/docs/primitives/a-torus-knot.md
@@ -6,10 +6,7 @@ parent_section: primitives
 source_code: src/extras/primitives/primitives/meshPrimitives.js
 ---
 
-[geometry]: ../components/geometry.md
-
-The torus knot primitive creates pretzel shapes using the [geometry][geometry]
-component with the type set to `torusKnot`.
+The torus-knot primitive creates a pretzel shape using the [geometry component] with type set to `torusKnot`.
 
 ## Example
 
@@ -52,3 +49,5 @@ component with the type set to `torusKnot`.
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+  
+[geometry component]: ../components/geometry.md/#torusKnot


### PR DESCRIPTION
**Description:**
I noticed that the definitions in many of the primitives pages were not described in a similar way and sometimes there was not a definition. I also noticed that the link would not take you directly to the geometry.

Here, I updated a-torus-knot.

**Changes proposed:**
- I standardized the text for the primitive to match the formatting style of other primitives and to match the definition given in the geometry component page. 

- I also changed the geometry component page link to the anchor link in the geometry component page.