### PR TITLE
Updated primitives link, resolves #5348

### DIFF
--- a/docs/guides/building-a-basic-scene.md
+++ b/docs/guides/building-a-basic-scene.md
@@ -14,7 +14,7 @@ examples:
     src: https://glitch.com/edit/#!/aframe-basic-guide-with-environment?path=index.html
 ---
 
-[primitives]: ../primitives/
+[primitives]: ../introduction/html-and-primitives.md
 [position]: ../components/position.md
 [rotation]: ../components/rotation.md
 [scale]: ../components/scale.md


### PR DESCRIPTION
**Description:**
From (https://aframe.io/docs/1.4.0/guides/building-a-basic-scene.html), the "Primitives" destination link results in a 404 page.

**Changes proposed:**
- Updated building-a-basic-scene.md file -> primitives link to reflect new destination.
