### PR TITLE
Single property schema array

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -204,7 +204,9 @@ Component.prototype = {
       return;
     }
 
-    if (value instanceof Object && !(value instanceof window.HTMLElement)) {
+    if ((value instanceof Object) &&
+        !(value instanceof Array) &&
+        !(value instanceof window.HTMLElement)) {
       // If value is an object, copy it to our pooled newAttrValue object to use to update
       // the attrValue.
       tempObject = this.objectPool.use();

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -833,10 +833,23 @@ suite('Component', function () {
         schema: {list: {default: ['a']}}
       });
       var component = new TestComponent(this.el);
+      assert.deepEqual(component.data.list, ['a']);
       component.update = updateStub;
       component.updateProperties({list: ['b']});
       component.updateProperties({list: ['b']});
       sinon.assert.calledOnce(updateStub);
+      assert.deepEqual(component.data.list, ['b']);
+    });
+
+    test('supports array property in single property schema', function () {
+      registerComponent('dummy', {
+        schema: {
+          schema: {default: ['a']}
+        }
+      });
+      var el = document.createElement('a-entity');
+      el.setAttribute('dummy', ['b']);
+      assert.deepEqual(el.components.dummy.data, ['b']);
     });
 
     test('emit componentchanged when update calls setAttribute', function (done) {

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -841,15 +841,34 @@ suite('Component', function () {
       assert.deepEqual(component.data.list, ['b']);
     });
 
-    test('supports array property in single property schema', function () {
+    test('supports array property on entity creation', function (done) {
+      entityFactory();
       registerComponent('dummy', {
-        schema: {
-          schema: {default: ['a']}
-        }
+        schema: { list: {type: 'array', default: ['a']} }
       });
-      var el = document.createElement('a-entity');
-      el.setAttribute('dummy', ['b']);
-      assert.deepEqual(el.components.dummy.data, ['b']);
+      var scene = document.querySelector('a-scene');
+      var el2 = document.createElement('a-entity');
+      el2.setAttribute('dummy', { list: ['b', 'c', 'd'] });
+      el2.addEventListener('componentinitialized', evt => {
+        assert.deepEqual(el2.components.dummy.data.list, ['b', 'c', 'd']);
+        done();
+      });
+      scene.appendChild(el2);
+    });
+
+    test('supports array property in single property schema on entity creation', function (done) {
+      entityFactory();
+      registerComponent('dummy', {
+        schema: {type: 'array', default: ['a']}
+      });
+      var scene = document.querySelector('a-scene');
+      var el2 = document.createElement('a-entity');
+      el2.setAttribute('dummy', ['b', 'c', 'd']);
+      el2.addEventListener('componentinitialized', () => {
+        assert.deepEqual(el2.components.dummy.data, ['b', 'c', 'd']);
+        done();
+      });
+      scene.appendChild(el2);
     });
 
     test('emit componentchanged when update calls setAttribute', function (done) {


### PR DESCRIPTION
**Description:**

Small change to fix #5242 and allow an array to be used as the property in a single property schema.
Unit tests for this.

**Changes proposed:**

I don't have much confidence in this fix, so needs review by someone who understands the code better.  It may be that an altogether different approach is needed.

Following up on my previous analysis [here](https://github.com/aframevr/aframe/issues/5242#issue-1583933484), I experimented with various changes.

What seemed to work best was skipping the object pool altogether for this array property, by updating this test:
```
if ((value instanceof Object) && !(value instanceof window.HTMLElement))
```
to this:
```
if ((value instanceof Object) &&
        !(value instanceof Array) &&
        !(value instanceof window.HTMLElement))
```

I tried this simple option:
```
if (this.isObjectBased && !(value instanceof window.HTMLElement))
```
but that broke some cursor UTs, presumably because of they use Vector3s, for which it's also the case that `instanceof Object` is true, but `isObject` is false...  I guess we don't want to make any changes for Vector3s, just arrays...?

A build including this fix does resolve the problem.
https://glitch.com/edit/#!/single-property-schema-array-fix?path=index.html%3A8%3A23

There's still lots I don't understand about the code I have modified, exactly when it is invoked, and what it should do.

Things I don't understand:
- Why does the problem we have with Arrays not also happen for Vector3s?  Components like `position` and `rotation` use a single property schema, with a Vector3, and they clearly work fine.
- Why did we only have a problem on entity creation, and not on subsequent `setAttribute()` calls?


Regarding the new UTs...

I have reasonable confidence that the 2 x new UTs are valid, but not sure they belong in the `component` suite: although they are testing code in `src/core/component` they are more like end-to-end tests, rather than unit tests of this module.

Maybe there's a better place for these?



