### PR TITLE
No longer bubble 'error' events from a-asset-items as these interfere with Karma

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -130,7 +130,7 @@ class AAssetItem extends ANode {
         xhr: xhr
       });
     }, function handleOnError (xhr) {
-      self.emit('error', {xhr: xhr});
+      self.emit('error', {xhr: xhr}, false);
     });
   }
 }


### PR DESCRIPTION
**Description:**
I noticed that not all unit tests are being executed. Turns out that emitting `error` events causes Karma to stop executing further tests. Interestingly enough this does not seem to be tied to the `error` event handler in `__init.test.js`. This PR ensure that the `error` event emitted by `<a-asset-item>` doesn't bubble, effectively resolving the issue.

Ideally we should avoid using the `error` event name, but I figured that is a bigger breaking change than changing it to not bubble.

**Before:** ✔ 1771 tests completed / ℹ 12 tests skipped
**After:** ✔ 2475 tests completed / ℹ 16 tests skipped
Note: Above results are obtained by running `npm run test`, which counts test double between FF and Chrome

**Changes proposed:**
- No longer bubble `error` events from a-asset-items
