### PR TITLE
Fix bug in handling processSound callback when sound hadn't loaded yet

### DIFF
--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -91,7 +91,7 @@ module.exports.Component = registerComponent('sound', {
 
         // Remove this key from cache, otherwise we can't play it again
         THREE.Cache.remove(data.src);
-        if (self.data.autoplay || self.mustPlay) { self.playSound(this.processSound); }
+        if (self.data.autoplay || self.mustPlay) { self.playSound(self.processSound); }
         self.el.emit('sound-loaded', self.evtDetail, false);
       });
     }

--- a/tests/components/sound.test.js
+++ b/tests/components/sound.test.js
@@ -176,6 +176,23 @@ suite('sound', function () {
       assert.ok(sound.play.called);
     });
 
+    test('plays sound and calls processSound callback when not loaded', function (done) {
+      var el = this.el;
+      var processSoundStub = sinon.stub();
+
+      el.setAttribute('sound', 'src', 'url(base/tests/assets/test.ogg)');
+      el.components.sound.playSound(processSoundStub);
+      assert.notOk(el.components.sound.isPlaying);
+      assert.ok(el.components.sound.mustPlay);
+
+      el.addEventListener('sound-loaded', function () {
+        assert.ok(el.components.sound.isPlaying);
+        assert.notOk(el.components.sound.mustPlay);
+        assert.ok(processSoundStub.calledOnce);
+        done();
+      });
+    });
+
     test('plays sound if sound already playing when changing src', function (done) {
       var el = this.el;
       var playSoundStub = el.components.sound.playSound = sinon.stub();


### PR DESCRIPTION
**Description:**
The changes made in #5365 can result in an error (see https://github.com/aframevr/aframe/pull/5365#issuecomment-1856510842). The code incorrectly uses `this` instead of `self`. This PR fixes it and adds a unit test covering this as well.

**Changes proposed:**
- Replace the incorrect `this` with `self`
- Introduce a unit test that verifies that the `processSound` callback given to `playSound` is correctly invoked upon the sound loading.