### PR TITLE
Remove deprecated AFRAME.utils.isGearVR and AFRAME.utils.isOculusGo functions

### DIFF
--- a/docs/core/utils.md
+++ b/docs/core/utils.md
@@ -146,10 +146,6 @@ diff({a: 1, b: 2, c: 3}, {b: 2, c: 4})
 
 Checks if a VR headset is connected by looking for orientation data. Returns a `boolean`.
 
-### `AFRAME.utils.device.isOculusGo ()`
-
-Checks if device is Oculus Go. Returns a `boolean`.
-
 ### `AFRAME.utils.device.isMobile ()`
 
 Checks if device is a smartphone. Returns a `boolean`.

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -27,17 +27,12 @@ export function checkHeadsetConnected () {
   warn('`utils.checkHeadsetConnected` has moved to `utils.device.checkHeadsetConnected`');
   return device.checkHeadsetConnected(arguments);
 }
-export function isGearVR () {
-  warn('`utils.isGearVR` has been deprecated, use `utils.device.isMobileVR`');
-}
 
 export function isIOS () {
   warn('`utils.isIOS` has moved to `utils.device.isIOS`');
   return device.isIOS(arguments);
 }
-export function isOculusGo () {
-  warn('`utils.isOculusGo` has been deprecated, use `utils.device.isMobileVR`');
-}
+
 export function isMobile () {
   warn('`utils.isMobile has moved to `utils.device.isMobile`');
   return device.isMobile(arguments);


### PR DESCRIPTION
**Description:**

Remove deprecated AFRAME.utils.isGearVR and AFRAME.utils.isOculusGo functions