### PR TITLE
Make isCompatibleTexture check stricter by requiring equal source

### DIFF
--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -291,13 +291,16 @@ module.exports.handleTextureEvents = handleTextureEvents;
  * @returns {boolean} True if the texture is compatible with the source, false otherwise
  */
 function isCompatibleTexture (texture, source) {
+  if (texture.source !== source) {
+    return false;
+  }
+
   if (source.data instanceof HTMLCanvasElement) {
     return texture.isCanvasTexture;
   }
 
   if (source.data instanceof HTMLVideoElement) {
-    // VideoTexture can't have its source changed after initial user
-    return texture.isVideoTexture && texture.source === source;
+    return texture.isVideoTexture;
   }
 
   return texture.isTexture && !texture.isCanvasTexture && !texture.isVideoTexture;


### PR DESCRIPTION
**Description:**
The compatibility check for textures allowed changes of the underlying source. Depending on the state of the texture in Three.js this might actually not be supported, causing incorrect reference counting, potentially leading to an exception upon disposal of the texture.

Instead of trying to inspect the internal state to make a decision, it's easier to make the check considerably stricter. This PR now requires the source to match the prior source. While this does lead to more texture instance being created when changing images, the corresponding `Source` (actual image data) and `WebGLTexture` resources remain shared whenever possible.

**Changes proposed:**
- Make `isCompatibleTexture` check stricter by requiring source to match previous source.