### PR TITLE
Use `fillPoses` and `fillJointRadii` instead of `getJointPose`

### DIFF
--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -1,4 +1,4 @@
-/* global THREE, XRRigidTransform */
+/* global THREE */
 var registerComponent = require('../core/component').registerComponent;
 var bind = require('../utils/bind');
 
@@ -35,6 +35,9 @@ var JOINTS = [
   'pinky-finger-phalanx-distal',
   'pinky-finger-tip'
 ];
+
+var THUMB_TIP_INDEX = 4;
+var INDEX_TIP_INDEX = 9;
 
 var PINCH_START_DISTANCE = 0.015;
 var PINCH_END_DISTANCE = 0.03;
@@ -82,6 +85,10 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
     this.pinchEventDetail = {position: new THREE.Vector3()};
     this.indexTipPosition = new THREE.Vector3();
 
+    this.hasPoses = false;
+    this.jointPoses = new Float32Array(16 * JOINTS.length);
+    this.jointRadii = new Float32Array(JOINTS.length);
+
     this.bindMethods();
 
     this.updateReferenceSpace = this.updateReferenceSpace.bind(this);
@@ -121,11 +128,17 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
     var controller = this.el.components['tracked-controls'] && this.el.components['tracked-controls'].controller;
     var frame = sceneEl.frame;
     var trackedControlsWebXR = this.el.components['tracked-controls-webxr'];
-    if (!controller || !frame || !trackedControlsWebXR) { return; }
+    var referenceSpace = this.referenceSpace;
+    if (!controller || !frame || !referenceSpace || !trackedControlsWebXR) { return; }
+    this.hasPoses = false;
     if (controller.hand) {
       this.el.object3D.position.set(0, 0, 0);
       this.el.object3D.rotation.set(0, 0, 0);
-      if (frame.getJointPose) { this.updateHandModel(); }
+
+      this.hasPoses = frame.fillPoses(controller.hand.values(), referenceSpace, this.jointPoses) &&
+        frame.fillJointRadii(controller.hand.values(), this.jointRadii);
+
+      this.updateHandModel();
       this.detectGesture();
     }
   },
@@ -148,47 +161,44 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
     return null;
   },
 
-  updateHandMeshModel: function () {
-    var frame = this.el.sceneEl.frame;
-    var controller = this.el.components['tracked-controls'] && this.el.components['tracked-controls'].controller;
-    var referenceSpace = this.referenceSpace;
+  updateHandMeshModel: (function () {
+    var jointPose = new THREE.Matrix4();
+    return function () {
+      var jointPoses = this.jointPoses;
+      var controller = this.el.components['tracked-controls'] && this.el.components['tracked-controls'].controller;
+      var i = 0;
 
-    if (!controller || !this.mesh || !referenceSpace) { return; }
-    this.mesh.visible = false;
-    for (var inputjoint of controller.hand.values()) {
-      var bone;
-      var jointPose;
-      var jointTransform;
-      jointPose = frame.getJointPose(inputjoint, referenceSpace);
-      bone = this.getBone(inputjoint.jointName);
-      if (bone != null && jointPose) {
-        jointTransform = jointPose.transform;
-        this.mesh.visible = true;
-        bone.position.copy(jointTransform.position);
-        bone.quaternion.copy(jointTransform.orientation);
+      if (!controller || !this.mesh) { return; }
+      this.mesh.visible = false;
+      if (!this.hasPoses) { return; }
+      for (var inputjoint of controller.hand.values()) {
+        var bone = this.getBone(inputjoint.jointName);
+        if (bone != null) {
+          this.mesh.visible = true;
+          jointPose.fromArray(jointPoses, i * 16);
+          bone.position.setFromMatrixPosition(jointPose);
+          bone.quaternion.setFromRotationMatrix(jointPose);
+        }
+        i++;
       }
-    }
-  },
+    };
+  })(),
 
   updateHandDotsModel: function () {
-    var frame = this.el.sceneEl.frame;
+    var jointPoses = this.jointPoses;
+    var jointRadii = this.jointRadii;
     var controller = this.el.components['tracked-controls'] && this.el.components['tracked-controls'].controller;
-    var trackedControlsWebXR = this.el.components['tracked-controls-webxr'];
-    var referenceSpace = trackedControlsWebXR.system.referenceSpace;
     var jointEl;
     var object3D;
-    var jointPose;
-    var i = 0;
 
-    for (var inputjoint of controller.hand.values()) {
-      jointEl = this.jointEls[i++];
+    for (var i = 0; i < controller.hand.size; i++) {
+      jointEl = this.jointEls[i];
       object3D = jointEl.object3D;
-      jointPose = frame.getJointPose(inputjoint, referenceSpace);
-      jointEl.object3D.visible = !!jointPose;
-      if (!jointPose) { continue; }
-      object3D.matrix.elements = jointPose.transform.matrix;
+      jointEl.object3D.visible = this.hasPoses;
+      if (!this.hasPoses) { continue; }
+      object3D.matrix.fromArray(jointPoses, i * 16);
       object3D.matrix.decompose(object3D.position, object3D.rotation, object3D.scale);
-      jointEl.setAttribute('scale', {x: jointPose.radius, y: jointPose.radius, z: jointPose.radius});
+      jointEl.setAttribute('scale', {x: jointRadii[i], y: jointRadii[i], z: jointRadii[i]});
     }
   },
 
@@ -198,23 +208,13 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
 
   detectPinch: (function () {
     var thumbTipPosition = new THREE.Vector3();
+    var jointPose = new THREE.Matrix4();
     return function () {
-      var frame = this.el.sceneEl.frame;
       var indexTipPosition = this.indexTipPosition;
-      var controller = this.el.components['tracked-controls'] && this.el.components['tracked-controls'].controller;
-      var trackedControlsWebXR = this.el.components['tracked-controls-webxr'];
-      var referenceSpace = this.referenceSpace || trackedControlsWebXR.system.referenceSpace;
-      var indexTip = controller.hand.get('index-finger-tip');
-      var thumbTip = controller.hand.get('thumb-tip');
-      if (!indexTip ||
-          !thumbTip) { return; }
-      var indexTipPose = frame.getJointPose(indexTip, referenceSpace);
-      var thumbTipPose = frame.getJointPose(thumbTip, referenceSpace);
+      if (!this.hasPoses) { return; }
 
-      if (!indexTipPose || !thumbTipPose) { return; }
-
-      thumbTipPosition.copy(thumbTipPose.transform.position);
-      indexTipPosition.copy(indexTipPose.transform.position);
+      thumbTipPosition.setFromMatrixPosition(jointPose.fromArray(this.jointPoses, THUMB_TIP_INDEX * 16));
+      indexTipPosition.setFromMatrixPosition(jointPose.fromArray(this.jointPoses, INDEX_TIP_INDEX * 16));
 
       var distance = indexTipPosition.distanceTo(thumbTipPosition);
 
@@ -234,7 +234,6 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
         this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, PINCH_POSITION_INTERPOLATION);
         this.el.emit('pinchmoved', this.pinchEventDetail);
       }
-
     };
   })(),
 

