### PR TITLE
Remove outdated skinning property to prevent a warning

### DIFF
--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -347,7 +347,7 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
     mesh.position.set(0, 0, 0);
     mesh.rotation.set(0, 0, 0);
     skinnedMesh.frustumCulled = false;
-    skinnedMesh.material = new THREE.MeshStandardMaterial({skinning: true, color: this.data.modelColor});
+    skinnedMesh.material = new THREE.MeshStandardMaterial({color: this.data.modelColor});
     this.el.setObject3D('mesh', mesh);
   }
 });


### PR DESCRIPTION
When hands are used a warning appears that the skinning property is not part of material