### PR TITLE
Fix hand-controls usage in interactions-and-controllers.md

### DIFF
--- a/docs/introduction/interactions-and-controllers.md
+++ b/docs/introduction/interactions-and-controllers.md
@@ -406,8 +406,8 @@ Touch controllers by:
 To add the hand-controls component:
 
 ```html
-<a-entity hand-controls="left"></a-entity>
-<a-entity hand-controls="right"></a-entity>
+<a-entity hand-controls="hand: left"></a-entity>
+<a-entity hand-controls="hand: right"></a-entity>
 ```
 
 Unfortunately, there is not yet a 3DoF controller component that abstracts well


### PR DESCRIPTION
**Description:**

Fix hand-controls usage in code snippet, this component is a multi-properties component since a long time now.

**Changes proposed:**
- hand-controls="left" -> hand-controls="hand: left"

and also please merge https://github.com/aframevr/aframe-school/pull/21
that shows up in https://aframe.io/aframe-school/#/12