### PR TITLE
Added unit tests covering previously inconsistent component update behaviour

### DIFF
--- a/tests/components/line.test.js
+++ b/tests/components/line.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test */
+/* global THREE, assert, process, setup, suite, test */
 var entityFactory = require('../helpers').entityFactory;
 
 suite('line', function () {
@@ -104,6 +104,23 @@ suite('line', function () {
       assert.equal(positionArray[3], 4);
       assert.equal(positionArray[4], 5);
       assert.equal(positionArray[5], 6);
+    });
+  });
+
+  suite('update', function () {
+    test('points can be updated with the same instance', function () {
+      var start = new THREE.Vector3(1, 2, 3);
+      el.setAttribute('line', {start: start});
+      var updateSpy = this.sinon.spy(el.components.line, 'update');
+
+      var data = el.getAttribute('line');
+      assert.shallowDeepEqual(data.start, {x: 1, y: 2, z: 3});
+
+      start.x += 10;
+      el.setAttribute('line', {start: start});
+
+      assert.shallowDeepEqual(data.start, {x: 11, y: 2, z: 3});
+      assert.ok(updateSpy.calledOnce);
     });
   });
 });

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -874,6 +874,18 @@ suite('Component', function () {
       assert.equal(el.getAttribute('dummy').color, 'green');
       sinon.assert.calledOnce(initCanaryStub);
     });
+
+    test('initializes numeric single-property with default value', function () {
+      var el = this.el;
+      registerComponent('dummy', {
+        schema: {type: 'number', default: 10},
+        init: function () {
+          assert.equal(this.data, 10);
+        }
+      });
+      el.setAttribute('dummy', '');
+      assert.equal(el.getAttribute('dummy'), 10);
+    });
   });
 
   suite('update', function () {
@@ -1041,6 +1053,24 @@ suite('Component', function () {
       });
       el.setAttribute('dummy', 'color: red');
       assert.equal(el.getAttribute('dummy').color, 'green');
+    });
+
+    test('parses asset property type in single property components', function () {
+      var el = this.el;
+      var assetsEl = el.sceneEl.querySelector('a-assets');
+      var assetItemEl = document.createElement('a-asset-item');
+      assetItemEl.setAttribute('id', 'model');
+      assetItemEl.setAttribute('src', 'url-to-model');
+      assetsEl.appendChild(assetItemEl);
+
+      registerComponent('dummy', {
+        schema: {type: 'asset'}
+      });
+
+      el.setAttribute('dummy', '');
+      assert.equal(el.getAttribute('dummy'), '');
+      el.setAttribute('dummy', '#model');
+      assert.equal(el.getAttribute('dummy'), 'url-to-model');
     });
   });
 

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -920,6 +920,37 @@ suite('Component', function () {
       component.updateProperties({list: ['b']});
       component.updateProperties({list: ['b']});
       sinon.assert.calledOnce(updateStub);
+      assert.deepEqual(component.data.list, ['b']);
+    });
+
+    test('supports array property on entity creation', function (done) {
+      entityFactory();
+      registerComponent('dummy', {
+        schema: { list: {type: 'array', default: ['a']} }
+      });
+      var scene = document.querySelector('a-scene');
+      var el2 = document.createElement('a-entity');
+      el2.setAttribute('dummy', { list: ['b', 'c', 'd'] });
+      el2.addEventListener('componentinitialized', evt => {
+        assert.deepEqual(el2.components.dummy.data.list, ['b', 'c', 'd']);
+        done();
+      });
+      scene.appendChild(el2);
+    });
+
+    test('supports array property in single property schema on entity creation', function (done) {
+      entityFactory();
+      registerComponent('dummy', {
+        schema: {type: 'array', default: ['a']}
+      });
+      var scene = document.querySelector('a-scene');
+      var el2 = document.createElement('a-entity');
+      el2.setAttribute('dummy', ['b', 'c', 'd']);
+      el2.addEventListener('componentinitialized', () => {
+        assert.deepEqual(el2.components.dummy.data, ['b', 'c', 'd']);
+        done();
+      });
+      scene.appendChild(el2);
     });
 
     test('emit componentchanged when update calls setAttribute', function (done) {


### PR DESCRIPTION
**Description:**
Following #5474 this PR adds a couple of unit tests covering the bugs that have been fixed. These are adopted from the (glitch) reproductions in the respective issues. All of them fail prior to #5474.

**Changes proposed:**
- Added unit tests based on #3442, #3681, #4018
- Incorporated @diarmidmackenzie's unit tests from https://github.com/aframevr/aframe/pull/5243
