### PR TITLE
Fix bug when loading models on child entities of controllers

### DIFF
--- a/src/components/oculus-go-controls.js
+++ b/src/components/oculus-go-controls.js
@@ -156,7 +156,7 @@ module.exports.Component = registerComponent('oculus-go-controls', {
     var controllerObject3D = evt.detail.model;
     var buttonMeshes;
 
-    if (!this.data.model) { return; }
+    if (evt.target !== this.el || !this.data.model) { return; }
     buttonMeshes = this.buttonMeshes = {};
     buttonMeshes.trigger = controllerObject3D.getObjectByName('oculus_go_button_trigger');
     buttonMeshes.trackpad = controllerObject3D.getObjectByName('oculus_go_touchpad');

--- a/src/components/oculus-touch-controls.js
+++ b/src/components/oculus-touch-controls.js
@@ -383,7 +383,7 @@ module.exports.Component = registerComponent('oculus-touch-controls', {
   },
 
   onModelLoaded: function (evt) {
-    if (!this.data.model) { return; }
+    if (evt.target !== this.el || !this.data.model) { return; }
     if (this.isTouchV3orPROorPlus) {
       this.onTouchV3orPROorPlusModelLoaded(evt);
     } else {

--- a/src/components/pico-controls.js
+++ b/src/components/pico-controls.js
@@ -154,7 +154,7 @@ module.exports.Component = registerComponent('pico-controls', {
   },
 
   onModelLoaded: function (evt) {
-    if (!this.data.model) { return; }
+    if (evt.target !== this.el || !this.data.model) { return; }
 
     this.el.emit('controllermodelready', {
       name: 'pico-controls',

--- a/src/components/valve-index-controls.js
+++ b/src/components/valve-index-controls.js
@@ -193,7 +193,7 @@ module.exports.Component = registerComponent('valve-index-controls', {
     var controllerObject3D = evt.detail.model;
     var self = this;
 
-    if (!this.data.model) { return; }
+    if (evt.target !== this.el || !this.data.model) { return; }
 
     // Store button meshes object to be able to change their colors.
     buttonMeshes = this.buttonMeshes = {};

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -199,7 +199,7 @@ module.exports.Component = registerComponent('vive-controls', {
     var controllerObject3D = evt.detail.model;
     var self = this;
 
-    if (!this.data.model) { return; }
+    if (evt.target !== this.el || !this.data.model) { return; }
 
     // Store button meshes object to be able to change their colors.
     buttonMeshes = this.buttonMeshes = {};

--- a/src/components/vive-focus-controls.js
+++ b/src/components/vive-focus-controls.js
@@ -126,7 +126,7 @@ module.exports.Component = registerComponent('vive-focus-controls', {
     var controllerObject3D = evt.detail.model;
     var buttonMeshes;
 
-    if (!this.data.model) { return; }
+    if (evt.target !== this.el || !this.data.model) { return; }
     buttonMeshes = this.buttonMeshes = {};
     buttonMeshes.trigger = controllerObject3D.getObjectByName('BumperKey');
     buttonMeshes.triggerPressed = controllerObject3D.getObjectByName('BumperKey_Press');

--- a/src/components/windows-motion-controls.js
+++ b/src/components/windows-motion-controls.js
@@ -276,6 +276,8 @@ module.exports.Component = registerComponent('windows-motion-controls', {
     var mesh;
     var meshInfo;
 
+    if (evt.target !== this.el) { return; }
+
     debug('Processing model');
 
     // Reset the caches


### PR DESCRIPTION
**Description:**
The various controls components handle the `model-loaded` event to configure the controller models. However, they don't check where the `model-loaded` event originates from. In case a child entity loads a model, the controls components would incorrectly assume it's the controller model that just loaded in.

This actually causes issues in A-Painter where the `model-loaded` event of the brush-tip would trigger the `onModelLoaded` for the `oculus-touch-controls` (and others).

**Changes proposed:**
- Include a guard in `onModelLoaded` checking that the event didn't originate from any child element
