### PR TITLE
Use AFRAME.utils.split in getComponentPropertyPath fixing caching behaviour

### DIFF
--- a/src/utils/entity.js
+++ b/src/utils/entity.js
@@ -1,27 +1,25 @@
+var split = require('./split').split;
+
 /**
  * Split a delimited component property string (e.g., `material.color`) to an object
  * containing `component` name and `property` name. If there is no delimiter, just return the
  * string back.
  *
- * Cache arrays from splitting strings via delimiter to save on memory.
+ * Uses the caching split implementation `AFRAME.utils.split`
  *
  * @param {string} str - e.g., `material.opacity`.
  * @param {string} delimiter - e.g., `.`.
  * @returns {array} e.g., `['material', 'opacity']`.
  */
-var propertyPathCache = {};
 function getComponentPropertyPath (str, delimiter) {
   delimiter = delimiter || '.';
-  if (!propertyPathCache[delimiter]) { propertyPathCache[delimiter] = {}; }
-  if (str.indexOf(delimiter) !== -1) {
-    propertyPathCache[delimiter][str] = str.split(delimiter);
-  } else {
-    propertyPathCache[delimiter][str] = str;
+  var parts = split(str, delimiter);
+  if (parts.length === 1) {
+    return parts[0];
   }
-  return propertyPathCache[delimiter][str];
+  return parts;
 }
 module.exports.getComponentPropertyPath = getComponentPropertyPath;
-module.exports.propertyPathCache = propertyPathCache;
 
 /**
  * Get component property using encoded component name + component property name with a

--- a/tests/utils/entity.test.js
+++ b/tests/utils/entity.test.js
@@ -24,16 +24,12 @@ suite('utils.entity', function () {
       var el = this.el;
       el.setAttribute('material', {color: 'red'});
       assert.equal(getComponentProperty(el, 'material.color'), 'red');
-      assert.equal(entity.propertyPathCache['.']['material.color'][0], 'material');
-      assert.equal(entity.propertyPathCache['.']['material.color'][1], 'color');
     });
 
     test('can get custom-delimited attribute', function () {
       var el = this.el;
       el.setAttribute('material', {color: 'red'});
       assert.equal(getComponentProperty(el, 'material|color', '|'), 'red');
-      assert.equal(entity.propertyPathCache['|']['material|color'][0], 'material');
-      assert.equal(entity.propertyPathCache['|']['material|color'][1], 'color');
     });
   });
 


### PR DESCRIPTION
**Description:**
Noticed that that `AFRAME.utils.entity.getComponentPropertyPath` didn't properly use its cache. It constructed a cache and populated it, but never checked if strings were already cached. Meaning it would always recompute (= split), place in cache and _then_ immediately return that value from the cache.

This PR simply replaces the broken caching mechanism with `AFRAME.utils.split`, since the split utility also uses a cache internally. Added benefit is that the cache is now also shared between the two.

**Changes proposed:**
- Fix property path caching by using `AFRAME.utils.split` which internally caches
