### PR TITLE
Allow async loading of aframe library and interoperation with ES module libraries

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -11,6 +11,17 @@ var MULTIPLE_COMPONENT_DELIMITER = '__';
 var OBJECT3D_COMPONENTS = ['position', 'rotation', 'scale', 'visible'];
 var ONCE = {once: true};
 
+var _resolveReadyPromise;
+var isReady = false;
+var isReadyPromise = new Promise(function (resolve) {
+  _resolveReadyPromise = resolve;
+});
+
+function ready () {
+  isReady = true;
+  _resolveReadyPromise();
+}
+
 /**
  * Entity is a container object that components are plugged into to comprise everything in
  * the scene. In A-Frame, they inherently have position, rotation, and scale.
@@ -67,6 +78,12 @@ class AEntity extends ANode {
       return;
     }
 
+    if (!isReady) {
+      isReadyPromise.then(
+        AEntity.prototype.doConnectedCallback.bind(this)
+      );
+      return;
+    }
     AEntity.prototype.doConnectedCallback.call(this);
   }
 
@@ -868,6 +885,7 @@ function getRotation (entityEl) {
 
 AEntity.componentsUpdated = [];
 AEntity.singlePropUpdate = {};
+AEntity.ready = ready;
 
 customElements.define('a-entity', AEntity);
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -191,7 +191,6 @@ class AScene extends AEntity {
    */
   initSystem (name) {
     if (this.systems[name]) { return; }
-    if (!systems[name]) { return; }
     this.systems[name] = new systems[name](this);
     this.systemNames.push(name);
   }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -191,6 +191,7 @@ class AScene extends AEntity {
    */
   initSystem (name) {
     if (this.systems[name]) { return; }
+    if (!systems[name]) { return; }
     this.systems[name] = new systems[name](this);
     this.systemNames.push(name);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -62,8 +62,6 @@ if (utils.device.isBrowserEnvironment) {
   require('./style/rStats.css');
 }
 
-// Required before `AEntity` so that all components are registered.
-var AScene = require('./core/scene/a-scene').AScene;
 var components = require('./core/component').components;
 var registerComponent = require('./core/component').registerComponent;
 var registerGeometry = require('./core/geometry').registerGeometry;
@@ -81,8 +79,16 @@ require('./components/index'); // Register standard components.
 require('./geometries/index'); // Register standard geometries.
 require('./shaders/index'); // Register standard shaders.
 require('./systems/index'); // Register standard systems.
+// Required before `AEntity` so that all components are registered.
+var AScene = require('./core/scene/a-scene').AScene;
 var ANode = require('./core/a-node').ANode;
 var AEntity = require('./core/a-entity').AEntity; // Depends on ANode and core components.
+setTimeout(function () {
+  if (window.AFRAME_ASYNC) {
+    return;
+  }
+  AEntity.ready();
+}, 0);
 
 require('./core/a-assets');
 require('./core/a-cubemap');
@@ -106,6 +112,7 @@ module.exports = window.AFRAME = {
   components: components,
   coreComponents: Object.keys(components),
   geometries: require('./core/geometry').geometries,
+  ready: AEntity.ready.bind(AEntity),
   registerComponent: registerComponent,
   registerGeometry: registerGeometry,
   registerPrimitive: registerPrimitive,


### PR DESCRIPTION
**Description:**
This allows interop with ES module libraries such as webxr.
ES modules are a part of the Web Component spec but it's a bit surprising that aframe doesn't play well with other Web Components that rely on ES modules.

It allows aframe to be loaded as a module or deferred on page load.
Currently, aframe needs to be loaded synchronously. Adding `async` or `defer` or `type="module"` can cause `aframe` library to fail in many different ways such as:
* `a-scene` is registered and connectedCallback hook does not find the camera component as it hasn't been registered
* `a-entity`'s connectedCallback hook unable to find that `a-scene` is initialized

These proposed changes allow the following code snippet to run:
Note that `new LookingGlassWebXRPolyfill()` needs to run before importing aframe in order to polyfill/override webxr for looking glass capabilities.

```html
    <script type="module">
      import { LookingGlassWebXRPolyfill } from "@lookingglass/webxr"
      new LookingGlassWebXRPolyfill()
      window.AFRAME_ASYNC = true;
      await import("aframe")
      // add any components
      await import("https://quadjr.github.io/aframe-gaussian-splatting/index.js")
      window.AFRAME.ready();
    </script>
```

Example of this working is at https://chrisirhc.github.io/looking-glass-viewer-experiments/aframe.html .

**Changes proposed:**
- Delay running `doConnectedCallback` until `ready` is called if `window.AFRAME_ASYNC` is set to a truthy value
- Reorder the initialization in index.js so that default components and system are registered before connectedCallback is called.

This is a strawman implementation. I'm not sure how to name these API surfaces and open to suggestions.

**Alternatives considered**
- Change the order or delay order in which the customElements are registered.
  - Not that this doesn't work well because a-scene element creates a-entity elements during its connectedCallback lifecycle hook, so if a-entity isn't already registered, then 