### PR TITLE
Fixed XR Layer rendering race condition with session initialization and RenderState Update

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -211,7 +211,7 @@ module.exports.Component = registerComponent('layer', {
   },
 
   tick: function () {
-    if (!this.el.sceneEl.xrSession) { return; }
+    if (!this.el.sceneEl.xrSession || !this.el.sceneEl.renderer.xr.isPresenting) { return; }
     if (!this.layer && this.el.sceneEl.is('vr-mode')) { this.initLayer(); }
     this.updateTransform();
     if (this.data.src.complete && (this.pendingCubeMapUpdate || this.loadingScreen || this.visibilityChanged)) { this.loadCubeMapImages(); }
@@ -367,7 +367,6 @@ module.exports.Component = registerComponent('layer', {
       return;
     }
     xrSession.requestReferenceSpace('local-floor').then(this.onRequestedReferenceSpace);
-    this.needsRedraw = true;
     this.layerEnabled = true;
     if (this.quadPanelEl) {
       this.quadPanelEl.object3D.visible = false;

--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -211,7 +211,7 @@ module.exports.Component = registerComponent('layer', {
   },
 
   tick: function () {
-    if (!this.el.sceneEl.xrSession || !this.el.sceneEl.renderer.xr.isPresenting) { return; }
+    if (!this.el.sceneEl.xrSession) { return; }
     if (!this.layer && this.el.sceneEl.is('vr-mode')) { this.initLayer(); }
     this.updateTransform();
     if (this.data.src.complete && (this.pendingCubeMapUpdate || this.loadingScreen || this.visibilityChanged)) { this.loadCubeMapImages(); }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -299,8 +299,6 @@ class AScene extends AEntity {
           self.usedOfferSession |= useOfferSession;
           requestSession(xrMode, xrInit).then(
             function requestSuccess (xrSession) {
-              self.xrSession = xrSession;
-
               if (useOfferSession) {
                 self.usedOfferSession = false;
               }
@@ -308,10 +306,11 @@ class AScene extends AEntity {
               vrManager.layersEnabled = xrInit.requiredFeatures.indexOf('layers') !== -1;
               vrManager.setSession(xrSession).then(function () {
                 vrManager.setFoveation(rendererSystem.foveationLevel);
+                self.xrSession = xrSession;
+                self.systems.renderer.setWebXRFrameRate(xrSession);
+                xrSession.addEventListener('end', self.exitVRBound);
+                enterVRSuccess(resolve);
               });
-              self.systems.renderer.setWebXRFrameRate(xrSession);
-              xrSession.addEventListener('end', self.exitVRBound);
-              enterVRSuccess(resolve);
             },
             function requestFail (error) {
               var useAR = xrMode === 'immersive-ar';


### PR DESCRIPTION
**Description:**
The aframe comicbook example was broken with exceptions of 

```
TypeError: Failed to execute 'updateRenderState' on 'XRSession': Failed to read the 'layers' property
from 'XRRenderStateInit': Failed to convert value to 'XRLayer'.
```

and 

```
Uncaught InvalidStateError: Failed to execute 'getSubImage' on 'XRWebGLBinding': Layer must be in the session's RenderState.
```

The issues are related to the race condition.  The`!this.el.sceneEl.xrSession` check in [this](https://github.com/aframevr/aframe/blob/master/src/components/layer.js#L214) line doesn't guarantee the full initialization of the xr session. We should actually use the `this.el.sceneEl.renderer.xr.isPresenting` value which is set to `true` at the end of XR session initialization [here](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webxr/WebXRManager.js#L366).

Another race condition is that the `this.xrGLFactory.getSubImage` call should happen AFTER the layer is added to the sessions layers array (related W3C [doc](https://www.w3.org/TR/webxrlayers-1/?fbclid=IwAR27yKqbCs571mbvJjx11QzGeI2bocMuieoMQ8-Psr4ai3TD-foT84WciIM#dom-xrwebglbinding-getsubimage)). This happens in the next frame after `sceneEl.renderer.xr.addLayer` is called. Thus, we shouldn't force a redraw in `onEnterVR`. Instead, we need to rely on the `this.layer.needsRedraw` value [here](https://github.com/aframevr/aframe/blob/master/src/components/layer.js#L218) to trigger a redraw after the layer is added to the session layers array.

**Changes proposed:**
- Skipped all layer `tick()` function if `this.el.sceneEl.renderer.xr.isPresenting === false`
- Removed the force redraw logic in the 1st frame in `onEnterVR `.


**Testing**
Ran `npm start` and used port forwarding to test in a Quest 3 headset. The comic book example works smoothly.
