### PR TITLE
Update particle system version and links to c-frame repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ objects straight from HTML:
     <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
     <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.min.js"></script>
-    <script src="https://unpkg.com/aframe-gradient-sky@1.0.4/dist/gradientsky.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fern-solutions/aframe-sky-background/dist/sky-background.umd.min.js"></script>
   </head>
   <body>
     <a-scene>
@@ -144,9 +144,7 @@ objects straight from HTML:
                 material="color: #9CE3F9; opacity: 0.75; metalness: 0; roughness: 1"
                 rotation="-90 0 0"></a-entity>
 
-      <a-entity id="sky" geometry="primitive: sphere; radius: 5000"
-                material="shader: gradient; topColor: 235 235 245; bottomColor: 185 185 210"
-                scale="-1 1 1"></a-entity>
+      <a-sky-background top-color="#EBEBF5" bottom-color="#B9B9D2"></a-sky-background>
 
       <a-entity id="light" light="type: ambient; color: #888"></a-entity>
     </a-scene>

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ objects straight from HTML:
 <html>
   <head>
     <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
-    <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.1.x/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
     <script src="https://unpkg.com/aframe-extras.ocean@%5E3.5.x/dist/aframe-extras.ocean.min.js"></script>
     <script src="https://unpkg.com/aframe-gradient-sky@1.0.4/dist/gradientsky.min.js"></script>
   </head>

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ objects straight from HTML:
   <head>
     <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
     <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
-    <script src="https://unpkg.com/aframe-extras.ocean@%5E3.5.x/dist/aframe-extras.ocean.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.min.js"></script>
     <script src="https://unpkg.com/aframe-gradient-sky@1.0.4/dist/gradientsky.min.js"></script>
   </head>
   <body>

--- a/docs/components/gltf-model.md
+++ b/docs/components/gltf-model.md
@@ -25,9 +25,9 @@ Work on the [three.js glTF loader][threejsgltf] and converters are still
 active.
 
 > **NOTE:** A-Frame supports glTF 2.0. For models using older versions of the
-> glTF format, use `gltf-model-legacy` from [donmccurdy/aframe-extras][extras].
+> glTF format, use `gltf-model-legacy` from [aframe-extras][extras].
 
-[extras]: https://github.com/donmccurdy/aframe-extras/tree/master/src/loaders
+[extras]: https://github.com/c-frame/aframe-extras/tree/master/src/loaders
 
 <!--toc-->
 
@@ -98,7 +98,7 @@ rendering.
 
 ## Using animations
 
