### PR TITLE
this.data may be undefined when the pressable component is removed

### DIFF
--- a/examples/showcase/hand-tracking/pressable.js
+++ b/examples/showcase/hand-tracking/pressable.js
@@ -11,6 +11,8 @@ AFRAME.registerComponent('pressable', {
   },
 
   tick: function () {
+    // this.data may be undefined when the pressable component is removed
+    if (!this.data) return;
     var handEls = this.handEls;
     var handEl;
     var distance;


### PR DESCRIPTION
**Description:**

I just got a complete freeze in VR because of an error on line 
`if (distance < this.data.pressDistance) {` with this.data undefined.

I'm using the pressable component with a custom button component with an additional disabled property that is toggled on pressedstarted and remove the pressable component.
So the issue here is removing a component may still execute tick at least one time it seems. Should this happen? Is this a regression? I don't know.
This is with aframe master Apr 5, 2024 https://cdn.jsdelivr.net/gh/aframevr/aframe@98c706cc0e9d318742f03a20c39cb3b3cc36ce38/dist/aframe-master.min.js
I'm opening the PR mainly for discussion. I know there were recent changes in master related to removing component @mrxz 
