### PR TITLE
Fix wrong description for AFRAME.utils.device.checkHeadsetConnected()

### DIFF
--- a/docs/core/utils.md
+++ b/docs/core/utils.md
@@ -144,7 +144,8 @@ diff({a: 1, b: 2, c: 3}, {b: 2, c: 4})
 
 ### `AFRAME.utils.device.checkHeadsetConnected ()`
 
-Checks if a VR headset is connected by looking for orientation data. Returns a `boolean`.
+Checks if a VR headset is connected by looking for browser support of
+immersive-vr or immersive-ar WebXR session. Returns a `boolean`.
 
 ### `AFRAME.utils.device.isOculusGo ()`
 


### PR DESCRIPTION
**Description:**

Fix wrong description for AFRAME.utils.device.checkHeadsetConnected() function, this has nothing to do with orientation data.