### PR TITLE
Update hand-tracking-grab-controls.md

### DIFF
--- a/docs/components/hand-tracking-grab-controls.md
+++ b/docs/components/hand-tracking-grab-controls.md
@@ -33,7 +33,7 @@ For debugging purposes you can make the colliders visible as below:
 | Property       | Description                                                                            | Default Value |
 |----------------|----------------------------------------------------------------------------------------|---------------|
 | hand           | The hand that will be tracked (i.e., right, left).                                     | left          |
-| handColor      | The color of the hand model.                                                           | white         |
+| color          | The color of the hand model.                                                           | white         |
 | hoverColor     | Hand color when hand intersects a grabbable entity bounding box.                       | #538df1       |
 | hoverEnabled   | If the hand model changes color when intersecting a grabbable entity.                  | false         |
 


### PR DESCRIPTION
**Description:**
The schema for [hand-tracking-grab-controls](https://github.com/aframevr/aframe/blob/v1.5.0/src/components/hand-tracking-grab-controls.js) uses the property "color" instead of "handColor" as mentioned in the documentation.

**Changes proposed:**
- rename property in the documentation to match the JavaScript implementation
