### PR TITLE
Properly reverse and cross-fade animations in hand-controls component

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -57,8 +57,6 @@ module.exports.Component = registerComponent('hand-controls', {
   init: function () {
     var self = this;
     var el = this.el;
-    // Current pose.
-    this.gesture = ANIMATIONS.open;
     // Active buttons populated by events provided by the attached controls.
     this.pressedButtons = {};
     this.touchedButtons = {};
@@ -360,34 +358,37 @@ module.exports.Component = registerComponent('hand-controls', {
 
     if (!mesh) { return; }
 
-    // Stop all current animations.
-    mesh.mixer.stopAllAction();
-
     // Grab clip action.
     clip = this.getClip(gesture);
     toAction = mesh.mixer.clipAction(clip);
+
+    // Reverse from gesture to no gesture.
+    if (reverse) {
+      toAction.paused = false;
+      toAction.timeScale = -1;
+      return;
+    }
+
     toAction.clampWhenFinished = true;
-    toAction.loop = THREE.LoopRepeat;
+    toAction.loop = THREE.LoopOnce;
     toAction.repetitions = 0;
-    toAction.timeScale = reverse ? -1 : 1;
-    toAction.time = reverse ? clip.duration : 0;
+    toAction.timeScale = 1;
+    toAction.time = 0;
     toAction.weight = 1;
 
-    // No gesture to gesture or gesture to no gesture.
-    if (!lastGesture || gesture === lastGesture) {
-      // Stop all current animations.
-      mesh.mixer.stopAllAction();
+    // No gesture to gesture.
+    if (!lastGesture) {
       // Play animation.
+      mesh.mixer.stopAllAction();
       toAction.play();
       return;
     }
 
     // Animate or crossfade from gesture to gesture.
     clip = this.getClip(lastGesture);
-    fromAction = mesh.mixer.clipAction(clip);
-    fromAction.weight = 0.15;
-    fromAction.play();
+    toAction.reset();
     toAction.play();
+    fromAction = mesh.mixer.clipAction(clip);
     fromAction.crossFadeTo(toAction, 0.15, true);
   }
 });


### PR DESCRIPTION
**Description:**
The `hand-controls` component plays animations to transition the hand model into certain gestures. Going from one gesture to another attempts a cross-fade but this doesn't work and results in the full animation playing from the start. Similarly the reversing of an animation to go to the "no gesture" state fails to account for the situation where the animation hasn't completed yet and always results in a flicker frame where the hand is already in the "no gesture" state before animating.

This PR addresses these to let the code behave in the way it seems it was originally intended. Obviously the cross-fading is not ideal (e.g. going from Point -> Point + Thumb moves all fingers slightly instead of just animating the thumb), but it at least doesn't snap to the "no gesture" state playing the full animation and results in a somewhat toned down animation.

**Changes proposed:**
- Set the initial gesture to `undefined` instead of `ANIMATIONS.open` as the open animation is never used
- In case of reversing a gesture simply reverse the timescale and unpause the corresponding action. This ensures that the animation is reversed from the right time in case the animation hadn't completed yet and avoids one frame of flickering.
- Don't stop all actions when going from gesture to gesture to allow the cross-fade to work (otherwise the `fromAction` would've been reset by the `stopAllActions` call)