### PR TITLE
Recycle nextData and previousOldData back into the objectPool upon component destroy

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -578,9 +578,11 @@ Component.prototype = {
    */
   destroy: function () {
     this.objectPool.recycle(this.attrValue);
+    this.objectPool.recycle(this.nextData);
     this.objectPool.recycle(this.oldData);
+    this.objectPool.recycle(this.previousOldData);
     this.objectPool.recycle(this.parsingAttrValue);
-    this.attrValue = this.oldData = this.parsingAttrValue = undefined;
+    this.nextData = this.attrValue = this.oldData = this.previousOldData = this.parsingAttrValue = undefined;
   }
 };
 


### PR DESCRIPTION
**Description:**
In the Component constructor four objects are requested from the object pool. Upon deletion only two of those were recycled back into the pool. This PR adds the missing two recycle calls, preventing them from leaking memory.

**Changes proposed:**
- Recycle `nextData` and `previousOldData` upon component destroy.
