### PR TITLE
Cursor component: remove addWebXREventListeners/removeWebXREventListeners in update

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -88,13 +88,6 @@ module.exports.Component = registerComponent('cursor', {
     if (this.data.rayOrigin === oldData.rayOrigin) { return; }
     if (this.data.rayOrigin === 'entity') { this.resetRaycaster(); }
     this.updateMouseEventListeners();
-    // Update the WebXR event listeners if needed
-    if (this.data.rayOrigin === 'xrselect') {
-      this.addWebXREventListeners();
-    }
-    if (oldData.rayOrigin === 'xrselect') {
-      this.removeWebXREventListeners();
-    }
   },
 
   tick: function () {


### PR DESCRIPTION
**Description:**

Those calls were introduced in https://github.com/aframevr/aframe/commit/655ab162d43f3d67327d4da69c3625aef324abb0
If you set `cursor="rayOrigin: xrselect"`, it calls `addWebXREventListeners` in `update` and then in `onEnterVR`, so adding the listeners twice.
Later if you update a property that is not rayOrigin like fuse, it will call `addWebXREventListeners` and right away `removeWebXREventListeners`, so registering and unregistering listeners, it doesn't make sense.

**Changes proposed:**
- Remove `addWebXREventListeners`/`removeWebXREventListeners` from update, only keep `addWebXREventListeners` in `onEnterVR`, and the `removeWebXREventListeners` in `removeEventListeners` that is called in `pause`/`remove`.

I tested that on Android examples/showcase/ui/index.html with `<a-scene xr-mode-ui="XRMode: xr"` and `cursor="rayOrigin: xrselect; fuse: false"`. When I click on AR button, touching the image opens the modal correctly.
Am I missing something @mrxz?