### PR TITLE
Remove --experimental-require-module flag for the test:node command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:firefox": "npm test -- --browsers Firefox",
     "test:chrome": "npm test -- --browsers Chrome",
     "test:nobrowser": "NO_BROWSER=true npm test",
-    "test:node": "node --experimental-require-module ./node_modules/mocha/bin/mocha --ui tdd tests/node"
+    "test:node": "node ./node_modules/mocha/bin/mocha --ui tdd tests/node"
   },
   "repository": "aframevr/aframe",
   "license": "MIT",


### PR DESCRIPTION
Remove `--experimental-require-module` flag for the `test:node` command, not needed on latest node 22.x.