### PR TITLE
vertexColors is now a boolean (since THREE.js r114 / A-Frame 1.1.0)

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -70,7 +70,6 @@ depending on the material type applied.
 | shader       | Which material to use. Defaults to the [standard material][standard]. Can be set to the [flat material][flat] or to a registered custom shader material. | standard      |
 | side         | Which sides of the mesh to render. Can be one of `front`, `back`, or `double`.                                                                    | front         |
 | transparent  | Whether material is transparent. Transparent entities are rendered after non-transparent entities.                                                | false         |
-| vertexColors | (deprecated) Whether to use vertex colors to shade the material. Can be one of `none` or `vertex`.  This property is deprecated as of A-Frame 1.4.1 and will be removed in a future release.  Use vertexColorsEnabled instead.                                             | none          |
 | vertexColorsEnabled | Whether to use vertex colors to shade the material.                                             | false        |
 | visible      | Whether material is visible. Raycasters will ignore invisible materials.                                                                          | true          |
 | blending     | The blending mode for the material's RGB and Alpha sent to the WebGLRenderer. Can be one of `none`, `normal`, `additive`, `subtractive` or `multiply`.  | normal          |

--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -70,7 +70,7 @@ depending on the material type applied.
 | shader       | Which material to use. Defaults to the [standard material][standard]. Can be set to the [flat material][flat] or to a registered custom shader material. | standard      |
 | side         | Which sides of the mesh to render. Can be one of `front`, `back`, or `double`.                                                                    | front         |
 | transparent  | Whether material is transparent. Transparent entities are rendered after non-transparent entities.                                                | false         |
-| vertexColors | Whether to use vertex or face colors to shade the material. Can be one of `none`, `vertex`, or `face`.                                            | none          |
+| vertexColors | Whether to use vertex colors to shade the material. Can be one of `none` or `vertex`.                                            | none          |
 | visible      | Whether material is visible. Raycasters will ignore invisible materials.                                                                          | true          |
 | blending     | The blending mode for the material's RGB and Alpha sent to the WebGLRenderer. Can be one of `none`, `normal`, `additive`, `subtractive` or `multiply`.  | normal          |
 | dithering    | Whether material is dithered with noise. Removes banding from gradients like ones produced by lighting.                                           | true          |

--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -70,7 +70,8 @@ depending on the material type applied.
 | shader       | Which material to use. Defaults to the [standard material][standard]. Can be set to the [flat material][flat] or to a registered custom shader material. | standard      |
 | side         | Which sides of the mesh to render. Can be one of `front`, `back`, or `double`.                                                                    | front         |
 | transparent  | Whether material is transparent. Transparent entities are rendered after non-transparent entities.                                                | false         |
