### PR TITLE
Make sure the model was loaded before we attempt to remove the mesh

### DIFF
--- a/src/components/obj-model.js
+++ b/src/components/obj-model.js
@@ -34,11 +34,11 @@ module.exports.Component = registerComponent('obj-model', {
   },
 
   remove: function () {
-    if (!this.model) { return; }
     this.resetMesh();
   },
 
   resetMesh: function () {
+    if (!this.model) { return; }
     this.el.removeObject3D('mesh');
   },
 


### PR DESCRIPTION
Fixes https://github.com/aframevr/aframe/issues/4139

I stumbled on this by having a look at a-painter to see how much it would take to have it running on latest aframe. The same warning would appear and seems the two lines at https://github.com/aframevr/a-painter/blob/0deba1f3314ee4cd053bf2a2ae2854994014dd65/index.html#L50-L51 are responsible.

This seems the same situation as per the example reported in https://github.com/aframevr/aframe/issues/4139#issuecomment-1371499138.

I basically moved the check for the model being present from the remove() to the resetMesh method.

All the best

