### PR TITLE
Set useLegacyLights only if necessary to remove warning about deprecated api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Multiview extension, Spatial computing UIs, Mixed Reality features, Hand manipul
 
 ### Bug fixes
 
-- Use renderer.physicallyCorrectLights instead of the now deprecated renderer.useLegacyLights (fix #5293) (@mrx)
+- Use renderer.useLegacyLights instead of the deprecated renderer.physicallyCorrectLights in three r150, but keep the physicallyCorrectLights property name for the renderer system for backward compatibility (fix #5293) (@mrx)
 - Fix `hand-controls` animations (#5300)
 - Fix outdated link in error message (#5313) (fix #5275) (@kolson25)
 - Fix visibility of controller in model-viewer example (#5317) (@DougReeder)

--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -34,7 +34,9 @@ module.exports.System = registerSystem('renderer', {
     // This is the rendering engine, such as THREE.js so copy over any persistent properties from the rendering system.
     var renderer = sceneEl.renderer;
 
-    renderer.useLegacyLights = !data.physicallyCorrectLights;
+    if (!data.physicallyCorrectLights) {
+      renderer.useLegacyLights = !data.physicallyCorrectLights;
+    }
     renderer.toneMapping = THREE[toneMappingName + 'ToneMapping'];
     THREE.Texture.DEFAULT_ANISOTROPY = data.anisotropy;
 


### PR DESCRIPTION
In #5297 we changed to use renderer.useLegacyLights setter instead of the deprecated renderer.physicallyCorrectLights in three r150, and kept the physicallyCorrectLights property name for the renderer system for backward compatibility. The changelog in aframe 1.5.0 release is wrong about this change, it says the reverse, I fixed it in this PR.

In three r155, the useLegacyLights api was also deprecated, such giving this warning
THREE.WebGLRenderer: The property .useLegacyLights has been deprecated. Migrate your lighting according to the following guide: https://discourse.threejs.org/t/updates-to-lighting-in-three-js-r155/53733.

The warning is shown when you use the setter useLegacyLights.
Because useLegacyLights is false by default now in threejs, we should only set useLegacyLights to true if renderer="physicallyCorrectLights:false" which is still the default in aframe 1.5.0.
I thought we changed the default to match three decision, but we didn't do it for 1.5.0. useLegacyLights will probably be removed in r165, so aframe 1.6.0 will need to switch the default for sure.

I propose to not set useLegacyLights at all when we use renderer="physicallyCorrectLights:true" to remove this warning, this is what this PR does.