### PR TITLE
Gracefully handles when calling getGamepads() is not allowed...

### DIFF
--- a/examples/test/iframe/index.html
+++ b/examples/test/iframe/index.html
@@ -41,7 +41,7 @@
     </style>
   </head>
   <body>
-    <iframe id="aframe" src="/examples/animation/aframe-logo/?ui=false"></iframe>
+    <iframe id="aframe" src="../../../examples/animation/aframe-logo/?ui=false" allow="gamepad 'none'"></iframe>
     <button class="enter-vr">ENTER VR</button>
   </body>
   <script>

--- a/src/systems/tracked-controls-webvr.js
+++ b/src/systems/tracked-controls-webvr.js
@@ -64,7 +64,11 @@ module.exports.System = registerSystem('tracked-controls-webvr', {
         this.el.emit('controllersupdated', undefined, false);
       }
     } catch (e) {
-      console.warn('A-Frame requires additional permissions to list the gamepads. If this is running in an IFRAME, you need to add `gamepads` to the `allow` attribute. If this is running as the top-level page, the HTTP `Permissions-Policy` header must not exclude this origin in the `gamepad` directive.', e);
+      if (e.name === 'SecurityError') {
+        console.warn('A-Frame requires additional permissions to list the gamepads. If this is running in an IFRAME, you need to add `gamepads` to the `allow` attribute. If this is running as the top-level page, the HTTP `Permissions-Policy` header must not exclude this origin in the `gamepad` directive.', e);
+      } else {
+        console.error('Can\'t update controller list:', e);
+      }
     }
   }
 });

--- a/src/systems/tracked-controls-webvr.js
+++ b/src/systems/tracked-controls-webvr.js
@@ -64,7 +64,7 @@ module.exports.System = registerSystem('tracked-controls-webvr', {
         this.el.emit('controllersupdated', undefined, false);
       }
     } catch (e) {
-      console.warn('can\'t update controller list:', e);
+      console.warn('A-Frame requires additional permissions to list the gamepads. If this is running in an IFRAME, you need to add `gamepads` to the `allow` attribute. If this is running as the top-level page, the HTTP `Permissions-Policy` header must not exclude this origin in the `gamepad` directive.', e);
     }
   }
 });

