### PR TITLE
Ensure a-entity rotation Euler has YXZ order even without rotation component

### DIFF
--- a/src/components/rotation.js
+++ b/src/components/rotation.js
@@ -10,8 +10,7 @@ module.exports.Component = registerComponent('rotation', {
   update: function () {
     var data = this.data;
     var object3D = this.el.object3D;
-    object3D.rotation.set(degToRad(data.x), degToRad(data.y), degToRad(data.z));
-    object3D.rotation.order = 'YXZ';
+    object3D.rotation.set(degToRad(data.x), degToRad(data.y), degToRad(data.z), 'YXZ');
   },
 
   remove: function () {

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -32,6 +32,7 @@ class AEntity extends ANode {
     this.isEntity = true;
     this.isPlaying = false;
     this.object3D = new THREE.Group();
+    this.object3D.rotation.order = 'YXZ';
     this.object3D.el = this;
     this.object3DMap = {};
     this.parentEl = null;


### PR DESCRIPTION
**Description:**
When using the `rotation` component the order is `YXZ` as set by the component. When setting rotation programmatically the recommended approach is directly through `Object3D.rotation` ([docs](https://aframe.io/docs/1.5.0/components/rotation.html#updating-rotation)). It's implied that the following two behave the same:

```JS
// With three.js
el.object3D.rotation.set(
  THREE.MathUtils.degToRad(15),
  THREE.MathUtils.degToRad(30),
  THREE.MathUtils.degToRad(90)
);

// With .setAttribute (less recommended).
el.setAttribute('rotation', {x: 15, y: 30, z: 90});
```
However, this is only the case if the element has had a `rotation` component before. Otherwise the user would have to explicitly set or pass the order. For consistency this PR sets the euler order upon entity creation, avoiding the issue. 
Example Glitch showing the inconsistency: https://glitch.com/edit/#!/mud-grateful-haze

Also noticed a small optimization opportunity. The `rotation` component sets the order separately, which actually invokes a setter that triggers a recalculation of the corresponding `Object3D.quaternion`. The [`Euler.set`](https://threejs.org/docs/#api/en/math/Euler.set) method actually allows the order to be passed as well, preventing this redundant calculation.

**Changes proposed:**
- Set rotation euler order upon entity creation
- Pass euler order into set method avoiding redundant calculations
