### PR TITLE
Use global variable for CDN root directory

### DIFF
--- a/src/components/daydream-controls.js
+++ b/src/components/daydream-controls.js
@@ -6,7 +6,8 @@ var checkControllerPresentAndSetup = trackedControlsUtils.checkControllerPresent
 var emitIfAxesChanged = trackedControlsUtils.emitIfAxesChanged;
 var onButtonEvent = trackedControlsUtils.onButtonEvent;
 
-var DAYDREAM_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/google/';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var DAYDREAM_CONTROLLER_MODEL_BASE_URL = AFRAME_CDN_ROOT + 'controllers/google/';
 var DAYDREAM_CONTROLLER_MODEL_OBJ_URL = DAYDREAM_CONTROLLER_MODEL_BASE_URL + 'vr_controller_daydream.obj';
 var DAYDREAM_CONTROLLER_MODEL_OBJ_MTL = DAYDREAM_CONTROLLER_MODEL_BASE_URL + 'vr_controller_daydream.mtl';
 

--- a/src/components/gearvr-controls.js
+++ b/src/components/gearvr-controls.js
@@ -7,7 +7,8 @@ var emitIfAxesChanged = trackedControlsUtils.emitIfAxesChanged;
 var onButtonEvent = trackedControlsUtils.onButtonEvent;
 var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;
 
-var GEARVR_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/samsung/';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var GEARVR_CONTROLLER_MODEL_BASE_URL = AFRAME_CDN_ROOT + 'controllers/samsung/';
 var GEARVR_CONTROLLER_MODEL_OBJ_URL = GEARVR_CONTROLLER_MODEL_BASE_URL + 'gear_vr_controller.obj';
 var GEARVR_CONTROLLER_MODEL_OBJ_MTL = GEARVR_CONTROLLER_MODEL_BASE_URL + 'gear_vr_controller.mtl';
 

--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -1,14 +1,15 @@
 /* global THREE */
 var registerComponent = require('../core/component').registerComponent;
 
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
 // Found at https://github.com/aframevr/assets.
 var MODEL_URLS = {
-  toonLeft: 'https://cdn.aframe.io/controllers/hands/leftHand.glb',
-  toonRight: 'https://cdn.aframe.io/controllers/hands/rightHand.glb',
-  lowPolyLeft: 'https://cdn.aframe.io/controllers/hands/leftHandLow.glb',
-  lowPolyRight: 'https://cdn.aframe.io/controllers/hands/rightHandLow.glb',
-  highPolyLeft: 'https://cdn.aframe.io/controllers/hands/leftHandHigh.glb',
-  highPolyRight: 'https://cdn.aframe.io/controllers/hands/rightHandHigh.glb'
+  toonLeft: AFRAME_CDN_ROOT + 'controllers/hands/leftHand.glb',
+  toonRight: AFRAME_CDN_ROOT + 'controllers/hands/rightHand.glb',
+  lowPolyLeft: AFRAME_CDN_ROOT + 'controllers/hands/leftHandLow.glb',
+  lowPolyRight: AFRAME_CDN_ROOT + 'controllers/hands/rightHandLow.glb',
+  highPolyLeft: AFRAME_CDN_ROOT + 'controllers/hands/leftHandHigh.glb',
+  highPolyRight: AFRAME_CDN_ROOT + 'controllers/hands/rightHandHigh.glb'
 };
 
 // Poses.

--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -5,8 +5,9 @@ var bind = require('../utils/bind');
 var trackedControlsUtils = require('../utils/tracked-controls');
 var checkControllerPresentAndSetup = trackedControlsUtils.checkControllerPresentAndSetup;
 
