### PR TITLE
Remove Chrome bug workaround from a-asset-item as it's no longer needed

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -115,15 +115,7 @@ class AAssetItem extends ANode {
       this.getAttribute('response-type') || inferResponseType(src));
     fileLoader.load(src, function handleOnLoad (response) {
       self.data = response;
-      /*
-        Workaround for a Chrome bug. If another XHR is sent to the same url before the
-        previous one closes, the second request never finishes.
-        setTimeout finishes the first request and lets the logic triggered by load open
-        subsequent requests.
-        setTimeout can be removed once the fix for the bug below ships:
-        https://bugs.chromium.org/p/chromium/issues/detail?id=633696&q=component%3ABlink%3ENetwork%3EXHR%20&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified
-      */
-      setTimeout(function load () { ANode.prototype.load.call(self); });
+      ANode.prototype.load.call(self);
     }, function handleOnProgress (xhr) {
       self.emit('progress', {
         loadedBytes: xhr.loaded,


### PR DESCRIPTION
**Description:**
The referenced Chrome bug has long been fixed in a patch version of Chrome 53. Affected browser usage is <0.01% based on https://caniuse.com/usage-table 

**Changes proposed:**
- Remove Chrome bug workaround that is no longer needed