### PR TITLE
#5364 Bugfix : Sound : processSound callback saved and used with loaded + mustPlay

### DIFF
--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -12,6 +12,8 @@ module.exports.Component = registerComponent('sound', {
     autoplay: {default: false},
     distanceModel: {default: 'inverse', oneOf: ['linear', 'inverse', 'exponential']},
     loop: {default: false},
+    loopStart: {default: 0},
+    loopEnd: {default: 0},
     maxDistance: {default: 10000},
     on: {default: ''},
     poolSize: {default: 1},
@@ -59,6 +61,8 @@ module.exports.Component = registerComponent('sound', {
         sound.setRolloffFactor(data.rolloffFactor);
       }
       sound.setLoop(data.loop);
+      sound.setLoopStart(data.loopStart);
+      sound.setLoopEnd(data.loopEnd);
       sound.setVolume(data.volume);
       sound.isPaused = false;
     }

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -62,7 +62,13 @@ module.exports.Component = registerComponent('sound', {
       }
       sound.setLoop(data.loop);
       sound.setLoopStart(data.loopStart);
-      sound.setLoopEnd(data.loopEnd);
+
+      // With a loop start specified without a specified loop end, the end of the loop should be the end of the file
+      if(data.loopStart != 0 && data.loopEnd == 0){ 
+        sound.setLoopEnd(sound.buffer.duration);
+      }
+      else sound.setLoopEnd(data.loopEnd);
+
       sound.setVolume(data.volume);
       sound.isPaused = false;
     }

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -32,6 +32,7 @@ module.exports.Component = registerComponent('sound', {
     this.pool = new THREE.Group();
     this.loaded = false;
     this.mustPlay = false;
+    this.processSound = undefined; // Saved callback for the mustPlay mechanic
 
     // Don't pass evt because playSound takes a function as parameter.
     this.playSoundBound = function () { self.playSound(); };
@@ -80,7 +81,7 @@ module.exports.Component = registerComponent('sound', {
 
         // Remove this key from cache, otherwise we can't play it again
         THREE.Cache.remove(data.src);
-        if (self.data.autoplay || self.mustPlay) { self.playSound(); }
+        if (self.data.autoplay || self.mustPlay) { self.playSound(this.processSound); }
         self.el.emit('sound-loaded', self.evtDetail, false);
       });
     }
@@ -208,6 +209,9 @@ module.exports.Component = registerComponent('sound', {
     if (!this.loaded) {
       warn('Sound not loaded yet. It will be played once it finished loading');
       this.mustPlay = true;
+      if(processSound){
+        this.processSound = processSound;
+      }
       return;
     }
 
@@ -231,6 +235,7 @@ module.exports.Component = registerComponent('sound', {
     }
 
     this.mustPlay = false;
+    this.processSound = undefined;
   },
 
   /**

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -34,7 +34,6 @@ module.exports.Component = registerComponent('sound', {
     this.pool = new THREE.Group();
     this.loaded = false;
     this.mustPlay = false;
-    this.processSound = undefined; // Saved callback for the mustPlay mechanic
 
     // Don't pass evt because playSound takes a function as parameter.
     this.playSoundBound = function () { self.playSound(); };
@@ -67,7 +66,9 @@ module.exports.Component = registerComponent('sound', {
       if(data.loopStart != 0 && data.loopEnd == 0){ 
         sound.setLoopEnd(sound.buffer.duration);
       }
-      else sound.setLoopEnd(data.loopEnd);
+      else {
+        sound.setLoopEnd(data.loopEnd);
+      }
 
       sound.setVolume(data.volume);
       sound.isPaused = false;
@@ -219,9 +220,7 @@ module.exports.Component = registerComponent('sound', {
     if (!this.loaded) {
       warn('Sound not loaded yet. It will be played once it finished loading');
       this.mustPlay = true;
-      if(processSound){
-        this.processSound = processSound;
-      }
+      this.processSound = processSound;
       return;
     }
 


### PR DESCRIPTION
The processSound callback given to playSound() before the sound was loaded will now be called when loaded and not ignored anymore.