-var LEFT_HAND_MODEL_URL = 'https://cdn.aframe.io/controllers/oculus-hands/v4/left.glb';
-var RIGHT_HAND_MODEL_URL = 'https://cdn.aframe.io/controllers/oculus-hands/v4/right.glb';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var LEFT_HAND_MODEL_URL = AFRAME_CDN_ROOT + 'controllers/oculus-hands/v4/left.glb';
+var RIGHT_HAND_MODEL_URL = AFRAME_CDN_ROOT + 'controllers/oculus-hands/v4/right.glb';
 
 var JOINTS = [
   'wrist',

--- a/src/components/hp-mixed-reality-controls.js
+++ b/src/components/hp-mixed-reality-controls.js
@@ -11,8 +11,8 @@ var onButtonEvent = trackedControlsUtils.onButtonEvent;
 // https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/registry
 // TODO: Add a more robust system for deriving gamepad name.
 var GAMEPAD_ID = 'hp-mixed-reality';
-
-var HP_MIXEDL_REALITY_MODEL_GLB_BASE_URL = 'https://cdn.aframe.io/controllers/hp/mixed-reality/';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var HP_MIXEDL_REALITY_MODEL_GLB_BASE_URL = AFRAME_CDN_ROOT + 'controllers/hp/mixed-reality/';
 
 var HP_MIXED_REALITY_POSITION_OFFSET = {x: 0, y: 0, z: 0.06};
 var HP_MIXED_REALITY_ROTATION_OFFSET = {_x: Math.PI / 4, _y: 0, _z: 0, _order: 'XYZ'};

--- a/src/components/magicleap-controls.js
+++ b/src/components/magicleap-controls.js
@@ -12,8 +12,8 @@ var onButtonEvent = trackedControlsUtils.onButtonEvent;
 var GAMEPAD_ID_PREFIX = 'magicleap';
 var GAMEPAD_ID_SUFFIX = '-one';
 var GAMEPAD_ID_COMPOSITE = GAMEPAD_ID_PREFIX + GAMEPAD_ID_SUFFIX;
-
-var MAGICLEAP_CONTROLLER_MODEL_GLB_URL = 'https://cdn.aframe.io/controllers/magicleap/magicleap-one-controller.glb';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var MAGICLEAP_CONTROLLER_MODEL_GLB_URL = AFRAME_CDN_ROOT + 'controllers/magicleap/magicleap-one-controller.glb';
 
 /**
  * Button IDs:

--- a/src/components/oculus-go-controls.js
+++ b/src/components/oculus-go-controls.js
@@ -9,8 +9,8 @@ var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;
 
 var GAMEPAD_ID_WEBXR = 'oculus-go';
 var GAMEPAD_ID_WEBVR = 'Oculus Go';
-
-var OCULUS_GO_CONTROLLER_MODEL_URL = 'https://cdn.aframe.io/controllers/oculus/go/oculus-go-controller.gltf';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var OCULUS_GO_CONTROLLER_MODEL_URL = AFRAME_CDN_ROOT + 'controllers/oculus/go/oculus-go-controller.gltf';
 
 // Prefix for Gen1 and Gen2 Oculus Touch Controllers.
 var GAMEPAD_ID_PREFIX = isWebXRAvailable ? GAMEPAD_ID_WEBXR : GAMEPAD_ID_WEBVR;

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -16,8 +16,9 @@ var GAMEPAD_ID_WEBVR = 'Oculus Touch';
 var GAMEPAD_ID_PREFIX = isWebXRAvailable ? GAMEPAD_ID_WEBXR : GAMEPAD_ID_WEBVR;
 
 // First generation model URL.
-var TOUCH_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/oculus/oculus-touch-controller-';
-var META_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/meta/';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var TOUCH_CONTROLLER_MODEL_BASE_URL = AFRAME_CDN_ROOT + 'controllers/oculus/oculus-touch-controller-';
+var META_CONTROLLER_MODEL_BASE_URL = AFRAME_CDN_ROOT + 'controllers/meta/';
 
 var OCULUS_TOUCH_WEBVR = {
   left: {

--- a/src/components/pico-controls.js
+++ b/src/components/pico-controls.js
@@ -11,7 +11,8 @@ var onButtonEvent = trackedControlsUtils.onButtonEvent;
 // https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/registry
 // TODO: Add a more robust system for deriving gamepad name.
 var GAMEPAD_ID = 'pico-4';
-var PICO_MODEL_GLB_BASE_URL = 'https://cdn.aframe.io/controllers/pico/pico4/';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var PICO_MODEL_GLB_BASE_URL = AFRAME_CDN_ROOT + 'controllers/pico/pico4/';
 
 /**
  * Button IDs:

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -16,7 +16,8 @@ var DEFAULT_WIDTH = 1;
 // @bryik set anisotropy to 16. Improves look of large amounts of text when viewed from angle.
 var MAX_ANISOTROPY = 16;
 
-var FONT_BASE_URL = 'https://cdn.aframe.io/fonts/';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var FONT_BASE_URL = AFRAME_CDN_ROOT + 'fonts/';
 var FONTS = {
   aileronsemibold: FONT_BASE_URL + 'Aileron-Semibold.fnt',
   dejavu: FONT_BASE_URL + 'DejaVu-sdf.fnt',

--- a/src/components/valve-index-controls.js
+++ b/src/components/valve-index-controls.js
@@ -7,7 +7,8 @@ var checkControllerPresentAndSetup = trackedControlsUtils.checkControllerPresent
 var emitIfAxesChanged = trackedControlsUtils.emitIfAxesChanged;
 var onButtonEvent = trackedControlsUtils.onButtonEvent;
 
-var INDEX_CONTROLLER_MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/valve/index/valve-index-';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var INDEX_CONTROLLER_MODEL_BASE_URL = AFRAME_CDN_ROOT + 'controllers/valve/index/valve-index-';
 var INDEX_CONTROLLER_MODEL_URL = {
   left: INDEX_CONTROLLER_MODEL_BASE_URL + 'left.glb',
   right: INDEX_CONTROLLER_MODEL_BASE_URL + 'right.glb'

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -6,8 +6,9 @@ var checkControllerPresentAndSetup = trackedControlsUtils.checkControllerPresent
 var emitIfAxesChanged = trackedControlsUtils.emitIfAxesChanged;
 var onButtonEvent = trackedControlsUtils.onButtonEvent;
 
-var VIVE_CONTROLLER_MODEL_OBJ_URL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.obj';
-var VIVE_CONTROLLER_MODEL_OBJ_MTL = 'https://cdn.aframe.io/controllers/vive/vr_controller_vive.mtl';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var VIVE_CONTROLLER_MODEL_OBJ_URL = AFRAME_CDN_ROOT + 'controllers/vive/vr_controller_vive.obj';
+var VIVE_CONTROLLER_MODEL_OBJ_MTL = AFRAME_CDN_ROOT + 'controllers/vive/vr_controller_vive.mtl';
 
 var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;
 

--- a/src/components/vive-focus-controls.js
+++ b/src/components/vive-focus-controls.js
@@ -8,7 +8,8 @@ var onButtonEvent = trackedControlsUtils.onButtonEvent;
 
 var GAMEPAD_ID_PREFIX = 'HTC Vive Focus';
 
-var VIVE_FOCUS_CONTROLLER_MODEL_URL = 'https://cdn.aframe.io/controllers/vive/focus-controller/focus-controller.gltf';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var VIVE_FOCUS_CONTROLLER_MODEL_URL = AFRAME_CDN_ROOT + 'controllers/vive/focus-controller/focus-controller.gltf';
 
 /**
  * Vive Focus controls.

--- a/src/components/windows-motion-controls.js
+++ b/src/components/windows-motion-controls.js
@@ -14,7 +14,8 @@ var warn = utils.debug('components:windows-motion-controls:warn');
 
 var DEFAULT_HANDEDNESS = require('../constants').DEFAULT_HANDEDNESS;
 
-var MODEL_BASE_URL = 'https://cdn.aframe.io/controllers/microsoft/';
+var AFRAME_CDN_ROOT = require('../constants').AFRAME_CDN_ROOT;
+var MODEL_BASE_URL = AFRAME_CDN_ROOT + 'controllers/microsoft/';
 var MODEL_FILENAMES = { left: 'left.glb', right: 'right.glb', default: 'universal.glb' };
 
 var isWebXRAvailable = require('../utils/').device.isWebXRAvailable;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,5 +2,6 @@ module.exports = {
   AFRAME_INJECTED: 'aframe-injected',
   DEFAULT_CAMERA_HEIGHT: 1.6,
   DEFAULT_HANDEDNESS: 'right',
-  keyboardevent: require('./keyboardevent')
+  keyboardevent: require('./keyboardevent'),
+  AFRAME_CDN_ROOT: window.AFRAME_CDN_ROOT || 'https://cdn.aframe.io/'
 };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,7 +1,7 @@
 module.exports = {
+  AFRAME_CDN_ROOT: window.AFRAME_CDN_ROOT || 'https://cdn.aframe.io/',
   AFRAME_INJECTED: 'aframe-injected',
   DEFAULT_CAMERA_HEIGHT: 1.6,
   DEFAULT_HANDEDNESS: 'right',
-  keyboardevent: require('./keyboardevent'),
-  AFRAME_CDN_ROOT: window.AFRAME_CDN_ROOT || 'https://cdn.aframe.io/'
+  keyboardevent: require('./keyboardevent')
 };


### PR DESCRIPTION
**Description:**

As per #5119 

**Changes proposed:**

Replace hardcoded instances of `https://cdn.aframe.io/` with a global variable AFRAME_ROOT_CDN.

Based on @vincentfretin's suggestion [here](https://github.com/aframevr/aframe/issues/5119#issuecomment-1382817113)

