### PR TITLE
Fix tests with Firefox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,11 @@ permissions:
 jobs:
   test:
     name: Test Cases
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: ['16.x']
+        firefox-version: ['latest']
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -31,20 +32,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Test Cases Using Chrome
-        uses: GabrielBB/xvfb-action@v1
-        env:
-          TEST_ENV: ci
-        with:
-          run: npm run test:chrome -- --single-run
-
-      - name: Test Cases Using Firefox
-        uses: GabrielBB/xvfb-action@v1
-        env:
-          TEST_ENV: ci
-        with:
-          run: npm run test:firefox -- --single-run
-
       - name: Check Lint
         run: npm run lint
 
@@ -53,6 +40,27 @@ jobs:
 
       - name: Check Docs
         run: npm run test:docs
+
+      - name: Test Cases Using Chrome
+        uses: GabrielBB/xvfb-action@v1
+        env:
+          TEST_ENV: ci
+        with:
+          run: npm run test:chrome -- --single-run
+
+      - name: Install Firefox
+        uses: browser-actions/setup-firefox@latest
+        with:
+          firefox-version: ${{ matrix['firefox-version'] }}
+
+      - run: firefox --version
+
+      - name: Test Cases Using Firefox
+        uses: GabrielBB/xvfb-action@v1
+        env:
+          TEST_ENV: ci
+        with:
+          run: npm run test:firefox -- --single-run
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/tests/components/scene/vr-mode-ui.test.js
+++ b/tests/components/scene/vr-mode-ui.test.js
@@ -38,6 +38,7 @@ suite('vr-mode-ui', function () {
       el: {object3D: {}},
       updateProjectionMatrix: function () {}
     };
+    window.hasNativeWebVRImplementation = false;
     scene.enterVR();
     UI_CLASSES.forEach(function (uiClass) {
       assert.ok(scene.querySelector(uiClass).className.indexOf('a-hidden'));
@@ -51,6 +52,7 @@ suite('vr-mode-ui', function () {
       el: {object3D: {}, getAttribute: function () { return {spectator: false}; }},
       updateProjectionMatrix: function () {}
     };
+    window.hasNativeWebVRImplementation = false;
     scene.enterVR();
     scene.exitVR();
 

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -182,6 +182,7 @@ suite('a-scene (without renderer)', function () {
     test('calls requestPresent if headset connected', function (done) {
       var sceneEl = this.el;
       this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(true);
+      window.hasNativeWebVRImplementation = false;
       sceneEl.enterVR().then(function () {
         assert.ok(sceneEl.renderer.xr.enabled);
         done();
@@ -203,6 +204,7 @@ suite('a-scene (without renderer)', function () {
     test('does not call requestPresent if flat desktop', function (done) {
       var sceneEl = this.el;
       this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(false);
+      window.hasNativeWebVRImplementation = false;
       sceneEl.enterVR().then(function () {
         assert.notOk(sceneEl.renderer.xr.enabled);
         done();
@@ -248,6 +250,7 @@ suite('a-scene (without renderer)', function () {
       }
 
       this.sinon.stub(sceneEl, 'checkHeadsetConnected').returns(false);
+      window.hasNativeWebVRImplementation = false;
       sceneEl.enterVR().then(function () {
         assert.ok(fullscreenSpy.called);
         done();


### PR DESCRIPTION
**Description:**

See debugging details on #5179. This PR closes #5179

**Changes proposed:**
- Run tests on Ubuntu 22.04
- Install firefox with https://github.com/browser-actions/setup-firefox
- Set window.hasNativeWebVRImplementation to false before calling enterVR in tests
