### PR TITLE
Remove attribute from DOM when removing component (through mixin removal/update)

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -379,6 +379,10 @@ class AEntity extends ANode {
     if (destroy) {
       component.destroy();
       delete this.components[name];
+      // Remove attribute from DOM, if still present
+      if (this.hasAttribute(name)) {
+        window.HTMLElement.prototype.removeAttribute.call(this, name);
+      }
     }
 
     this.emit('componentremoved', component.evtDetail, false);

--- a/tests/core/a-mixin.test.js
+++ b/tests/core/a-mixin.test.js
@@ -97,7 +97,7 @@ suite('a-mixin', function () {
       testEl.setAttribute('delete-mixin', '');
       testEl.addEventListener('loaded', function () {
         assert.equal(testEl.getAttribute('mixin'), null);
-        assert.equal(testEl.getAttribute('material'), '');
+        assert.equal(testEl.getAttribute('material'), null);
         done();
       });
       el.sceneEl.appendChild(testEl);


### PR DESCRIPTION
**Description:**
Components on an entity are reflected in the DOM. In case an entities mixins change, some of its components might end up getting removed ([a-entity.js#L614-L615](https://github.com/aframevr/aframe/blob/master/src/core/a-entity.js#L614-L615)). In this case the DOM attribute would remain. This PR ensures that, similar to `initComponent` the change is reflected in the DOM if not done already.

**Changes proposed:**
- Remove DOM attribute in case `removeComponent` is called without being caused by a `removeAttribute` call.
