### PR TITLE
Fix error when using the reflection component on desktop browsers

### DIFF
--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -42,11 +42,10 @@ module.exports.Component = register('reflection', {
     }
 
     this.el.addEventListener('enter-vr', function () {
+      if (!self.el.is('ar-mode')) { return; }
       var renderer = self.el.renderer;
       var session = renderer.xr.getSession();
-      if (
-        session.requestLightProbe && self.el.is('ar-mode')
-      ) {
+      if (session.requestLightProbe) {
         self.startLightProbe();
       }
     });


### PR DESCRIPTION
Dear maintainers,

when opening the excellent boilerplate example available at https://aframe-xr-starterkit.glitch.me/ with a desktop browser such as Chrome, upon entering fullscreen mode, the console will complain about:

![image](https://github.com/aframevr/aframe/assets/3331940/54df7ea8-17b5-4ca9-9310-be85200a740f)

The code responsible for this error seem to be relevant only to AR mode and to my understanding should not be executed in other contexts. I have simply ensured that the session is not null to fix the problem.

Additionally, I have also changed that the VR environment update performed in stopLightProbe is executed only if a light probe was set up in the first place (e.g. startLightProbe was executed), which again seems to be supposed to happen only in limited circumstances.

All the best
