### PR TITLE
Add aframe-injected attribute to the created a-loader-title div

### DIFF
--- a/src/core/scene/loadingScreen.js
+++ b/src/core/scene/loadingScreen.js
@@ -1,4 +1,5 @@
 /* global THREE */
+var AFRAME_INJECTED = require('../../constants').AFRAME_INJECTED;
 var utils = require('../../utils/');
 var styleParser = utils.styleParser;
 
@@ -88,5 +89,6 @@ function setupTitle () {
   titleEl.className = LOADER_TITLE_CLASS;
   titleEl.innerHTML = document.title;
   titleEl.style.display = 'none';
+  titleEl.setAttribute(AFRAME_INJECTED, '');
   sceneEl.appendChild(titleEl);
 }


### PR DESCRIPTION
Add aframe-injected attribute to the created a-loader-title div so it doesn't show up when copying a-scene to clipboard in aframe-inspector (fix aframevr/aframe-inspector#764)