### PR TITLE
Stop the light probe only if this was set up in the first place

### DIFF
--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -51,7 +51,9 @@ module.exports.Component = register('reflection', {
     });
 
     this.el.addEventListener('exit-vr', function () {
-      self.stopLightProbe();
+      if (self.xrLightProbe) {
+        self.stopLightProbe();
+      }
     });
 
     this.el.object3D.environment = this.cubeRenderTarget.texture;

--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -51,9 +51,7 @@ module.exports.Component = register('reflection', {
     });
 
     this.el.addEventListener('exit-vr', function () {
-      if (self.xrLightProbe) {
-        self.stopLightProbe();
-      }
+      if (self.xrLightProbe) { self.stopLightProbe(); }
     });
 
     this.el.object3D.environment = this.cubeRenderTarget.texture;


### PR DESCRIPTION
Following #5384 and https://github.com/aframevr/aframe/pull/5384#issuecomment-1812849138 in particular

In this proposed change we stop the light probe only when this has been set up in the first place.

All the best