### PR TITLE
[docs] Updates to aincraft tutorial and code

### DIFF
--- a/docs/guides/building-a-minecraft-demo.md
+++ b/docs/guides/building-a-minecraft-demo.md
@@ -400,7 +400,20 @@ and the camera:
 [blink-controls]: https://github.com/jure/aframe-blink-controls
 For teleportation, there's a component called [blink-controls][blink-controls].
 Following the README, we add the component via a `<script>` tag and just set
-the `blink-controls` component on the controller on the entity.
+the `blink-controls` component on the controller on the entity:
+
+```html
+<script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/aframe-blink-controls/dist/aframe-blink-controls.min.js"></script>
+
+<!-- ... -->
+
+<a-entity id="player">
+  <a-entity id="teleHand" hand-controls="hand: left"></a-entity>
+  <a-entity id="blockHand" hand-controls="hand: right"></a-entity>
+  <a-camera></a-camera>
+</a-entity>
+```
 
 By default, `blink-controls` will only teleport on the ground, but we can 
 specify with `collisionEntities` to teleport on the blocks *and* the ground 
@@ -429,8 +442,15 @@ that attaches the clicking laser to VR tracked controllers.  Like the
 `laser-controls` component. This time to the right hand:
 
 ```html
+<script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/aframe-blink-controls/dist/aframe-blink-controls.min.js"></script>
+
+<!-- ... -->
+
+<a-entity id="teleHand" hand-controls="hand: left" blink-controls="collisionEntities: [mixin='voxel'], #ground"></a-entity>
 <a-entity id="blockHand" hand-controls="hand: right" laser-controls></a-entity>
 ```
+
 
 Now when we pull the trigger button on the tracked controllers,
 `laser-controls` will emit a `click` event on both the controller and the

--- a/docs/guides/building-a-minecraft-demo.md
+++ b/docs/guides/building-a-minecraft-demo.md
@@ -472,10 +472,11 @@ To generalize creating entities from an intersection event, we've created an
 of properties. We won't go into the detail of the implementation, but you can
 [check out the simple `intersection-spawn` component source code on
 GitHub][intersection-spawn]. We attach `intersection-spawn` capabilities to the
-right hand:
+right hand, and it's also a good idea to give the raycaster a half-meter buffer  
+to prevent voxels from spawning right at the controller:
 
 ```html
-<a-entity id="blockHand" hand-controls="hand: right" laser-controls intersection-spawn="event: click; mixin: voxel"></a-entity>
+<a-entity id="blockHand" hand-controls="hand: right" laser-controls raycaster="near: 0.5" intersection-spawn="event: click; mixin: voxel"></a-entity>
 ```
 
 Now when we click, we spawn voxels!
@@ -490,8 +491,7 @@ component with the gaze-based `cursor` component so that we can also spawn
 blocks on mobile and desktop, without changing a thing about the component!
 
 ```html
-<a-entity id="blockHand" hand-controls="hand: right" laser-controls intersection-spawn="event: click; mixin: voxel"></a-entity>
-
+<a-entity id="blockHand" hand-controls="hand: right" laser-controls raycaster="near: 0.5" intersection-spawn="event: click; mixin: voxel"></a-entity>
 <a-camera>
   <a-cursor intersection-spawn="event: click; mixin: voxel"></a-cursor>
 </a-camera>

--- a/docs/guides/building-a-minecraft-demo.md
+++ b/docs/guides/building-a-minecraft-demo.md
@@ -376,18 +376,20 @@ and placing blocks.
 
 ### Adding Teleportation to the Left Hand
 
-We'll plug in teleportation capabilities to the left hand such that we hold a
-button to show an arc coming out of the controller, and let go of the button to
-teleport to the end of the arc. Before, we wrote our own A-Frame components.
-But we can also use open source components already made from the community
-and just use them straight from HTML!
+We'll plug in teleportation capabilities to the left hand such that we push a
+thumbstick to show an arc coming out of the controller, and let go of the
+thumbstick to teleport to the end of the arc. Before, we wrote our own A-Frame
+components. But we can also use open source components already made from the
+community and just use them straight from HTML!
 
-Even though we haven't explicity defined one, our scene has an implicit camera 
-component from which the user views the scene. Since teleporting is going to be
-moving this camera along with the player, we'll need to make it explicit and 
-part of the player:
-
+To enable this, let's first define a `player` entity that wraps the controllers 
+and the camera:
+ 
 ```html
+<script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
+
+<!-- ... -->
+
 <a-entity id="player">
   <a-entity id="teleHand" hand-controls="hand: left"></a-entity>
   <a-entity id="blockHand" hand-controls="hand: right"></a-entity>

--- a/docs/guides/building-a-minecraft-demo.md
+++ b/docs/guides/building-a-minecraft-demo.md
@@ -382,26 +382,28 @@ teleport to the end of the arc. Before, we wrote our own A-Frame components.
 But we can also use open source components already made from the community
 and just use them straight from HTML!
 