--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -96,7 +96,7 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
     if (!xrSession) { return; }
     var referenceSpaceType = self.el.sceneEl.systems.webxr.sessionReferenceSpaceType;
     xrSession.requestReferenceSpace(referenceSpaceType).then(function (referenceSpace) {
-      self.referenceSpace = referenceSpace.getOffsetReferenceSpace(new XRRigidTransform({x: 0, y: 1.5, z: 0}));
+      self.referenceSpace = referenceSpace;
     }).catch(function (error) {
       self.el.sceneEl.systems.webxr.warnIfFeatureNotRequested(referenceSpaceType, 'tracked-controls-webxr uses reference space ' + referenceSpaceType);
       throw error;
@@ -221,24 +221,20 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
       if (distance < PINCH_START_DISTANCE && this.isPinched === false) {
         this.isPinched = true;
         this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, PINCH_POSITION_INTERPOLATION);
-        this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchstarted', this.pinchEventDetail);
       }
 
       if (distance > PINCH_END_DISTANCE && this.isPinched === true) {
         this.isPinched = false;
         this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, PINCH_POSITION_INTERPOLATION);
-        this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchended', this.pinchEventDetail);
       }
 
       if (this.isPinched) {
         this.pinchEventDetail.position.copy(indexTipPosition).lerp(thumbTipPosition, PINCH_POSITION_INTERPOLATION);
-        this.pinchEventDetail.position.y += 1.5;
         this.el.emit('pinchmoved', this.pinchEventDetail);
       }
 
-      indexTipPosition.y += 1.5;
     };
   })(),
 
@@ -314,7 +310,7 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
     if (!this.skinnedMesh) { return; }
     this.bones = skinnedMesh.skeleton.bones;
     this.el.removeObject3D('mesh');
-    mesh.position.set(0, 1.5, 0);
+    mesh.position.set(0, 0, 0);
     mesh.rotation.set(0, 0, 0);
     skinnedMesh.frustumCulled = false;
     skinnedMesh.material = new THREE.MeshStandardMaterial({skinning: true, color: this.data.modelColor});


### PR DESCRIPTION
**Description:**
Changes the logic in `hand-tracking-controls` to use `fillPoses` and `fillJointRadii` instead of calling `getJointPose` many times over. The downside of `getJointPose` is that it allocates temporary objects, which quickly becomes inefficient.

As described in the [WebXR hand input explainer](https://github.com/immersive-web/webxr-hand-input/blob/main/explainer.md#efficiently-obtaining-hand-poses)
> Each use of `getPose()` allocates one short-lived `XRPose` object, one `XRRigidTransform` object, and at least one `DOMPointReadOnly` or `Float32Array`. For 25 joints per hand and two hands, this is 150-250 objects created per frame. This can have noticeable performance implications, especially around garbage collection.

Also removed the offset on the reference space. It didn't seem to serve any purpose and only required the rest of the code to apply a counter offset to get the actual position of the hand joints.

**Changes proposed:**
- No longer apply an offset to the reference space
- Per tick call `fillPoses` and `fillJointRadii` once
- Let `updateHandMeshModel`, `updateHandDotsModel` and `detectPinch` use these poses and radii.
