### PR TITLE
Update broken link

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -292,7 +292,7 @@ A-Frame, below are links to some background reading:
 
 [mattdesl]: http://slides.com/mattdeslauriers/hacking-with-three-js#/7
 [parris]: https://www.eventbrite.com/engineering/its-2015-and-drawing-text-is-still-hard-webgl-threejs/
-[valve]: http://www.valvesoftware.com/publications/2007/SIGGRAPH2007_AlphaTestedMagnification.pdf
+[valve]: https://steamcdn-a.akamaihd.net/apps/valve/2007/SIGGRAPH2007_AlphaTestedMagnification.pdf
 
 - [`three-bmfont-text` documentation][three-bmfont-text]
 - [*Hacking with three.js*][mattdesl]


### PR DESCRIPTION
Fixes #5277

**Description:**
While looking for a copy of this document on the Wayback Machine, I came across a redirect to a copy hosted on valve's CDN. It seemed to load faster than the copy on archive.org. 

Alternative resource link found here: https://web.archive.org/web/20180526090324/https://www.valvesoftware.com/en/publications/2007/SIGGRAPH2007_AlphaTestedMagnification.pdf
