### PR TITLE
Use `window.isSecureContext` instead of manual check for localhost and/or https

### DIFF
--- a/src/components/scene/device-orientation-permission-ui.js
+++ b/src/components/scene/device-orientation-permission-ui.js
@@ -37,9 +37,7 @@ module.exports.Component = registerComponent('device-orientation-permission-ui',
 
     if (!this.data.enabled) { return; }
 
-    if (location.hostname !== 'localhost' &&
-        location.hostname !== '127.0.0.1' &&
-        location.protocol === 'http:') {
+    if (!window.isSecureContext) {
       this.showHTTPAlert();
     }
 


### PR DESCRIPTION
**Description:**
As detailed in #4672, the check performed in the `device-orientation-permission-ui` component is attempting to determine if the user is accessing the page in a secure context. Using `window.isSecureContext` for this should be more reliable and avoids false negatives, as the browser _knows_ whether this is the case.

Fixes #4672

**Changes proposed:**
- Replace manual check for localhost and/or https with `window.isSecureContext`
