### PR TITLE
Fix incorrect unknown property warnings for components with dynamic schema

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -93,7 +93,6 @@ var Component = module.exports.Component = function (el, attrValue, id) {
 
   // Dynamic schema requires special handling of unknown properties to avoid false-positives.
   this.deferUnknownPropertyWarnings = !!this.updateSchema;
-  this.silenceUnknownPropertyWarnings = false;
 
   // Last value passed to updateProperties.
   // This type of throttle ensures that when a burst of changes occurs, the final change to the
@@ -298,23 +297,30 @@ Component.prototype = {
   },
 
   updateSchemaIfNeeded: function (attrValue) {
-    if (!this.schemaChangeRequired || !this.updateSchema) {
-      // Log any pending unknown property warning
-      for (var i = 0; i < encounteredUnknownProperties.length; i++) {
-        warn('Unknown property `' + encounteredUnknownProperties[i] +
-              '` for component `' + this.name + '`.');
-      }
+    if (this.schemaChangeRequired && this.updateSchema) {
       encounteredUnknownProperties.length = 0;
-      return;
+
+      this.updateSchema(this.data);
+      utils.objectPool.removeUnusedKeys(this.data, this.schema);
+      this.recomputeData(attrValue);
+      this.schemaChangeRequired = false;
+
+      // Report any excess properties not valid in the updated schema
+      for (var key in this.attrValue) {
+        if (this.attrValue[key] === undefined) { continue; }
+        if (encounteredUnknownProperties.indexOf(key) !== -1) { continue; }
+        if (!(key in this.schema)) {
+          warn('Unknown property `' + key + '` for component `' + this.name + '`.');
+        }
+      }
+    }
+
+    // Log any pending unknown property warning
+    for (var i = 0; i < encounteredUnknownProperties.length; i++) {
+      warn('Unknown property `' + encounteredUnknownProperties[i] +
+            '` for component `' + this.name + '`.');
     }
     encounteredUnknownProperties.length = 0;
-
-    this.updateSchema(this.data);
-    utils.objectPool.removeUnusedKeys(this.data, this.schema);
-    this.silenceUnknownPropertyWarnings = true;
-    this.recomputeData(attrValue);
-    this.silenceUnknownPropertyWarnings = false;
-    this.schemaChangeRequired = false;
   },
 
   /**
@@ -490,13 +496,10 @@ Component.prototype = {
     // Handle warning the user about the unknown property.
     // Since a component might have a dynamic schema, the warning might be
     // silenced or deferred to avoid false-positives.
-    if (!this.silenceUnknownPropertyWarnings) {
-      // Not silenced, so either deferred or logged.
-      if (this.deferUnknownPropertyWarnings) {
-        encounteredUnknownProperties.push(key);
-      } else if (!this.silenceUnknownPropertyWarnings) {
-        warn('Unknown property `' + key + '` for component `' + this.name + '`.');
-      }
+    if (this.deferUnknownPropertyWarnings) {
+      encounteredUnknownProperties.push(key);
+    } else if (!this.silenceUnknownPropertyWarnings) {
+      warn('Unknown property `' + key + '` for component `' + this.name + '`.');
     }
   },
 
@@ -542,28 +545,15 @@ Component.prototype = {
       return;
     }
 
-    if (attrValue && typeof attrValue === 'object') {
-      for (key in this.schema) {
-        this.attrValueProxy[key] = attrValue[key];
-      }
-    } else {
-      for (key in this.schema) {
-        this.attrValueProxy[key] = undefined;
-      }
+    for (key in this.schema) {
+      this.attrValueProxy[key] = undefined;
     }
 
-    if (typeof attrValue === 'string') {
+    if (attrValue && typeof attrValue === 'object') {
+      utils.extend(this.attrValueProxy, attrValue);
+    } else if (typeof attrValue === 'string') {
       // AttrValue is a style string, parse it into the attrValueProxy object
       styleParser.parse(attrValue, this.attrValueProxy);
-    }
-
-    // Report any unknown properties
-    for (key in this.attrValue) {
-      if (this.attrValue[key] === undefined) { continue; }
-      if (encounteredUnknownProperties.indexOf(key) === -1) { continue; }
-      if (!(key in this.schema)) {
-        warn('Unknown property `' + key + '` for component `' + this.name + '`.');
-      }
     }
   },
 

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -553,7 +553,7 @@ suite('a-entity', function () {
 
     test('updates DOM attributes of a multiple component', function () {
       var soundAttrValue;
-      var soundStr = 'autoplay: true; src: url(mysoundfile.mp3)';
+      var soundStr = 'src: url(mysoundfile.mp3); autoplay: true';
       el.setAttribute('sound__1', {'src': 'url(mysoundfile.mp3)', autoplay: true});
       soundAttrValue = HTMLElement.prototype.getAttribute.call(el, 'sound__1');
       assert.equal(soundAttrValue, '');


### PR DESCRIPTION
**Description:**
As reported in #5525 unknown property warnings can be logged, even when these properties exist for the component. This can occur when a component has a dynamic schema and the update clobbers using a style-string value.

This PR addresses the above issue by ensuring `recomputeData` behaves consistently when given either an object or a style-string value. Furthermore the silencing of unknown properties has been simplified and moved inside `updateSchemaIfNeeded`. In short unknown property warnings are always deferred with dynamic schemas (as a schema update might need to be processed), and the decision to silence them is handled by `updateSchemaIfNeeded` which knows whether or not the schema needed to updated.

Unit tests for this behaviour have been introduced as well, that should hopefully catch regressions in the future.

**Changes proposed:**
- Fix difference with regards to excess properties between object and style-string based updates
- Simplify deferred unknown property handling
- Introduce unit test verifying the unknown property warning message logging
