### PR TITLE
Fix bug in a-scene's setAttribute in case of uninitialized systems

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -515,10 +515,15 @@ class AScene extends AEntity {
    * setAttribute.
    */
   setAttribute (attr, value, componentPropValue) {
-    var system = this.systems[attr];
-    if (system) {
+    // Check if system exists (i.e. is registered).
+    if (systems[attr]) {
       ANode.prototype.setAttribute.call(this, attr, value);
-      system.updateProperties(value);
+
+      // Update system instance, if initialized on the scene.
+      var system = this.systems[attr];
+      if (system) {
+        system.updateProperties(value);
+      }
       return;
     }
     AEntity.prototype.setAttribute.call(this, attr, value, componentPropValue);


### PR DESCRIPTION
**Description:**
The `setAttribute` method in `<a-scene>` prioritizes systems over components and other attributes. However, it did this by checking if the attribute name was present in the object with _initialized_ systems. When programmatically creating an `a-scene` these might not have been initialized yet.

This PR changes the condition to first check if the attribute name matches a _registered_ system.

Fixes: #3211

**Changes proposed:**
- Check if attribute name matches a registered system in `setAttribute`
- Introduce unit tests for checking `<a-scene>`'s `setAttribute`
