### PR TITLE
setup canvas on first capture screenshot.js

### DIFF
--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -77,7 +77,6 @@ module.exports.Component = registerComponent('screenshot', {
       self.ctx = self.canvas.getContext('2d');
       el.object3D.add(self.quad);
       self.onKeyDown = self.onKeyDown.bind(self);
-      self.setupDone = true;
     }  
   },
 

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -49,34 +49,29 @@ module.exports.Component = registerComponent('screenshot', {
     height: {default: 2048},
     camera: {type: 'selector'}
   },
-
-  init: function () {
-  },
-
+  
   setup: function () {
     var el = this.el;
-    var self = this;
-    if (!self.canvas) {
-      var gl = el.renderer.getContext();
-      if (!gl) { return; }
-      self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
-      self.material = new THREE.RawShaderMaterial({
-        uniforms: {map: {type: 't', value: null}},
-        vertexShader: VERTEX_SHADER,
-        fragmentShader: FRAGMENT_SHADER,
-        side: THREE.DoubleSide
-      });
-      self.quad = new THREE.Mesh(
-        new THREE.PlaneGeometry(1, 1),
-        self.material
-      );
-      self.quad.visible = false;
-      self.camera = new THREE.OrthographicCamera(-1 / 2, 1 / 2, 1 / 2, -1 / 2, -10000, 10000);
-      self.canvas = document.createElement('canvas');
-      self.ctx = self.canvas.getContext('2d');
-      el.object3D.add(self.quad);
-      self.onKeyDown = self.onKeyDown.bind(self);
-    }
+    if (this.canvas) { return; }
+    var gl = el.renderer.getContext();
+    if (!gl) { return; }
+    this.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+    this.material = new THREE.RawShaderMaterial({
+      uniforms: {map: {type: 't', value: null}},
+      vertexShader: VERTEX_SHADER,
+      fragmentShader: FRAGMENT_SHADER,
+      side: THREE.DoubleSide
+    });
+    this.quad = new THREE.Mesh(
+      new THREE.PlaneGeometry(1, 1),
+      this.material
+    );
+    this.quad.visible = false;
+    this.camera = new THREE.OrthographicCamera(-1 / 2, 1 / 2, 1 / 2, -1 / 2, -10000, 10000);
+    this.canvas = document.createElement('canvas');
+    this.ctx = self.canvas.getContext('2d');
+    el.object3D.add(self.quad);
+    this.onKeyDown = self.onKeyDown.bind(this);
   },
 
   getRenderTarget: function (width, height) {
@@ -174,10 +169,10 @@ module.exports.Component = registerComponent('screenshot', {
    * Maintained for backwards compatibility.
    */
   capture: function (projection) {
-    this.setup();
     var isVREnabled = this.el.renderer.xr.enabled;
     var renderer = this.el.renderer;
     var params;
+    this.setup();
     // Disable VR.
     renderer.xr.enabled = false;
     params = this.setCapture(projection);

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -76,7 +76,7 @@ module.exports.Component = registerComponent('screenshot', {
       self.ctx = self.canvas.getContext('2d');
       el.object3D.add(self.quad);
       self.onKeyDown = self.onKeyDown.bind(self);
-    }  
+    }
   },
   
   getRenderTarget: function (width, height) {

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -51,7 +51,7 @@ module.exports.Component = registerComponent('screenshot', {
   },
 
   init: function () {
-    this.setupDone = false
+    this.setupDone = false;
   },
 
   setup: function () {
@@ -175,7 +175,7 @@ module.exports.Component = registerComponent('screenshot', {
    */
   capture: function (projection) {
     if (!this.setupDone) {
-      this.setup()
+      this.setup();
     }
     var isVREnabled = this.el.renderer.xr.enabled;
     var renderer = this.el.renderer;

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -51,7 +51,6 @@ module.exports.Component = registerComponent('screenshot', {
   },
 
   init: function () {
-    
   },
 
   setup: function () {
@@ -79,7 +78,7 @@ module.exports.Component = registerComponent('screenshot', {
       self.onKeyDown = self.onKeyDown.bind(self);
     }  
   },
-
+  
   getRenderTarget: function (width, height) {
     return new THREE.WebGLRenderTarget(width, height, {
       colorSpace: this.el.sceneEl.renderer.outputColorSpace,

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -51,36 +51,32 @@ module.exports.Component = registerComponent('screenshot', {
   },
 
   init: function () {
+    this.setupDone = false
+  },
+
+  setup: function () {
     var el = this.el;
     var self = this;
-
-    if (el.renderer) {
-      setup();
-    } else {
-      el.addEventListener('render-target-loaded', setup);
-    }
-
-    function setup () {
-      var gl = el.renderer.getContext();
-      if (!gl) { return; }
-      self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
-      self.material = new THREE.RawShaderMaterial({
-        uniforms: {map: {type: 't', value: null}},
-        vertexShader: VERTEX_SHADER,
-        fragmentShader: FRAGMENT_SHADER,
-        side: THREE.DoubleSide
-      });
-      self.quad = new THREE.Mesh(
-        new THREE.PlaneGeometry(1, 1),
-        self.material
-      );
-      self.quad.visible = false;
-      self.camera = new THREE.OrthographicCamera(-1 / 2, 1 / 2, 1 / 2, -1 / 2, -10000, 10000);
-      self.canvas = document.createElement('canvas');
-      self.ctx = self.canvas.getContext('2d');
-      el.object3D.add(self.quad);
-      self.onKeyDown = self.onKeyDown.bind(self);
-    }
+    var gl = el.renderer.getContext();
+    if (!gl) { return; }
+    self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+    self.material = new THREE.RawShaderMaterial({
+      uniforms: {map: {type: 't', value: null}},
+      vertexShader: VERTEX_SHADER,
+      fragmentShader: FRAGMENT_SHADER,
+      side: THREE.DoubleSide
+    });
+    self.quad = new THREE.Mesh(
+      new THREE.PlaneGeometry(1, 1),
+      self.material
+    );
+    self.quad.visible = false;
+    self.camera = new THREE.OrthographicCamera(-1 / 2, 1 / 2, 1 / 2, -1 / 2, -10000, 10000);
+    self.canvas = document.createElement('canvas');
+    self.ctx = self.canvas.getContext('2d');
+    el.object3D.add(self.quad);
+    self.onKeyDown = self.onKeyDown.bind(self);
+    self.setupDone = true;
   },
 
   getRenderTarget: function (width, height) {
@@ -178,6 +174,9 @@ module.exports.Component = registerComponent('screenshot', {
    * Maintained for backwards compatibility.
    */
   capture: function (projection) {
+    if (!this.setupDone) {
+      this.setup()
+    }
     var isVREnabled = this.el.renderer.xr.enabled;
     var renderer = this.el.renderer;
     var params;

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -49,7 +49,7 @@ module.exports.Component = registerComponent('screenshot', {
     height: {default: 2048},
     camera: {type: 'selector'}
   },
-  
+
   setup: function () {
     var el = this.el;
     if (this.canvas) { return; }
@@ -69,9 +69,9 @@ module.exports.Component = registerComponent('screenshot', {
     this.quad.visible = false;
     this.camera = new THREE.OrthographicCamera(-1 / 2, 1 / 2, 1 / 2, -1 / 2, -10000, 10000);
     this.canvas = document.createElement('canvas');
-    this.ctx = self.canvas.getContext('2d');
-    el.object3D.add(self.quad);
-    this.onKeyDown = self.onKeyDown.bind(this);
+    this.ctx = this.canvas.getContext('2d');
+    el.object3D.add(this.quad);
+    this.onKeyDown = this.onKeyDown.bind(this);
   },
 
   getRenderTarget: function (width, height) {

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -51,32 +51,34 @@ module.exports.Component = registerComponent('screenshot', {
   },
 
   init: function () {
-    this.setupDone = false;
+    
   },
 
   setup: function () {
     var el = this.el;
     var self = this;
-    var gl = el.renderer.getContext();
-    if (!gl) { return; }
-    self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
-    self.material = new THREE.RawShaderMaterial({
-      uniforms: {map: {type: 't', value: null}},
-      vertexShader: VERTEX_SHADER,
-      fragmentShader: FRAGMENT_SHADER,
-      side: THREE.DoubleSide
-    });
-    self.quad = new THREE.Mesh(
-      new THREE.PlaneGeometry(1, 1),
-      self.material
-    );
-    self.quad.visible = false;
-    self.camera = new THREE.OrthographicCamera(-1 / 2, 1 / 2, 1 / 2, -1 / 2, -10000, 10000);
-    self.canvas = document.createElement('canvas');
-    self.ctx = self.canvas.getContext('2d');
-    el.object3D.add(self.quad);
-    self.onKeyDown = self.onKeyDown.bind(self);
-    self.setupDone = true;
+    if (!self.canvas) {
+      var gl = el.renderer.getContext();
+      if (!gl) { return; }
+      self.cubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+      self.material = new THREE.RawShaderMaterial({
+        uniforms: {map: {type: 't', value: null}},
+        vertexShader: VERTEX_SHADER,
+        fragmentShader: FRAGMENT_SHADER,
+        side: THREE.DoubleSide
+      });
+      self.quad = new THREE.Mesh(
+        new THREE.PlaneGeometry(1, 1),
+        self.material
+      );
+      self.quad.visible = false;
+      self.camera = new THREE.OrthographicCamera(-1 / 2, 1 / 2, 1 / 2, -1 / 2, -10000, 10000);
+      self.canvas = document.createElement('canvas');
+      self.ctx = self.canvas.getContext('2d');
+      el.object3D.add(self.quad);
+      self.onKeyDown = self.onKeyDown.bind(self);
+      self.setupDone = true;
+    }  
   },
 
   getRenderTarget: function (width, height) {
@@ -174,9 +176,7 @@ module.exports.Component = registerComponent('screenshot', {
    * Maintained for backwards compatibility.
    */
   capture: function (projection) {
-    if (!this.setupDone) {
-      this.setup();
-    }
+    this.setup();
     var isVREnabled = this.el.renderer.xr.enabled;
     var renderer = this.el.renderer;
     var params;

--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -78,7 +78,7 @@ module.exports.Component = registerComponent('screenshot', {
       self.onKeyDown = self.onKeyDown.bind(self);
     }
   },
-  
+
   getRenderTarget: function (width, height) {
     return new THREE.WebGLRenderTarget(width, height, {
       colorSpace: this.el.sceneEl.renderer.outputColorSpace,


### PR DESCRIPTION
**Description:**
The  default Screenshot Component always creates a shader and canvas on init()
this PR change it on first usage of screenshot capture.

**Changes proposed:**
-set canvas on first capture usage

