### PR TITLE
Implement low / high refresh rates on WebXR devices

### DIFF
--- a/docs/components/renderer.md
+++ b/docs/components/renderer.md
@@ -30,7 +30,7 @@ It also configures presentation attributes when entering WebVR/WebXR.
 |-------------------------|---------------------------------------------------------------------------------|---------------|
 | antialias               | Whether to perform antialiasing. If `auto`, antialiasing is disabled on mobile. | auto          |
 | colorManagement         | Whether to use a color-managed linear workflow.                                 | false         |
-| highRefreshRate         | Toggles 72hz mode on Oculus Browser. Defaults to 60hz.                          | false         |
+| highRefreshRate         | Increases frame rate from the default (for browsers that support control of frame rate). | false         |
 | foveationLevel          | Amount of foveation used in VR to improve perf, from 0 (min) to 1 (max).        | 1             |
 | sortObjects             | Whether to sort objects before rendering.                                       | false         |
 | physicallyCorrectLights | Whether to use physically-correct light attenuation.                            | false         |
@@ -64,8 +64,16 @@ other engines and tools.
 
 ### highRefreshRate
 
-Toggles on the highest refresh rate for the given device. Currently this is supported on the Oculus
-Browser in Oculus Go and switches rendering from 60hz to 72hz.
+Switches to a higher frame rate than the default, for the given device.
+
+This requires support for  `supportedFrameRates` and `updateTargetFrameRate` as defined in the WebXR specs.  Currently this is supported on the Oculus Browser, but is expected to be supported by other browsers in future.
+
+Frame rates used are as follows:
+
+| Device capabilities                                          | Default Frame Rate | High Frame Rate |
+| ------------------------------------------------------------ | ------------------ | --------------- |
+| Device supports 90Hz refresh rate (e.g. Quest 2, Quest Pro)  | 72 Hz              | 90 Hz           |
+| Device does not support 90Hz refresh rate (e.g. Oculus Go, Quest) | 60Hz               | 72Hz            |
 
 ### foveationLevel
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -301,6 +301,19 @@ class AScene extends AEntity {
               vrManager.setSession(xrSession).then(function () {
                 vrManager.setFoveation(rendererSystem.foveationLevel);
               });
+              const rates = xrSession.supportedFrameRates;
+              if (rates && xrSession.updateTargetFrameRate) {
+                let targetRate;
+                if (rates.includes(90)) {
+                  targetRate = rendererSystem.highRefreshRate ? 90 : 72;
+                } else {
+                  targetRate = rendererSystem.highRefreshRate ? 72 : 60;
+                }
+                xrSession.updateTargetFrameRate(targetRate).catch(function (error) {
+                  console.warn('failed to set target frame rate of ' + targetRate + '. Error info: ' + error);
+                });
+              }
+
               xrSession.addEventListener('end', self.exitVRBound);
               enterVRSuccess(resolve);
             },

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -301,19 +301,7 @@ class AScene extends AEntity {
               vrManager.setSession(xrSession).then(function () {
                 vrManager.setFoveation(rendererSystem.foveationLevel);
               });
-              const rates = xrSession.supportedFrameRates;
-              if (rates && xrSession.updateTargetFrameRate) {
-                let targetRate;
-                if (rates.includes(90)) {
-                  targetRate = rendererSystem.highRefreshRate ? 90 : 72;
-                } else {
-                  targetRate = rendererSystem.highRefreshRate ? 72 : 60;
-                }
-                xrSession.updateTargetFrameRate(targetRate).catch(function (error) {
-                  console.warn('failed to set target frame rate of ' + targetRate + '. Error info: ' + error);
-                });
-              }
-
+              this.sceneEl.systems.renderer.setWebXRFrameRate(xrSession);
               xrSession.addEventListener('end', self.exitVRBound);
               enterVRSuccess(resolve);
             },

--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -70,5 +70,21 @@ module.exports.System = registerSystem('renderer', {
     } else if (colorOrTexture.isTexture) {
       colorOrTexture.encoding = THREE.sRGBEncoding;
     }
+  },
+
+  setWebXRFrameRate: function (xrSession) {
+    var data = this.data;
+    var rates = xrSession.supportedFrameRates;
+    if (rates && xrSession.updateTargetFrameRate) {
+      let targetRate;
+      if (rates.includes(90)) {
+        targetRate = data.highRefreshRate ? 90 : 72;
+      } else {
+        targetRate = data.highRefreshRate ? 72 : 60;
+      }
+      xrSession.updateTargetFrameRate(targetRate).catch(function (error) {
+        console.warn('failed to set target frame rate of ' + targetRate + '. Error info: ' + error);
+      });
+    }
   }
 });


### PR DESCRIPTION
**Description:**

The renderer component offers a property `highRefreshRate`.
https://aframe.io/docs/1.4.0/components/renderer.html#properties_highrefreshrate

Currently this is only implemented for WebVR.(sets the `highRefreshRate` value in `presentationAttributes`)

This means that in WebXR, A-Frame does not influence frame rate, meaning expriences run at the frame rate preferred by the browser.  On Quest 2 that is 90fps, which is arguably too high (and often results in experiences missing frames & hitting 45fps).

**Changes proposed:**

This PR provides a WebXR implementation of the `highRefreshRate` for devices/browsers that support the WebXR API to control frame rate:
https://www.w3.org/TR/webxr/#dom-xrsession-updatetargetframerate

Proposed behaviour:
1 - if device does not support 90fps, low -> 60, high -> 72
2 - if device supports 90fps, low -> 72, high -> 90

Currently 1 = Quest 1; 2 = Quest 2 & Quest Pro.

Other browsers / devices do not yet support the WebXR spec linked above, but when they do this seems like sensible default behaviour - it can be further tuned when additional info is known about what frame rates these browsers support.

**Other notes**

This PR is not ready to merge yet.  Sharing for an initial view of what the code / function should be.  If we get agreement on that, I'll add UTs & updated documentation to reflect the changes.
