### PR TITLE
Check exitVR property of keyboard-shortcuts to enable Escape shortcut

### DIFF
--- a/docs/components/keyboard-shortcuts.md
+++ b/docs/components/keyboard-shortcuts.md
@@ -14,7 +14,7 @@ keyboard-shortcuts component applies only to the [`<a-scene>` element][scene].
 ## Example
 
 ```html
-<a-scene keyboard-shortcuts="enterVR: false"></a-scene>
+<a-scene keyboard-shortcuts="enterVR: false; exitVR: false;"></a-scene>
 ```
 
 ## Properties
@@ -22,3 +22,4 @@ keyboard-shortcuts component applies only to the [`<a-scene>` element][scene].
 | Property    | Description                                           | Default Value |
 |-------------|-------------------------------------------------------|---------------|
 | enterVR     | Enables the shortcut to press 'F' to enter VR.        | true          |
+| exitVR      | Enables the shortcut to press 'Escape' to exit VR.    | true          |

--- a/src/components/scene/keyboard-shortcuts.js
+++ b/src/components/scene/keyboard-shortcuts.js
@@ -13,11 +13,6 @@ module.exports.Component = registerComponent('keyboard-shortcuts', {
     this.onKeyup = this.onKeyup.bind(this);
   },
 
-  update: function (oldData) {
-    var data = this.data;
-    this.enterVREnabled = data.enterVR;
-  },
-
   play: function () {
     window.addEventListener('keyup', this.onKeyup, false);
   },
@@ -29,10 +24,10 @@ module.exports.Component = registerComponent('keyboard-shortcuts', {
   onKeyup: function (evt) {
     var scene = this.el;
     if (!shouldCaptureKeyEvent(evt)) { return; }
-    if (this.enterVREnabled && evt.keyCode === 70) {  // f.
+    if (this.data.enterVR && evt.keyCode === 70) {  // f.
       scene.enterVR();
     }
-    if (this.enterVREnabled && evt.keyCode === 27) {  // escape.
+    if (this.data.exitVR && evt.keyCode === 27) {   // escape.
       scene.exitVR();
     }
   }


### PR DESCRIPTION
**Description:**
Noticed that the `keyboard-shortcuts` component only had an option to disable the `enterVR` shortcut, but it actually disabled both the enter and exit shortcuts. This doesn't match the documentation nor the user's expectation, so this PR splits it into a `enterVR` and `exitVR` property to configure the enter and exit shortcuts respectively.

**Changes proposed:**
- Introduce `exitVR` property to `keyboard-shortcuts` similar to the existing `enterVR` property
