### PR TITLE
[docs] Update a-triangle.md

### DIFF
--- a/docs/primitives/a-triangle.md
+++ b/docs/primitives/a-triangle.md
@@ -6,8 +6,7 @@ parent_section: primitives
 source_code: src/extras/primitives/primitives/meshPrimitives.js
 ---
 
-The triangle primitive creates triangle surfaces using the [geometry][geometry]
-component with the type set to `triangle`.
+The triangle primitive creates a triangle surface using the [geometry component] with type set to `triangle`.
 
 ## Example
 
@@ -66,4 +65,4 @@ To make a triangle parallel to the ground, rotate it around the X-axis:
 <a-triangle rotation="-90 0 0"></a-triangle>
 ```
 
-[geometry]: ../components/geometry.md
+[geometry component]: ../components/geometry.md/#triangle


### PR DESCRIPTION
**Description:**
I noticed that the definitions in many of the primitives pages were not described in a similar way and sometimes there was not a definition. I also noticed that the link would not take you directly to the geometry.

Here, I updated a-triangle.

**Changes proposed:**
- I standardized the text for the primitive to match the formatting style of other primitives and to match the definition given in the geometry component page. 

- I also changed the geometry component page link to the anchor link in the geometry component page.