### PR TITLE
hand-tracking-grab-controls.md: Minor error and clarification

### DIFF
--- a/docs/components/hand-tracking-grab-controls.md
+++ b/docs/components/hand-tracking-grab-controls.md
@@ -22,10 +22,10 @@ The `grabbable` component makes any entity hand grababble.
 <a-box grabbable></a-box>
 ```
 
-For debugging purposes you can make the colliders visible as below:
+For debugging purposes you can make the colliders visible, changing color when a collision is detected, as shown below:
 
 ```html
-<a-scene obb-collider="showColliders: false"></a-scene>
+<a-scene obb-collider="showColliders: true"></a-scene>
 ```
 
 ## Properties


### PR DESCRIPTION
**Description:**

Fix for a minor error in the example about how to make colliders visible.

**Changes proposed:**

* The `showColliders` property should be set to true to show the colliders, not to false.

* I take the opportunity to clarify that colliders change color when a collision is detected.
