### PR TITLE
Reintroduce light intensity scale factor removed in THREE r165 after WebGLRenderer.useLegacyLights deprecation (fix #5556, #5546)

### DIFF
--- a/docs/components/light.md
+++ b/docs/components/light.md
@@ -97,7 +97,7 @@ Directional lights are the most efficient type for adding realtime shadows to a 
 <a-light type="directional" light="castShadow:true;" position="1 1 1" intensity="0.5" shadow-camera-automatic="#objects"></a-light>
 ```
 
-The `shadow-camera-automatic` configuration maps to `light.shadowCameraAutomatic` which tells the light to automatically update the shadow camera to be the minimum size and position to encompass the target elements. 
+The `shadow-camera-automatic` configuration maps to `light.shadowCameraAutomatic` which tells the light to automatically update the shadow camera to be the minimum size and position to encompass the target elements.
 
 ### Hemisphere
 
@@ -129,7 +129,7 @@ lit.
 
 | Property    | Description                                                                                                | Default Value |
 |-------------|------------------------------------------------------------------------------------------------------------|---------------|
-| decay       | Amount the light dims along the distance of the light.                                                     | 1.0           |
+| decay       | Amount the light dims along the distance of the light.                                                     | 2.0           |
 | distance    | Distance where intensity becomes 0. If `distance` is `0`, then the point light does not decay with distance. | 0.0           |
 
 ### Spot

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -20,7 +20,7 @@ module.exports.Component = registerComponent('light', {
     color: {type: 'color', if: {type: ['ambient', 'directional', 'hemisphere', 'point', 'spot']}},
     envMap: {default: '', if: {type: ['probe']}},
     groundColor: {type: 'color', if: {type: ['hemisphere']}},
-    decay: {default: 1, if: {type: ['point', 'spot']}},
+    decay: {default: 2, if: {type: ['point', 'spot']}},
     distance: {default: 0.0, min: 0, if: {type: ['point', 'spot']}},
     intensity: {default: 1.0, min: 0, if: {type: ['ambient', 'directional', 'hemisphere', 'point', 'spot', 'probe']}},
     penumbra: {default: 0, min: 0, max: 1, if: {type: ['spot']}},
@@ -281,7 +281,11 @@ module.exports.Component = registerComponent('light', {
     var distance = data.distance;
     var groundColor = new THREE.Color(data.groundColor);
     groundColor = groundColor.getHex();
-    var intensity = data.intensity;
+    // WebGLRenderer.useLegacyLights has been removed in THREE r165
+    // Lights intensity had an implicit scaleFactor of PI now removed.
+    // It's reintroduced here since it's easier to think about integers vs multiples of PI.
+    var intensityScaleFactor = Math.PI;
+    var intensity = data.intensity * intensityScaleFactor;
     var type = data.type;
     var target = data.target;
     var light = null;


### PR DESCRIPTION
Is this good? @vincentfretin @mrxz 