### PR TITLE
remove fullscreen styles when scene gets detached

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -179,6 +179,7 @@ class AScene extends AEntity {
     scenes.splice(sceneIndex, 1);
 
     window.removeEventListener('sessionend', this.resize);
+    this.removeFullScreenStyles();
     this.renderer.dispose();
   }
 


### PR DESCRIPTION
**Description:**
Removes the fullscreen styles added by aframe when scene is removed/"disconnected" (doDisconnectCallback).
As a-frame adds these styles on adding the scene it should also make sure to clean them up when the scene gets removed.

**Detailed explanation:**
I use a-frame in an SPA and only some of the pages are using a-frame. On entering a route that uses aframe I load aframe. The a-scene tag will add 'a-fullscreen' class to the documentElement (html tag) that effectively disables scrollbars. This css class should only be present when visiting a route with a (fullscreen) a-scene. Leaving an a-scene route should remove the class. If these styles arent removed other non-vr routes will have no scrollbars, even when the browser would normally render scrollbars.

fixes #5600
