### PR TITLE
Adjust iterator index when removing behaviors during tick/tock

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -58,6 +58,7 @@ class AScene extends AEntity {
     self.time = self.delta = 0;
 
     self.behaviors = {tick: [], tock: []};
+    self.behaviorIterators = {tick: -1, tock: -1};
     self.hasLoaded = false;
     self.isPlaying = false;
     self.originalHTML = self.innerHTML;
@@ -540,7 +541,12 @@ class AScene extends AEntity {
       if (!behavior[behaviorType]) { continue; }
       behaviorArr = this.behaviors[behaviorType];
       index = behaviorArr.indexOf(behavior);
-      if (index !== -1) { behaviorArr.splice(index, 1); }
+      if (index !== -1) {
+        if (index <= this.behaviorIterators[behaviorType]) {
+          this.behaviorIterators[behaviorType]--;
+        }
+        behaviorArr.splice(index, 1);
+      }
     }
   }
 
@@ -693,13 +699,15 @@ class AScene extends AEntity {
    */
   tick (time, timeDelta) {
     var i;
+    var it = this.behaviorIterators;
     var systems = this.systems;
 
     // Components.
-    for (i = 0; i < this.behaviors.tick.length; i++) {
-      if (!this.behaviors.tick[i].el.isPlaying) { continue; }
-      this.behaviors.tick[i].tick(time, timeDelta);
+    for (it.tick = 0; it.tick < this.behaviors.tick.length; it.tick++) {
+      if (!this.behaviors.tick[it.tick].el.isPlaying) { continue; }
+      this.behaviors.tick[it.tick].tick(time, timeDelta);
     }
+    it.tick = -1;
 
     // Systems.
     for (i = 0; i < this.systemNames.length; i++) {
@@ -715,13 +723,15 @@ class AScene extends AEntity {
    */
   tock (time, timeDelta, camera) {
     var i;
+    var it = this.behaviorIterators;
     var systems = this.systems;
 
     // Components.
-    for (i = 0; i < this.behaviors.tock.length; i++) {
-      if (!this.behaviors.tock[i].el.isPlaying) { continue; }
-      this.behaviors.tock[i].tock(time, timeDelta, camera);
+    for (it.tock = 0; it.tock < this.behaviors.tock.length; it.tock++) {
+      if (!this.behaviors.tock[it.tock].el.isPlaying) { continue; }
+      this.behaviors.tock[it.tock].tock(time, timeDelta, camera);
     }
+    it.tock = -1;
 
     // Systems.
     for (i = 0; i < this.systemNames.length; i++) {


### PR DESCRIPTION
**Description:**
While looking into #5400 I noticed that following an element removal the `tick` method of the `animation` component wasn't called for that frame. The scene iterates over the `tick`/`tock` behaviours but doesn't handle the situation where the behaviour array is mutated mid iteration, which can result in `tick`/`tock` behaviours to be skipped.

While there are several possible solutions, letting the scene detect these cases and adjusting the loop indices seemed the most straightforward. It's worth noting that this bug is likely pretty common across A-Frame experiences, as it isn't tied to _element removal_ per se, but any behaviour removal, meaning removing a component can trigger it. Luckily skipping the tick method for a frame isn't a problem for most components.

**Changes proposed:**
- Keep track of the iterator indices when iterating over the tick/tock behaviors
- When removing a behavior check if the iterator index needs to be adjusted
