### PR TITLE
Don't call raycaster setDirty on each mouse move unnecessarily

### DIFF
--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -131,7 +131,9 @@ module.exports.Component = registerComponent('raycaster', {
 
     if (oldData.enabled && !data.enabled) { this.clearAllIntersections(); }
 
-    this.setDirty();
+    if (data.objects !== oldData.objects) {
+      this.setDirty();
+    }
   },
 
   play: function () {


### PR DESCRIPTION
**Description:**

Before this PR, `setAttribute('raycaster', {origin, direction})` is called by the `cursor` component in `onMouseMove` triggering raycaster update method and `this.setDirty()` so actually calling `raycaster.refreshObjects()` on every tick with the default raycaster refresh interval that is 0, or every 100ms minimum if you set raycaster interval to 100 for example, even if nothing changed in the scene.

Some notes:
- cursor `this.el.setAttribute('raycaster', rayCasterConfig)` was introduced in 2017-07-18 22:28 in https://github.com/aframevr/aframe/commit/a4b91bcec6f2e222de8e98414456be6593416bab
- setDirty was introduced in 2017-09-19 20:26 in https://github.com/aframevr/aframe/commit/a463d6413f9ab20d126b0a70b2ae2be2645330a9 it was calling `refreshObjects` directly before that.

**Changes proposed:**
- In `raycaster` update, call `this.setDirty()` only if `objects` property changed