### PR TITLE
Set renderer.useLegacyLights instead of renderer.physicallyCorrectLights

### DIFF
--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -32,7 +32,7 @@ module.exports.System = registerSystem('renderer', {
     // This is the rendering engine, such as THREE.js so copy over any persistent properties from the rendering system.
     var renderer = sceneEl.renderer;
     renderer.sortObjects = data.sortObjects;
-    renderer.physicallyCorrectLights = data.physicallyCorrectLights;
+    renderer.useLegacyLights = !data.physicallyCorrectLights;
     renderer.toneMapping = THREE[toneMappingName + 'ToneMapping'];
 
     THREE.ColorManagement.enabled = data.colorManagement;

--- a/tests/systems/renderer.test.js
+++ b/tests/systems/renderer.test.js
@@ -22,7 +22,7 @@ suite('renderer', function () {
       var renderingEngine = sceneEl.renderer;
       assert.strictEqual(renderingEngine.outputColorSpace, THREE.SRGBColorSpace);
       assert.notOk(renderingEngine.sortObjects);
-      assert.strictEqual(renderingEngine.physicallyCorrectLights, false);
+      assert.strictEqual(renderingEngine.useLegacyLights, true);
       done();
     });
     document.body.appendChild(sceneEl);
@@ -53,7 +53,7 @@ suite('renderer', function () {
     var sceneEl = createScene();
     sceneEl.setAttribute('renderer', 'physicallyCorrectLights: true;');
     sceneEl.addEventListener('loaded', function () {
-      assert.ok(sceneEl.renderer.physicallyCorrectLights);
+      assert.notOk(sceneEl.renderer.useLegacyLights);
       done();
     });
     document.body.appendChild(sceneEl);


### PR DESCRIPTION
**Description:**
Fixes https://github.com/aframevr/aframe/issues/5293

**Changes proposed:**
- Set `renderer.useLegacyLights` instead of the deprecated `renderer.physicallyCorrectLights`