### PR TITLE
Add workflows path to the scan

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,2 +1,3 @@
 paths:
   - src
+  - .github/workflows


### PR DESCRIPTION
Doh, by filtering by `src` I actually excluded workflows from the scan. Fixing it.