### PR TITLE
Close a tiny gap in A-Frame loading order

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -20,8 +20,8 @@ class AAssets extends ANode {
 
   connectedCallback () {
     // Defer if DOM is not ready.
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', this.connectedCallback.bind(this));
+    if (document.readyState !== 'complete') {
+      document.addEventListener('readystatechange', this.onReadyStateChange.bind(this));
       return;
     }
 

--- a/src/core/a-cubemap.js
+++ b/src/core/a-cubemap.js
@@ -17,10 +17,16 @@ class ACubeMap extends HTMLElement {
     return self;
   }
 
+  onReadyStateChange () {
+    if (document.readyState === 'complete') {
+      this.doConnectedCallback();
+    }
+  }
+
   connectedCallback () {
     // Defer if DOM is not ready.
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', this.connectedCallback.bind(this));
+    if (document.readyState !== 'complete') {
+      document.addEventListener('readystatechange', this.onReadyStateChange.bind(this));
       return;
     }
     ACubeMap.prototype.doConnectedCallback.call(this);

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -62,8 +62,8 @@ class AEntity extends ANode {
   */
   connectedCallback () {
     // Defer if DOM is not ready.
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', this.connectedCallback.bind(this));
+    if (document.readyState !== 'complete') {
+      document.addEventListener('readystatechange', this.onReadyStateChange.bind(this));
       return;
     }
 

--- a/src/core/a-mixin.js
+++ b/src/core/a-mixin.js
@@ -18,8 +18,8 @@ class AMixin extends ANode {
 
   connectedCallback () {
     // Defer if DOM is not ready.
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', this.connectedCallback.bind(this));
+    if (document.readyState !== 'complete') {
+      document.addEventListener('readystatechange', this.onReadyStateChange.bind(this));
       return;
     }
 

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -32,10 +32,16 @@ class ANode extends HTMLElement {
     this.mixinEls = [];
   }
 
+  onReadyStateChange () {
+    if (document.readyState === 'complete') {
+      this.doConnectedCallback();
+    }
+  }
+
   connectedCallback () {
     // Defer if DOM is not ready.
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', this.connectedCallback.bind(this));
+    if (document.readyState !== 'complete') {
+      document.addEventListener('readystatechange', this.onReadyStateChange.bind(this));
       return;
     }
     ANode.prototype.doConnectedCallback.call(this);

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -73,8 +73,8 @@ class AScene extends AEntity {
 
   connectedCallback () {
     // Defer if DOM is not ready.
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', this.connectedCallback.bind(this));
+    if (document.readyState !== 'complete') {
+      document.addEventListener('readystatechange', this.onReadyStateChange.bind(this));
       return;
     }
 


### PR DESCRIPTION
**Description:**

There is a small period between `document.readyState === 'interactive'` and `DOMContentLoaded`, notably this is when deferred scripts (including modules) run, so the existing checks leave a gap where attaching an entity would cause it to initialze early and fail. fixes #5228

**Changes proposed:**
- Track whether DOMContentLoaded has fired with a static property on ANode
- Use that static property instead of readyState in connected callbacks to check if DOM is ready
