### PR TITLE
Layer component: wait referenceSpace to be set before calling initLayer

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -212,6 +212,7 @@ module.exports.Component = registerComponent('layer', {
 
   tick: function () {
     if (!this.el.sceneEl.xrSession) { return; }
+    if (!this.referenceSpace) { return; }
     if (!this.layer && (this.el.sceneEl.is('vr-mode') || this.el.sceneEl.is('ar-mode'))) { this.initLayer(); }
     this.updateTransform();
     if (this.data.src.complete && (this.pendingCubeMapUpdate || this.loadingScreen || this.visibilityChanged)) { this.loadCubeMapImages(); }


### PR DESCRIPTION
**Description:**

I got an error `space argument required` when calling `xrGLFactory.createQuadLayer` here
https://github.com/aframevr/aframe/blob/6de81190a6891deb4ee59f3c549acd0011eb783c/src/components/layer.js#L247-L253

In `onEnterVR`, `this.referenceSpace` is set asynchronously via
https://github.com/aframevr/aframe/blob/6de81190a6891deb4ee59f3c549acd0011eb783c/src/components/layer.js#L369
that does
https://github.com/aframevr/aframe/blob/6de81190a6891deb4ee59f3c549acd0011eb783c/src/components/layer.js#L385
so in my case `createQuadLayer` was called before `this.referenceSpace` was set.

**Changes proposed:**
- Wait `this.referenceSpace` to be set before calling `this.initLayer`