### PR TITLE
Adds link in documentation to three.js manual re: creating BufferGeometries

### DIFF
--- a/docs/components/geometry.md
+++ b/docs/components/geometry.md
@@ -320,10 +320,10 @@ the `material` component.
 
 We can register our own geometries using `AFRAME.registerGeometry` and creating
 an object that is an instance of [`THREE.BufferGeometry`][three-geometry].
-(Recent versions of three.js rename this to `Geometry`, which used to refer
-to unbuffered geometries.)
-See the [three.js manual](https://github.com/DougReeder/aframe/pull/new/buffer-geometry)
-to learn about creating a custom `BufferGeometry`.
+Recent versions of three.js rename generators such as PlaneBufferGeometry to just
+[PlaneGeometry](https://threejs.org/docs/#api/en/geometries/PlaneGeometry),
+but support the old name as an alias. See the three.js manual to learn about creating a
+[custom `BufferGeometry`](https://threejs.org/manual/#en/custom-buffergeometry).
 A-Frame
 registers all built-in geometries using this API. Here is how A-Frame registers
 the `box` geometry:
@@ -386,4 +386,4 @@ We can then use that custom geometry in HTML:
 [cd]: https://en.wikipedia.org/wiki/Compact_disc
 [component-schema]: ../core/component.md#schema
 [prisms-wiki]: https://en.wikipedia.org/wiki/Prism_%28geometry%29
-[three-geometry]: https://threejs.org/docs/#api/core/Geometry
+[three-geometry]: https://threejs.org/docs/#api/en/core/BufferGeometry

--- a/docs/components/geometry.md
+++ b/docs/components/geometry.md
@@ -319,7 +319,12 @@ the `material` component.
 ## Register a Custom Geometry
 
 We can register our own geometries using `AFRAME.registerGeometry` and creating
-an object that is an instance of [`THREE.Geometry`][three-geometry]. A-Frame
+an object that is an instance of [`THREE.BufferGeometry`][three-geometry].
+(Recent versions of three.js rename this to `Geometry`, which used to refer
+to unbuffered geometries.)
+See the [three.js manual](https://github.com/DougReeder/aframe/pull/new/buffer-geometry)
+to learn about creating a custom `BufferGeometry`.
+A-Frame
 registers all built-in geometries using this API. Here is how A-Frame registers
 the `box` geometry:
 

--- a/docs/introduction/html-and-primitives.md
+++ b/docs/introduction/html-and-primitives.md
@@ -127,7 +127,11 @@ for [Don McCurdy's
 `aframe-physics-system`](https://github.com/n5ro/aframe-physics-system) and attach
 the physics components via HTML attributes:
 
-> :warning: **If you are using A-Frame 1.4.0 or later**: [`aframe-physics-system`](https://github.com/donmccurdy/aframe-physics-system) and you're having issues make sure you're using THREE.BufferGeometry, not  the now-deprecated THREE.Geometry. (Recent versions of three.js rename BufferGeometry to just Geometry, confusingly.) More info on [this GitHub issue](https://github.com/n5ro/aframe-physics-system/issues/187).
+> :warning: **If you are using A-Frame 1.4.0 or later**: [`aframe-physics-system`](https://github.com/donmccurdy/aframe-physics-system)
+> and you're having issues, make sure you're using THREE.BufferGeometry, not  the
+> [now-deprecated THREE.Geometry](https://discourse.threejs.org/t/three-geometry-will-be-removed-from-core-with-r125/22401).
+> Recent versions of three.js rename generators such as PlaneBufferGeometry to just [PlaneGeometry](https://threejs.org/docs/#api/en/geometries/PlaneGeometry),
+> but support the old name as an alias. More info on [this GitHub issue](https://github.com/n5ro/aframe-physics-system/issues/187).
 
 ```html
 <html>

--- a/docs/introduction/html-and-primitives.md
+++ b/docs/introduction/html-and-primitives.md
@@ -127,7 +127,7 @@ for [Don McCurdy's
 `aframe-physics-system`](https://github.com/n5ro/aframe-physics-system) and attach
 the physics components via HTML attributes:
 
-> :warning: **If you are using A-Frame 1.4.0 or later**: [`aframe-physics-system`](https://github.com/donmccurdy/aframe-physics-system) and you're having issues make sure you're no longer using the now deprecated THREE.Geometry. More info on [this GitHub issue](https://github.com/n5ro/aframe-physics-system/issues/187).
+> :warning: **If you are using A-Frame 1.4.0 or later**: [`aframe-physics-system`](https://github.com/donmccurdy/aframe-physics-system) and you're having issues make sure you're using THREE.BufferGeometry, not  the now-deprecated THREE.Geometry. (Recent versions of three.js rename BufferGeometry to just Geometry, confusingly.) More info on [this GitHub issue](https://github.com/n5ro/aframe-physics-system/issues/187).
 
 ```html
 <html>

--- a/docs/introduction/writing-a-component.md
+++ b/docs/introduction/writing-a-component.md
@@ -504,16 +504,17 @@ Later, when we use this component via HTML, the syntax will look like:
 ### Creating the Box Mesh
 
 [mesh]: https://threejs.org/docs/index.html#Reference/Objects/Mesh
-[threegeometry]: https://threejs.org/docs/index.html#Reference/Geometries/BoxBufferGeometry
+[threegeometry]: https://threejs.org/docs/index.html#Reference/Geometries/BoxGeometry
 [threematerial]: https://threejs.org/docs/index.html#Reference/Materials/MeshStandardMaterial
 [setobject3d]: ./developing-with-threejs.md#setting-an-object3d-on-an-entity
 
 Let's create our three.js box mesh from the `.init()`, and we'll later let the
 `.update()` handler handle all the property updates. To create a box in
-three.js, we'll create a [`THREE.BoxBufferGeometry`][threegeometry].
+three.js, we'll create a [`THREE.BoxGeometry`][threegeometry].
+Generators such as `BoxGeometry` now create a BufferGeometry.
 See the [three.js manual](https://threejs.org/manual/#en/custom-buffergeometry) to
-learn about creating a `BufferGeometry`.  The less-performant `Geometry` classes are not
-available in recent versions of three.js nor A-Frame.
+learn about creating a custom `BufferGeometry`.  (The less-performant `Geometry` class is not
+available in recent versions of three.js nor A-Frame.)
 
 We'll also need a
 [`THREE.MeshStandardMaterial`][threematerial], and finally a
@@ -537,7 +538,7 @@ AFRAME.registerComponent('box', {
     var el = this.el;
 
     // Create geometry.
-    this.geometry = new THREE.BoxBufferGeometry(data.width, data.height, data.depth);
+    this.geometry = new THREE.BoxGeometry(data.width, data.height, data.depth);
 
     // Create material.
     this.material = new THREE.MeshStandardMaterial({color: data.color});
@@ -569,7 +570,7 @@ AFRAME.registerComponent('box', {
   init: function () {
     var data = this.data;
     var el = this.el;
-    this.geometry = new THREE.BoxBufferGeometry(data.width, data.height, data.depth);
+    this.geometry = new THREE.BoxGeometry(data.width, data.height, data.depth);
     this.material = new THREE.MeshStandardMaterial({color: data.color});
     this.mesh = new THREE.Mesh(this.geometry, this.material);
     el.setObject3D('mesh', this.mesh);
@@ -590,7 +591,7 @@ AFRAME.registerComponent('box', {
     if (data.width !== oldData.width ||
         data.height !== oldData.height ||
         data.depth !== oldData.depth) {
-      el.getObject3D('mesh').geometry = new THREE.BoxBufferGeometry(data.width, data.height,
+      el.getObject3D('mesh').geometry = new THREE.BoxGeometry(data.width, data.height,
                                                                     data.depth);
     }
 

--- a/docs/introduction/writing-a-component.md
+++ b/docs/introduction/writing-a-component.md
@@ -510,7 +510,12 @@ Later, when we use this component via HTML, the syntax will look like:
 
 Let's create our three.js box mesh from the `.init()`, and we'll later let the
 `.update()` handler handle all the property updates. To create a box in
-three.js, we'll create a [`THREE.BoxBufferGeometry`][threegeometry],
+three.js, we'll create a [`THREE.BoxBufferGeometry`][threegeometry].
+See the [three.js manual](https://threejs.org/manual/#en/custom-buffergeometry) to
+learn about creating a `BufferGeometry`.  The less-performant `Geometry` classes are not
+available in recent versions of three.js nor A-Frame.
+
+We'll also need a
 [`THREE.MeshStandardMaterial`][threematerial], and finally a
 [`THREE.Mesh`][mesh]. Then we set the mesh on our entity to add the mesh to the
 three.js scene graph [using `.setObject3D(name, object)`][setobject3d]:


### PR DESCRIPTION
**Description:**

Custom three.js BufferGeometries are difficult to grok and the A-Frame documentation doesn't link to the very helpful manual article.

**Changes proposed:**

This adds links to the three.js manual page "Custom BufferGeometry" to the A-Frame docs.
