### PR TITLE
enterVR: reject promise if xr.requestSession fails

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -308,7 +308,7 @@ class AScene extends AEntity {
             function requestFail (error) {
               var useAR = xrMode === 'immersive-ar';
               var mode = useAR ? 'AR' : 'VR';
-              throw new Error('Failed to enter ' + mode + ' mode (`requestSession`) ' + error);
+              reject(new Error('Failed to enter ' + mode + ' mode (`requestSession`)', { cause: error }));
             }
           );
         });


### PR DESCRIPTION
**Description:**

When calling enterVR (or enterAR), the function `navigator.xr.requestSession` may fail (e.g. if the user denied the required permissions). In this case, an error is thrown but it is impossible to catch it.

**Changes proposed:**
- Instead of simply throwing the error, the returned promise is rejected with the error.