### PR TITLE
Fix duplicate check in registerPropertyType

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -38,9 +38,8 @@ registerPropertyType('vec4', {x: 0, y: 0, z: 0, w: 1}, vecParse, coordinates.str
  * @param {function} [stringify=defaultStringify] - Stringify to DOM function.
  */
 function registerPropertyType (type, defaultValue, parse, stringify) {
-  if ('type' in propertyTypes) {
-    error('Property type ' + type + ' is already registered.');
-    return;
+  if (type in propertyTypes) {
+    throw new Error('Property type ' + type + ' is already registered.');
   }
 
   propertyTypes[type] = {

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -81,6 +81,15 @@ suite('propertyTypes', function () {
       assert.ok('mytype' in propertyTypes);
       assert.equal(propertyTypes.mytype.default, 5);
     });
+
+    test('rejects duplicate type names', function () {
+      assert.notOk('duplicate' in propertyTypes);
+      register('duplicate', 'first');
+      assert.equal(propertyTypes.duplicate.default, 'first');
+      assert.throws(function () {
+        register('duplicate', 'second');
+      }, 'Property type duplicate is already registered.');
+    });
   });
 
   suite('int', function () {

--- a/tests/core/schema.test.js
+++ b/tests/core/schema.test.js
@@ -1,5 +1,6 @@
 /* global assert, suite, test */
 var Schema = require('core/schema');
+var propertyTypes = require('core/propertyTypes').propertyTypes;
 var registerPropertyType = require('core/propertyTypes').registerPropertyType;
 
 var isSingleProperty = Schema.isSingleProperty;
@@ -160,6 +161,7 @@ suite('schema', function () {
     });
 
     test('sets default value if not defined', function () {
+      delete propertyTypes.faketype;
       registerPropertyType('faketype', 'FAKEDEFAULT');
       var definition = processSchema({type: 'faketype'});
       assert.equal(definition.default, 'FAKEDEFAULT');
@@ -181,6 +183,7 @@ suite('schema', function () {
 
   suite('processSchema', function () {
     test('processes all property definitions', function () {
+      delete propertyTypes.faketype;
       registerPropertyType('faketype', 'FAKEDEFAULT');
 
       var schema = processSchema({


### PR DESCRIPTION
**Description:**
The check preventing duplicate `propertyTypes` from being registered incorrectly tested the string literal `"type"` instead of the type argument.

**Changes proposed:**
- Fix the duplicate check in `registerPropertyType`
- Throw an error instead of logging an error (in line with `registerComponent`, `registerSystem`, etc...) 
