### PR TITLE
POC: Reparent grabbed entity onto wrist object upon grab

### DIFF
--- a/src/components/hand-tracking-grab-controls.js
+++ b/src/components/hand-tracking-grab-controls.js
@@ -24,16 +24,6 @@ registerComponent('hand-tracking-grab-controls', {
     el.setAttribute('obb-collider', {trackedObject3D: trackedObject3DVariable, size: 0.04});
 
     this.auxMatrix = new THREE.Matrix4();
-    this.auxQuaternion = new THREE.Quaternion();
-    this.auxQuaternion2 = new THREE.Quaternion();
-    this.auxVector = new THREE.Vector3();
-    this.auxVector2 = new THREE.Vector3();
-
-    this.grabbingObjectPosition = new THREE.Vector3();
-    this.grabbedObjectPosition = new THREE.Vector3();
-    this.grabbedObjectPositionDelta = new THREE.Vector3();
-    this.grabDeltaPosition = new THREE.Vector3();
-    this.grabInitialRotation = new THREE.Quaternion();
 
     this.onCollisionStarted = this.onCollisionStarted.bind(this);
     this.el.addEventListener('obbcollisionstarted', this.onCollisionStarted);
@@ -46,9 +36,6 @@ registerComponent('hand-tracking-grab-controls', {
 
     this.onPinchEnded = this.onPinchEnded.bind(this);
     this.el.addEventListener('pinchended', this.onPinchEnded);
-
-    this.onPinchMoved = this.onPinchMoved.bind(this);
-    this.el.addEventListener('pinchmoved', this.onPinchMoved);
   },
 
   transferEntityOwnership: function () {
@@ -86,8 +73,6 @@ registerComponent('hand-tracking-grab-controls', {
 
   onPinchStarted: function (evt) {
     if (!this.collidedEl) { return; }
-    this.pinchPosition = evt.detail.position;
-    this.wristRotation = evt.detail.wristRotation;
     this.grabbedEl = this.collidedEl;
     this.transferEntityOwnership();
     this.grab();
@@ -97,21 +82,18 @@ registerComponent('hand-tracking-grab-controls', {
     this.releaseGrabbedEntity();
   },
 
-  onPinchMoved: function (evt) {
-    this.wristRotation = evt.detail.wristRotation;
-  },
-
   releaseGrabbedEntity: function () {
     var grabbedEl = this.grabbedEl;
     if (!grabbedEl) { return; }
 
-    grabbedEl.object3D.updateMatrixWorld = this.originalUpdateMatrixWorld;
-    grabbedEl.object3D.matrixAutoUpdate = true;
-    grabbedEl.object3D.matrixWorldAutoUpdate = true;
+    var child = grabbedEl.object3D;
+    var parent = child.parent;
+    var newParent = child.originalParent;
 
-    grabbedEl.object3D.matrixWorld.decompose(this.auxVector, this.auxQuaternion, this.auxVector2);
-    grabbedEl.object3D.position.copy(this.auxVector);
-    grabbedEl.object3D.quaternion.copy(this.auxQuaternion);
+    child.applyMatrix4(parent.matrixWorld);
+    child.applyMatrix4(this.auxMatrix.copy(newParent.matrixWorld).invert());
+    parent.remove(child);
+    newParent.add(child);
 
     this.el.emit('grabended', {grabbedEl: grabbedEl});
     this.grabbedEl = undefined;
@@ -119,82 +101,16 @@ registerComponent('hand-tracking-grab-controls', {
 
   grab: function () {
     var grabbedEl = this.grabbedEl;
-    var grabbedObjectWorldPosition;
+    var child = grabbedEl.object3D;
+    var parent = child.parent;
+    child.originalParent = parent;
+    var newParent = this.el.components['hand-tracking-controls'].wristObject3D;
 
-    grabbedObjectWorldPosition = grabbedEl.object3D.getWorldPosition(this.grabbedObjectPosition);
-
-    this.grabDeltaPosition.copy(grabbedObjectWorldPosition).sub(this.pinchPosition);
-    this.grabInitialRotation.copy(this.auxQuaternion.copy(this.wristRotation).invert());
-
-    this.originalUpdateMatrixWorld = grabbedEl.object3D.updateMatrixWorld;
-    grabbedEl.object3D.updateMatrixWorld = function () { /* no op */ };
-    grabbedEl.object3D.updateMatrixWorldChildren = function (force) {
-      var children = this.children;
-
-      for (var i = 0, l = children.length; i < l; i++) {
-        var child = children[i];
-
-        if (child.matrixWorldAutoUpdate === true || force === true) {
-          child.updateMatrixWorld(true);
-        }
-      }
-    };
-    grabbedEl.object3D.matrixAutoUpdate = false;
-    grabbedEl.object3D.matrixWorldAutoUpdate = false;
+    child.applyMatrix4(parent.matrixWorld);
+    child.applyMatrix4(this.auxMatrix.copy(newParent.matrixWorld).invert());
+    parent.remove(child);
+    newParent.add(child);
 
     this.el.emit('grabstarted', {grabbedEl: grabbedEl});
-  },
-
-  tock: function () {
-    var auxMatrix = this.auxMatrix;
-    var auxQuaternion = this.auxQuaternion;
-    var auxQuaternion2 = this.auxQuaternion2;
-
-    var grabbedObject3D;
-    var grabbedEl = this.grabbedEl;
-
-    if (!grabbedEl) { return; }
-
-    // We have to compose 4 transformations.
-    // Both grabbing and grabbed entities position and rotation.
-
-    // 1. Move grabbed entity to the pinch position (middle point between index and thumb)
-    // 2. Apply the rotation delta (subtract initial rotation) of the grabbing entity position (wrist).
-    // 3. Translate grabbed entity to the original position: distance between grabbed and grabbing entities at collision time.
-    // 4. Apply grabbed entity rotation.
-    // 5. Preserve original scale.
-
-    // Store grabbed entity local rotation.
-    grabbedObject3D = grabbedEl.object3D;
-    grabbedObject3D.getWorldQuaternion(auxQuaternion2);
-
-    // Reset grabbed entity matrix.
-    grabbedObject3D.matrixWorld.identity();
-
-    // 1.
-    auxMatrix.identity();
-    auxMatrix.makeTranslation(this.pinchPosition);
-    grabbedObject3D.matrixWorld.multiply(auxMatrix);
-
-    // 2.
-    auxMatrix.identity();
-    auxMatrix.makeRotationFromQuaternion(auxQuaternion.copy(this.wristRotation).multiply(this.grabInitialRotation));
-    grabbedObject3D.matrixWorld.multiply(auxMatrix);
-
-    // 3.
-    auxMatrix.identity();
-    auxMatrix.makeTranslation(this.grabDeltaPosition);
-    grabbedObject3D.matrixWorld.multiply(auxMatrix);
-
-    // 4.
-    auxMatrix.identity();
-    auxMatrix.makeRotationFromQuaternion(auxQuaternion2);
-    grabbedObject3D.matrixWorld.multiply(auxMatrix);
-
-    // 5.
-    auxMatrix.makeScale(grabbedEl.object3D.scale.x, grabbedEl.object3D.scale.y, grabbedEl.object3D.scale.z);
-    grabbedObject3D.matrixWorld.multiply(auxMatrix);
-
-    grabbedObject3D.updateMatrixWorldChildren();
   }
 });


### PR DESCRIPTION
**Description:**
Proof-of-concept demonstrating the simplified logic for grabbing when reparenting.
The grabbed element is reparented to the `wristObject` upon grab, and inversely restored to its original parent upon release.

Unrelated to this change:

- grabbing is a bit finicky (see https://github.com/aframevr/aframe/issues/5505)
- `hand-tracking-grab-controls` is broken due to a Three.js update:
```
2c70bc24596dd644084e66b0010dab5b1ff208ef is the first bad commit
commit 2c70bc24596dd644084e66b0010dab5b1ff208ef
Author: Diego Marcos <diego.marcos@gmail.com>
Date:   Thu Jul 25 18:25:35 2024 -0700

    Bump THREE to r167

 package.json | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
 ```
