### PR TITLE
Additional device check for Ipad Pro on Safari

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -8,7 +8,7 @@ script below from the [jsdelivr CDN](https://www.jsdelivr.com/):
 ```html
 <html>
   <head>
-    <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@830c2567bbbb82ff40a565932b038529df348788/dist/aframe-master.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@a14dc2a266218c65a869f4e8cbafe3c855be0cb4/dist/aframe-master.min.js"></script>
   </head>
   <body>
     <a-scene>

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -124,10 +124,10 @@ module.exports.isMobile = isMobile;
 function isTablet (mockUserAgent) {
   var userAgent = mockUserAgent || window.navigator.userAgent;
 
-  var isTablet = /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
+  var _isTablet = /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
 
   // Additional check for iPad or MacIntel with touch capabilities and not an MSStream device
-  return isTablet || isIpad();
+  return _isTablet || isIpad();
 }
 module.exports.isTablet = isTablet;
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -123,7 +123,16 @@ module.exports.isMobile = isMobile;
  */
 function isTablet (mockUserAgent) {
   var userAgent = mockUserAgent || window.navigator.userAgent;
-  return /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
+  var platform = window.navigator.platform;
+  var maxTouchPoints = window.navigator.maxTouchPoints || 0;
+
+  var isTabletUA = /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
+
+  // Additional check for iPad or MacIntel with touch capabilities and not an MSStream device
+  var isTouchDevice = platform === 'iPad' ||
+                      (platform === 'MacIntel' && maxTouchPoints > 0 && !window.MSStream);
+
+  return isTabletUA || isTouchDevice;
 }
 module.exports.isTablet = isTablet;
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -124,10 +124,10 @@ module.exports.isMobile = isMobile;
 function isTablet (mockUserAgent) {
   var userAgent = mockUserAgent || window.navigator.userAgent;
 
-  var _isTablet = /Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
+  var isTablet = /Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
 
   // Additional check for iPad or MacIntel with touch capabilities and not an MSStream device
-  return _isTablet || isIpad();
+  return isTablet || isIpad();
 }
 module.exports.isTablet = isTablet;
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -123,19 +123,27 @@ module.exports.isMobile = isMobile;
  */
 function isTablet (mockUserAgent) {
   var userAgent = mockUserAgent || window.navigator.userAgent;
-  var platform = window.navigator.platform;
-  var maxTouchPoints = window.navigator.maxTouchPoints || 0;
 
-  var isTabletUA = /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
+  var isTablet = /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
 
   // Additional check for iPad or MacIntel with touch capabilities and not an MSStream device
-  var isTouchDevice = platform === 'iPad' ||
-                      (platform === 'MacIntel' && maxTouchPoints > 0 && !window.MSStream);
-
-  return isTabletUA || isTouchDevice;
+  return isTablet || isIpad();
 }
 module.exports.isTablet = isTablet;
 
+/**
+ *  Detect ipad devices.
+ *  @param {string} mockUserAgent - Allow passing a mock user agent for testing.
+ *  @param {string} mockDevicePlatform - Allow passing a mock device platform for testing.
+ *  @param {string} mockDeviceTouchPoints - Allow passing a mock device touch points for testing.
+*/
+function isIpad (mockUserAgent, mockDevicePlatform, mockDeviceTouchPoints) {
+  var userAgent = mockUserAgent || window.navigator.userAgent;
+  var platform = mockDevicePlatform || window.navigator.platform;
+  var maxTouchPoints = mockDeviceTouchPoints || window.navigator.maxTouchPoints || 0;
+
+  return platform === 'iPad' || (platform === 'MacIntel' && maxTouchPoints > 0 && /Macintosh|Intel|iPad/i.test(userAgent) && !window.MSStream);
+}
 function isIOS () {
   return /iPad|iPhone|iPod/.test(window.navigator.platform);
 }

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -124,7 +124,7 @@ module.exports.isMobile = isMobile;
 function isTablet (mockUserAgent) {
   var userAgent = mockUserAgent || window.navigator.userAgent;
 
-  var _isTablet = /ipad|Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
+  var _isTablet = /Nexus (7|9)|xoom|sch-i800|playbook|tablet|kindle/i.test(userAgent);
 
   // Additional check for iPad or MacIntel with touch capabilities and not an MSStream device
   return _isTablet || isIpad();
@@ -142,7 +142,7 @@ function isIpad (mockUserAgent, mockDevicePlatform, mockDeviceTouchPoints) {
   var platform = mockDevicePlatform || window.navigator.platform;
   var maxTouchPoints = mockDeviceTouchPoints || window.navigator.maxTouchPoints || 0;
 
-  return platform === 'iPad' || (platform === 'MacIntel' && maxTouchPoints > 0 && /Macintosh|Intel|iPad/i.test(userAgent) && !window.MSStream);
+  return ((platform === 'iPad' || platform === 'MacIntel') && maxTouchPoints > 0 && /Macintosh|Intel|iPad|ipad/i.test(userAgent) && !window.MSStream);
 }
 module.exports.isIpad = isIpad;
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -145,6 +145,7 @@ function isIpad (mockUserAgent, mockDevicePlatform, mockDeviceTouchPoints) {
   return platform === 'iPad' || (platform === 'MacIntel' && maxTouchPoints > 0 && /Macintosh|Intel|iPad/i.test(userAgent) && !window.MSStream);
 }
 module.exports.isIpad = isIpad;
+
 function isIOS () {
   return /iPad|iPhone|iPod/.test(window.navigator.platform);
 }

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -144,6 +144,7 @@ function isIpad (mockUserAgent, mockDevicePlatform, mockDeviceTouchPoints) {
 
   return platform === 'iPad' || (platform === 'MacIntel' && maxTouchPoints > 0 && /Macintosh|Intel|iPad/i.test(userAgent) && !window.MSStream);
 }
+module.exports.isIpad = isIpad;
 function isIOS () {
   return /iPad|iPhone|iPod/.test(window.navigator.platform);
 }

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -10,7 +10,7 @@ suite('isTablet', function () {
   });
 });
 
-suite('isIpad', function () {
+suite.only('isIpad', function () {
   test('is true for iPad', function () {
     var iPadUserAgent = 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1';
     var platform = 'iPad';
@@ -29,7 +29,7 @@ suite('isIpad', function () {
     var macUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15';
     var platform = 'MacIntel';
     var maxTouchPoints = 0;
-    assert.ok(device.isIpad(macUserAgent, platform, maxTouchPoints));
+    assert.ok(!device.isIpad(macUserAgent, platform, maxTouchPoints));
   });
 });
 

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -10,7 +10,7 @@ suite('isTablet', function () {
   });
 });
 
-suite.only('isIpad', function () {
+suite('isIpad', function () {
   test('is true for iPad', function () {
     var iPadUserAgent = 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1';
     var platform = 'iPad';

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -15,7 +15,7 @@ suite('isIpad', function () {
     var iPadUserAgent = 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1';
     var platform = 'iPad';
     var maxTouchPoints = 5;
-    assert.ok(device.isTablet(iPadUserAgent, platform, maxTouchPoints));
+    assert.ok(device.isIpad(iPadUserAgent, platform, maxTouchPoints));
   });
 
   test('is true for MacIntel with touch capabilities', function () {

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -8,6 +8,20 @@ suite('isTablet', function () {
     assert.ok(device.isTablet(nexus7));
     assert.ok(device.isTablet(nexus9));
   });
+
+  test('is true for iPad', function () {
+    var iPadUserAgent = 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1';
+    var platform = 'iPad';
+    var maxTouchPoints = 5; // Assuming iPad has touch points
+    assert.ok(device.isTablet(iPadUserAgent, platform, maxTouchPoints));
+  });
+
+  test('is true for MacIntel with touch capabilities', function () {
+    var macUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15';
+    var platform = 'MacIntel';
+    var maxTouchPoints = 5; // Simulate a Mac with touch capabilities
+    assert.ok(device.isTablet(macUserAgent, platform, maxTouchPoints));
+  });
 });
 
 suite('environment', function () {

--- a/tests/utils/device.test.js
+++ b/tests/utils/device.test.js
@@ -8,19 +8,28 @@ suite('isTablet', function () {
     assert.ok(device.isTablet(nexus7));
     assert.ok(device.isTablet(nexus9));
   });
+});
 
+suite('isIpad', function () {
   test('is true for iPad', function () {
     var iPadUserAgent = 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1';
     var platform = 'iPad';
-    var maxTouchPoints = 5; // Assuming iPad has touch points
+    var maxTouchPoints = 5;
     assert.ok(device.isTablet(iPadUserAgent, platform, maxTouchPoints));
   });
 
   test('is true for MacIntel with touch capabilities', function () {
     var macUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15';
     var platform = 'MacIntel';
-    var maxTouchPoints = 5; // Simulate a Mac with touch capabilities
-    assert.ok(device.isTablet(macUserAgent, platform, maxTouchPoints));
+    var maxTouchPoints = 5;
+    assert.ok(device.isIpad(macUserAgent, platform, maxTouchPoints));
+  });
+
+  test('is false for MacIntel with no touch capabilities', function () {
+    var macUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15';
+    var platform = 'MacIntel';
+    var maxTouchPoints = 0;
+    assert.ok(device.isIpad(macUserAgent, platform, maxTouchPoints));
   });
 });
 


### PR DESCRIPTION
**Description:**
Issue raised in [#5494](https://github.com/aframevr/aframe/issues/5494). 

The issue: iPadOS User Agent in Safari is same as on MacOS Catalina.

User case:
> There are some use cases in which it is necessary to know whether it is a mobile device, e.g. a help dialogue that describes either touch or mouse/keyboard gestures.

**Changes proposed:**
-  In `isTablet()` we want to extend the ipad check for those special cases where the user agent from the Ipad is labeled "MacOS"


Test also added and Results are shown below:

![image](https://github.com/aframevr/aframe/assets/37879461/82ee3661-9edb-41ef-b19e-a661843b314e)

