### PR TITLE
Add additional isWebXRAvailable check to isAppleVisionPro to not have a false positive on iPhones / iPads (fix #5605)

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -127,9 +127,8 @@ function isAppleVisionPro () {
   // Safari for Apple Vision Pro presents itself as a desktop browser.
   var isMacintosh = navigator.userAgent.includes('Macintosh');
   // Discriminates between a "real" desktop browser and Safari for Vision Pro.
-  // Note: need to check for posible false positives on iPhones / iPads.
   var hasFiveTouchPoints = navigator.maxTouchPoints === 5;
-  return isMacintosh && hasFiveTouchPoints;
+  return isMacintosh && hasFiveTouchPoints && isWebXRAvailable;
 }
 module.exports.isAppleVisionPro = isAppleVisionPro;
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -128,6 +128,8 @@ function isAppleVisionPro () {
   var isMacintosh = navigator.userAgent.includes('Macintosh');
   // Discriminates between a "real" desktop browser and Safari for Vision Pro.
   var hasFiveTouchPoints = navigator.maxTouchPoints === 5;
+  // isWebXRAvailable discriminates between Vision Pro and iPad / iPhone. 
+  // This will no longer work once WebXR ships in iOS / iPad OS.
   return isMacintosh && hasFiveTouchPoints && isWebXRAvailable;
 }
 module.exports.isAppleVisionPro = isAppleVisionPro;


### PR DESCRIPTION
Now that WebXR is enabled by default on Apple Vision Pro, we can add a check for navigation.xr to discriminate AVP and iPhones / iPads.

This fixes #5605