### PR TITLE
[docs] fix live example link of Building a 360° Image Gallery 

### DIFF
--- a/docs/guides/building-a-360-image-gallery.md
+++ b/docs/guides/building-a-360-image-gallery.md
@@ -9,7 +9,7 @@ examples:
     src: https://github.com/aframevr/aframe/tree/master/examples/docs/360-gallery/index.html
 ---
 
-[live-example]: https://aframe.io/examples/docs/360-gallery/
+[live-example]: https://aframe.io/aframe/examples/docs/360-gallery/
 
 ![360&deg; Image Viewer](/images/docs/360-image-viewer.png)
 


### PR DESCRIPTION
**Description:**
[The demo link for Building a 360° Image Gallery](https://aframe.io/examples/docs/360-gallery/) is 404 Not Found. https://aframe.io/docs/master/guides/building-a-360-image-gallery.html

**Changes proposed:**
- Use https://aframe.io/aframe/examples/docs/360-gallery/ instead of https://aframe.io/examples/docs/360-gallery/