### PR TITLE
Unify envmap textures and deprecate sphericalEnvMap

### DIFF
--- a/src/core/a-cubemap.js
+++ b/src/core/a-cubemap.js
@@ -4,7 +4,7 @@ var debug = require('../utils/debug');
 var warn = debug('core:cubemap:warn');
 
 /**
- * Cubemap element that handles validation and exposes list of URLs.
+ * Cubemap element that handles validation and exposes list of six image sources (URL or <img>).
  * Does not listen to updates.
  */
 class ACubeMap extends HTMLElement {
@@ -38,10 +38,9 @@ class ACubeMap extends HTMLElement {
 
   /**
    * Checks for exactly six elements with [src].
-   * Does not check explicitly for <img>s in case user does not want
-   * prefetching.
+   * When <img>s are used they will be prefetched.
    *
-   * @returns {Array|null} - six URLs if valid, else null.
+   * @returns {Array|null} - six URLs or <img> elements if valid, else null.
    */
   validate () {
     var elements = this.querySelectorAll('[src]');
@@ -49,7 +48,11 @@ class ACubeMap extends HTMLElement {
     var srcs = [];
     if (elements.length === 6) {
       for (i = 0; i < elements.length; i++) {
-        srcs.push(elements[i].getAttribute('src'));
+        if (elements[i].tagName === 'IMG') {
+          srcs.push(elements[i]);
+        } else {
+          srcs.push(elements[i].getAttribute('src'));
+        }
       }
       return srcs;
     }

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -6,7 +6,7 @@ var warn = debug('core:propertyTypes:warn');
 
 var propertyTypes = module.exports.propertyTypes = {};
 var nonCharRegex = /[,> .[\]:]/;
-var urlRegex = /\url\((.+)\)/;
+var urlRegex = /url\((.+)\)/;
 
 // Built-in property types.
 registerPropertyType('audio', '', assetParse);

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -2,9 +2,6 @@ var registerShader = require('../core/shader').registerShader;
 var THREE = require('../lib/three');
 var utils = require('../utils/');
 
-var CubeLoader = new THREE.CubeTextureLoader();
-var texturePromises = {};
-
 /**
  * Standard (physically-based) shader using THREE.MeshStandardMaterial.
  */
@@ -74,7 +71,7 @@ module.exports.Shader = registerShader('standard', {
     utils.material.updateDistortionMap('ambientOcclusion', this, data);
     utils.material.updateDistortionMap('metalness', this, data);
     utils.material.updateDistortionMap('roughness', this, data);
-    this.updateEnvMap(data);
+    utils.material.updateEnvMap(this, data);
   },
 
   /**
@@ -90,60 +87,6 @@ module.exports.Shader = registerShader('standard', {
     for (key in this.materialData) {
       material[key] = this.materialData[key];
     }
-  },
-
-  /**
-   * Handle environment cubemap. Textures are cached in texturePromises.
-   */
-  updateEnvMap: function (data) {
-    var self = this;
-    var material = this.material;
-    var envMap = data.envMap;
-    var sphericalEnvMap = data.sphericalEnvMap;
-
-    // No envMap defined or already loading.
-    if ((!envMap && !sphericalEnvMap) || this.isLoadingEnvMap) {
-      material.envMap = null;
-      material.needsUpdate = true;
-      return;
-    }
-    this.isLoadingEnvMap = true;
-
-    // if a spherical env map is defined then use it.
-    if (sphericalEnvMap) {
-      this.el.sceneEl.systems.material.loadTexture(sphericalEnvMap, {src: sphericalEnvMap}, function textureLoaded (texture) {
-        self.isLoadingEnvMap = false;
-        texture.mapping = THREE.EquirectangularReflectionMapping;
-        material.envMap = texture;
-        utils.material.handleTextureEvents(self.el, texture);
-        material.needsUpdate = true;
-      });
-      return;
-    }
-
-    // Another material is already loading this texture. Wait on promise.
-    if (texturePromises[envMap]) {
-      texturePromises[envMap].then(function (cube) {
-        self.isLoadingEnvMap = false;
-        material.envMap = cube;
-        utils.material.handleTextureEvents(self.el, cube);
-        material.needsUpdate = true;
-      });
-      return;
-    }
-
-    // Material is first to load this texture. Load and resolve texture.
-    texturePromises[envMap] = new Promise(function (resolve) {
-      utils.srcLoader.validateCubemapSrc(envMap, function loadEnvMap (urls) {
-        CubeLoader.load(urls, function (cube) {
-          // Texture loaded.
-          self.isLoadingEnvMap = false;
-          material.envMap = cube;
-          utils.material.handleTextureEvents(self.el, cube);
-          resolve(cube);
-        });
-      });
-    });
   }
 });
 

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -70,6 +70,39 @@ module.exports.System = registerSystem('material', {
   },
 
   /**
+   * Load the six individual sides and construct a cube texture, then call back.
+   *
+   * @param {Array} srcs - Array of six texture URLs or elements.
+   * @param {function} cb - Callback to pass cube texture to.
+   */
+  loadCubeMapTexture: function (srcs, cb) {
+    var self = this;
+    var loaded = 0;
+    var cube = new THREE.CubeTexture();
+    cube.colorSpace = THREE.SRGBColorSpace;
+
+    function loadSide (index) {
+      self.loadTexture(srcs[index], {src: srcs[index]}, function (texture) {
+        cube.images[index] = texture.image;
+        loaded++;
+        if (loaded === 6) {
+          cube.needsUpdate = true;
+          cb(cube);
+        }
+      });
+    }
+
+    if (srcs.length !== 6) {
+      warn('Cube map texture requires exactly 6 sources, got only %s sources', srcs.length);
+      return;
+    }
+
+    for (var i = 0; i < srcs.length; i++) {
+      loadSide(i);
+    }
+  },
+
+  /**
    * High-level function for loading image textures (THREE.Texture).
    *
    * @param {Element|string} src - Texture source.

--- a/tests/utils/src-loader.test.js
+++ b/tests/utils/src-loader.test.js
@@ -1,0 +1,93 @@
+/* global assert, suite, setup, test, Image */
+var srcLoader = require('utils/src-loader');
+var entityFactory = require('../helpers').entityFactory;
+
+suite('utils.src-loader', function () {
+  suite('validateEnvMapSrc', function () {
+    setup(function (done) {
+      var el;
+      var imgAsset = document.createElement('img');
+      imgAsset.setAttribute('id', 'image');
+      imgAsset.setAttribute('src', 'base/tests/assets/test.png');
+      var imgCubemap = constructACubemap('img');
+      imgCubemap.setAttribute('id', 'cubemap-imgs');
+      var assetCubemap = constructACubemap('a-asset-item');
+      assetCubemap.setAttribute('id', 'cubemap-assets');
+
+      el = this.el = entityFactory({assets: [imgAsset, imgCubemap, assetCubemap]});
+      if (el.hasLoaded) { done(); }
+      el.addEventListener('loaded', function () {
+        done();
+      });
+    });
+
+    test('validates six urls as cubemap', function (done) {
+      const srcs = `url(base/tests/assets/test.png),
+              url(base/tests/assets/test.png),
+              url(base/tests/assets/test.png),
+              url(base/tests/assets/test.png),
+              url(base/tests/assets/test.png),
+              url(base/tests/assets/test.png)`;
+      srcLoader.validateEnvMapSrc(srcs, function isCubemapCb () {
+        done();
+      }, function isEquirectCb () {
+        assert.fail();
+      });
+    });
+
+    test('validates one url as equirectangular map', function (done) {
+      const srcs = 'url(base/tests/assets/test.png)';
+      srcLoader.validateEnvMapSrc(srcs, function isCubemapCb () {
+        assert.fail();
+      }, function isEquirectCb () {
+        done();
+      });
+    });
+
+    test('validates selector to <img> as equirectangular map', function (done) {
+      const srcs = '#image';
+      srcLoader.validateEnvMapSrc(srcs, function isCubemapCb () {
+        assert.fail();
+      }, function isEquirectCb () {
+        done();
+      });
+    });
+
+    test('validates selector to <a-cubemap> (with <img> children) as cubemap', function (done) {
+      const srcs = '#cubemap-imgs';
+      srcLoader.validateEnvMapSrc(srcs, function isCubemapCb () {
+        done();
+      }, function isEquirectCb () {
+        assert.fail();
+      });
+    });
+
+    test('validates selector to <a-cubemap> (without <img> children) as cubemap', function (done) {
+      const srcs = '#cubemap-assets';
+      srcLoader.validateEnvMapSrc(srcs, function isCubemapCb () {
+        done();
+      }, function isEquirectCb () {
+        assert.fail();
+      });
+    });
+
+    test('validates single non-wrapped URL as equirectangular map', function (done) {
+      const srcs = 'base/tests/assets/test.png';
+      srcLoader.validateEnvMapSrc(srcs, function isCubemapCb () {
+        assert.fail();
+      }, function isEquirectCb () {
+        done();
+      });
+    });
+  });
+});
+
+function constructACubemap (childTag) {
+  var aCubemap = document.createElement('a-cubemap');
+  for (let i = 0; i < 6; i++) {
+    var child = document.createElement(childTag);
+    child.setAttribute('src', 'base/tests/assets/test.png');
+    aCubemap.appendChild(child);
+  }
+  return aCubemap;
+}


### PR DESCRIPTION
**Description:**
Follow-up of #5453, also preparation work for #5449. In A-Frame environment maps were handled separately in both the `standard` and `phong` shader. Besides the code-duplication this also meant that there was no texture re-use between them or other textures.

This PR moves the envMap logic into `utils/material` and `systems/material` in a similar vein to other textures. The eventual texture loads now also go through the texture cache. The possible values for `envMap` has been broadened to support both cubemaps and equirectangular maps. The latter allows a fallback for the currently incorrect behaviour of `sphericalEnvMap`. There is one small breaking change, the `envMap` value now behaves closer to `asset` property types, meaning it now only supports ID based selectors and would otherwise assume a URL in case it's unwrapped (e.g. breaking `envMap="#someElement > a-cubemap.active"`).

**Changes proposed:**
- Move loading of `envMap` to a common implementation in `utils/material` and `systems/material` making use of existing texture loading and caching.
- Expand the possible values for `envMap` to support both cubemap (six images/`<a-cubemap>`) as well as Equirectangular images.
- Deprecate `sphericalEnvMap` as Three.js dropped support for them long ago and A-Frame incorrectly uses them as Equirectangular images. Fallback is in place, logging a warning, but otherwise ensuring those expecting the equirectangular behaviour won't notice a regression.
- Added unit tests for `utils/src-loader` and `shaders/phong`
