### PR TITLE
Update draco decoder to 1.5.6

### DIFF
--- a/docs/components/gltf-model.md
+++ b/docs/components/gltf-model.md
@@ -144,7 +144,7 @@ When using glTF models compressed with Draco, KTX2 or Meshopt, you must configur
 
 | Property         | Description                                                                                                                                                                                           | Default Value                       |
 |------------------|--------------------------------------|----|
-| dracoDecoderPath | Path to the Draco decoder libraries. | 'https://www.gstatic.com/draco/versioned/decoders/1.5.5/' |
+| dracoDecoderPath | Path to the Draco decoder libraries. | 'https://www.gstatic.com/draco/versioned/decoders/1.5.6/' |
 | basisTranscoderPath | Path to the basis/KTX2 transcoder libraries. | '' |
 | meshoptDecoderPath | Path to the Meshopt decoder.       | '' |
 

--- a/src/systems/gltf-model.js
+++ b/src/systems/gltf-model.js
@@ -24,7 +24,7 @@ function fetchScript (src) {
  */
 module.exports.System = registerSystem('gltf-model', {
   schema: {
-    dracoDecoderPath: {default: 'https://www.gstatic.com/draco/versioned/decoders/1.5.5/'},
+    dracoDecoderPath: {default: 'https://www.gstatic.com/draco/versioned/decoders/1.5.6/'},
     basisTranscoderPath: {default: ''},
     meshoptDecoderPath: {default: ''}
   },


### PR DESCRIPTION
**Description:**
Draco decoder 1.5.6 was released https://github.com/google/draco/releases/tag/1.5.6

**Changes proposed:**
- Update default draco decoder url from 1.5.5 to 1.5.6