### PR TITLE
Detach unused pool elements from THREE.js scene

### DIFF
--- a/docs/components/attached.md
+++ b/docs/components/attached.md
@@ -7,15 +7,20 @@ source_code: src/components/attached.js
 examples: []
 ---
 
+[visible]: ./visible.md
+[pool]: ./pool.md
+[attach]: ../core/entity.md#attachtoscene-
+[detach]: ../core/entity.md#detachfromscene-
+
 The attached component determines whether an entity is attached to the THREE.js scene graph at all.
 
 All entities are attached by default.  Detaching an entity from the scene means that the entity and its descendants will have no interactions in the 3D scene at all: it is not rendered, it will not interact with raycasters.
 
-This is similar to the [visible](visible) component, but places even more limitations on the entity.
+This is similar to the [visible][visible] component, but places even more limitations on the entity.
 
 Invisible entities are not rendered, but their position in space is still updated every frame, and they can interact with raycasters, be checked for collisions etc.
 
-In contrast, when an entity is detached from the scene, by setting `attached="false"`, even these interactions do not occur, which will improve performance even further vs. just making an entity invisible.  For example, entity pools implemented by the [pool](pool) component detach entities in the pool when they are not in use.
+In contrast, when an entity is detached from the scene, by setting `attached="false"`, even these interactions do not occur, which will improve performance even further vs. just making an entity invisible.  For example, entity pools implemented by the [pool][pool] component detach entities in the pool when they are not in use.
 
 It's a common pattern to create container entities that contain an entire group of entities that you can flip on an off with `attached`.
 
@@ -36,7 +41,7 @@ It's a common pattern to create container entities that contain an entire group 
 
 ## Updating Attachment
 
