### PR TITLE
Cursor component: remove raycaster-closest-entity-changed listener when removing the component

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -193,6 +193,7 @@ module.exports.Component = registerComponent('cursor', {
       el.removeEventListener(upEvent, self.onCursorUp);
     });
     el.removeEventListener('raycaster-intersection', this.onIntersection);
+    el.removeEventListener('raycaster-closest-entity-changed', this.onIntersection);
     el.removeEventListener('raycaster-intersection-cleared', this.onIntersectionCleared);
     canvas.removeEventListener('mousemove', this.onMouseMove);
     canvas.removeEventListener('touchstart', this.onMouseMove);


### PR DESCRIPTION
**Description:**

Remove the `raycaster-closest-entity-changed` listener (event introduced in https://github.com/aframevr/aframe/commit/981cb8105cf0d59a28b3a7ec3943cfad45dc2964) when removing the cursor component.
This fixes `getIntersection on undefined` error when we dynamically remove cursor and raycaster components on the scene when entering VR and there is a hand raycaster emitting this event.

**Changes proposed:**
- The `raycaster-closest-entity-changed` listener is added in `addEventListeners` but never removed, remove it in `removeEventListeners` like the other listeners.