### PR TITLE
Fix bug when checking schema properties for schemaChange

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -364,7 +364,7 @@ Component.prototype = {
     // Check if we need to update schema.
     if (this.schemaChangeKeys.length) {
       for (key in attrValue) {
-        if (this.schema[key].schemaChange) {
+        if (key in this.schema && this.schema[key].schemaChange) {
           mayNeedSchemaUpdate = true;
           break;
         }

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -543,6 +543,72 @@ suite('Component', function () {
       assert.equal(3, el.object3D.position.y);
       assert.equal(3, el.object3D.position.z);
     });
+
+    test('calls updateSchema when initializing component', function () {
+      let updateSchemaSpy = this.sinon.spy();
+      registerComponent('dummy', {
+        schema: {
+          type: {default: 'plane', schemaChange: true}
+        },
+        updateSchema: function () {
+          updateSchemaSpy();
+        }
+      });
+      el.hasLoaded = true;
+      el.setAttribute('dummy', {});
+      assert.ok(updateSchemaSpy.calledOnce);
+    });
+
+    test('updates schema when property with schemaChange is changed', function () {
+      let updateSchemaSpy = this.sinon.spy();
+      registerComponent('dummy', {
+        schema: {
+          type: {default: 'plane', schemaChange: true},
+          color: {default: 'blue'}
+        },
+        updateSchema: function () {
+          updateSchemaSpy();
+        }
+      });
+      el.hasLoaded = true;
+      el.setAttribute('dummy', {});
+      el.setAttribute('dummy', {type: 'box'});
+      assert.ok(updateSchemaSpy.calledTwice);
+    });
+
+    test('does not update schema when no property with schemaChange is changed', function () {
+      let updateSchemaSpy = this.sinon.spy();
+      registerComponent('dummy', {
+        schema: {
+          type: {default: 'plane', schemaChange: true},
+          color: {default: 'blue'}
+        },
+        updateSchema: function () {
+          updateSchemaSpy();
+        }
+      });
+      el.hasLoaded = true;
+      el.setAttribute('dummy', {});
+      el.setAttribute('dummy', {color: 'red'});
+      assert.ok(updateSchemaSpy.calledOnce);
+    });
+
+    test('ignores invalid properties when checking if schema needs to be updated', function () {
+      let updateSchemaSpy = this.sinon.spy();
+      registerComponent('dummy', {
+        schema: {
+          type: {default: 'plane', schemaChange: true},
+          color: {default: 'blue'}
+        },
+        updateSchema: function () {
+          updateSchemaSpy();
+        }
+      });
+      el.hasLoaded = true;
+      el.setAttribute('dummy', {});
+      el.setAttribute('dummy', {invalidProperty: 'should be ignored', color: 'red'});
+      assert.ok(updateSchemaSpy.calledOnce);
+    });
   });
 
   suite('resetProperty', function () {


### PR DESCRIPTION
**Description:**
Components that have one or more properties marked as `schemaChange` will check if any of these properties change to trigger an `updateSchema`. While checking the properties in an update, it incorrectly assumes each property to also exist, which might not be the case.

Reproduction (https://glitch.com/edit/#!/beaded-basalt-church?path=index.html):
```HTML
<script>
    AFRAME.registerComponent('bug', {
      init: function() {
        this.el.setAttribute('material', {
            invalidProperty: 'causes an error',
        })
      }
    })
</script>
(...)
<a-scene>
    <a-entity material bug></a-entity>
</a-scene>
```

**Changes proposed:**
- Ensure a property is part of the schema before checking its `schemaChange` flag