-| vertexColors | Whether to use vertex colors to shade the material. Can be one of `none` or `vertex`.                                            | none          |
+| vertexColors | (deprecated) Whether to use vertex colors to shade the material. Can be one of `none` or `vertex`.  This property is deprecated as of A-Frame 1.4.1 and will be removed in a future release.  Use vertexColorsEnabled instead.                                             | none          |
+| vertexColorsEnabled | Whether to use vertex colors to shade the material.                                             | false        |
 | visible      | Whether material is visible. Raycasters will ignore invisible materials.                                                                          | true          |
 | blending     | The blending mode for the material's RGB and Alpha sent to the WebGLRenderer. Can be one of `none`, `normal`, `additive`, `subtractive` or `multiply`.  | normal          |
 | dithering    | Whether material is dithered with noise. Removes banding from gradients like ones produced by lighting.                                           | true          |

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -30,6 +30,7 @@ module.exports.Component = registerComponent('material', {
     side: {default: 'front', oneOf: ['front', 'back', 'double']},
     transparent: {default: false},
     vertexColors: {type: 'string', default: 'none', oneOf: ['vertex', 'none']},
+    vertexColorsEnabled: {default: false},
     visible: {default: true},
     blending: {default: 'normal', oneOf: ['none', 'normal', 'additive', 'subtractive', 'multiply']},
     dithering: {default: true}
@@ -135,7 +136,7 @@ module.exports.Component = registerComponent('material', {
     material.flatShading = data.flatShading;
     material.side = parseSide(data.side);
     material.transparent = data.transparent !== false || data.opacity < 1.0;
-    material.vertexColors = parseVertexColors(data.vertexColors);
+    material.vertexColors = data.vertexColorsEnabled || parseVertexColors(data.vertexColors);
     material.visible = data.visible;
     material.blending = parseBlending(data.blending);
     material.dithering = data.dithering;
@@ -145,7 +146,8 @@ module.exports.Component = registerComponent('material', {
     if (oldDataHasKeys &&
         (oldData.alphaTest !== data.alphaTest ||
          oldData.side !== data.side ||
-         oldData.vertexColors !== data.vertexColors)) {
+         oldData.vertexColors !== data.vertexColors ||
+         oldData.vertexColorsEnabled !== data.vertexColorsEnabled)) {
       material.needsUpdate = true;
     }
   },
@@ -222,10 +224,14 @@ function parseSide (side) {
 function parseVertexColors (coloring) {
   switch (coloring) {
     case 'face': {
+      console.warn('The vertexColors property is deprecated as of A-Frame 1.4.1 and will be removed in a future release.');
+      console.warn('Use vertexColorEnabled instead.');
       console.warn('Face coloring is deprecated, as it is not supported on THREE.BufferGeometry');
       return false;
     }
     case 'vertex': {
+      console.warn('The vertexColors property is deprecated as of A-Frame 1.4.1 and will be removed in a future release.');
+      console.warn('Use vertexColorEnabled instead.');
       return true;
     }
     default: {

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -29,7 +29,6 @@ module.exports.Component = registerComponent('material', {
     shader: {default: 'standard', oneOf: shaderNames, schemaChange: true},
     side: {default: 'front', oneOf: ['front', 'back', 'double']},
     transparent: {default: false},
-    vertexColors: {type: 'string', default: 'none', oneOf: ['vertex', 'none']},
     vertexColorsEnabled: {default: false},
     visible: {default: true},
     blending: {default: 'normal', oneOf: ['none', 'normal', 'additive', 'subtractive', 'multiply']},
@@ -136,7 +135,7 @@ module.exports.Component = registerComponent('material', {
     material.flatShading = data.flatShading;
     material.side = parseSide(data.side);
     material.transparent = data.transparent !== false || data.opacity < 1.0;
-    material.vertexColors = data.vertexColorsEnabled || parseVertexColors(data.vertexColors);
+    material.vertexColors = data.vertexColorsEnabled;
     material.visible = data.visible;
     material.blending = parseBlending(data.blending);
     material.dithering = data.dithering;
@@ -146,7 +145,6 @@ module.exports.Component = registerComponent('material', {
     if (oldDataHasKeys &&
         (oldData.alphaTest !== data.alphaTest ||
          oldData.side !== data.side ||
-         oldData.vertexColors !== data.vertexColors ||
          oldData.vertexColorsEnabled !== data.vertexColorsEnabled)) {
       material.needsUpdate = true;
     }
@@ -214,28 +212,6 @@ function parseSide (side) {
     default: {
       // Including case `front`.
       return THREE.FrontSide;
-    }
-  }
-}
-
-/**
- * Return an appropriate three.js for vertex coloring.
- */
-function parseVertexColors (coloring) {
-  switch (coloring) {
-    case 'face': {
-      console.warn('The vertexColors property is deprecated as of A-Frame 1.4.1 and will be removed in a future release.');
-      console.warn('Use vertexColorEnabled instead.');
-      console.warn('Face coloring is deprecated, as it is not supported on THREE.BufferGeometry');
-      return false;
-    }
-    case 'vertex': {
-      console.warn('The vertexColors property is deprecated as of A-Frame 1.4.1 and will be removed in a future release.');
-      console.warn('Use vertexColorEnabled instead.');
-      return true;
-    }
-    default: {
-      return false;
     }
   }
 }

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -29,7 +29,7 @@ module.exports.Component = registerComponent('material', {
     shader: {default: 'standard', oneOf: shaderNames, schemaChange: true},
     side: {default: 'front', oneOf: ['front', 'back', 'double']},
     transparent: {default: false},
-    vertexColors: {type: 'string', default: 'none', oneOf: ['face', 'vertex']},
+    vertexColors: {type: 'string', default: 'none', oneOf: ['vertex', 'none']},
     visible: {default: true},
     blending: {default: 'normal', oneOf: ['none', 'normal', 'additive', 'subtractive', 'multiply']},
     dithering: {default: true}
@@ -217,18 +217,19 @@ function parseSide (side) {
 }
 
 /**
- * Return a three.js constant determining vertex coloring.
+ * Return an appropriate three.js for vertex coloring.
  */
 function parseVertexColors (coloring) {
   switch (coloring) {
     case 'face': {
-      return THREE.FaceColors;
+      console.warn('Face coloring is deprecated, as it is not supported on THREE.BufferGeometry');
+      return false;
     }
     case 'vertex': {
-      return THREE.VertexColors;
+      return true;
     }
     default: {
-      return THREE.NoColors;
+      return false;
     }
   }
 }

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -300,22 +300,30 @@ suite('material', function () {
 
   suite('vertexColor', function () {
     test('defaults to no color', function () {
-      assert.equal(el.getAttribute('material').vertexColors, 'none');
+      assert.equal(el.getAttribute('material').vertexColorsEnabled, false);
       assert.equal(el.components.material.material.vertexColors, false);
     });
 
     test('can set to vertex color', function () {
       var oldMaterialVersion = el.getObject3D('mesh').material.version;
+      // Note, this property is deprecated and generates a warning when used.
       el.setAttribute('material', 'vertexColors', 'vertex');
       assert.equal(el.components.material.material.vertexColors, true);
       assert.equal(el.components.material.material.version, oldMaterialVersion + 2);
     });
 
     test('can set to face color', function () {
-      // Note, this value is deprecated and generates a warning when used.
       var oldMaterialVersion = el.getObject3D('mesh').material.version;
+      // Note, this property is deprecated and generates a warning when used.
       el.setAttribute('material', 'vertexColors', 'face');
       assert.equal(el.components.material.material.vertexColors, false);
+      assert.equal(el.components.material.material.version, oldMaterialVersion + 2);
+    });
+
+    test('can set vertex colors using new vertexColorsEnabled property', function () {
+      var oldMaterialVersion = el.getObject3D('mesh').material.version;
+      el.setAttribute('material', 'vertexColorsEnabled', true);
+      assert.equal(el.components.material.material.vertexColors, true);
       assert.equal(el.components.material.material.version, oldMaterialVersion + 2);
     });
   });

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -306,7 +306,7 @@ suite('material', function () {
 
     test('can set to vertex color', function () {
       var oldMaterialVersion = el.getObject3D('mesh').material.version;
-      // Note, this property is deprecated and generates a warning when used.
+      // This property is deprecated and generates a warning when used.
       el.setAttribute('material', 'vertexColors', 'vertex');
       assert.equal(el.components.material.material.vertexColors, true);
       assert.equal(el.components.material.material.version, oldMaterialVersion + 2);
@@ -314,7 +314,7 @@ suite('material', function () {
 
     test('can set to face color', function () {
       var oldMaterialVersion = el.getObject3D('mesh').material.version;
-      // Note, this property is deprecated and generates a warning when used.
+      // This property is deprecated and generates a warning when used.
       el.setAttribute('material', 'vertexColors', 'face');
       assert.equal(el.components.material.material.vertexColors, false);
       assert.equal(el.components.material.material.version, oldMaterialVersion + 2);

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -301,20 +301,21 @@ suite('material', function () {
   suite('vertexColor', function () {
     test('defaults to no color', function () {
       assert.equal(el.getAttribute('material').vertexColors, 'none');
-      assert.equal(el.components.material.material.vertexColors, THREE.NoColors);
+      assert.equal(el.components.material.material.vertexColors, false);
     });
 
     test('can set to vertex color', function () {
       var oldMaterialVersion = el.getObject3D('mesh').material.version;
       el.setAttribute('material', 'vertexColors', 'vertex');
-      assert.equal(el.components.material.material.vertexColors, THREE.VertexColors);
+      assert.equal(el.components.material.material.vertexColors, true);
       assert.equal(el.components.material.material.version, oldMaterialVersion + 2);
     });
 
     test('can set to face color', function () {
+      // Note, this value is deprecated and generates a warning when used.
       var oldMaterialVersion = el.getObject3D('mesh').material.version;
       el.setAttribute('material', 'vertexColors', 'face');
-      assert.equal(el.components.material.material.vertexColors, THREE.FaceColors);
+      assert.equal(el.components.material.material.vertexColors, false);
       assert.equal(el.components.material.material.version, oldMaterialVersion + 2);
     });
   });

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -298,29 +298,13 @@ suite('material', function () {
     });
   });
 
-  suite('vertexColor', function () {
+  suite('vertexColors', function () {
     test('defaults to no color', function () {
       assert.equal(el.getAttribute('material').vertexColorsEnabled, false);
       assert.equal(el.components.material.material.vertexColors, false);
     });
 
-    test('can set to vertex color', function () {
-      var oldMaterialVersion = el.getObject3D('mesh').material.version;
-      // This property is deprecated and generates a warning when used.
-      el.setAttribute('material', 'vertexColors', 'vertex');
-      assert.equal(el.components.material.material.vertexColors, true);
-      assert.equal(el.components.material.material.version, oldMaterialVersion + 2);
-    });
-
-    test('can set to face color', function () {
-      var oldMaterialVersion = el.getObject3D('mesh').material.version;
-      // This property is deprecated and generates a warning when used.
-      el.setAttribute('material', 'vertexColors', 'face');
-      assert.equal(el.components.material.material.vertexColors, false);
-      assert.equal(el.components.material.material.version, oldMaterialVersion + 2);
-    });
-
-    test('can set vertex colors using new vertexColorsEnabled property', function () {
+    test('can set vertex colors using vertexColorsEnabled property', function () {
       var oldMaterialVersion = el.getObject3D('mesh').material.version;
       el.setAttribute('material', 'vertexColorsEnabled', true);
       assert.equal(el.components.material.material.vertexColors, true);

--- a/tests/components/sound.test.js
+++ b/tests/components/sound.test.js
@@ -7,8 +7,6 @@ suite('sound', function () {
     var el = this.el = entityFactory();
     THREE.Cache.files = {};
     setTimeout(() => {
-      el.sceneEl.addEventListener('loaded', function () { done(); });
-
       el.setAttribute('sound', {
         autoplay: true,
         src: 'url(mysoundfile.mp3)',
@@ -19,6 +17,9 @@ suite('sound', function () {
         rolloffFactor: 4,
         poolSize: 3
       });
+
+      if (el.sceneEl.hasLoaded) { done(); }
+      el.sceneEl.addEventListener('loaded', function () { done(); });
     });
   });
 


### PR DESCRIPTION
**Description:**

Since THREE.js r114, vertexColors is a boolean, and THREE.VertexColors is undefined.
https://github.com/mrdoob/three.js/pull/18584

This means the vertexColors property of the material component has been broken since 1.1.0.


**Changes proposed:**

- Remove vertexColors "face" option from the material component interface.  Face vertexColoring is not supported on BufferGeometries, hence not usable any more.
- Rest of the material component interface remains unchanged (it would be more natural to move vertexColors to a Boolean, but we don't want to break back-compatibility unecessarily).
- Change internal code in material component to map to boolean value.
- Update UTs & docs
- Add warning to assist users upgrading from older versions of A-Frame.

