### PR TITLE
Remove unneeded `crossOrigin` configuration for THREE loaders

### DIFF
--- a/src/lib/three.js
+++ b/src/lib/three.js
@@ -1,27 +1,8 @@
 var THREE = require('./three.module.js').default;
 
-// Allow cross-origin images to be loaded.
-
-// This should not be on `THREE.Loader` nor `THREE.ImageUtils`.
-// Must be on `THREE.TextureLoader`.
-if (THREE.TextureLoader) {
-  THREE.TextureLoader.prototype.crossOrigin = 'anonymous';
-}
-
-// This is for images loaded from the model loaders.
-if (THREE.ImageLoader) {
-  THREE.ImageLoader.prototype.crossOrigin = 'anonymous';
-}
-
 // In-memory caching for XHRs (for images, audio files, textures, etc.).
 if (THREE.Cache) {
   THREE.Cache.enabled = true;
 }
-
-THREE.DRACOLoader.prototype.crossOrigin = 'anonymous';
-THREE.GLTFLoader.prototype.crossOrigin = 'anonymous';
-THREE.KTX2Loader.prototype.crossOrigin = 'anonymous';
-THREE.MTLLoader.prototype.crossOrigin = 'anonymous';
-THREE.OBJLoader.prototype.crossOrigin = 'anonymous';
 
 module.exports = THREE;

--- a/src/lib/three.module.js
+++ b/src/lib/three.module.js
@@ -8,8 +8,7 @@ import { MTLLoader } from 'super-three/examples/jsm/loaders/MTLLoader';
 import * as BufferGeometryUtils from 'super-three/examples/jsm/utils/BufferGeometryUtils';
 import { LightProbeGenerator } from 'super-three/examples/jsm/lights/LightProbeGenerator';
 
-var objectAssign = require('object-assign');
-var THREE = window.THREE = objectAssign({}, SUPER_THREE);
+var THREE = window.THREE = SUPER_THREE;
 
 // TODO: Eventually include these only if they are needed by a component.
 require('../../vendor/DeviceOrientationControls'); // THREE.DeviceOrientationControls


### PR DESCRIPTION
**Description:**
The `crossOrigin` property of various THREE loaders was set to `anonymous`, but this has become the default value for them in Three.js (https://github.com/mrdoob/three.js/pull/14331). As such, there's no longer any need to manually set them.

**Changes proposed:**
- No longer set `crossOrigin` on loaders
- Remove unnecessary `Object.assign` 
