### PR TITLE
Only enable shadowMap if an entity uses the shadow component and the shadow system is enabled

### DIFF
--- a/tests/systems/shadow.test.js
+++ b/tests/systems/shadow.test.js
@@ -7,12 +7,12 @@ suite('shadow system', function () {
   });
 
   suite('init', function () {
-    test('enabled by default', function (done) {
+    test('shadowMap disabled by default', function (done) {
       var el = this.el;
       this.el.addEventListener('loaded', function () {
         var sceneEl = el.sceneEl;
         var renderer = sceneEl.renderer;
-        assert.ok(renderer.shadowMap.enabled);
+        assert.notOk(renderer.shadowMap.enabled);
         done();
       });
     });
@@ -31,6 +31,43 @@ suite('shadow system', function () {
       });
 
       document.body.appendChild(div);
+    });
+
+    test('shadwMap automatically enables', function (done) {
+      var el = this.el;
+      el.setAttribute('shadow', 'receive: false');
+      el.addEventListener('loaded', function () {
+        var renderer = el.sceneEl.renderer;
+        assert.ok(renderer.shadowMap.enabled);
+        done();
+      });
+    });
+  });
+
+  suite('enabled', function () {
+    test('shadowMap remains disabled when system is explicitly disabled', function (done) {
+      var el = this.el;
+      el.setAttribute('shadow', 'receive: false');
+      el.sceneEl.setAttribute('shadow', 'enabled: false');
+      el.addEventListener('loaded', function () {
+        var renderer = el.sceneEl.renderer;
+        assert.notOk(renderer.shadowMap.enabled);
+        done();
+      });
+    });
+
+    test('shadowMap enables when system is (re)enabled', function (done) {
+      var el = this.el;
+      el.setAttribute('shadow', 'receive: false');
+      el.sceneEl.setAttribute('shadow', 'enabled: false');
+      el.addEventListener('loaded', function () {
+        var renderer = el.sceneEl.renderer;
+        assert.notOk(renderer.shadowMap.enabled);
+
+        el.sceneEl.setAttribute('shadow', 'enabled: true');
+        assert.ok(renderer.shadowMap.enabled);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
**Description:**
The shadow system has logic for only enabling once an entity uses shadows. However, this logic is broken since https://github.com/aframevr/aframe/pull/4040, resulting in `renderer.shadowMap.enabled` to always default to true. This means that by default every A-Frame scene renders an empty shadowMap and compiles the materials with `USE_SHADOWMAP` defined.

On top of that, while the system would update `renderer.shadowMap.enabled` when changing the system's enabled property, this alone isn't enough to actually toggle the shadows in Three.js. It's needed for materials to be updated whenever `shadowMap.enabled` changes ([How to update things](https://threejs.org/docs/index.html#manual/en/introduction/How-to-update-things)).

This PR addresses both issues, restoring the original intended behaviour and ensuring enabling and disabling the shadow system on the fly works as well.

**Changes proposed:**
- Use `this.data.enabled` for if the shadow _system_ is enabled and `this.shadowMapEnabled` for if a shadowMap is needed (e.g. an entity uses the `shadow` component). As a result `renderer.shadowMap.enabled = this.data.enabled && this.shadowMapEnabled`
- Mark all materials as `needsUpdate` whenever the actual value of `renderer.shadowMap.enabled` changes
- Update unit tests to reflect the above changes
