### PR TITLE
Hide fullscreen button in desktop mode on iPad

### DIFF
--- a/src/components/scene/vr-mode-ui.js
+++ b/src/components/scene/vr-mode-ui.js
@@ -135,7 +135,7 @@ module.exports.Component = registerComponent('vr-mode-ui', {
     var sceneEl = this.el;
     if (!this.enterVREl) { return; }
     if (sceneEl.is('vr-mode') ||
-       (sceneEl.isMobile && !this.data.cardboardModeEnabled && !utils.device.checkVRSupport())) {
+       ((sceneEl.isMobile || utils.device.isMobileDeviceRequestingDesktopSite()) && !this.data.cardboardModeEnabled && !utils.device.checkVRSupport())) {
       this.enterVREl.classList.add(HIDDEN_CLASS);
     } else {
       if (!utils.device.checkVRSupport()) { this.enterVREl.classList.add('fullscreen'); }


### PR DESCRIPTION
**Description:**

As discussed in #4814 hide the fullscreen button on iPad in desktop mode when `cardboardModeEnabled` is `false`, it just rendered a black screen.

**Changes proposed:**
- Using `utils.device.isMobileDeviceRequestingDesktopSite()` to detect desktop mode on iPad