### PR TITLE
Fix random error when exiting VR

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -404,7 +404,6 @@ class AScene extends AEntity {
         // Capture promise to avoid errors.
         this.xrSession.end().then(function () {}, function () {});
         this.xrSession = undefined;
-        vrManager.setSession(null);
       } else {
         if (vrDisplay.isPresenting) {
           return vrDisplay.exitPresent().then(exitVRSuccess, exitVRFailure);


### PR DESCRIPTION
**Description:**
Fix random error when exiting VR that could make the page unresponsive.
`Uncaught TypeError: Cannot read properties of null (reading 'removeEventListener') at XRSession.onSessionEnd (three.js:18792:1)`
See discussion in #5137

**Changes proposed:**
- Remove setSession(null) call on exiting VR, threejs is already setting session to null in its onSessionEnd listener