--- a/src/systems/tracked-controls-webvr.js
+++ b/src/systems/tracked-controls-webvr.js
@@ -65,7 +65,11 @@ module.exports.System = registerSystem('tracked-controls-webvr', {
       }
     } catch (e) {
       if (e.name === 'SecurityError') {
-        console.warn('A-Frame requires additional permissions to list the gamepads. If this is running in an IFRAME, you need to add `gamepads` to the `allow` attribute. If this is running as the top-level page, the HTTP `Permissions-Policy` header must not exclude this origin in the `gamepad` directive.', e);
+        if (window.self === window.top) {
+          console.warn('A-Frame requires additional permissions to list the gamepads. The HTTP `Permissions-Policy` header must not exclude this origin in the `gamepad` directive.', e);
+        } else {
+          console.warn('A-Frame requires additional permissions to list the gamepads. The iframe `allow` attribute must not block this origin.', e);
+        }
       } else {
         console.error('Can\'t update controller list:', e);
       }

--- a/src/systems/tracked-controls-webvr.js
+++ b/src/systems/tracked-controls-webvr.js
@@ -41,26 +41,30 @@ module.exports.System = registerSystem('tracked-controls-webvr', {
    * Update controller list.
    */
   updateControllerList: function () {
-    var controllers = this.controllers;
-    var gamepad;
-    var gamepads;
-    var i;
-    var prevCount;
+    try {
+      var controllers = this.controllers;
+      var gamepad;
+      var gamepads;
+      var i;
+      var prevCount;
 
-    gamepads = navigator.getGamepads && navigator.getGamepads();
-    if (!gamepads) { return; }
+      gamepads = navigator.getGamepads && navigator.getGamepads();
+      if (!gamepads) { return; }
 
-    prevCount = controllers.length;
-    controllers.length = 0;
-    for (i = 0; i < gamepads.length; ++i) {
-      gamepad = gamepads[i];
-      if (gamepad && gamepad.pose) {
-        controllers.push(gamepad);
+      prevCount = controllers.length;
+      controllers.length = 0;
+      for (i = 0; i < gamepads.length; ++i) {
+        gamepad = gamepads[i];
+        if (gamepad && gamepad.pose) {
+          controllers.push(gamepad);
+        }
       }
-    }
 
-    if (controllers.length !== prevCount) {
-      this.el.emit('controllersupdated', undefined, false);
+      if (controllers.length !== prevCount) {
+        this.el.emit('controllersupdated', undefined, false);
+      }
+    } catch (e) {
+      console.warn('can\'t update controller list:', e);
     }
   }
 });

--- a/src/systems/tracked-controls-webvr.js
+++ b/src/systems/tracked-controls-webvr.js
@@ -66,9 +66,9 @@ module.exports.System = registerSystem('tracked-controls-webvr', {
     } catch (e) {
       if (e.name === 'SecurityError') {
         if (window.self === window.top) {
-          console.warn('A-Frame requires additional permissions to list the gamepads. The HTTP `Permissions-Policy` header must not exclude this origin in the `gamepad` directive.', e);
+          console.warn('The HTTP `Permissions-Policy` header must not block this origin in the `gamepad` directive, to allow A-Frame to list the gamepads.', e);
         } else {
-          console.warn('A-Frame requires additional permissions to list the gamepads. The iframe `allow` attribute must not block this origin.', e);
+          console.warn('The iframe `allow` attribute must not block the origin of this A-Frame app, to allow A-Frame to list the gamepads.', e);
         }
       } else {
         console.error('Can\'t update controller list:', e);

--- a/src/systems/tracked-controls-webvr.js
+++ b/src/systems/tracked-controls-webvr.js
@@ -50,6 +50,7 @@ module.exports.System = registerSystem('tracked-controls-webvr', {
       var i;
       var prevCount;
 
+      if (!this.el.is('vr-mode')) { return; }
       gamepads = navigator.getGamepads && navigator.getGamepads();
       if (!gamepads) { return; }
 

--- a/src/systems/tracked-controls-webvr.js
+++ b/src/systems/tracked-controls-webvr.js
@@ -37,6 +37,8 @@ module.exports.System = registerSystem('tracked-controls-webvr', {
     }
   },
 
+  permissionsWarningDisplayed: false,
+
   /**
    * Update controller list.
    */
@@ -65,10 +67,13 @@ module.exports.System = registerSystem('tracked-controls-webvr', {
       }
     } catch (e) {
       if (e.name === 'SecurityError') {
-        if (window.self === window.top) {
-          console.warn('The HTTP `Permissions-Policy` header must not block this origin in the `gamepad` directive, to allow A-Frame to list the gamepads.', e);
-        } else {
-          console.warn('The iframe `allow` attribute must not block the origin of this A-Frame app, to allow A-Frame to list the gamepads.', e);
+        if (!this.permissionsWarningDisplayed) {
+          this.permissionsWarningDisplayed = true;
+          if (window.self === window.top) {
+            console.warn('The HTTP `Permissions-Policy` header must not block this origin in the `gamepad` directive, to allow A-Frame to list the gamepads.', e);
+          } else {
+            console.warn('The iframe `allow` attribute must not block the origin of this A-Frame app, to allow A-Frame to list the gamepads.', e);
+          }
         }
       } else {
         console.error('Can\'t update controller list:', e);


### PR DESCRIPTION
… from the context (such as an IFRAME), by the Document's Permission Policy, by catching the DOMException.

When AFrame is run in an IFRAME without the needed permission, the call to Navigator.getGamepads() throws a DOMException which prevents AFrame from loading properly.