### PR TITLE
Use correct default value (null) for glslVersion for non-raw shaders

### DIFF
--- a/src/core/shader.js
+++ b/src/core/shader.js
@@ -55,7 +55,7 @@ Shader.prototype = {
     this.material = new (this.raw ? THREE.RawShaderMaterial : THREE.ShaderMaterial)({
       // attributes: this.attributes,
       uniforms: this.uniforms,
-      glslVersion: this.raw ? THREE.GLSL3 : undefined,
+      glslVersion: this.raw ? THREE.GLSL3 : null,
       vertexShader: this.vertexShader,
       fragmentShader: this.fragmentShader
     });


### PR DESCRIPTION
**Description:**
As reported by @vincentfretin on the aframe-environment-component: https://github.com/supermedium/aframe-environment-component/issues/96

When registering non-raw shaders, a warning would be logged by Three.js indicating that the `glslVersion` was undefined. This was introduced in https://github.com/aframevr/aframe/pull/5328 when addressing related changes in Three.js. However, the 'default' value of `undefined` for non-raw shaders is incorrect and the cause of these warnings.

Looking at the Three.js source, it's clear the default value is `null` ([ShaderMaterial.js#L53](https://github.com/mrdoob/three.js/blob/dev/src/materials/ShaderMaterial.js#L53)). Changing this resolves the issue.

**Changes proposed:**
- Change default `glslVersion` value from `undefined` to `null` matching Three.js default
