### PR TITLE
Correct documentation for a-cylinder radius

### DIFF
--- a/docs/primitives/a-cylinder.md
+++ b/docs/primitives/a-cylinder.md
@@ -57,8 +57,7 @@ Also, we can create a tube by making the cylinder open-ended, which removes the 
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
 | open-ended                       | geometry.openEnded                     | false         |
-| radius-bottom                    | geometry.radiusBottom                  | 1             |
-| radius-top                       | geometry.radiusTop                     | 0.8           |
+| radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
 | segments-height                  | geometry.segmentsHeight                | 18            |


### PR DESCRIPTION
Unlike THREE.js CylinderGeometry, the A-Frame `cylinder` geometry does not have distinct radii for top & bottom.

Distinct radii for top & bottom are only provided by the A-Frame `cone` geometry (which also uses the THREE.js CylinderGeometry).

The docs for `a-cylinder` are currently wrong, referring to `radius-bottom` and `radius-top` attributes that don't exist, and not mentioning the `radius` attribute that does exist.

This change fixes them.