### PR TITLE
Use underlying data as cubemap faces instead of Source instances

### DIFF
--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -90,7 +90,7 @@ module.exports.System = registerSystem('material', {
 
     function loadSide (index) {
       self.loadTextureSource(srcs[index], function (source) {
-        cube.images[index] = source;
+        cube.images[index] = source.data;
         loaded++;
         if (loaded === 6) {
           cube.needsUpdate = true;


### PR DESCRIPTION
**Description:**
Fixes #5531 

**Changes proposed:**
- Fixed a bug where the individual faces of a `CubeTexture` were assigned instances of `Source` instead of the underlying image data.
