### PR TITLE
Relax the clientWidth constraint in the controls tests

### DIFF
--- a/tests/core/controls.test.js
+++ b/tests/core/controls.test.js
@@ -407,7 +407,7 @@ suite('rotation controls on camera with touch drag (integration unit test)', fun
 
     canvas = sceneEl.canvas;
     sceneEl.isMobile = true;
-    assert.isAtLeast(canvas.clientWidth, 1000);
+    assert.isAtLeast(canvas.clientWidth, 800);
 
     // Dispatch touchstart event.
     touchStartEvent = new Event('touchstart');
@@ -437,7 +437,7 @@ suite('rotation controls on camera with touch drag (integration unit test)', fun
 
     canvas = sceneEl.canvas;
     sceneEl.isMobile = true;
-    assert.isAtLeast(canvas.clientWidth, 1000);
+    assert.isAtLeast(canvas.clientWidth, 800);
 
     // Dispatch touchstart event.
     touchStartEvent = new Event('touchstart');


### PR DESCRIPTION
**Description:**

In #5632, the line was changed from

```js
canvas.clientWidth = 1000;
```

that really did nothing because `canvas.clientWidth` is read-only.

to

```js
assert.isAtLeast(canvas.clientWidth, 1000);
```

but those tests now fail on my Ubuntu machine, the window opens with width 886.

**Changes proposed:**

- Relax the clientWidth constraint in the controls tests to use 800, from the tests it should be a value above 500
