### PR TITLE
Don't use object pool for initialOldData, and properly recycle tempObject

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -278,7 +278,7 @@ class AEntity extends ANode {
   /**
    * Initialize component.
    *
-   * @param {string} attrName - Attribute name asociated to the component.
+   * @param {string} attrName - Attribute name associated to the component.
    * @param {object} data - Component data
    * @param {boolean} isDependency - True if the component is a dependency.
    */

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -19,6 +19,7 @@ var upperCaseRegExp = new RegExp('[A-Z]+');
 
 // Object pools by component, created upon registration.
 var objectPools = {};
+var emptyInitialOldData = Object.freeze({});
 
 /**
  * Component class definition.
@@ -223,7 +224,7 @@ Component.prototype = {
     }
     utils.objectPool.clearObject(this.attrValue);
     this.attrValue = extendProperties(this.attrValue, newAttrValue, this.isObjectBased);
-    utils.objectPool.clearObject(tempObject);
+    this.objectPool.recycle(tempObject);
   },
 
   /**
@@ -271,7 +272,7 @@ Component.prototype = {
    *
    * @param {string} attrValue - HTML attribute value.
    *        If undefined, use the cached attribute value and continue updating properties.
-   * @param {boolean} clobber - The previous component data is overwritten by the atrrValue.
+   * @param {boolean} clobber - The previous component data is overwritten by the attrValue.
    */
   updateProperties: function (attrValue, clobber) {
     var el = this.el;
@@ -324,9 +325,8 @@ Component.prototype = {
 
     // For oldData, pass empty object to multiple-prop schemas or object single-prop schema.
     // Pass undefined to rest of types.
-    initialOldData = this.isObjectBased ? this.objectPool.use() : undefined;
+    initialOldData = this.isObjectBased ? emptyInitialOldData : undefined;
     this.update(initialOldData);
-    if (this.isObjectBased) { this.objectPool.recycle(initialOldData); }
 
     // Play the component if the entity is playing.
     if (el.isPlaying) { this.play(); }


### PR DESCRIPTION
**Description:**
A temporary object was never released to the objectPool, causing a leak. After fixing this leak, some unit tests regressed. It turns out that the `initialOldData` provided to a component's `update(oldData)` is also leased from this pool. The pool however makes no guarantees about the state of the object. It might very well not be an empty object. (And due to the various leaks, it likely was an empty object)

This PR correctly clears and returns the `tempObject` to the pool and uses a constant frozen empty object for the `initialOldData`. This is a slight change in behaviour in case users mutate this object, but that was never correct and will now give an error.

**Changes proposed:**
- Correctly clear and recycle `tempObject` in Component update logic (`updateCachedAttrValue`)
- No longer use object pool for `initialOldData` for a Component's first `update` call
