### PR TITLE
Remove epsilon for scale as Three.js handles zero scale

### DIFF
--- a/src/components/animation.js
+++ b/src/components/animation.js
@@ -376,12 +376,6 @@ module.exports.Component = registerComponent('animation', {
         return function (anim) {
           var value = anim.animatables[0].target;
 
-          if (data.property === PROP_SCALE) {
-            value.x = Math.max(0.0001, value.x);
-            value.y = Math.max(0.0001, value.y);
-            value.z = Math.max(0.0001, value.z);
-          }
-
           // For animation timeline.
           if (value.x === lastValue.x &&
               value.y === lastValue.y &&

--- a/src/components/scale.js
+++ b/src/components/scale.js
@@ -1,8 +1,5 @@
 var registerComponent = require('../core/component').registerComponent;
 
-// Avoids triggering a zero-determinant which makes object3D matrix non-invertible.
-var zeroScale = 0.00001;
-
 module.exports.Component = registerComponent('scale', {
   schema: {
     type: 'vec3',
@@ -12,10 +9,7 @@ module.exports.Component = registerComponent('scale', {
   update: function () {
     var data = this.data;
     var object3D = this.el.object3D;
-    var x = data.x === 0 ? zeroScale : data.x;
-    var y = data.y === 0 ? zeroScale : data.y;
-    var z = data.z === 0 ? zeroScale : data.z;
-    object3D.scale.set(x, y, z);
+    object3D.scale.set(data.x, data.y, data.z);
   },
 
   remove: function () {


### PR DESCRIPTION
**Description:**
Three.js gracefully handles objects with zero scale for quite a while now (https://github.com/mrdoob/three.js/issues/17926, https://github.com/mrdoob/three.js/pull/18885). As a result it's no longer needed for A-Frame to use an epsilon value to prevent scale from becoming zero along any or all axes.

For the animation component this also allows the animation to go from positive to negative or vice versa, which is currently prevented.

**Changes proposed:**
- Remove epsilon value when scaling to 0 (with `scale` or `animation` component)