### PR TITLE
Cursor component: call addWebXREventListeners also when rayOrigin is entity

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -85,14 +85,17 @@ module.exports.Component = registerComponent('cursor', {
   },
 
   update: function (oldData) {
-    if (this.data.rayOrigin === oldData.rayOrigin) { return; }
-    if (this.data.rayOrigin === 'entity') { this.resetRaycaster(); }
+    var rayOrigin = this.data.rayOrigin;
+    if (rayOrigin === oldData.rayOrigin) { return; }
+    if (rayOrigin === 'entity') { this.resetRaycaster(); }
     this.updateMouseEventListeners();
-    // Update the WebXR event listeners if needed
-    if (this.data.rayOrigin !== 'mouse') {
+    // Update the WebXR event listeners if needed.
+    // This handles the cases a cursor is created or has its rayOrigin changed during an XR session.
+    // In the case the cursor is created before we have an active XR session, it does not add the WebXR event listeners here (addWebXREventListeners is a no-op without xrSession), upon onEnterVR they are added.
+    if (rayOrigin === 'xrselect' || rayOrigin === 'entity') {
       this.addWebXREventListeners();
     }
-    if (oldData.rayOrigin !== 'mouse') {
+    if (oldData.rayOrigin === 'xrselect' || oldData.rayOrigin === 'entity') {
       this.removeWebXREventListeners();
     }
   },
@@ -445,8 +448,9 @@ module.exports.Component = registerComponent('cursor', {
   },
 
   onEnterVR: function () {
+    var rayOrigin = this.data.rayOrigin;
     this.clearCurrentIntersection(true);
-    if (this.data.rayOrigin !== 'mouse') {
+    if (rayOrigin === 'xrselect' || rayOrigin === 'entity') {
       this.addWebXREventListeners();
     }
   },

--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -89,10 +89,10 @@ module.exports.Component = registerComponent('cursor', {
     if (this.data.rayOrigin === 'entity') { this.resetRaycaster(); }
     this.updateMouseEventListeners();
     // Update the WebXR event listeners if needed
-    if (this.data.rayOrigin === 'xrselect') {
+    if (this.data.rayOrigin !== 'mouse') {
       this.addWebXREventListeners();
     }
-    if (oldData.rayOrigin === 'xrselect') {
+    if (oldData.rayOrigin !== 'mouse') {
       this.removeWebXREventListeners();
     }
   },
@@ -446,7 +446,7 @@ module.exports.Component = registerComponent('cursor', {
 
   onEnterVR: function () {
     this.clearCurrentIntersection(true);
-    if (this.data.rayOrigin === 'xrselect') {
+    if (this.data.rayOrigin !== 'mouse') {
       this.addWebXREventListeners();
     }
   },


### PR DESCRIPTION
**Description:**

When I tried to update https://aframe-xr-starterkit.glitch.me to use master, the buttons on the wrist were not clickable anymore.
```html
  <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@4d97225a04cfdc9ab3e44f84687f70d6816a366b/dist/aframe-master.min.js"></script><!-- Dec 31, 2024 not working -->
  <!--<script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@86d847fa80dcaa1c7306a93890000d5bb3183416/dist/aframe-master.min.js"></script>--><!-- Nov 15, 2024 not working, include https://github.com/aframevr/aframe/commit/655ab162d43f3d67327d4da69c3625aef324abb0 -->
  <!--<script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@8e52e89e813b440ee52e0a78aaddde33f98657e0/dist/aframe-master.min.js"></script>--><!-- Nov 15, 2024 working, don't include https://github.com/aframevr/aframe/commit/655ab162d43f3d67327d4da69c3625aef324abb0 -->
```

The culpurit was commit https://github.com/aframevr/aframe/commit/655ab162d43f3d67327d4da69c3625aef324abb0 that removed the webxr listeners for cursor with rayOrigin: entity (the default).

**Changes proposed:**
- Modify the check to use rayOrigin !== mouse, that what it was really before the commit
