### PR TITLE
Don't call img.onload() manually during test as images might've already loaded

### DIFF
--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -71,9 +71,6 @@ suite('a-assets', function () {
 
     // Load image.
     document.body.appendChild(scene);
-    process.nextTick(function () {
-      img.onload();
-    });
   });
 
   test('caches image in three.js', function (done) {


### PR DESCRIPTION
**Description:**
One of the `a-assets` tests waits for an image to be loaded, but then proceeds to manually invoke `img.onload()`. With the change made in https://github.com/aframevr/aframe/pull/5253 it's possible that this `onload` isn't defined, causing the test to fail. This seems to happen consistently with Firefox 115, but not on Chrome or older Firefox versions.

There is actually no need for the test to call `onload`. It might've been done in an attempt to speed the loading up(?), but that partially invalidates the test, not to mention that other tests do wait on the underlying assets to load naturally.

Fixes #5095 

**Changes proposed:**
- Don't manually invoke `img.onload()`, but instead rely on the actual loading mechanism (either short-circuiting if already completed or `onload`) 