### PR TITLE
Make test teardown in __init.test.js synchronous

### DIFF
--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -82,7 +82,7 @@ window.addEventListener('unhandledrejection', event => {
   pendingErrorNotice = 'An uncaught promise rejection occurred between tests';
 });
 
-teardown(function (done) {
+teardown(function () {
   // Clean up any attached elements.
   var attachedEls = ['canvas', 'a-assets', 'a-scene'];
   var els = document.querySelectorAll(attachedEls.join(','));
@@ -92,11 +92,6 @@ teardown(function (done) {
   this.sinon.restore();
   delete AFRAME.components.test;
   delete AFRAME.systems.test;
-
-  // Allow detachedCallbacks to clean themselves up.
-  setTimeout(function () {
-    done();
-  });
 
   if (pendingError) {
     console.error(pendingErrorNotice);


### PR DESCRIPTION
**Description:**
Removing the timeout from the `teardown` in `__init.test.js` speeds up test execution significantly on my machine. According to the accompanying comment this timeout is there to let `detachCallbacks` clean themselves up before considering the teardown complete. However, custom elements v1 uses `disconnectedCallback` which is (effectively) synchronous, and therefore the `setTimeout` should have no bearing on them.

Removing the timeout doesn't seem to have a negative impact. All tests are still green after making this change.

**Changes proposed:**
- Make `teardown` synchronous in `__init.test.js` speeding up tests
