### PR TITLE
Fix failing tests with firefox by mocking canvas.classList

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   test:
     name: Test Cases
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['16.x']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,19 +31,19 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Test Cases Using Firefox
-        uses: GabrielBB/xvfb-action@v1
-        env:
-          TEST_ENV: ci
-        with:
-          run: npm run test:firefox -- --single-run
-
       - name: Test Cases Using Chrome
         uses: GabrielBB/xvfb-action@v1
         env:
           TEST_ENV: ci
         with:
           run: npm run test:chrome -- --single-run
+
+      - name: Test Cases Using Firefox
+        uses: GabrielBB/xvfb-action@v1
+        env:
+          TEST_ENV: ci
+        with:
+          run: npm run test:firefox -- --single-run
 
       - name: Check Lint
         run: npm run lint

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -136,7 +136,15 @@ suite('a-scene (without renderer)', function () {
       var sceneEl = this.el;
 
       // Stub canvas.
-      sceneEl.canvas = document.createElement('canvas');
+      sceneEl.canvas = {
+        addEventListener: function () {},
+        removeEventListener: function () {},
+        requestFullscreen: function () {},
+        classList: {
+          add: function () {},
+          remove: function () {}
+        }
+      };
 
       // Stub renderer.
       sceneEl.renderer = {
@@ -158,13 +166,6 @@ suite('a-scene (without renderer)', function () {
       sceneEl.camera = {
         el: {object3D: {}},
         updateProjectionMatrix: function () {}
-      };
-
-      // mock canvas
-      sceneEl.canvas = {
-        addEventListener: function () {},
-        removeEventListener: function () {},
-        requestFullscreen: function () {}
       };
     });
 


### PR DESCRIPTION
**Description:**

Fix failing tests with firefox on master, see https://github.com/aframevr/aframe/actions/runs/3520429062/jobs/5901336232

**Changes proposed:**
- Don't create canvas element when we mock it completely afterwards
- Mock classList as well to fix tests on firefox (fix initially proposed by @diarmidmackenzie on https://github.com/aframevr/aframe/pull/5033#issuecomment-1320322715)
- Run tests on ubuntu-20.04 where firefox is still present. ubuntu-latest is now using 22.04 and gives an error saying it can't find the firefox binary.
