### PR TITLE
[Issue 5275] Updated old 0.5.0 local server doc reference to 1.4.0 

### DIFF
--- a/dist/aframe-master.js
+++ b/dist/aframe-master.js
@@ -30332,7 +30332,7 @@ if (window.document.currentScript && window.document.currentScript.parentNode !=
 
 // Error if not using a server.
 if (!window.cordova && window.location.protocol === 'file:') {
-  error('This HTML file is currently being served via the file:// protocol. ' + 'Assets, textures, and models WILL NOT WORK due to cross-origin policy! ' + 'Please use a local or hosted server: ' + 'https://aframe.io/docs/0.5.0/introduction/getting-started.html#using-a-local-server.');
+  error('This HTML file is currently being served via the file:// protocol. ' + 'Assets, textures, and models WILL NOT WORK due to cross-origin policy! ' + 'Please use a local or hosted server: ' + 'https://aframe.io/docs/1.4.0/introduction/installation.html#use-a-local-server.');
 }
 __webpack_require__(/*! present */ "./node_modules/present/lib/present-browser.js"); // Polyfill `performance.now()`.
 

--- a/dist/aframe-v1.4.2.js
+++ b/dist/aframe-v1.4.2.js
@@ -30182,7 +30182,7 @@ if (window.document.currentScript && window.document.currentScript.parentNode !=
 
 // Error if not using a server.
 if (!window.cordova && window.location.protocol === 'file:') {
-  error('This HTML file is currently being served via the file:// protocol. ' + 'Assets, textures, and models WILL NOT WORK due to cross-origin policy! ' + 'Please use a local or hosted server: ' + 'https://aframe.io/docs/0.5.0/introduction/getting-started.html#using-a-local-server.');
+  error('This HTML file is currently being served via the file:// protocol. ' + 'Assets, textures, and models WILL NOT WORK due to cross-origin policy! ' + 'Please use a local or hosted server: ' + 'https://aframe.io/docs/1.4.0/introduction/installation.html#use-a-local-server.');
 }
 __webpack_require__(/*! present */ "./node_modules/present/lib/present-browser.js"); // Polyfill `performance.now()`.
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ if (!window.cordova && window.location.protocol === 'file:') {
     'This HTML file is currently being served via the file:// protocol. ' +
     'Assets, textures, and models WILL NOT WORK due to cross-origin policy! ' +
     'Please use a local or hosted server: ' +
-    'https://aframe.io/docs/0.5.0/introduction/getting-started.html#using-a-local-server.');
+    'https://aframe.io/docs/1.4.0/introduction/installation.html#use-a-local-server.');
 }
 
 require('present'); // Polyfill `performance.now()`.


### PR DESCRIPTION
I updated all of the old 0.5.0 local server references to the newer 1.4.0 documentation link. The information referenced wasn't available at the old url.

This fixes an issue reported [here ](https://github.com/aframevr/aframe/issues/5275)where help was requested. 
https://github.com/aframevr/aframe/issues/5275