### PR TITLE
Add support for offerSession

### DIFF
--- a/src/components/scene/xr-mode-ui.js
+++ b/src/components/scene/xr-mode-ui.js
@@ -150,6 +150,7 @@ module.exports.Component = registerComponent('xr-mode-ui', {
     } else {
       if (!utils.device.checkVRSupport()) { this.enterVREl.classList.add('fullscreen'); }
       this.enterVREl.classList.remove(HIDDEN_CLASS);
+      sceneEl.enterVR(false, true);
     }
   },
 
@@ -161,6 +162,7 @@ module.exports.Component = registerComponent('xr-mode-ui', {
       this.enterAREl.classList.add(HIDDEN_CLASS);
     } else {
       this.enterAREl.classList.remove(HIDDEN_CLASS);
+      sceneEl.enterVR(true, true);
     }
   },
 

--- a/src/components/scene/xr-mode-ui.js
+++ b/src/components/scene/xr-mode-ui.js
@@ -120,6 +120,8 @@ module.exports.Component = registerComponent('xr-mode-ui', {
 
     this.orientationModalEl = createOrientationModal(this.onModalClick);
     sceneEl.appendChild(this.orientationModalEl);
+
+    this.updateEnterInterfaces();
   },
 
   remove: function () {

--- a/src/components/scene/xr-mode-ui.js
+++ b/src/components/scene/xr-mode-ui.js
@@ -120,8 +120,6 @@ module.exports.Component = registerComponent('xr-mode-ui', {
 
     this.orientationModalEl = createOrientationModal(this.onModalClick);
     sceneEl.appendChild(this.orientationModalEl);
-
-    this.updateEnterInterfaces();
   },
 
   remove: function () {

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -278,7 +278,7 @@ class AScene extends AEntity {
     var xrInit;
 
     // Don't enter VR if already in VR.
-    if (useOfferSession && navigator.xr.offerSession === undefined) { return Promise.resolve('OfferSession is not supported.'); }
+    if (useOfferSession && (navigator.xr === undefined || navigator.xr.offerSession === undefined)) { return Promise.resolve('OfferSession is not supported.'); }
     if (self.usedOfferSession && useOfferSession) { return Promise.resolve('OfferSession was already called.'); }
     if (this.is('vr-mode')) { return Promise.resolve('Already in VR.'); }
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -297,9 +297,9 @@ class AScene extends AEntity {
         var xrMode = useAR ? 'immersive-ar' : 'immersive-vr';
         xrInit = this.sceneEl.systems.webxr.sessionConfiguration;
         return new Promise(function (resolve, reject) {
-          var requestFunction = useOfferSession ? navigator.xr.offerSession.bind(navigator.xr) : navigator.xr.requestSession.bind(navigator.xr);
+          var requestSession = useOfferSession ? navigator.xr.offerSession.bind(navigator.xr) : navigator.xr.requestSession.bind(navigator.xr);
           self.usedOfferSession |= useOfferSession;
-          requestFunction(xrMode, xrInit).then(
+          requestSession(xrMode, xrInit).then(
             function requestSuccess (xrSession) {
               self.xrSession = xrSession;
               self.usedOfferSession = false;

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -279,7 +279,7 @@ class AScene extends AEntity {
 
     // Don't enter VR if already in VR.
     if (useOfferSession && navigator.xr.offerSession === undefined) { return Promise.resolve('OfferSession is not supported.'); }
-    if (self.usedOfferSession) { return Promise.resolve('OfferSession was already called.'); }
+    if (self.usedOfferSession && useOfferSession) { return Promise.resolve('OfferSession was already called.'); }
     if (this.is('vr-mode')) { return Promise.resolve('Already in VR.'); }
 
     // Has VR.
@@ -302,7 +302,10 @@ class AScene extends AEntity {
           requestSession(xrMode, xrInit).then(
             function requestSuccess (xrSession) {
               self.xrSession = xrSession;
-              self.usedOfferSession = false;
+
+              if (useOfferSession) {
+                self.usedOfferSession = false;
+              }
 
               vrManager.layersEnabled = xrInit.requiredFeatures.indexOf('layers') !== -1;
               vrManager.setSession(xrSession).then(function () {

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -278,7 +278,7 @@ class AScene extends AEntity {
     var xrInit;
 
     // Don't enter VR if already in VR.
-    if (useOfferSession && (navigator.xr === undefined || navigator.xr.offerSession === undefined)) { return Promise.resolve('OfferSession is not supported.'); }
+    if (useOfferSession && (!navigator.xr || !navigator.xr.offerSession)) { return Promise.resolve('OfferSession is not supported.'); }
     if (self.usedOfferSession && useOfferSession) { return Promise.resolve('OfferSession was already called.'); }
     if (this.is('vr-mode')) { return Promise.resolve('Already in VR.'); }
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -278,7 +278,6 @@ class AScene extends AEntity {
 
     // Don't enter VR if already in VR.
     if (navigator.xr.offerSession === undefined) { return Promise.resolve('OfferSession is not supported.'); }
-    if (this.is('has-offer-session')) { return Promise.resolve('Already has offerSession.'); }
     if (this.is('vr-mode')) { return Promise.resolve('Already in VR.'); }
 
     // Has VR.
@@ -297,13 +296,9 @@ class AScene extends AEntity {
         xrInit = this.sceneEl.systems.webxr.sessionConfiguration;
         return new Promise(function (resolve, reject) {
           var requestFunction = useOfferSession ? navigator.xr.offerSession.bind(navigator.xr) : navigator.xr.requestSession.bind(navigator.xr);
-          if (useOfferSession) {
-            self.addState('has-offer-session');
-          }
           requestFunction(xrMode, xrInit).then(
             function requestSuccess (xrSession) {
               self.xrSession = xrSession;
-              self.removeState('has-offer-session');
 
               vrManager.layersEnabled = xrInit.requiredFeatures.indexOf('layers') !== -1;
               vrManager.setSession(xrSession).then(function () {
@@ -314,7 +309,6 @@ class AScene extends AEntity {
               enterVRSuccess(resolve);
             },
             function requestFail (error) {
-              self.removeState('has-offer-session');
               var useAR = xrMode === 'immersive-ar';
               var mode = useAR ? 'AR' : 'VR';
               reject(new Error('Failed to enter ' + mode + ' mode (`requestSession`)', { cause: error }));


### PR DESCRIPTION
`offerSession` is a recent addition to WebXR that makes it more obvious that a page can enter WebXR.
Quest browser got feedback that the "Enter VR/AR/XR" buttons on a lot of sites is hard to find. 
Often the button is small or scrolled of the bottom of the page. To remedy this, we worked with the W3C Immersive group on a new API that adds a button to the URL bar. This button will launch a pending immersive session.

This change will call `offerSession` when the page is opened or when the immersive session exits.

cc @dmarcos 