### PR TITLE
Fix toggleable dark/light mode button in hand-tracking example

### DIFF
--- a/examples/showcase/hand-tracking/button.js
+++ b/examples/showcase/hand-tracking/button.js
@@ -3,7 +3,7 @@ AFRAME.registerComponent('button', {
   schema: {
     label: {default: 'label'},
     width: {default: 0.11},
-    toggable: {default: false}
+    toggleable: {default: false}
   },
   init: function () {
     var el = this.el;
@@ -58,7 +58,7 @@ AFRAME.registerComponent('button', {
     var el = this.el;
     el.setAttribute('material', {color: 'green'});
     el.emit('click');
-    if (this.data.togabble) {
+    if (this.data.toggleable) {
       if (el.is('pressed')) {
         el.removeState('pressed');
       } else {

--- a/examples/showcase/hand-tracking/index.html
+++ b/examples/showcase/hand-tracking/index.html
@@ -55,7 +55,7 @@
         <a-entity id="sphereButton" button="label: sphere" position="-0.15 0 0"></a-entity>
         <a-entity id="boxButton" button="label: box" position="0 0 0"></a-entity>
         <a-entity id="torusButton" button="label: torus" position="0.15 0 0"></a-entity>
-        <a-entity id="darkModeButton" button="label: Dark Mode; width: 0.20; toggable: true" position="0 -0.10 0"></a-entity>
+        <a-entity id="darkModeButton" button="label: Dark Mode; width: 0.20; toggleable: true" position="0 -0.10 0"></a-entity>
       </a-entity>
       <a-entity hand-tracking-controls="hand: left"></a-entity>
       <a-entity hand-tracking-controls="hand: right"></a-entity>

--- a/examples/test/layer/button.js
+++ b/examples/test/layer/button.js
@@ -3,7 +3,7 @@ AFRAME.registerComponent('button', {
   schema: {
     label: {default: 'label'},
     width: {default: 0.50},
-    toggable: {default: false}
+    toggleable: {default: false}
   },
   init: function () {
     var el = this.el;


### PR DESCRIPTION
**Description:**

In the button component, in the schema it's "toggable", this is what is used for the dark/light mode button.
The condition in onPressedStarted incorrectly use this.data.togabble instead of this.data.toggable, such the green color wasn't correctly toggled for the button.

**Changes proposed:**
- Fix the condition