### PR TITLE
Don't stringify properties with undefined values in flushToDOM

### DIFF
--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -187,7 +187,9 @@ module.exports.stringifyProperties = function (propData, schema) {
       value = stringifyProperty(propValue, propDefinition);
       if (!propDefinition) { warn('Unknown component property: ' + propName); }
     }
-    stringifiedData[propName] = value;
+    if (value !== undefined) {
+      stringifiedData[propName] = value;
+    }
   }
   return stringifiedData;
 };

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -1149,6 +1149,19 @@ suite('Component', function () {
       el.components.dummy.flushToDOM();
       assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), 'isDurrr: false');
     });
+
+    test('omits cleared properties', function () {
+      var el = document.createElement('a-entity');
+      registerComponent('dummy', {
+        schema: {name: {type: 'string'}}
+      });
+      el.setAttribute('dummy', 'name', 'John');
+      el.components.dummy.flushToDOM();
+      assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), 'name: John');
+      el.setAttribute('dummy', 'name', '');
+      el.components.dummy.flushToDOM();
+      assert.equal(HTMLElement.prototype.getAttribute.call(el, 'dummy'), '');
+    });
   });
 
   suite('play', function () {


### PR DESCRIPTION
**Description:**
This PR ensures that the stringification process skips over properties with `undefined` values. These would otherwise lead to the string literal `"undefined"` ending up in the output. 

Context for this change: https://github.com/aframevr/aframe-inspector/issues/722#issuecomment-2192080695  
Prior to 1.6.0 an empty string would remain an empty string, but now ends up as `undefined`, hence causing issue when using `flushToDOM`. The reason to change the stringification behaviour is that even in version <=1.5.0 it's possible to end up with `undefined` values (e.g. `removeAttribute('material', 'src')`).

Take for example the following operations:
```js
el.setAttribute('test', {a: 'Value', b: 'Another value'});
el.setAttribute('test', 'a', '');
el.removeAttribute('test', 'b');
el.flushToDOM();
```
Would lead to the following outputs:
| Version | Internal attrValue | Output |
|-------------|---------------------------|------------|
| 1.5.0      | `{a: '', b: undefined}`| `"a: ; b: undefined"`  |
| 1.6.0 / master     | `{a: undefined, b: undefined}`| `"a: undefined; b: undefined"`  |
| this PR  | `{a: undefined, b: undefined}`| `""`  |

**Changes proposed:**
- Skip over properties with `undefined` values when stringifying
- Add unit test covering this behaviour when using `flushToDOM`
