### PR TITLE
Proposed fix for 5411

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -66,6 +66,7 @@ module.exports.Component = registerComponent('cursor', {
     this.canvasBounds = document.body.getBoundingClientRect();
     this.isCursorDown = false;
     this.activeXRInput = null;
+    this.mouseAvailable = true;
 
     // Debounce.
     this.updateCanvasBounds = utils.debounce(function updateCanvasBounds () {
@@ -230,6 +231,7 @@ module.exports.Component = registerComponent('cursor', {
       var pose;
       var transform;
 
+      this.mouseAvailable = true;
       camera.parent.updateMatrixWorld();
 
       // Calculate mouse position based on the canvas element
@@ -276,6 +278,7 @@ module.exports.Component = registerComponent('cursor', {
    * Trigger mousedown and keep track of the mousedowned entity.
    */
   onCursorDown: function (evt) {
+    this.mouseAvailable = true;
     this.isCursorDown = true;
     // Raycast again for touch.
     if (this.data.rayOrigin === 'mouse' && evt.type === 'touchstart') {
@@ -313,6 +316,7 @@ module.exports.Component = registerComponent('cursor', {
    *   in case user mousedowned one entity, dragged to another, and mouseupped.
    */
   onCursorUp: function (evt) {
+    this.mouseAvailable = true;
     if (!this.isCursorDown) { return; }
 
     this.isCursorDown = false;
@@ -393,6 +397,7 @@ module.exports.Component = registerComponent('cursor', {
   },
 
   onEnterVR: function () {
+    this.mouseAvailable = false;
     this.clearCurrentIntersection(true);
     var xrSession = this.el.sceneEl.xrSession;
     var self = this;
@@ -410,6 +415,9 @@ module.exports.Component = registerComponent('cursor', {
     var cursorEl = this.el;
     var data = this.data;
     var self = this;
+
+    // mouse not available for use as rayOrigin (e.g. in VR w/o mouse)
+    if (this.data.rayOrigin === 'mouse' && !this.mouseAvailable) { return; }
 
     // Already intersecting.
     if (this.intersectedEl === intersectedEl) { return; }


### PR DESCRIPTION
**Description:**

See #5411

**Changes proposed:**

In VR mode, when no mouse is available, prevent `cursor` from firing a  "mouseenter" event, as follows:

- on entering VR, set a flag this.mouseAvailable to false
- on detection of a mouse move or click event, set this.mouseAvailable to true
- use this.mouseAvailable to determine whether ot not to so an early return on detection of a raycaster intersection.

This is intended to allow use of a mouse in "VR mode" for e.g. cases such as desktop full screen.

This PR is still a draft.  I haven't yet:
- run UTs
- added UTs
- done any live testing

If a fix along these lines is wanted, I'll take care of the above, and submit for review.  For now awaiting feedback either here or in #5411.