### PR TITLE
Only update position and rotation of wristObject3D when joint poses are available

### DIFF
--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -194,7 +194,7 @@ module.exports.Component = registerComponent('hand-tracking-controls', {
     var jointPose = new THREE.Matrix4();
     return function () {
       var wristObject3D = this.wristObject3D;
-      if (!wristObject3D) { return; }
+      if (!wristObject3D || !this.hasPoses) { return; }
       jointPose.fromArray(this.jointPoses, WRIST_INDEX * 16);
       wristObject3D.position.setFromMatrixPosition(jointPose);
       wristObject3D.quaternion.setFromRotationMatrix(jointPose);


### PR DESCRIPTION
**Description:**
The issue reported in #5437 is caused by the `wristObject3D` in the `hand-tracking-controls` component ending up with NaN in its matrix. This happens when no joint poses are available, and causes subsequent computations (like bounding box overlap) to give incorrect results.

This PR simply checks that pose information is present before updating the `wristObject3D`. This does mean that the object in question remains at its last location and orientation. For short intermittent lack of pose information this is likely desirable, but for longer period this might be counter-intuitive.

**Changes proposed:**
- Check that joint pose information is present before updating the `wristObject3D`
