### PR TITLE
Don't cache parsed value of selector(All) property types

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -426,7 +426,8 @@ Component.prototype = {
 
       // Parse the new value into attrValue (re-using objects where possible)
       var newAttrValue = key ? this.attrValue[key] : this.attrValue;
-      newAttrValue = parseProperty(newValue, propertySchema, newAttrValue);
+      // Some property types (like selectors) depend on external state (e.g. DOM) during parsing and can't be cached.
+      newAttrValue = propertySchema.isCacheable ? parseProperty(newValue, propertySchema, newAttrValue) : newValue;
       // In case the output is a string, store the unparsed value (no double parsing and helps inspector)
       if (typeof newAttrValue === 'string') {
         // Quirk: empty strings aren't considered values for single-property schemas

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -1,7 +1,6 @@
 var coordinates = require('../utils/coordinates');
 var debug = require('debug');
 
-var error = debug('core:propertyTypes:warn');
 var warn = debug('core:propertyTypes:warn');
 
 var propertyTypes = module.exports.propertyTypes = {};
@@ -13,15 +12,15 @@ registerPropertyType('audio', '', assetParse);
 registerPropertyType('array', [], arrayParse, arrayStringify, arrayEquals);
 registerPropertyType('asset', '', assetParse);
 registerPropertyType('boolean', false, boolParse);
-registerPropertyType('color', '#FFF', defaultParse, defaultStringify);
+registerPropertyType('color', '#FFF');
 registerPropertyType('int', 0, intParse);
 registerPropertyType('number', 0, numberParse);
 registerPropertyType('map', '', assetParse);
 registerPropertyType('model', '', assetParse);
-registerPropertyType('selector', null, selectorParse, selectorStringify);
-registerPropertyType('selectorAll', null, selectorAllParse, selectorAllStringify);
+registerPropertyType('selector', null, selectorParse, selectorStringify, defaultEquals, false);
+registerPropertyType('selectorAll', null, selectorAllParse, selectorAllStringify, arrayEquals, false);
 registerPropertyType('src', '', srcParse);
-registerPropertyType('string', '', defaultParse, defaultStringify);
+registerPropertyType('string', '');
 registerPropertyType('time', 0, intParse);
 registerPropertyType('vec2', {x: 0, y: 0}, vecParse, coordinates.stringify, coordinates.equals);
 registerPropertyType('vec3', {x: 0, y: 0, z: 0}, vecParse, coordinates.stringify, coordinates.equals);
@@ -37,8 +36,9 @@ registerPropertyType('vec4', {x: 0, y: 0, z: 0, w: 1}, vecParse, coordinates.str
  * @param {function} [parse=defaultParse] - Parse string function.
  * @param {function} [stringify=defaultStringify] - Stringify to DOM function.
  * @param {function} [equals=defaultEquals] - Equality comparator.
+ * @param {boolean} [cachable=false] - Whether or not the parsed value of a property can be cached.
  */
-function registerPropertyType (type, defaultValue, parse, stringify, equals) {
+function registerPropertyType (type, defaultValue, parse, stringify, equals, cacheable) {
   if (type in propertyTypes) {
     throw new Error('Property type ' + type + ' is already registered.');
   }
@@ -47,7 +47,8 @@ function registerPropertyType (type, defaultValue, parse, stringify, equals) {
     default: defaultValue,
     parse: parse || defaultParse,
     stringify: stringify || defaultStringify,
-    equals: equals || defaultEquals
+    equals: equals || defaultEquals,
+    isCacheable: cacheable !== false
   };
 }
 module.exports.registerPropertyType = registerPropertyType;

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -83,6 +83,7 @@ function processPropertyDefinition (propDefinition, componentName) {
   propDefinition.parse = propDefinition.parse || propType.parse;
   propDefinition.stringify = propDefinition.stringify || propType.stringify;
   propDefinition.equals = propDefinition.equals || propType.equals;
+  propDefinition.isCacheable = propDefinition.isCacheable === true || propType.isCacheable;
 
   // Fill in type name.
   propDefinition.type = typeName;

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -455,6 +455,33 @@ suite('a-entity', function () {
       assert.notOk(geometry.width);
     });
 
+    test('do not cache properties with non-cacheable types', function () {
+      el.setAttribute('light', { target: '#some-element' });
+      assert.deepEqual(el.components.light.attrValue, {target: '#some-element'});
+
+      const light = el.getAttribute('light');
+      assert.notOk(light.target);
+    });
+
+    test('non-cacheable selectors are parsed at component initialization', function (done) {
+      const newEl = document.createElement('a-entity');
+      newEl.setAttribute('light', { target: '#target-element' });
+
+      // Light refers to target that doesn't exist yet.
+      assert.deepEqual(newEl.components.light.attrValue, {target: '#target-element'});
+      assert.notOk(newEl.getAttribute('light').target);
+
+      // Setup target element.
+      el.id = 'target-element';
+      el.appendChild(newEl);
+
+      newEl.addEventListener('loaded', function () {
+        assert.deepEqual(newEl.components.light.attrValue, {target: '#target-element'});
+        assert.strictEqual(newEl.getAttribute('light').target, el);
+        done();
+      });
+    });
+
     test('parses individual properties when passing object', function (done) {
       AFRAME.registerComponent('foo', {
         schema: {


### PR DESCRIPTION
**Description:**
This PR addresses a small regression introduced with #5474. The `selector` and `selectorAll` property types have a parse function that can be considered _impure_, i.e. the output depends on more than just the value being parsed. The current state of the DOM at the time of parsing factors in as well.

#5474 shifted the moment properties were parsed and cached in case of entities that hadn't loaded yet. This works fine as long as the selector can already match the relevant entities at that time. @arpu ran into a situation where a small HTML template was constructed in full _before_ being inserted into the scene. These could contain selectors that would refer to elements in the same snippet. For illustration, consider the following snippet being constructed dynamically post scene-load:
```HTML
<a-entity>
    <a-entity id="target"></a-entity>
    <a-entity component-with-selector="target: #target"></a-entity>
</a-entity>
```

To resolve this, the PR adds a `isCacheable` property to the property types which signals if the parsed value may be cached or not. This prevents the `selector/selectorAll` property types from being prematurely parsed and cached, better matching the old behaviour.

@arpu Could you verify that this solves the issue for you?

**Changes proposed:**
- Add `isCacheable` flag to property types `selector` and `selectorAll`
- Don't cache the parsed result in case a property isn't cacheable
