### PR TITLE
Cache Source instead of Texture instances in material system

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -250,4 +250,13 @@ function parseBlending (blending) {
 function disposeMaterial (material, system) {
   material.dispose();
   system.unregisterMaterial(material);
+
+  // Dispose textures on this material
+  Object.keys(material)
+    .filter(function (propName) {
+      return material[propName] && material[propName].isTexture;
+    })
+    .forEach(function (mapName) {
+      material[mapName].dispose();
+    });
 }

--- a/src/core/shader.js
+++ b/src/core/shader.js
@@ -135,9 +135,6 @@ Shader.prototype = {
         color = new THREE.Color(value);
         return new THREE.Vector3(color.r, color.g, color.b);
       }
-      case 'map': {
-        return THREE.ImageUtils.loadTexture(value);
-      }
       default: {
         return value;
       }

--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -78,8 +78,11 @@ module.exports.System = registerSystem('renderer', {
   applyColorCorrection: function (texture) {
     if (!this.data.colorManagement || !texture) {
       return;
-    } else if (texture.isTexture) {
+    }
+
+    if (texture.isTexture && texture.colorSpace !== THREE.SRGBColorSpace) {
       texture.colorSpace = THREE.SRGBColorSpace;
+      texture.needsUpdate = true;
     }
   },
 

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -44,6 +44,32 @@ suite('material', function () {
       assert.ok(disposeSpy.called);
     });
 
+    test('disposes material when removing material', function () {
+      var material = el.getObject3D('mesh').material;
+      var disposeSpy = this.sinon.spy(material, 'dispose');
+      el.removeAttribute('material');
+      assert.ok(disposeSpy.called);
+    });
+
+    test('disposes textures when removing material', function () {
+      var material = el.getObject3D('mesh').material;
+      var texture1 = {uuid: 'tex1', isTexture: true, dispose: sinon.spy()};
+      var texture2 = {uuid: 'tex2', isTexture: true, dispose: sinon.spy()};
+      material.map = texture1;
+      material.normalMap = texture2;
+      el.removeAttribute('material');
+      assert.ok(texture1.dispose.called);
+      assert.ok(texture2.dispose.called);
+    });
+
+    test('disposes texture when removing texture', function () {
+      var material = el.getObject3D('mesh').material;
+      var texture1 = {uuid: 'tex1', isTexture: true, dispose: sinon.spy()};
+      material.map = texture1;
+      el.setAttribute('material', 'map', '');
+      assert.ok(texture1.dispose.called);
+    });
+
     test('defaults to standard material', function () {
       el.removeAttribute('material'); // setup creates a non-default component
       el.setAttribute('material', '');
@@ -158,11 +184,11 @@ suite('material', function () {
     });
 
     test('invokes XHR if <img> not cached', function (done) {
-      var textureLoaderSpy = this.sinon.spy(THREE.TextureLoader.prototype, 'load');
+      var imageLoaderSpy = this.sinon.spy(THREE.ImageLoader.prototype, 'load');
       el.addEventListener('materialtextureloaded', function () {
-        assert.ok(textureLoaderSpy.called);
+        assert.ok(imageLoaderSpy.called);
         assert.ok(IMG_SRC in THREE.Cache.files);
-        THREE.TextureLoader.prototype.load.restore();
+        THREE.ImageLoader.prototype.load.restore();
         done();
       });
       el.setAttribute('material', 'src', IMG_SRC);
@@ -252,9 +278,9 @@ suite('material', function () {
       el.setAttribute('material', 'side: front');
       assert.equal(el.getObject3D('mesh').material.version, oldMaterialVersion);
       el.setAttribute('material', 'side: double');
-      assert.equal(el.getObject3D('mesh').material.version, oldMaterialVersion + 2);
+      assert.equal(el.getObject3D('mesh').material.version, oldMaterialVersion + 1);
       el.setAttribute('material', 'side: front');
-      assert.equal(el.getObject3D('mesh').material.version, oldMaterialVersion + 4);
+      assert.equal(el.getObject3D('mesh').material.version, oldMaterialVersion + 2);
     });
   });
 
@@ -308,8 +334,8 @@ suite('material', function () {
       el.setAttribute('material', 'alphaTest: 0.0');
       assert.equal(el.getObject3D('mesh').material.version, oldMaterialVersion);
       el.setAttribute('material', 'alphaTest: 1.0');
-      // A-Frame sets needsUpdate twice and THREE one more internally when setting alphaTest.
-      assert.equal(el.getObject3D('mesh').material.version, oldMaterialVersion + 3);
+      // A-Frame sets needsUpdate once and THREE one more internally when setting alphaTest.
+      assert.equal(el.getObject3D('mesh').material.version, oldMaterialVersion + 2);
     });
   });
 
@@ -323,7 +349,7 @@ suite('material', function () {
       var oldMaterialVersion = el.getObject3D('mesh').material.version;
       el.setAttribute('material', 'vertexColorsEnabled', true);
       assert.equal(el.components.material.material.vertexColors, true);
-      assert.equal(el.components.material.material.version, oldMaterialVersion + 2);
+      assert.equal(el.components.material.material.version, oldMaterialVersion + 1);
     });
   });
 

--- a/tests/shaders/phong.test.js
+++ b/tests/shaders/phong.test.js
@@ -5,7 +5,7 @@ var THREE = require('index').THREE;
 suite('phong material', function () {
   setup(function (done) {
     var el = this.el = entityFactory();
-    el.sceneEl.systems.material.clearTextureCache();
+    el.sceneEl.systems.material.clearTextureSourceCache();
     el.setAttribute('geometry', '');
     el.setAttribute('material', {shader: 'phong'});
     if (el.hasLoaded) { done(); }

--- a/tests/systems/material.test.js
+++ b/tests/systems/material.test.js
@@ -17,7 +17,7 @@ suite('material system', function () {
   });
 
   suite('registerMaterial', function () {
-    test('registers material to scene', function () {
+    test('registers material to system', function () {
       var el = this.el;
       var material;
       var system;
@@ -45,44 +45,33 @@ suite('material system', function () {
   });
 
   suite('unregisterMaterial', function () {
-    test('disposes of unused textures', function () {
+    test('unregisters material from system', function () {
       var el = this.el;
-      var sinon = this.sinon;
       var system = el.sceneEl.systems.material;
-      var texture1 = {uuid: 'tex1', isTexture: true, dispose: sinon.spy()};
-      var texture2 = {uuid: 'tex2', isTexture: true, dispose: sinon.spy()};
-      var material1 = {fooMap: texture1, barMap: texture2, dispose: sinon.spy()};
-      var material2 = {fooMap: texture1, dispose: sinon.spy()};
+      var material = {uuid: 'material' };
 
-      el.emit('materialtextureloaded', {texture: texture1});
-      el.emit('materialtextureloaded', {texture: texture1});
-      el.emit('materialtextureloaded', {texture: texture2});
+      system.registerMaterial(material);
+      assert.equal(system.materials[material.uuid], material);
 
-      system.unregisterMaterial(material1);
-      assert.notOk(texture1.dispose.called);
-      assert.ok(texture2.dispose.called);
-
-      system.unregisterMaterial(material2);
-      assert.ok(texture1.dispose.called);
-      assert.equal(texture2.dispose.callCount, 1);
+      system.unregisterMaterial(material);
+      assert.notOk(system.materials[material.uuid]);
     });
   });
 
   suite('texture caching', function () {
     setup(function () {
-      this.system.clearTextureCache();
+      this.system.clearTextureSourceCache();
     });
 
-    suite('loadImage', function () {
-      test('loads image texture', function (done) {
+    suite('loadTextureSource', function () {
+      test('loads image texture source', function (done) {
         var system = this.system;
         var src = IMAGE1;
-        var data = {src: IMAGE1};
-        var hash = system.hash(data);
+        var hash = system.hash(src);
 
-        system.loadImage(src, data, function (texture) {
-          system.textureCache[hash].then(function (texture2) {
-            assert.equal(texture, texture2);
+        system.loadTextureSource(src, function (source) {
+          system.sourceCache[hash].then(function (source2) {
+            assert.equal(source, source2);
             done();
           });
         });
@@ -90,71 +79,46 @@ suite('material system', function () {
 
       test('loads image given an <img> element', function (done) {
         var img = document.createElement('img');
-        var system = this.system;
-        var data = {src: IMAGE1};
-        var hash = system.hash(data);
-
         img.setAttribute('src', IMAGE1);
-        system.loadImage(img, data, function (texture) {
-          assert.equal(texture.image, img);
-          system.textureCache[hash].then(function (texture2) {
-            assert.equal(texture, texture2);
+
+        var system = this.system;
+        var hash = system.hash(img);
+
+        system.loadTextureSource(img, function (source) {
+          assert.equal(source.data, img);
+          system.sourceCache[hash].then(function (source2) {
+            assert.equal(source, source2);
             done();
           });
         });
       });
 
-      test('caches identical image textures', function (done) {
+      test('caches identical image texture sources', function (done) {
         var system = this.system;
         var src = IMAGE1;
-        var data = {src: src};
-        var hash = system.hash(data);
+        var hash = system.hash(src);
 
         Promise.all([
-          new Promise(function (resolve) { system.loadImage(src, data, resolve); }),
-          new Promise(function (resolve) { system.loadImage(src, data, resolve); })
+          new Promise(function (resolve) { system.loadTextureSource(src, resolve); }),
+          new Promise(function (resolve) { system.loadTextureSource(src, resolve); })
         ]).then(function (results) {
           assert.equal(results[0], results[1]);
-          assert.ok(system.textureCache[hash]);
-          assert.equal(Object.keys(system.textureCache).length, 1);
+          assert.ok(system.sourceCache[hash]);
+          assert.equal(Object.keys(system.sourceCache).length, 1);
           done();
         });
       });
 
-      test('caches different textures for different images', function (done) {
+      test('caches different texture sources for different images', function (done) {
         var system = this.system;
         var src1 = IMAGE1;
         var src2 = IMAGE2;
-        var data1 = {src: src1};
-        var data2 = {src: src2};
 
         Promise.all([
-          new Promise(function (resolve) { system.loadImage(src1, data1, resolve); }),
-          new Promise(function (resolve) { system.loadImage(src2, data2, resolve); })
+          new Promise(function (resolve) { system.loadTextureSource(src1, resolve); }),
+          new Promise(function (resolve) { system.loadTextureSource(src2, resolve); })
         ]).then(function (results) {
           assert.notEqual(results[0].uuid, results[1].uuid);
-          done();
-        });
-      });
-
-      test('caches different textures for different repeat', function (done) {
-        var system = this.system;
-        var src = IMAGE1;
-        var data1 = {src: src};
-        var data2 = {src: src, repeat: {x: 5, y: 5}};
-        var hash1 = system.hash(data1);
-        var hash2 = system.hash(data2);
-
-        Promise.all([
-          new Promise(function (resolve) { system.loadImage(src, data1, resolve); }),
-          new Promise(function (resolve) { system.loadImage(src, data2, resolve); })
-        ]).then(function (results) {
-          assert.notEqual(results[0].uuid, results[1].uuid);
-          assert.shallowDeepEqual(results[0].repeat, {x: 1, y: 1});
-          assert.shallowDeepEqual(results[1].repeat, {x: 5, y: 5});
-          assert.equal(Object.keys(system.textureCache).length, 2);
-          assert.ok(system.textureCache[hash1]);
-          assert.ok(system.textureCache[hash2]);
           done();
         });
       });
@@ -164,98 +128,71 @@ suite('material system', function () {
       test('loads video texture', function (done) {
         var system = this.system;
         var src = VIDEO1;
-        var data = {src: VIDEO1};
 
-        system.loadVideo(src, data, function (texture) {
-          var hash = Object.keys(system.textureCache)[0];
-          system.textureCache[hash].then(function (result) {
-            assert.equal(texture, result.texture);
-            assert.equal(texture.image, result.videoEl);
+        system.loadTextureSource(src, function (source) {
+          var hash = Object.keys(system.sourceCache)[0];
+          system.sourceCache[hash].then(function (result) {
+            assert.equal(source, result);
             done();
           });
         });
       });
 
-      test('loads image given a <video> element', function (done) {
+      test('loads video given a <video> element', function (done) {
         var videoEl = document.createElement('video');
         var system = this.system;
-        var data = {src: VIDEO1};
 
         videoEl.setAttribute('src', VIDEO1);
-        system.loadVideo(videoEl, data, function (texture) {
-          var hash = Object.keys(system.textureCache)[0];
-          assert.equal(texture.image, videoEl);
-          system.textureCache[hash].then(function (result) {
-            assert.equal(texture, result.texture);
-            assert.equal(texture.image, result.videoEl);
+        system.loadTextureSource(videoEl, function (source) {
+          var hash = Object.keys(system.sourceCache)[0];
+          assert.equal(source.data, videoEl);
+          system.sourceCache[hash].then(function (result) {
+            assert.equal(source, result);
             done();
           });
         });
       });
 
-      test('loads image given a <video> element with <source>', function (done) {
+      test('loads video given a <video> element with <source>', function (done) {
         var videoEl = document.createElement('video');
         var system = this.system;
-        var data = {};
 
         videoEl.insertAdjacentHTML('beforeend',
           '<source src="' + VIDEO1 + '"></source>');
-        system.loadVideo(videoEl, data, function (texture) {
-          var hash = Object.keys(system.textureCache)[0];
-          assert.equal(texture.image, videoEl);
-          system.textureCache[hash].then(function (result) {
-            assert.equal(texture, result.texture);
-            assert.equal(texture.image, result.videoEl);
+        system.loadTextureSource(videoEl, function (source) {
+          var hash = Object.keys(system.sourceCache)[0];
+          assert.equal(source.data, videoEl);
+          system.sourceCache[hash].then(function (result) {
+            assert.equal(source, result);
             done();
           });
         });
       });
 
-      test('caches identical video textures', function (done) {
+      test('caches identical video texture sources', function (done) {
         var system = this.system;
         var src = VIDEO1;
-        var data = {src: src};
 
         Promise.all([
-          new Promise(function (resolve) { system.loadVideo(src, data, resolve); }),
-          new Promise(function (resolve) { system.loadVideo(src, data, resolve); })
+          new Promise(function (resolve) { system.loadTextureSource(src, resolve); }),
+          new Promise(function (resolve) { system.loadTextureSource(src, resolve); })
         ]).then(function (results) {
           assert.equal(results[0], results[1]);
-          assert.equal(Object.keys(system.textureCache).length, 1);
+          assert.equal(Object.keys(system.sourceCache).length, 1);
           done();
         });
       });
 
-      test('caches different textures for different videos', function (done) {
+      test('caches different texture sources for different videos', function (done) {
         var system = this.system;
         var src1 = VIDEO1;
         var src2 = VIDEO2;
-        var data1 = {src: src1};
-        var data2 = {src: src2};
 
         Promise.all([
-          new Promise(function (resolve) { system.loadVideo(src1, data1, resolve); }),
-          new Promise(function (resolve) { system.loadVideo(src2, data2, resolve); })
+          new Promise(function (resolve) { system.loadTextureSource(src1, resolve); }),
+          new Promise(function (resolve) { system.loadTextureSource(src2, resolve); })
         ]).then(function (results) {
           assert.notEqual(results[0].uuid, results[1].uuid);
-          done();
-        });
-      });
-
-      test('caches different textures for different repeat', function (done) {
-        var system = this.system;
-        var src = VIDEO1;
-        var data1 = {src: src};
-        var data2 = {src: src, repeat: {x: 5, y: 5}};
-
-        Promise.all([
-          new Promise(function (resolve) { system.loadVideo(src, data1, resolve); }),
-          new Promise(function (resolve) { system.loadVideo(src, data2, resolve); })
-        ]).then(function (results) {
-          assert.notEqual(results[0].uuid, results[1].uuid);
-          assert.shallowDeepEqual(results[0].repeat, {x: 1, y: 1});
-          assert.shallowDeepEqual(results[1].repeat, {x: 5, y: 5});
-          assert.equal(Object.keys(system.textureCache).length, 2);
           done();
         });
       });


### PR DESCRIPTION
**Description:**
Final part of #5449, resolving #5441, #5120, #1372. Instead of caching textures and trying to do reference counting, the underlying Sources are cached instead. Actual reference counting is done by Three.js internally, which allows the same texture source to be shared with multiple textures, even if they differ in `offset` or `repeat` (which before would result in uploads). 

This PR also improves the disposing behaviour, which previously only disposed when the material unregistered itself from the material system, missing any textures that were no longer assigned to that material. This also means that since Texture instances aren't shared, they can be changed by users without affecting other textures, while still using the same underlying image.

**Changes proposed:**
- Let `systems/material` cache `Source` instances instead of Textures
- Let helpers in `utils/material` request these `Source` instances and create/update the material's `Texture` instance