-If you want to use the animations from your glTF model, you can use the [animation-mixer](https://github.com/donmccurdy/aframe-extras/tree/master/src/loaders#animation) component from [aframe-extras](https://github.com/donmccurdy/aframe-extras). By default all animations are played in a loop.
+If you want to use the animations from your glTF model, you can use the [animation-mixer](https://github.com/c-frame/aframe-extras/tree/master/src/loaders#animation) component from [aframe-extras](https://github.com/c-frame/aframe-extras). By default all animations are played in a loop.
 
 ```html
 <a-entity gltf-model="#monster" animation-mixer></a-entity>

--- a/docs/guides/building-a-minecraft-demo.md
+++ b/docs/guides/building-a-minecraft-demo.md
@@ -91,7 +91,7 @@ See a live version [here](https://aframe.io/aframe/examples/docs/aincraft/step2.
 [a-sky]: https://aframe.io/docs/1.6.0/primitives/a-sky.html
 [flickr]: https://www.flickr.com/groups/equirectangular/
 
-[gradient]: https://github.com/zcanter/aframe-gradient-sky
+[gradient]: https://github.com/mrxz/fern-aframe-components/tree/main/sky-background
 
 Let's add a 360&deg; background to our `<a-scene>` with the [`<a-sky>`
 element][a-sky]. `<a-sky>` is a large 3D sphere with a material mapped on the

--- a/docs/introduction/entity-component-system.md
+++ b/docs/introduction/entity-component-system.md
@@ -356,14 +356,14 @@ The [A-Frame Wiki](https://aframe.wiki/) is a useful community-driven initiative
 
 ### Using a Community Component
 
-[particlesystem]: https://www.npmjs.com/package/aframe-particle-system-component
+[particlesystem]: https://www.npmjs.com/package/@c-frame/aframe-particle-system-component
 
 Once we find a component that we want to use, we can include the component as a
 `<script>` tag and use it from HTML.
 
 [unpkg.com]: http://unpkg.com/
 
-For example, let's use IdeaSpaceVR's [particle system component][particlesystem]:
+For example, let's use the [particle system component][particlesystem]:
 
 #### Using unpkg
 
@@ -411,7 +411,7 @@ For the particle system component, the CDN link we found earlier (at time of
 writing) was:
 
 ```
-https://unpkg.com/@c-frame/aframe-particle-system-component@1.1.x/dist/aframe-particle-system-component.min.js
+https://unpkg.com/@c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js
 ```
 
 Now we can include it into our HTML:
@@ -420,7 +420,7 @@ Now we can include it into our HTML:
 <html>
   <head>
     <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
-    <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.1.x/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
   </head>
   <body>
     <a-scene>
@@ -441,7 +441,7 @@ Now we can include it into our HTML:
 <html>
   <head>
     <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
-    <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.1.x/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
   </head>
   <body>
     <a-scene>
@@ -476,7 +476,7 @@ Registry and using the JSDELIVR CDN.  This example can also be viewed in the [A-
     <title>Community Components Example</title>
     <meta name="description" content="Community Components Example">
     <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>  
-    <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.1.x/dist/aframe-particle-system-component.min.js"></script>
+    <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/aframe-simple-sun-sky@^1.2.2/simple-sun-sky.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.min.js"></script>
   </head>

--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -233,7 +233,7 @@ This depends on what devices you plan to support and how you allow users to
 navigate your scene. For most VR experiences, follow best practices and only
 move the camera proportionately to the user's motion.
 
-[teleport]: https://github.com/fernandojsg/aframe-teleport-controls
+[teleport]: https://github.com/jure/aframe-blink-controls
 
 Don't block the camera if the user steps forward in a room-scale VR space. For
 most VR applications it's better to do locomotion with methods such as using

--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -166,12 +166,6 @@ component][whygltf].
 [Wavefront (`.obj`)][obj] is also a well-known format but has some limitations
 like the lack of animation and vertex color support.
 
-There are also components in the ecosystem for loading other formats:
-
-- [`.PLY` models](https://github.com/donmccurdy/aframe-extras/blob/master/src/loaders/ply-model.js)
-- [three.js `.JSON` Object](https://github.com/donmccurdy/aframe-extras/blob/master/src/loaders/json-model.js)
-- [three.js `.JSON` Scene](https://github.com/donmccurdy/aframe-extras/blob/master/src/loaders/object-model.js)
-
 Below are a couple basic examples for using models:
 
 - [Model Example 1](https://aframe.io/aframe/examples/test/model/)
@@ -241,7 +235,7 @@ most VR applications it's better to do locomotion with methods such as using
 of the way or not require much movement, or explore more creative ways of
 moving users through the world.
 
-[physics]: https://github.com/donmccurdy/aframe-physics-system
+[physics]: https://github.com/c-frame/aframe-physics-system
 
 For non-VR desktop experiences with a gamepad or keyboard controls or for VR
 scenes where the camera is inside a vehicle, you can add a [physics

--- a/docs/introduction/html-and-primitives.md
+++ b/docs/introduction/html-and-primitives.md
@@ -181,9 +181,9 @@ AFRAME.registerPrimitive('a-box', extendDeep({}, meshMixin, {
 }));
 ```
 
-[aframe-extras]: https://github.com/donmccurdy/aframe-extras
+[aframe-extras]: https://github.com/c-frame/aframe-extras
 
-For example, Don McCurdy's [`aframe-extras`][aframe-extras] package includes an
+For example, [`aframe-extras`][aframe-extras] package includes an
 `<a-ocean>` primitive that wraps his `ocean` component. Here is the definition
 for `<a-ocean>`.
 

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -137,7 +137,7 @@ and fly around to peek under the hood!
 [environment]: https://github.com/supermedium/aframe-environment-component
 [multiuser]: https://github.com/networked-aframe/networked-aframe
 [oceans]: https://github.com/n5ro/aframe-extras/tree/master/src/primitives
-[particle systems]: https://github.com/IdeaSpaceVR/aframe-particle-system-component
+[particle systems]: https://github.com/c-frame/aframe-particle-system-component
 [physics]: https://github.com/n5ro/aframe-physics-system
 [state]: https://npmjs.com/package/aframe-state-component
 [super hands]: https://github.com/wmurphyrd/aframe-super-hands-component

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -136,11 +136,11 @@ and fly around to peek under the hood!
 [augmented reality]: https://github.com/jeromeetienne/AR.js#augmented-reality-for-the-web-in-less-than-10-lines-of-html
 [environment]: https://github.com/supermedium/aframe-environment-component
 [multiuser]: https://github.com/networked-aframe/networked-aframe
-[oceans]: https://github.com/n5ro/aframe-extras/tree/master/src/primitives
+[oceans]: https://github.com/c-frame/aframe-extras/tree/master/src/primitives
 [particle systems]: https://github.com/c-frame/aframe-particle-system-component
-[physics]: https://github.com/n5ro/aframe-physics-system
+[physics]: https://github.com/c-frame/aframe-physics-system
 [state]: https://npmjs.com/package/aframe-state-component
-[super hands]: https://github.com/wmurphyrd/aframe-super-hands-component
+[super hands]: https://github.com/c-frame/aframe-super-hands-component
 [teleportation]: https://github.com/fernandojsg/aframe-teleport-controls
 
 :runner: **Components**: Hit the ground running with A-Frame's core components

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -141,7 +141,7 @@ and fly around to peek under the hood!
 [physics]: https://github.com/c-frame/aframe-physics-system
 [state]: https://npmjs.com/package/aframe-state-component
 [super hands]: https://github.com/c-frame/aframe-super-hands-component
-[teleportation]: https://github.com/fernandojsg/aframe-teleport-controls
+[teleportation]: https://github.com/jure/aframe-blink-controls
 
 :runner: **Components**: Hit the ground running with A-Frame's core components
 such as geometries, materials, lights, animations, models, raycasters, shadows,

--- a/docs/introduction/interactions-and-controllers.md
+++ b/docs/introduction/interactions-and-controllers.md
@@ -589,8 +589,8 @@ The [documentation for super-hands][superhandsdocs] and
 
 ### Other Examples
 
-[aframe-extras]: https://github.com/donmccurdy/aframe-extras
-[aframe-physics]: https://github.com/donmccurdy/aframe-physics-system
+[aframe-extras]: https://github.com/c-frame/aframe-extras
+[aframe-physics]: https://github.com/c-frame/aframe-physics-system
 
 Other examples to look at include:
 

--- a/docs/introduction/javascript-events-dom-apis.md
+++ b/docs/introduction/javascript-events-dom-apis.md
@@ -321,7 +321,7 @@ entityEl.setAttribute('geometry', {
 });
 ```
 
-[physics]: https://github.com/donmccurdy/aframe-physics-system
+[physics]: https://github.com/c-frame/aframe-physics-system
 
 Or adding [the community physics component][physics]:
 

--- a/docs/introduction/models.md
+++ b/docs/introduction/models.md
@@ -30,7 +30,7 @@ three.js loaders.
 
 ## Animating Models
 
-[mixer]: https://github.com/donmccurdy/aframe-extras/tree/master/src/loaders#animation
+[mixer]: https://github.com/c-frame/aframe-extras/tree/master/src/loaders#animation
 
 We can use [Don McCurdy's animation-mixer component][mixer] to play a model's
 built-in animations. Animations usually come in the model built via animation
@@ -148,7 +148,7 @@ If this didn't work, you should check your MTL file and you might notice it is t
 
 ### My Model Isn't Animating
 
-[aframe-extras]: https://github.com/donmccurdy/aframe-extras
+[aframe-extras]: https://github.com/c-frame/aframe-extras
 
 The [animation-mixer component][mixer], part of [aframe-extras] by Don McCurdy,
 provides controls for playing animations in three.js (.json) and glTF (.gltf)

--- a/examples/docs/community-components/index.html
+++ b/examples/docs/community-components/index.html
@@ -7,7 +7,7 @@
     <script src="https://aframe.io/releases/<release_number>/aframe.min.js"></script>
     -->
     <script src="../../../dist/aframe-master.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-particle-system-component@1.1.4/dist/aframe-particle-system-component.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/aframe-simple-sun-sky@1.2.3/simple-sun-sky.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.min.js"></script>
   </head>


### PR DESCRIPTION
**Changes proposed:**
- Update to c-frame/aframe-particle-system-component@1.2.x
- Update some urls of some components that were moved to c-frame organization
- Replace aframe-teleport-controls by aframe-blink-controls
- Update more links to c-frame organization

![Capture d’écran du 2024-09-07 12-57-07](https://github.com/user-attachments/assets/f0821900-6b69-49ba-9851-ebacb63550e8)

- aframe-extras.ocean package is not maintained, use aframe-extras to get the ocean component
- Replace not working aframe-gradient-sky by aframe-sky-background

