### PR TITLE
A more robust fix that doesn't depend on hardcoded indices

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -204,7 +204,7 @@ module.exports.Component = registerComponent('hand-controls', {
         mesh.mixer = new THREE.AnimationMixer(mesh);
         self.clips = gltf.animations;
         el.setObject3D('mesh', mesh);
-        mesh.traverse((o) => {
+        mesh.traverse(function (o) {
           if (o.isMesh) {
             o.material.color = new THREE.Color(handColor);
           }

--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -204,9 +204,9 @@ module.exports.Component = registerComponent('hand-controls', {
         mesh.mixer = new THREE.AnimationMixer(mesh);
         self.clips = gltf.animations;
         el.setObject3D('mesh', mesh);
-        mesh.traverse(function (o) {
-          if (o.isMesh) {
-            o.material.color = new THREE.Color(handColor);
+        mesh.traverse(function (object) {
+          if (object.isMesh) {
+            object.material.color = new THREE.Color(handColor);
           }
         });
         mesh.position.set(0, 0, 0);

--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -204,9 +204,11 @@ module.exports.Component = registerComponent('hand-controls', {
         mesh.mixer = new THREE.AnimationMixer(mesh);
         self.clips = gltf.animations;
         el.setObject3D('mesh', mesh);
-
-        var handMaterial = mesh.children[0].material;
-        handMaterial.color = new THREE.Color(handColor);
+        mesh.traverse((o) => {
+          if (o.isMesh) {
+            o.material.color = new THREE.Color(handColor);
+          }
+        });
         mesh.position.set(0, 0, 0);
         mesh.rotation.set(handModelOrientationX, 0, handModelOrientationZ);
         el.setAttribute('magicleap-controls', controlConfiguration);

--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -205,9 +205,8 @@ module.exports.Component = registerComponent('hand-controls', {
         self.clips = gltf.animations;
         el.setObject3D('mesh', mesh);
         mesh.traverse(function (object) {
-          if (object.isMesh) {
-            object.material.color = new THREE.Color(handColor);
-          }
+          if (!object.isMesh) { return; }
+          object.material.color = new THREE.Color(handColor);
         });
         mesh.position.set(0, 0, 0);
         mesh.rotation.set(handModelOrientationX, 0, handModelOrientationZ);


### PR DESCRIPTION
**Description:**

Background here:
https://github.com/aframevr/aframe/commit/701477decf6dedef341a87b4c0d94bd7d8b97032

I thought this was a bug, so I prespared a fix.  Looks like this was actually due to an issue with my test environment.  Neverthless, I think this version of the code is more robust and should be more resilient to future changes in how GLB models get loaded.

**Changes proposed:**

Having hardcoded assumptions about the order that Bones vs. SkinnedMesh will appear in the three.js object tree makes the code vulnerable to changes in future.  This version of the code doesn't make such assumptions, and so should be more robust in future.

