### PR TITLE
Check if XRSession exists before adding inputsourceschange listener

### DIFF
--- a/src/systems/tracked-controls.js
+++ b/src/systems/tracked-controls.js
@@ -17,6 +17,8 @@ module.exports.System = registerSystem('tracked-controls', {
   },
 
   onEnterVR: function () {
+    var xrSession = this.el.xrSession;
+    if (!xrSession) { return; }
     this.el.xrSession.addEventListener('inputsourceschange', this.onInputSourcesChange);
   },
 


### PR DESCRIPTION
**Description:**
The `tracked-controls` system unconditionally adds an `inputsourcechange` listener when "entering VR". However, the `enter-vr` event is also used when entering fullscreen mode, in which case an error occurs. This is a regression introduced in fd9043482554384ca4932cb9b5ac7e00f3c21074.

This PR simply adds a check to make sure there is an `XRSession` before adding the event listener.

**Changes proposed:**
- Check if there's an `XRSession` before adding `inputsourcechange` listener in `tracked-controls` system.

