### PR TITLE
Fix render order of background fade in User Interface example

### DIFF
--- a/examples/showcase/ui/index.html
+++ b/examples/showcase/ui/index.html
@@ -73,7 +73,7 @@
         <a-entity
           id="fadeBackground"
           geometry="primitive: sphere; radius: 2.5"
-          material="color: black; side: back; shader: flat; transparent: true; opacity: 0.6" visible="false">
+          material="color: #999999; side: back; shader: flat; blending: subtractive;" visible="false">
         </a-entity>
       </a-entity>
 

--- a/examples/showcase/ui/info-panel.js
+++ b/examples/showcase/ui/info-panel.js
@@ -32,9 +32,9 @@ AFRAME.registerComponent('info-panel', {
       buttonEls[i].addEventListener('click', this.onMenuButtonClick);
     }
     this.backgroundEl.addEventListener('click', this.onBackgroundClick);
-    this.el.object3D.renderOrder = 9999999;
+    this.el.object3D.renderOrder = 2;
     this.el.object3D.depthTest = false;
-    fadeBackgroundEl.object3D.renderOrder = 9;
+    fadeBackgroundEl.object3D.renderOrder = 1;
     fadeBackgroundEl.getObject3D('mesh').material.depthTest = false;
   },
 


### PR DESCRIPTION
**Description:**
The background fade effect in the UI showcase was broken. This can be traced back to the change in sorting made in #5341. The example assumed the document order was used for rendering, which would place the `fadeBackground` element between the movie posters and the info panel.

However, objects are now sorted, putting all opaque objects in order followed by all transparent objects (unsorted). This placed the `fadeBackground` after both the movie posters and the info panel.

To resolve this issue, this PR changes the `fadeBackground` to not be transparent, but use subtractive blending. This allows it to be part of the opaque queue. The render order can then be configured as follows: 0 (background + movie posters), 1 (fadeBackground), 2 (info panel), transparent elements.

**Changes proposed:**
- Change `fadeBackground` to use subtractive blending instead of transparency and set desired renderOrder.