### PR TITLE
Add assetStringify for asset based properties

### DIFF
--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -8,18 +8,18 @@ var nonCharRegex = /[,> .[\]:]/;
 var urlRegex = /url\((.+)\)/;
 
 // Built-in property types.
-registerPropertyType('audio', '', assetParse);
+registerPropertyType('audio', '', assetParse, assetStringify);
 registerPropertyType('array', [], arrayParse, arrayStringify, arrayEquals);
-registerPropertyType('asset', '', assetParse);
+registerPropertyType('asset', '', assetParse, assetStringify);
 registerPropertyType('boolean', false, boolParse);
 registerPropertyType('color', '#FFF');
 registerPropertyType('int', 0, intParse);
 registerPropertyType('number', 0, numberParse);
-registerPropertyType('map', '', assetParse);
-registerPropertyType('model', '', assetParse);
+registerPropertyType('map', '', assetParse, assetStringify);
+registerPropertyType('model', '', assetParse, assetStringify);
 registerPropertyType('selector', null, selectorParse, selectorStringify, defaultEquals, false);
 registerPropertyType('selectorAll', null, selectorAllParse, selectorAllStringify, arrayEquals, false);
-registerPropertyType('src', '', srcParse);
+registerPropertyType('src', '', srcParse, assetStringify);
 registerPropertyType('string', '');
 registerPropertyType('time', 0, intParse);
 registerPropertyType('vec2', {x: 0, y: 0}, vecParse, coordinates.stringify, coordinates.equals);
@@ -119,6 +119,19 @@ function assetParse (value) {
 
   // Non-wrapped url().
   return value;
+}
+
+function assetStringify (value) {
+  if (value.getAttribute) {
+    var id = value.getAttribute('id');
+    if (id) {
+      return '#' + value.getAttribute('id');
+    }
+    // HTMLElement without id can not be stringified, as there is no string assetParse
+    // could convert back to this exact element, using the src attribute instead.
+    return value.getAttribute('src');
+  }
+  return defaultStringify(value);
 }
 
 function defaultParse (value) {

--- a/tests/core/propertyTypes.test.js
+++ b/tests/core/propertyTypes.test.js
@@ -9,6 +9,7 @@ var register = PropertyTypes.registerPropertyType;
 suite('propertyTypes', function () {
   suite('asset', function () {
     var parse = propertyTypes.asset.parse;
+    var stringify = propertyTypes.asset.stringify;
 
     setup(function () {
       var el = this.el = document.createElement('div');
@@ -51,6 +52,18 @@ suite('propertyTypes', function () {
       video.setAttribute('id', 'foo');
       this.el.appendChild(video);
       assert.equal(parse('#foo'), video);
+    });
+
+    test('stringifies to id', function () {
+      var video = document.createElement('video');
+      video.setAttribute('id', 'foo');
+      assert.equal(stringify(video), '#foo');
+    });
+
+    test('stringifies to src if no id available', function () {
+      var video = document.createElement('video');
+      video.setAttribute('src', '/some-url');
+      assert.equal(stringify(video), '/some-url');
     });
   });
 


### PR DESCRIPTION
**Description:**
Asset based property types could either be a string, or directly refer to an `HTMLElement` (using an id selector, or passing instance to it). The stringification used for these property types was just the default one, which works for strings, but fails for `HTMLElement` instances.

This PR introduces an `assetStringify` that attempts to construct a suitable id selector. In case that isn't possible it will resort to using the `src` attribute instead.

See https://github.com/aframevr/aframe-inspector/issues/722 for some context where this caused issues when using `flushToDOM`.

**Changes proposed:**
- Introduce an `assetStringify` for asset based property types
