### PR TITLE
Mark which touch/scroll related event listeners are passive

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -129,10 +129,10 @@ module.exports.Component = registerComponent('cursor', {
       canvas = el.sceneEl.canvas;
       if (data.downEvents.length || data.upEvents.length) { return; }
       CANVAS_EVENTS.DOWN.forEach(function (downEvent) {
-        canvas.addEventListener(downEvent, self.onCursorDown);
+        canvas.addEventListener(downEvent, self.onCursorDown, {passive: false});
       });
       CANVAS_EVENTS.UP.forEach(function (upEvent) {
-        canvas.addEventListener(upEvent, self.onCursorUp);
+        canvas.addEventListener(upEvent, self.onCursorUp, {passive: false});
       });
     }
 
@@ -205,8 +205,8 @@ module.exports.Component = registerComponent('cursor', {
     canvas.removeEventListener('touchmove', this.onMouseMove);
     el.setAttribute('raycaster', 'useWorldCoordinates', false);
     if (this.data.rayOrigin !== 'mouse') { return; }
-    canvas.addEventListener('mousemove', this.onMouseMove, false);
-    canvas.addEventListener('touchmove', this.onMouseMove, false);
+    canvas.addEventListener('mousemove', this.onMouseMove);
+    canvas.addEventListener('touchmove', this.onMouseMove, {passive: false});
     el.setAttribute('raycaster', 'useWorldCoordinates', true);
     this.updateCanvasBounds();
   },

--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -159,9 +159,9 @@ module.exports.Component = registerComponent('look-controls', {
     window.addEventListener('mouseup', this.onMouseUp, false);
 
     // Touch events.
-    canvasEl.addEventListener('touchstart', this.onTouchStart);
-    window.addEventListener('touchmove', this.onTouchMove);
-    window.addEventListener('touchend', this.onTouchEnd);
+    canvasEl.addEventListener('touchstart', this.onTouchStart, {passive: true});
+    window.addEventListener('touchmove', this.onTouchMove, {passive: true});
+    window.addEventListener('touchend', this.onTouchEnd, {passive: true});
 
     // sceneEl events.
     sceneEl.addEventListener('enter-vr', this.onEnterVR);

--- a/src/components/scene/xr-mode-ui.js
+++ b/src/components/scene/xr-mode-ui.js
@@ -277,8 +277,8 @@ function createOrientationModal (onClick) {
 function applyStickyHoverFix (buttonEl) {
   buttonEl.addEventListener('touchstart', function () {
     buttonEl.classList.remove('resethover');
-  });
+  }, {passive: true});
   buttonEl.addEventListener('touchend', function () {
     buttonEl.classList.add('resethover');
-  });
+  }, {passive: true});
 }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -1005,7 +1005,7 @@ function setupCanvas (sceneEl) {
   document.addEventListener('MSFullscreenChange', onFullScreenChange);
 
   // Prevent overscroll on mobile.
-  canvasEl.addEventListener('touchmove', function (event) { event.preventDefault(); });
+  canvasEl.addEventListener('touchmove', function (event) { event.preventDefault(); }, {passive: false});
 
   // Set canvas on scene.
   sceneEl.canvas = canvasEl;


### PR DESCRIPTION
**Description:**
This PR sets the `passive` flag whenever a touch/scroll related event listener is added.

Fixes #5510

**Changes proposed:**
- Explicitly set `passive` flag for touch/scroll event listeners
