### PR TITLE
Fix fog removal from scene

### DIFF
--- a/src/components/scene/fog.js
+++ b/src/components/scene/fog.js
@@ -30,7 +30,6 @@ module.exports.Component = register('fog', {
     // (Re)create fog if fog doesn't exist or fog type changed.
     if (!fog || data.type !== fog.name) {
       el.object3D.fog = getFog(data);
-      el.systems.material.updateMaterials();
       return;
     }
 
@@ -51,7 +50,6 @@ module.exports.Component = register('fog', {
     if (!fog) { return; }
 
     el.object3D.fog = null;
-    el.systems.material.updateMaterials();
   }
 });
 

--- a/src/components/scene/fog.js
+++ b/src/components/scene/fog.js
@@ -46,10 +46,12 @@ module.exports.Component = register('fog', {
    * Remove fog on remove (callback).
    */
   remove: function () {
+    var el = this.el;
     var fog = this.el.object3D.fog;
     if (!fog) { return; }
-    fog.far = 0;
-    fog.near = 0.1;
+
+    el.object3D.fog = null;
+    el.systems.material.updateMaterials();
   }
 });
 

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -223,16 +223,6 @@ module.exports.System = registerSystem('material', {
   },
 
   /**
-   * Trigger update to all registered materials.
-   */
-  updateMaterials: function (material) {
-    var materials = this.materials;
-    Object.keys(materials).forEach(function (uuid) {
-      materials[uuid].needsUpdate = true;
-    });
-  },
-
-  /**
    * Track textures used by material components, so that they can be safely
    * disposed when no longer in use. Textures must be registered here, and not
    * through registerMaterial(), because textures may not be attached at the

--- a/tests/components/scene/fog.test.js
+++ b/tests/components/scene/fog.test.js
@@ -8,7 +8,6 @@ suite('fog', function () {
     var self = this;
 
     el.addEventListener('loaded', function () {
-      self.updateMaterialsSpy = self.sinon.spy(el.systems.material, 'updateMaterials');
       // Stub scene load to avoid WebGL code.
       el.hasLoaded = true;
       el.setAttribute('fog', '');
@@ -26,10 +25,6 @@ suite('fog', function () {
   suite('update', function () {
     test('creates fog', function () {
       assert.ok(this.el.object3D.fog);
-    });
-
-    test('triggers material update when adding fog', function () {
-      assert.ok(this.updateMaterialsSpy.called);
     });
 
     test('updates fog', function () {

--- a/tests/components/scene/fog.test.js
+++ b/tests/components/scene/fog.test.js
@@ -67,16 +67,7 @@ suite('fog', function () {
     test('removes fog when detaching fog', function () {
       var el = this.el;
       el.removeAttribute('fog');
-      assert.equal(el.object3D.fog.far, 0);
-      assert.equal(el.object3D.fog.near, 0.1);
-    });
-
-    test('removes exp. fog when detaching fog', function () {
-      var el = this.el;
-      el.setAttribute('fog', 'type: exponential');
-      el.removeAttribute('fog');
-      assert.equal(el.object3D.fog.far, 0);
-      assert.equal(el.object3D.fog.near, 0.1);
+      assert.equal(el.object3D.fog, null);
     });
   });
 });


### PR DESCRIPTION
**Description:**
When removing the `fog` component, the fog wouldn't actually be removed but instead rendered "ineffective" by adjusting the `near` and `far` values. This however has two issues:

- Fog type `exponential` doesn't use `near` and `far` meaning the fog would still be visible after removal
- Shaders would still perform fog calculations for no reason

**Changes proposed:**
- Instead of adjusting fog when removing, outright set it to `null` ([Three.js default value](https://threejs.org/docs/index.html?q=scene#api/en/scenes/Scene.fog))
- Remove `updateMaterials()` method as it was only used by the `fog` component and is not needed since https://github.com/mrdoob/three.js/pull/20135
- Update unit tests to match
