### PR TITLE
Correct default value for new XRMode field

### DIFF
--- a/docs/components/xr-mode-ui.md
+++ b/docs/components/xr-mode-ui.md
@@ -27,7 +27,7 @@ to the [`<a-scene>` element][scene]. If we wish to simply toggle the UI, use CSS
 | enterVREnabled        | If the VR button is displayed when applicable                       | false         |
 | enterARButton         | Selector to a custom AR button. On click, the button will enter AR. | ''            |
 | enterAREnabled        | If the AR button is displayed when applicable                       | false         |
-| XRMode                | If the AR, VR button or both will be displayed.                     | ar, vr, xr    |
+| XRMode                | If the AR, VR button or both will be displayed.  One of 'ar', 'vr' or 'xr'.| vr            |
 
 ### Specifying a Custom Enter VR Button
 


### PR DESCRIPTION
**Description:**

1.5.0 docs say the default value for the new field is `vr, ar, xr`.  In fact the default value is `vr`, and `ar` & `xr` are other possible values.

The relevant line of the schema is:
```
XRMode: {default: 'vr', oneOf: ['vr', 'ar', 'xr']}
```

**Changes proposed:**

Update docs to indicate the actual default value.
