### PR TITLE
Make sure attribute mutation observers are in place before initializing components on an entity.

### DIFF
--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -140,8 +140,8 @@ class ANode extends HTMLElement {
       });
 
       self.hasLoaded = true;
-      if (cb) { cb(); }
       self.setupMutationObserver();
+      if (cb) { cb(); }
       self.emit('loaded', undefined, false);
     });
   }
@@ -151,7 +151,7 @@ class ANode extends HTMLElement {
    * for attributes defined statically via observedAttributes.
    * One can assign any arbitrary components to an A-Frame entity
    * hence we can't know the list of attributes beforehand.
-   * This function setup a mutation observer to keep track of the entiy attribute changes
+   * This function setup a mutation observer to keep track of the entity attribute changes
    * in the DOM and update components accordingly.
    */
   setupMutationObserver () {

--- a/tests/extras/primitives/primitives/a-torus.test.js
+++ b/tests/extras/primitives/primitives/a-torus.test.js
@@ -1,5 +1,6 @@
 /* global assert, suite, test, setup */
 var helpers = require('../../../helpers');
+var registerComponent = require('core/component').registerComponent;
 
 suite('a-torus', function () {
   setup(function (done) {
@@ -28,6 +29,67 @@ suite('a-torus', function () {
     torusEl.setAttribute('radius', '2');
     torusEl.setAttribute('radius-tubular', '0.1');
 
+    process.nextTick(function () {
+      geometry = torusEl.getAttribute('geometry');
+      assert.equal(geometry.primitive, 'torus');
+      assert.equal(geometry.segmentsTubular, 100);
+      assert.equal(geometry.radius, 2);
+      assert.equal(geometry.radiusTubular, 0.1);
+      done();
+    });
+  });
+
+  test('can set torus properties when creating in JavaScript', function (done) {
+    var el = helpers.entityFactory();
+    var geometry;
+    var torusEl = document.createElement('a-torus');
+    torusEl.setAttribute('segments-tubular', '100');
+    torusEl.setAttribute('radius', '2');
+    torusEl.setAttribute('radius-tubular', '0.1');
+    el.sceneEl.appendChild(torusEl);
+
+    process.nextTick(function () {
+      geometry = torusEl.getAttribute('geometry');
+      assert.equal(geometry.primitive, 'torus');
+      assert.equal(geometry.segmentsTubular, 100);
+      assert.equal(geometry.radius, 2);
+      assert.equal(geometry.radiusTubular, 0.1);
+      done();
+    });
+  });
+
+  test('can set torus properties after creation when creating in JavaScript', function (done) {
+    var el = helpers.entityFactory();
+    var geometry;
+    var torusEl = document.createElement('a-torus');
+    el.sceneEl.appendChild(torusEl);
+    torusEl.setAttribute('segments-tubular', '100');
+    torusEl.setAttribute('radius', '2');
+    torusEl.setAttribute('radius-tubular', '0.1');
+
+    process.nextTick(function () {
+      geometry = torusEl.getAttribute('geometry');
+      assert.equal(geometry.primitive, 'torus');
+      assert.equal(geometry.segmentsTubular, 100);
+      assert.equal(geometry.radius, 2);
+      assert.equal(geometry.radiusTubular, 0.1);
+      done();
+    });
+  });
+
+  test('can set torus properties via an additional component', function (done) {
+    var el = helpers.entityFactory();
+    var geometry;
+    var torusEl = document.createElement('a-torus');
+    torusEl.setAttribute('test', '');
+    el.sceneEl.appendChild(torusEl);
+    registerComponent('test', {
+      init () {
+        this.el.setAttribute('segments-tubular', '100');
+        this.el.setAttribute('radius', '2');
+        this.el.setAttribute('radius-tubular', '0.1');
+      }
+    });
     process.nextTick(function () {
       geometry = torusEl.getAttribute('geometry');
       assert.equal(geometry.primitive, 'torus');

--- a/tests/extras/primitives/primitives/a-torus.test.js
+++ b/tests/extras/primitives/primitives/a-torus.test.js
@@ -40,13 +40,13 @@ suite('a-torus', function () {
   });
 
   test('can set torus properties when creating in JavaScript', function (done) {
-    var el = helpers.entityFactory();
+    var scene = document.querySelector('a-scene');
     var geometry;
     var torusEl = document.createElement('a-torus');
     torusEl.setAttribute('segments-tubular', '100');
     torusEl.setAttribute('radius', '2');
     torusEl.setAttribute('radius-tubular', '0.1');
-    el.sceneEl.appendChild(torusEl);
+    scene.appendChild(torusEl);
 
     process.nextTick(function () {
       geometry = torusEl.getAttribute('geometry');
@@ -59,10 +59,10 @@ suite('a-torus', function () {
   });
 
   test('can set torus properties after creation when creating in JavaScript', function (done) {
-    var el = helpers.entityFactory();
+    var scene = document.querySelector('a-scene');
     var geometry;
     var torusEl = document.createElement('a-torus');
-    el.sceneEl.appendChild(torusEl);
+    scene.appendChild(torusEl);
     torusEl.setAttribute('segments-tubular', '100');
     torusEl.setAttribute('radius', '2');
     torusEl.setAttribute('radius-tubular', '0.1');
@@ -78,11 +78,11 @@ suite('a-torus', function () {
   });
 
   test('can set torus properties via an additional component', function (done) {
-    var el = helpers.entityFactory();
+    var scene = document.querySelector('a-scene');
     var geometry;
     var torusEl = document.createElement('a-torus');
     torusEl.setAttribute('test', '');
-    el.sceneEl.appendChild(torusEl);
+    scene.appendChild(torusEl);
     registerComponent('test', {
       init () {
         this.el.setAttribute('segments-tubular', '100');


### PR DESCRIPTION
**Description:**

See #5203 for background.  This PR is a proposed fix for that issue, as described [here](https://github.com/aframevr/aframe/issues/5203#issuecomment-1373811602) 

**Changes proposed:**

Set up mutation obervers for attributes *before* initializing components on an entity.
This is important in the case where the component sets attributes that need obsevers in place to be set correctly - a particular example being attributes like `radius` and `color` on `a-sphere`, which map to `geometry.radius` and `material.color`.