-[blink-controls]: https://github.com/fernandojsg/aframe-teleport-controls/
-For teleportation, there's a component called [blink-controls][blink-controls].
-Following the README, we add the component via a `<script>` tag and just set
-the `blink-controls` component on the controller on the entity:
+Even though we haven't explicity defined one, our scene has an implicit camera 
+component from which the user views the scene. Since teleporting is going to be
+moving this camera along with the player, we'll need to make it explicit and 
+part of the player:
 
 ```html
-<script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/aframe-blink-controls/dist/aframe-blink-controls.min.js"></script>
-
-<!-- ... -->
-
-<a-entity id="teleHand" hand-controls="hand: left" teleport-controls></a-entity>
-<a-entity id="blockHand" hand-controls="hand: right"></a-entity>
+<a-entity id="player">
+  <a-entity id="teleHand" hand-controls="hand: left"></a-entity>
+  <a-entity id="blockHand" hand-controls="hand: right"></a-entity>
+  <a-camera></a-camera>
+</a-entity>
 ```
 
-Then we'll configure the `blink-controls` component to use an arc `type` of
-teleportation. By default, `blink-controls` will only teleport on the
-ground, but we can specify with `collisionEntities` to teleport on the blocks
-*and* the ground using selectors. These properties are part of the API that the
-`blink-controls` component was created with:
+[blink-controls]: https://github.com/jure/aframe-blink-controls
+For teleportation, there's a component called [blink-controls][blink-controls].
+Following the README, we add the component via a `<script>` tag and just set
+the `blink-controls` component on the controller on the entity.
+
+By default, `blink-controls` will only teleport on the ground, but we can 
+specify with `collisionEntities` to teleport on the blocks *and* the ground 
+using selectors. This property is part of the API that the`blink-controls` 
+component was created with:
 
 ```html
 <a-entity id="teleHand" hand-controls="hand: left" blink-controls="collisionEntities: [mixin='voxel'], #ground"></a-entity>
@@ -425,15 +427,8 @@ that attaches the clicking laser to VR tracked controllers.  Like the
 `laser-controls` component. This time to the right hand:
 
 ```html
-<script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/aframe-blink-controls/dist/aframe-blink-controls.min.js"></script>
-
-<!-- ... -->
-
-<a-entity id="teleHand" hand-controls="hand: left" teleport-controls="type: parabolic; collisionEntities: [mixin='voxel'], #ground"></a-entity>
 <a-entity id="blockHand" hand-controls="hand: right" laser-controls></a-entity>
 ```
-
 
 Now when we pull the trigger button on the tracked controllers,
 `laser-controls` will emit a `click` event on both the controller and the

--- a/examples/docs/aincraft/index.html
+++ b/examples/docs/aincraft/index.html
@@ -27,19 +27,20 @@
 
     <a-sky id="background" src="#skyTexture" theta-length="90" radius="30"></a-sky>
 
-    <!-- Hands -->
-    <a-entity id="teleHand"
-              hand-controls="hand: left"
-              blink-controls="collisionEntities: [mixin='voxel'], #ground"></a-entity>
-    <a-entity id="blockHand"
-              hand-controls="hand: right"
-              laser-controls
-              intersection-spawn="event: click; mixin: voxel"></a-entity>
+    <a-entity id="player">
+      <!-- Hands -->
+      <a-entity id="teleHand"
+                hand-controls="hand: left"
+                blink-controls="collisionEntities: [mixin='voxel'], #ground"></a-entity>
+      <a-entity id="blockHand"
+                hand-controls="hand: right"
+                laser-controls
+                intersection-spawn="event: click; mixin: voxel"></a-entity>
 
-    <!-- Camera -->
-    <a-camera>
-      <a-cursor intersection-spawn="event: click; mixin: voxel"></a-cursor>
-    </a-camera>
-
+      <!-- Camera -->
+      <a-camera>
+        <a-cursor intersection-spawn="event: click; mixin: voxel"></a-cursor>
+      </a-camera>
+    </a-entity>
   </a-scene>
 </html>

--- a/examples/docs/aincraft/index.html
+++ b/examples/docs/aincraft/index.html
@@ -35,11 +35,13 @@
       <a-entity id="blockHand"
                 hand-controls="hand: right"
                 laser-controls
+                raycaster="near: 0.5"
                 intersection-spawn="event: click; mixin: voxel"></a-entity>
 
       <!-- Camera -->
       <a-camera>
-        <a-cursor intersection-spawn="event: click; mixin: voxel"></a-cursor>
+        <!-- Uncomment the line below to place blocks on desktop or mobile -->
+        <!-- <a-cursor intersection-spawn="event: click; mixin: voxel"></a-cursor> -->
       </a-camera>
     </a-entity>
   </a-scene>


### PR DESCRIPTION
**Description:**

The tutorial (and corresponding html file) was partially converted to use `aframe-blink-controls` instead of `aframe-teleport-controls` and wouldn't run. With that fixed, the scene had a problem where blocks would spawn right on the controller instead of at the end of the raycaster. 

**Changes proposed:**
- Update aincraft code to work with `aframe-blink-controls`
- Update the tutorial to describe the correct use of `aframe-blink-controls`.
- Update aincraft right hand to give its raycaster a 0.5m buffer
- Update the tutorial to note the buffer.

With these changes, I was able to finish the tutorial.