-It is slightly faster to control attachment to the THREE.js scene using direct calls to [`attachToScene()`](../core/entity#attachtoscene) and [`detachFromScene()`](../core/entity#detachfromscene):
+It is slightly faster to control attachment to the THREE.js scene using direct calls to [`attachToScene()`][attach] and [`detachFromScene()`][detach]:
 
 ```js
 // direct use of entity interface

--- a/docs/components/attached.md
+++ b/docs/components/attached.md
@@ -1,0 +1,51 @@
+---
+title: attached
+type: components
+layout: docs
+parent_section: components
+source_code: src/components/attached.js
+examples: []
+---
+
+The attached component determines whether an entity is attached to the THREE.js scene graph at all.
+
+All entities are attached by default.  Detaching an entity from the scene means that the entity and its descendants will have no interactions in the 3D scene at all: it is not rendered, it will not interact with raycasters.
+
+This is similar to the [visible](visible) component, but places even more limitations on the entity.
+
+Invisible entities are not rendered, but their position in space is still updated every frame, and they can interact with raycasters, be checked for collisions etc.
+
+In contrast, when an entity is detached from the scene, by setting `attached="false"`, even these interactions do not occur, which will improve performance even further vs. just making an entity invisible.  For example, entity pools implemented by the [pool](pool) component detach entities in the pool when they are not in use.
+
+It's a common pattern to create container entities that contain an entire group of entities that you can flip on an off with `attached`.
+
+
+## Example
+
+```html
+<a-entity attached="false"></a-entity>
+```
+
+## Value
+
+| Value | Description                                                                            |
+|-------|----------------------------------------------------------------------------------------|
+| true  | The entity will be rendered and visible; the default value.                            |
+| false | The entity will be detached from the THREE.js scene.  It will not be rendered nor
+          visible, and will not interact with anything else in the scene. |
+
+## Updating Attachment
+
+It is slightly faster to control attachment to the THREE.js scene using direct calls to [`attachToScene()`](../core/entity#attachtoscene) and [`detachFromScene()`](../core/entity#detachfromscene):
+
+```js
+// direct use of entity interface
+el.detachFromScene()
+
+// with setAttribute.
+e.setAttribute('attached', false)
+
+```
+
+Updates at the three.js level will still be reflected when doing
+`entityEl.getAttribute('attached');`.

--- a/docs/components/pool.md
+++ b/docs/components/pool.md
@@ -15,6 +15,8 @@ entities in dynamic scenes. Object pooling helps reduce garbage collection pause
 Note that entities requested from the pool are paused by default and you need 
 to call `.play()` in order to activate their components' tick functions.
 
+For performance reasons, unused entities in the pool are [detached from the THREE.js scene](attached).
+
 ## Example
 
 For example, we may have a game with enemy entities that we want to reuse.

--- a/docs/components/pool.md
+++ b/docs/components/pool.md
@@ -7,6 +7,8 @@ source_code: src/components/scene/pool.js
 examples: []
 ---
 
+[attached]: ./attached.md
+
 The pool component allows for [object
 pooling](https://en.wikipedia.org/wiki/Object_pool_pattern). This gives us a
 reusable pool of entities to avoid creating and destroying the same kind of
@@ -15,7 +17,7 @@ entities in dynamic scenes. Object pooling helps reduce garbage collection pause
 Note that entities requested from the pool are paused by default and you need 
 to call `.play()` in order to activate their components' tick functions.
 
-For performance reasons, unused entities in the pool are [detached from the THREE.js scene](attached).
+For performance reasons, unused entities in the pool are [detached from the THREE.js scene][attached].
 
 ## Example
 

--- a/docs/components/visible.md
+++ b/docs/components/visible.md
@@ -12,8 +12,13 @@ The visible component determines whether to render an entity. If set to
 
 Visibility effectively applies to all children. If an entity's parent or
 ancestor entity has visibility set to false, then the entity will also not be
-visible nor draw.  It's a common pattern to create container entities that
-contain an entire group of entities that you can flip on an off with `visible`.
+visible nor draw.  However, the entity's position in space is still maintained,
+so it can still iuinteract with raycasters, be checked for collisions etc.
+
+When you want an entity or group of entities to have no interactions at all, it 
+is usually preferable (for performance reasons) to detach them from the THREE.js scene
+entirely by toggling the [`attached`](attached) component.
+
 
 ## Example
 

--- a/docs/components/visible.md
+++ b/docs/components/visible.md
@@ -6,6 +6,7 @@ parent_section: components
 source_code: src/components/visible.js
 examples: []
 ---
+[attached]: ./attached.md
 
 The visible component determines whether to render an entity. If set to
 `false`, then the entity will not be visible nor drawn.
@@ -17,7 +18,7 @@ so it can still iuinteract with raycasters, be checked for collisions etc.
 
 When you want an entity or group of entities to have no interactions at all, it 
 is usually preferable (for performance reasons) to detach them from the THREE.js scene
-entirely by toggling the [`attached`](attached) component.
+entirely by toggling the [`attached`][attached] component.
 
 
 ## Example
@@ -35,7 +36,7 @@ entirely by toggling the [`attached`](attached) component.
 
 ## Updating Visibility
 
-[update]: ../introduction/javascript-events-and-dom-apis.md#updating-a-component-with-setattribute
+[update]: ../introduction/javascript-events-dom-apis.md#updating-a-component-with-setattribute-
 
 It is slightly faster to update visibility at the three.js level versus [via
 `.setAttribute`][update].

--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -168,9 +168,10 @@ entity.addState('selected');
 entity.is('selected');  // >> true
 ```
 
-### `attachToScene ()`
-
+[attach]: #attachtoscene-
 [detach]: #detachfromscene-
+
+### `attachToScene ()`
 
 `attachToScene` can be used to re-attach an entity to the THREE.js scene that has been detached 
 using `detachFromScene`.
@@ -479,6 +480,8 @@ entity.is('selected');  // >> false
 |----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | child-attached       | A child entity was attached to the entity.                                                                                                                                                                             |
 | child-detached       | A child entity was detached from the entity.                                                                                                                                                                           |
+| attached-to-scene    | The entity was attached to the THREE.js scene.  This occurs on initial entity creation, and following subsequent calls to [`attachToScene()`][attach]                                                                                                                                                             |
+| detached-from-scene  | The entity was detached from the THREE.js scene.  This occurs a call to to [`detachFromScene()`][detach] (unless the call is made durign entity creation, prior to the entity being attached to the THREE.js scene).                                                                                                                                                                             |
 | componentchanged     | One of the entity's components was modified. This event is throttled. Do not use this for reading position and rotation changes, rather [use a tick handler](../camera.md#reading-position-or-rotation-of-the-camera). |
 | componentinitialized | One of the entity's components was initialized.                                                                                                                                                                        |
 | componentremoved     | One of the entity's components was removed.                                                                                                                                                                            |

--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -168,9 +168,31 @@ entity.addState('selected');
 entity.is('selected');  // >> true
 ```
 
+### `attachToScene ()`
+
+`attachToScene` can be used to re-attach an entity to the THREE.js scene that has been detached 
+using `detachFromScene`.
+
+See [`detachFromScene`](#detachfromscene) for more explanation.
+
 ### `destroy ()`
 
 Clean up memory related to the entity such as clearing all components and their data.
+
+### `detachFromScene ()`
+
+`detachFromScene` will detach the element from the THREE.js scene, typically for performance reasons.
+Detaching an entity from the scene means that the entity and its descendants will have no interactions
+in the 3D scene at all: it is not rendered, it will not interact with raycasters.
+
+The main reason for detaching an entity from the scene, rather than destroying it are:
+- to maintain state on the entity
+- for performance reasons, as it is typically faster to re-attach an entity to the scene, than to recreate it and all its descendants.
+
+For performance reasons, entity pools implemented by the [pool](pool) component detach entities in the pool when they are not in use.
+
+Attachment to the THREE.js scene can also be controlled through the [attached](attached) component.
+
 
 ### `emit (name, detail, bubbles)`
 

--- a/docs/core/entity.md
+++ b/docs/core/entity.md
@@ -170,16 +170,21 @@ entity.is('selected');  // >> true
 
 ### `attachToScene ()`
 
+[detach]: #detachfromscene-
+
 `attachToScene` can be used to re-attach an entity to the THREE.js scene that has been detached 
 using `detachFromScene`.
 
-See [`detachFromScene`](#detachfromscene) for more explanation.
+See [`detachFromScene`][detach] for more explanation.
 
 ### `destroy ()`
 
 Clean up memory related to the entity such as clearing all components and their data.
 
 ### `detachFromScene ()`
+
+[pool]: ../components/pool.md
+[attached]: ../components/attached.md
 
 `detachFromScene` will detach the element from the THREE.js scene, typically for performance reasons.
 Detaching an entity from the scene means that the entity and its descendants will have no interactions
@@ -189,9 +194,9 @@ The main reason for detaching an entity from the scene, rather than destroying i
 - to maintain state on the entity
 - for performance reasons, as it is typically faster to re-attach an entity to the scene, than to recreate it and all its descendants.
 
-For performance reasons, entity pools implemented by the [pool](pool) component detach entities in the pool when they are not in use.
+For performance reasons, entity pools implemented by the [pool][pool] component detach entities in the pool when they are not in use.
 
-Attachment to the THREE.js scene can also be controlled through the [attached](attached) component.
+Attachment to the THREE.js scene can also be controlled through the [attached][attached] component.
 
 
 ### `emit (name, detail, bubbles)`

--- a/src/components/attached.js
+++ b/src/components/attached.js
@@ -1,0 +1,16 @@
+var registerComponent = require('../core/component').registerComponent;
+
+/**
+ * Attached component.
+ */
+module.exports.Component = registerComponent('attached', {
+  schema: {default: true},
+
+  update: function () {
+    if (this.data) {
+      this.el.attachToScene();
+    } else {
+      this.el.detachFromScene();
+    }
+  }
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 require('./animation');
+require('./attached');
 require('./camera');
 require('./cursor');
 require('./daydream-controls');

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -154,12 +154,16 @@ module.exports.Component = registerComponent('raycaster', {
     this.observer.observe(this.el.sceneEl, OBSERVER_CONFIG);
     this.el.sceneEl.addEventListener('object3dset', this.setDirty);
     this.el.sceneEl.addEventListener('object3dremove', this.setDirty);
+    this.el.sceneEl.addEventListener('attached-to-scene', this.setDirty);
+    this.el.sceneEl.addEventListener('detached-from-scene', this.setDirty);
   },
 
   removeEventListeners: function () {
     this.observer.disconnect();
     this.el.sceneEl.removeEventListener('object3dset', this.setDirty);
     this.el.sceneEl.removeEventListener('object3dremove', this.setDirty);
+    this.el.sceneEl.removeEventListener('attached-to-scene', this.setDirty);
+    this.el.sceneEl.removeEventListener('detached-from-scene', this.setDirty);
   },
 
   /**
@@ -409,13 +413,23 @@ module.exports.Component = registerComponent('raycaster', {
     var key;
     var i;
     var objects = this.objects;
+    var scene = this.el.sceneEl.object3D;
+
+    function isAttachedToScene (object) {
+      if (object.parent) {
+        return isAttachedToScene(object.parent);
+      } else {
+        return (object === scene);
+      }
+    }
 
     // Push meshes and other attachments onto list of objects to intersect.
     objects.length = 0;
     for (i = 0; i < els.length; i++) {
-      if (els[i].isEntity && els[i].object3D) {
-        for (key in els[i].object3DMap) {
-          objects.push(els[i].getObject3D(key));
+      var el = els[i];
+      if (el.isEntity && el.object3D && isAttachedToScene(el.object3D)) {
+        for (key in el.object3DMap) {
+          objects.push(el.getObject3D(key));
         }
       }
     }

--- a/src/components/scene/pool.js
+++ b/src/components/scene/pool.js
@@ -61,6 +61,7 @@ module.exports.Component = registerComponent('pool', {
     el.setAttribute('mixin', this.data.mixin);
     el.object3D.visible = false;
     el.pause();
+    el.detachFromScene();
     this.container.appendChild(el);
     this.availableEls.push(el);
   },
@@ -93,6 +94,7 @@ module.exports.Component = registerComponent('pool', {
       this.createEntity();
     }
     el = this.availableEls.shift();
+    el.attachToScene();
     this.usedEls.push(el);
     el.object3D.visible = true;
     return el;
@@ -110,6 +112,7 @@ module.exports.Component = registerComponent('pool', {
     this.usedEls.splice(index, 1);
     this.availableEls.push(el);
     el.object3D.visible = false;
+    el.detachFromScene();
     el.pause();
     return el;
   }

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -769,6 +769,7 @@ class AEntity extends ANode {
     if (attr === 'rotation') { return getRotation(this); }
     if (attr === 'scale') { return this.object3D.scale; }
     if (attr === 'visible') { return this.object3D.visible; }
+    if (attr === 'attached') { return this.attachedToScene; }
     component = this.components[attr];
     if (component) { return component.data; }
     return window.HTMLElement.prototype.getAttribute.call(this, attr);

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -210,6 +210,7 @@ class AEntity extends ANode {
     }
     if (el.attachedToScene) {
       this.object3D.add(el.object3D);
+      el.emit('attached-to-scene');
     } else {
       // store off parent, for a later call to 'attachToScene()'
       el.object3DParent = this.object3D;
@@ -281,6 +282,7 @@ class AEntity extends ANode {
         this.object3DParent = this.parentNode.object3D;
       }
       this.object3DParent.add(this.object3D);
+      this.emit('attached-to-scene');
     }
   }
 
@@ -292,6 +294,7 @@ class AEntity extends ANode {
     this.object3DParent = this.object3D.parent;
     if (this.object3DParent) {
       this.object3DParent.remove(this.object3D);
+      this.emit('detached-from-scene');
     }
   }
 

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -37,6 +37,11 @@ class AEntity extends ANode {
     this.parentEl = null;
     this.rotationObj = {};
     this.states = [];
+    this.attachedToParent = false;
+    // tracks attach to / detach from THREE.js Scene graph (independent of DOM attachment)
+    this.attachedToScene = true;
+    // Used to preserve object3D's parent when detached from THREE.js scene graph
+    this.object3DParent = null;
   }
 
   /**
@@ -203,7 +208,13 @@ class AEntity extends ANode {
     if (!el.object3D) {
       throw new Error("Trying to add an element that doesn't have an `object3D`");
     }
-    this.object3D.add(el.object3D);
+    if (el.attachedToScene) {
+      this.object3D.add(el.object3D);
+    } else {
+      // store off parent, for a later call to 'attachToScene()'
+      el.object3DParent = this.object3D;
+    }
+
     this.emit('child-attached', {el: el});
   }
 
@@ -253,8 +264,34 @@ class AEntity extends ANode {
   remove (el) {
     if (el) {
       this.object3D.remove(el.object3D);
+      el.object3DParent = null;
     } else {
       this.parentNode.removeChild(this);
+    }
+  }
+
+  /**
+   * Attach el to THREE.js scene graph
+   */
+  attachToScene () {
+    this.attachedToScene = true;
+
+    if (this.attachedToParent) {
+      if (!this.object3DParent) {
+        this.object3DParent = this.parentNode.object3D;
+      }
+      this.object3DParent.add(this.object3D);
+    }
+  }
+
+  /**
+   * Detach el from THREE.js scene graph
+   */
+  detachFromScene () {
+    this.attachedToScene = false;
+    this.object3DParent = this.object3D.parent;
+    if (this.object3DParent) {
+      this.object3DParent.remove(this.object3D);
     }
   }
 

--- a/tests/components/attached.test.js
+++ b/tests/components/attached.test.js
@@ -31,7 +31,7 @@ suite('attached', function () {
     });
 
     test('Non-default object3D parent maintained when detached & re-attached', function () {
-      const alternateParent = new THREE.Group();
+      var alternateParent = new THREE.Group();
       alternateParent.add(el.object3D);
       el.setAttribute('attached', false);
       assert.equal(el.object3D.parent, null);

--- a/tests/components/attached.test.js
+++ b/tests/components/attached.test.js
@@ -1,0 +1,44 @@
+/* global assert, process, setup, suite, test, THREE */
+var elFactory = require('../helpers').elFactory;
+
+suite('attached', function () {
+  var el;
+
+  setup(function (done) {
+    elFactory().then(_el => {
+      el = _el;
+      done();
+    });
+  });
+
+  suite('update', function () {
+    test('treats empty as true', function () {
+      el.setAttribute('attached', '');
+      assert.equal(el.object3D.parent, el.parentNode.object3D);
+      assert.ok(el.attachedToScene);
+    });
+
+    test('can set to attached', function () {
+      el.setAttribute('attached', true);
+      assert.equal(el.object3D.parent, el.parentNode.object3D);
+      assert.ok(el.attachedToScene);
+    });
+
+    test('can set to not attached', function () {
+      el.setAttribute('attached', false);
+      assert.equal(el.object3D.parent, null);
+      assert.notOk(el.attachedToScene);
+    });
+
+    test('Non-default object3D parent maintained when detached & re-attached', function () {
+      const alternateParent = new THREE.Group();
+      alternateParent.add(el.object3D);
+      el.setAttribute('attached', false);
+      assert.equal(el.object3D.parent, null);
+      assert.notOk(el.attachedToScene);
+      el.setAttribute('attached', true);
+      assert.equal(el.object3D.parent, alternateParent);
+      assert.ok(el.attachedToScene);
+    });
+  });
+});

--- a/tests/components/attached.test.js
+++ b/tests/components/attached.test.js
@@ -40,5 +40,14 @@ suite('attached', function () {
       assert.equal(el.object3D.parent, alternateParent);
       assert.ok(el.attachedToScene);
     });
+
+    test('getAttribute is affected by changes made direct to entity', function () {
+      el.setAttribute('attached', true);
+      assert.ok(el.getAttribute('attached'));
+      el.detachFromScene();
+      assert.notOk(el.getAttribute('attached'));
+      el.attachToScene();
+      assert.ok(el.getAttribute('attached'));
+    });
   });
 });

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -118,6 +118,44 @@ suite('raycaster', function () {
       sceneEl.appendChild(el2);
       sceneEl.appendChild(el3);
     });
+
+    test('Objects not attached to scene are not whitelisted', function (done) {
+      var el2 = document.createElement('a-entity');
+      var el3 = document.createElement('a-entity');
+      el2.setAttribute('class', 'clickable');
+      el2.setAttribute('geometry', 'primitive: box');
+      el3.setAttribute('class', 'clickable');
+      el3.setAttribute('geometry', 'primitive: box');
+      el3.detachFromScene();
+      el3.addEventListener('loaded', function () {
+        el.setAttribute('raycaster', 'objects', '.clickable');
+        component.tock();
+        assert.equal(component.objects.length, 1);
+        assert.equal(component.objects[0], el2.object3D.children[0]);
+        assert.equal(el2, el2.object3D.children[0].el);
+        done();
+      });
+      sceneEl.appendChild(el2);
+      sceneEl.appendChild(el3);
+    });
+
+    test('Objects with parent not attached to scene are not whitelisted', function (done) {
+      var el2 = document.createElement('a-entity');
+      var el3 = document.createElement('a-entity');
+      el2.setAttribute('class', 'clickable');
+      el2.setAttribute('geometry', 'primitive: box');
+      el3.setAttribute('class', 'clickable');
+      el3.setAttribute('geometry', 'primitive: box');
+      el2.detachFromScene();
+      el3.addEventListener('loaded', function () {
+        el.setAttribute('raycaster', 'objects', '.clickable');
+        component.tock();
+        assert.equal(component.objects.length, 0);
+        done();
+      });
+      sceneEl.appendChild(el2);
+      el2.appendChild(el3);
+    });
   });
 
   suite('tock', function () {
@@ -213,6 +251,18 @@ suite('raycaster', function () {
       component.tock();
       assert.equal(component.dirty, false);
       sceneEl.emit('object3dremove');
+      assert.equal(component.dirty, true);
+    });
+
+    test('refresh objects when attachToScene() or detachFromScene() is called', function () {
+      el.setAttribute('raycaster', {objects: '[ray-target]'});
+      component.tock();
+      assert.equal(component.dirty, false);
+      sceneEl.emit('attached-to-scene');
+      assert.equal(component.dirty, true);
+      component.tock();
+      assert.equal(component.dirty, false);
+      sceneEl.emit('detached-from-scene');
       assert.equal(component.dirty, true);
     });
   });

--- a/tests/components/scene/pool.test.js
+++ b/tests/components/scene/pool.test.js
@@ -99,6 +99,23 @@ suite('pool', function () {
     });
   });
 
+  suite('attachmentToThreeScene', function () {
+    test('Pool entity is not initially attached to scene', function () {
+      var sceneEl = this.sceneEl;
+      var poolComponent = sceneEl.components.pool;
+      assert.equal(poolComponent.availableEls[0].object3D.parent, null);
+    });
+
+    test('Pool entity is attached to scene when requested, and detached when released', function () {
+      var sceneEl = this.sceneEl;
+      var poolComponent = sceneEl.components.pool;
+      var el = poolComponent.requestEntity();
+      assert.equal(el.object3D.parent, sceneEl.object3D);
+      poolComponent.returnEntity(el);
+      assert.equal(el.object3D.parent, null);
+    });
+  });
+
   suite('wrapPlay', function () {
     test('cannot play an entity that is not in use', function () {
       var sceneEl = this.sceneEl;

--- a/tests/components/visible.test.js
+++ b/tests/components/visible.test.js
@@ -27,5 +27,12 @@ suite('visible', function () {
       el.setAttribute('visible', false);
       assert.notOk(el.object3D.visible);
     });
+
+    test('getAttribute is affected by changes to Object3D.visible', function () {
+      el.setAttribute('visible', true);
+      assert.ok(el.getAttribute('visible'));
+      el.object3D.visible = false;
+      assert.notOk(el.getAttribute('visible'));
+    });
   });
 });


### PR DESCRIPTION
**Description:**

A PR based on the performance enhancement described here:
https://github.com/diarmidmackenzie/moonrider/issues/3#issuecomment-1356447670

The scope of this has grown a little.  I know you are pretty conservative about adding new components & API changes for A-Frame, so if you prefer me to dial back the scope of changes here, let me know.

To explain how I got from my original fix to this PR...

- Detaching entities from the scene & re-attaching might be valuable outside of the `pool` component, so better to provide a clean API on `a-entity` and handle the fiddly details (like window conditions around initialization) inside  `a-entity`

- There are existing use cases for which the new API is actually a great fit.  Use case described in `visible` component where you can toggle a group of entities in / out of the scene is actually better met by the new API.  Making such elements invisible cuts any cost of the GPU, but still leaves some CPU cost for updateMatrixWorld() and raycasting.  The new API would get rid of the CPU cost as well, as well as raycasting false positives, which have caused me problems in the past when usign this pattern.

- Support for this use case requires a component, so that detachment from THREE.js scene can be encoded declaratively in HTML.  Hence new "attached" component.

- It's important for raycasting to ignore object3Ds that are not part of the main scene graph: they are orphaned, and matrixWolrld values are not meaningful.  Hence updates to raycaster to explicitly ignore them.

- For raycaster auto-refresh to work, new events were needed to indicate detachment from scene & re-attachment to it.  I had a slight concern about perf impacts here, but I think any impacts that do occur can be mitigated by disabling autoRefresh on the raycaster component, as already described [here](https://aframe.io/docs/1.3.0/components/raycaster.html#manually-refreshing-the-target-entities-of-the-raycaster) 

**Changes proposed:**

- `a-entity` offers `detachFromScene()` and `attachToScene()` API calls
- `a-entity` emits new events, `attached-to-scene` and `detached-from-scene` indicating when these new operations complete.
- `pool` component uses these to ensure that unused pool entities do not appear in the scene graph (gives major perf boost for Moonrider)
- New `attached` component gives HTML-l;evel contol of detachment from THREE,js scene graph, very similar to `visible` component.
- `raycaster` updated to ignore all objects that are not rooted in the main THREE.js scene graph (including auto-updates)
- Documentation & UT for the above.  Documentation for toggling on/off a part of the HTML scene graph now points to `attach` component rather than `visible` component.

