### PR TITLE
Handle missing mixins and applying mixin attributes to mappings of primitives

### DIFF
--- a/src/core/a-mixin.js
+++ b/src/core/a-mixin.js
@@ -8,11 +8,13 @@ var MULTIPLE_COMPONENT_DELIMITER = '__';
 /**
  * @member {object} componentCache - Cache of pre-parsed values. An object where the keys
  *         are component names and the values are already parsed by the component.
+ * @member {object} rawAttributeCache - Cache of the raw attribute values.
  */
 class AMixin extends ANode {
   constructor () {
     super();
     this.componentCache = {};
+    this.rawAttributeCache = {};
     this.isMixin = true;
   }
 
@@ -60,10 +62,11 @@ class AMixin extends ANode {
     // Get component data.
     componentName = utils.split(attr, MULTIPLE_COMPONENT_DELIMITER)[0];
     component = components[componentName];
-    if (!component) { return; }
     if (value === undefined) {
       value = window.HTMLElement.prototype.getAttribute.call(this, attr);
     }
+    this.rawAttributeCache[attr] = value;
+    if (!component) { return; }
     this.componentCache[attr] = component.parseAttrValueForCache(value);
   }
 

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -219,7 +219,7 @@ class ANode extends HTMLElement {
     this.computedMixinStr = '';
     this.mixinEls.length = 0;
     for (i = 0; i < newMixinIds.length; i++) {
-      this.registerMixin(document.getElementById(newMixinIds[i]));
+      this.registerMixin(newMixinIds[i]);
     }
 
     // Update DOM. Keep track of `computedMixinStr` to not recurse back here after
@@ -240,21 +240,25 @@ class ANode extends HTMLElement {
   /**
    * From mixin ID, add mixin element to `mixinEls`.
    *
-   * @param {Element} mixinEl
+   * @param {string} mixinId - ID of the mixin to register.
    */
-  registerMixin (mixinEl) {
+  registerMixin (mixinId) {
     var compositedMixinIds;
     var i;
     var mixin;
+    var mixinEl = document.getElementById(mixinId);
 
-    if (!mixinEl) { return; }
+    if (!mixinEl) {
+      warn('No mixin was found with id `%s`', mixinId);
+      return;
+    }
 
     // Register composited mixins (if mixin has mixins).
     mixin = mixinEl.getAttribute('mixin');
     if (mixin) {
       compositedMixinIds = utils.split(mixin.trim(), /\s+/);
       for (i = 0; i < compositedMixinIds.length; i++) {
-        this.registerMixin(document.getElementById(compositedMixinIds[i]));
+        this.registerMixin(compositedMixinIds[i]);
       }
     }
 
@@ -268,6 +272,11 @@ class ANode extends HTMLElement {
     window.HTMLElement.prototype.setAttribute.call(this, attr, newValue);
   }
 
+  /**
+   * Removes the mixin element from `mixinEls`.
+   *
+   * @param {string} mixinId - ID of the mixin to remove.
+   */
   unregisterMixin (mixinId) {
     var i;
     var mixinEls = this.mixinEls;

--- a/tests/extras/primitives/primitives.test.js
+++ b/tests/extras/primitives/primitives.test.js
@@ -226,6 +226,23 @@ suite('registerPrimitive (using innerHTML)', function () {
     });
   });
 
+  test('applies mappings to mixin attributes', function (done) {
+    AFRAME.registerComponent('test', {
+      schema: {default: 'foo'}
+    });
+    primitiveFactory({
+      defaultComponents: {
+        material: {color: 'blue'}
+      },
+      mappings: {foo: 'material.color'}
+    }, 'mixin="bar"', function postCreation (el) {
+      assert.equal(el.getAttribute('material').color, 'purple');
+      done();
+    }, function preCreation (sceneEl) {
+      helpers.mixinFactory('bar', {foo: 'purple'}, sceneEl);
+    });
+  });
+
   test('handles mapping to a single-property component', function (done) {
     primitiveFactory({
       mappings: {


### PR DESCRIPTION
**Description:**
Primitives handled mixins differently compared to `a-node`. In case a mixin was referenced that didn't exist, the primitive would throw an error while the `a-node` silently ignored it. Now a warning is logged in both cases. Primitives now also check if attributes on mixins correspond to any of their mappings, allowing things like the following to work:
```HTML
<a-assets>
    <a-mixin id="red" color="red"></a-mixin>
</a-assets>

<a-box mixin="red"></a-box>
```

Fixes #4455
Fixes #4717 

**Changes proposed:**
- Log warning when mixin can't be found (instead of throwing an error or silently continuing).
- Apply mapping in primitive for any mixin attributes that correspond with defined mappings.
