### PR TITLE
Fix for Wolvic + Pico4 controllers

### DIFF
--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -98,6 +98,10 @@ registerComponent('laser-controls', {
       raycaster: {origin: {x: 0, y: 0, z: 0}}
     },
 
+    'pico-controls': {
+      cursor: {downEvents: ['triggerdown'], upEvents: ['triggerup']}
+    },
+
     'valve-index-controls': {
       cursor: {downEvents: ['triggerdown'], upEvents: ['triggerup']}
     },


### PR DESCRIPTION
**Description:**
Pico4 controllers works well in default browser but in Wolvic they were visible but triggers were not working. 

**Changes proposed:**
- Updated laser-controls config