### PR TITLE
Only apply position and orientation of spatial anchor space to anchored entity

### DIFF
--- a/src/components/anchored.js
+++ b/src/components/anchored.js
@@ -52,8 +52,9 @@ module.exports.Component = registerComponent('anchored', {
     refSpace = xrManager.getReferenceSpace();
 
     pose = frame.getPose(this.anchor.anchorSpace, refSpace);
-    object3D.matrix.elements = pose.transform.matrix;
-    object3D.matrix.decompose(object3D.position, object3D.rotation, object3D.scale);
+    // Apply position and orientation, leave scale as-is (see aframevr/aframe#5630)
+    object3D.position.copy(pose.transform.position);
+    object3D.quaternion.copy(pose.transform.orientation);
   },
 
   createAnchor: async function createAnchor (position, quaternion) {


### PR DESCRIPTION
**Description:**
As reported in #5630 the `anchored` component would set the scale to 1, despite only needing to position and orientate the entity based on the spatial anchor's pose. This PR replaces the matrix decomposition with a straightforward copy of the position and orientation, leaving the scale of the entity as-is.

Fixes #5630 

**Changes proposed:**
- Only apply position and orientation of spatial anchor space to anchored entity

