### PR TITLE
Don't generate aframe-master.min.js.LICENSE.txt file

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var merge = require('webpack-merge').merge;
 var commonConfiguration = require('./webpack.config.js');
+var TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = merge(commonConfiguration, {
   output: {
@@ -10,5 +11,21 @@ module.exports = merge(commonConfiguration, {
     publicPath: '/dist/',
     filename: 'aframe-master.min.js'
   },
-  mode: 'production'
+  mode: 'production',
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          compress: {
+            passes: 2
+          },
+          format: {
+            comments: false
+          }
+        },
+        extractComments: false
+      })
+    ]
+  }
 });


### PR DESCRIPTION
**Description:**

Don't generate aframe-master.min.js.LICENSE.txt file.
This closes #5192

See documentation:
https://github.com/webpack-contrib/terser-webpack-plugin#remove-comments
and default config was:
https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/config/defaults.js#L1160-L1174
