### PR TITLE
Set `.background` null when removing `background` component

### DIFF
--- a/src/components/scene/background.js
+++ b/src/components/scene/background.js
@@ -1,6 +1,5 @@
 /* global THREE */
 var register = require('../../core/component').registerComponent;
-var COMPONENTS = require('../../core/component').components;
 
 module.exports.Component = register('background', {
   schema: {
@@ -19,12 +18,7 @@ module.exports.Component = register('background', {
   },
 
   remove: function () {
-    var data = this.data;
     var object3D = this.el.object3D;
-    if (data.transparent) {
-      object3D.background = null;
-      return;
-    }
-    object3D.background = COMPONENTS[this.name].schema.color.default;
+    object3D.background = null;
   }
 });

--- a/tests/components/scene/background.test.js
+++ b/tests/components/scene/background.test.js
@@ -14,11 +14,11 @@ suite('background', function () {
     assert.shallowDeepEqual(sceneEl.object3D.background, {r: 1, g: 1, b: 0});
   });
 
-  test('change the background color', function () {
+  test('remove the background', function () {
     var sceneEl = this.sceneEl;
     assert.shallowDeepEqual(sceneEl.object3D.background, null);
     sceneEl.setAttribute('background', {color: 'yellow'});
     sceneEl.removeAttribute('background');
-    assert.equal(sceneEl.object3D.background, 'black');
+    assert.equal(sceneEl.object3D.background, null);
   });
 });


### PR DESCRIPTION
**Description:**
The `background` component set the scene background to the string value `black` when removed. Not only is this an invalid value for the background property in Three.js, it also doesn't match the default value from before adding the `background` component.

**Changes proposed:**
- Set `sceneEl.object3D.background` to `null` when removing `background` component
