### PR TITLE
Fix quest 1 controller and ray offsets

### DIFF
--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -57,15 +57,15 @@ var CONTROLLER_PROPERTIES = {
   'oculus-touch-v2': {
     left: {
       modelUrl: TOUCH_CONTROLLER_MODEL_BASE_URL + 'gen2-left.gltf',
-      rayOrigin: {origin: {x: -0.01, y: 0, z: -0.02}, direction: {x: 0, y: -0.5, z: -1}},
-      modelPivotOffset: new THREE.Vector3(0, 0, 0),
-      modelPivotRotation: new THREE.Euler(0, 0, 0)
+      rayOrigin: {origin: {x: -0.006, y: -0.03, z: -0.04}, direction: {x: 0, y: -0.9, z: -1}},
+      modelPivotOffset: new THREE.Vector3(0, -0.007, -0.021),
+      modelPivotRotation: new THREE.Euler(-Math.PI / 4, 0, 0)
     },
     right: {
       modelUrl: TOUCH_CONTROLLER_MODEL_BASE_URL + 'gen2-right.gltf',
-      rayOrigin: {origin: {x: 0.01, y: 0, z: -0.02}, direction: {x: 0, y: -0.5, z: -1}},
-      modelPivotOffset: new THREE.Vector3(0, 0, 0),
-      modelPivotRotation: new THREE.Euler(0, 0, 0)
+      rayOrigin: {origin: {x: 0.006, y: -0.03, z: -0.04}, direction: {x: 0, y: -0.9, z: -1}},
+      modelPivotOffset: new THREE.Vector3(0, -0.007, -0.021),
+      modelPivotRotation: new THREE.Euler(-Math.PI / 4, 0, 0)
     }
   },
   'oculus-touch-v3': {


### PR DESCRIPTION
**Description:**

I tweaked the values by trial and error.
This close #5183 

**Changes proposed:**
- Modify modelPivotOffset modelPivotRotation rayOrigin for oculus-touch-v2 that are used for Quest 1 controllers
