### PR TITLE
Make cursor component work when camera is not an entity like in the inspector

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -263,7 +263,7 @@ module.exports.Component = registerComponent('cursor', {
     return function (evt) {
       var bounds = this.canvasBounds;
       var camera = this.el.sceneEl.camera;
-      var cameraElParent = camera.el ? camera.el.object3D.parent : null;
+      var cameraElParent;
       var left;
       var point;
       var top;
@@ -301,10 +301,9 @@ module.exports.Component = registerComponent('cursor', {
           origin.copy(transform.position);
 
           // Transform XRPose into world space
-          if (cameraElParent) {
-            cameraElParent.localToWorld(origin);
-            direction.transformDirection(cameraElParent.matrixWorld);
-          }
+          cameraElParent = camera.el.object3D.parent;
+          cameraElParent.localToWorld(origin);
+          direction.transformDirection(cameraElParent.matrixWorld);
         }
       } else if (evt.type === 'fakeselectout') {
         direction.set(0, 1, 0);

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -263,7 +263,7 @@ module.exports.Component = registerComponent('cursor', {
     return function (evt) {
       var bounds = this.canvasBounds;
       var camera = this.el.sceneEl.camera;
-      var cameraElParent = camera.el.object3D.parent;
+      var cameraElParent = camera.el ? camera.el.object3D.parent : null;
       var left;
       var point;
       var top;
@@ -301,8 +301,10 @@ module.exports.Component = registerComponent('cursor', {
           origin.copy(transform.position);
 
           // Transform XRPose into world space
-          cameraElParent.localToWorld(origin);
-          direction.transformDirection(cameraElParent.matrixWorld);
+          if (cameraElParent) {
+            cameraElParent.localToWorld(origin);
+            direction.transformDirection(cameraElParent.matrixWorld);
+          }
         }
       } else if (evt.type === 'fakeselectout') {
         direction.set(0, 1, 0);


### PR DESCRIPTION
**Description:**

@mrxz #5606 broke the inspector that uses a threejs camera directly, not an entity.

**Changes proposed:**
- Check if camera.el is defined and only transform local to world coordinates if it is defined