### PR TITLE
Update package.json shelljs dependabot Severity High 7.1 / 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "markserv": "github:sukima/markserv#feature/fix-broken-websoketio-link",
     "mocha": "^10.0.0",
     "replace-in-file": "^2.5.3",
-    "shelljs": "^0.7.7",
+    "shelljs": "^0.8.5",
     "shx": "^0.2.2",
     "sinon": "<12.0.0",
     "sinon-chai": "^3.7.0",


### PR DESCRIPTION
dependabot

https://access.redhat.com/security/cve/cve-2022-0144

@dmarcos the shelljs is only used in the https://github.com/aframevr/aframe/blob/master/scripts/preghpages.js
is this still used? 