### PR TITLE
Add documentation for the before and after properties for component definitions

### DIFF
--- a/docs/core/component.md
+++ b/docs/core/component.md
@@ -625,6 +625,46 @@ AFRAME.registerComponent('foo', {
 });
 ```
 
+### `before` / `after`
+
+The `before` and `after` properties allow a component to specify when their `.tick()`
+and `.tock()` methods should be called in relation to other components. This is
+useful in cases where the component depends on the result of others. For example, a
+component that uses the world position of the users hands would want to run _after_ the
+`hand-tracking-controls` component so that the position it sees is up to date.
+
+While both a `before` and a `after` constraint can be specified, only one is needed.
+A-Frame will automatically determine a suitable order among all registered components.
+In case the constraints cause an impossible situation, e.g. when one component would
+need to be both _before_ and _after_ another component, a warning will be logged and
+the resulting order is undefined.
+
+Here's an example showing how to use `before` and `after`:
+
+```js
+AFRAME.registerComponent('foo', {
+  after: ['bar'],
+  // ...
+  tick: function() {
+    console.log('Called second');
+  }
+  // ...
+});
+
+AFRAME.registerComponent('bar', {
+  before: ['foo'],
+  // ...
+  tick: function() {
+    console.log('Called first');
+  }
+  // ...
+});
+```
+
+Note that the order is global, meaning in the above example _all_ `bar` components get
+their `.tick()` method called before _any_ `foo` component. It does not matter if these
+components are on the same entity or not.
+
 ## Component Prototype Methods
 
 ### `.flushToDOM ()`


### PR DESCRIPTION
**Description:**
Fixes #5503 

**Changes proposed:**
- Add documentation describing the `before` and `after` properties on component definitions
