### PR TITLE
Fix errors when buttons are pressed on Quest 2 controllers before the model is loaded

### DIFF
--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -340,6 +340,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     var buttonObjects = this.buttonObjects;
     var analogValue;
 
+    if (!buttonObjects) { return; }
     analogValue = evt.detail.state.value;
     analogValue *= this.data.hand === 'left' ? -1 : 1;
 
@@ -491,11 +492,13 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
 
   updateButtonModel: function (buttonName, state) {
     // update the button mesh colors
-    var button;
-    var color = (state === 'up' || state === 'touchend') ? this.buttonMeshes[buttonName].originalColor || this.data.buttonColor : state === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
     var buttonMeshes = this.buttonMeshes;
+    var button;
+    var color;
 
-    if (buttonMeshes && buttonMeshes[buttonName]) {
+    if (!buttonMeshes) { return; }
+    if (buttonMeshes[buttonName]) {
+      color = (state === 'up' || state === 'touchend') ? buttonMeshes[buttonName].originalColor || this.data.buttonColor : state === 'touchstart' ? this.data.buttonTouchColor : this.data.buttonHighlightColor;
       button = buttonMeshes[buttonName];
       button.material.color.set(color);
       this.rendererSystem.applyColorCorrection(button.material.color);

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -309,25 +309,24 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onButtonChanged: function (evt) {
+    var buttonMeshes = this.buttonMeshes;
     var button = this.mapping[this.data.hand].buttons[evt.detail.id];
     if (!button) { return; }
+    if (!buttonMeshes) { return; }
     // move the button meshes
     if (this.isOculusTouchV3) {
       this.onButtonChangedV3(evt);
     } else {
-      var buttonMeshes = this.buttonMeshes;
       var analogValue;
 
       if (button === 'trigger' || button === 'grip') { analogValue = evt.detail.state.value; }
 
-      if (buttonMeshes) {
-        if (button === 'trigger' && buttonMeshes.trigger) {
-          buttonMeshes.trigger.rotation.x = this.originalXRotationTrigger - analogValue * (Math.PI / 26);
-        }
-        if (button === 'grip' && buttonMeshes.grip) {
-          analogValue *= this.data.hand === 'left' ? -1 : 1;
-          buttonMeshes.grip.position.x = this.originalXPositionGrip + analogValue * 0.004;
-        }
+      if (button === 'trigger' && buttonMeshes.trigger) {
+        buttonMeshes.trigger.rotation.x = this.originalXRotationTrigger - analogValue * (Math.PI / 26);
+      }
+      if (button === 'grip' && buttonMeshes.grip) {
+        analogValue *= this.data.hand === 'left' ? -1 : 1;
+        buttonMeshes.grip.position.x = this.originalXPositionGrip + analogValue * 0.004;
       }
     }
     // Pass along changed event with button state, using the buttom mapping for convenience.
@@ -340,7 +339,6 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     var buttonObjects = this.buttonObjects;
     var analogValue;
 
-    if (!buttonObjects) { return; }
     analogValue = evt.detail.state.value;
     analogValue *= this.data.hand === 'left' ? -1 : 1;
 

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -309,24 +309,25 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onButtonChanged: function (evt) {
-    var buttonMeshes = this.buttonMeshes;
     var button = this.mapping[this.data.hand].buttons[evt.detail.id];
     if (!button) { return; }
-    if (!buttonMeshes) { return; }
     // move the button meshes
     if (this.isOculusTouchV3) {
       this.onButtonChangedV3(evt);
     } else {
+      var buttonMeshes = this.buttonMeshes;
       var analogValue;
 
       if (button === 'trigger' || button === 'grip') { analogValue = evt.detail.state.value; }
 
-      if (button === 'trigger' && buttonMeshes.trigger) {
-        buttonMeshes.trigger.rotation.x = this.originalXRotationTrigger - analogValue * (Math.PI / 26);
-      }
-      if (button === 'grip' && buttonMeshes.grip) {
-        analogValue *= this.data.hand === 'left' ? -1 : 1;
-        buttonMeshes.grip.position.x = this.originalXPositionGrip + analogValue * 0.004;
+      if (buttonMeshes) {
+        if (button === 'trigger' && buttonMeshes.trigger) {
+          buttonMeshes.trigger.rotation.x = this.originalXRotationTrigger - analogValue * (Math.PI / 26);
+        }
+        if (button === 'grip' && buttonMeshes.grip) {
+          analogValue *= this.data.hand === 'left' ? -1 : 1;
+          buttonMeshes.grip.position.x = this.originalXPositionGrip + analogValue * 0.004;
+        }
       }
     }
     // Pass along changed event with button state, using the buttom mapping for convenience.
@@ -339,6 +340,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
     var buttonObjects = this.buttonObjects;
     var analogValue;
 
+    if (!buttonObjects) { return; }
     analogValue = evt.detail.state.value;
     analogValue *= this.data.hand === 'left' ? -1 : 1;
 


### PR DESCRIPTION
**Description:**
Fix errors when buttons are pressed on Quest 2 controllers before the model is loaded.
I don't have a Quest 2, please someone test the changes.
I tested on Quest 1, I didn't break it. :)

**Changes proposed:**
- Check if buttonObjects or buttonMeshes is defined before accessing it, this fixes Quest 2 buttons highlighting errors when the model is not loaded yet (fix #5212 and #5220)-
