### PR TITLE
Fix wrong assert in a getDOMAttribute test, it now returns undefined instead of empty object

### DIFF
--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -727,9 +727,9 @@ suite('a-entity', function () {
       assert.notOk('height' in componentData);
     });
 
-    test('returns empty object if component is at defaults', function () {
+    test('returns undefined if component is at defaults', function () {
       el.setAttribute('material', '');
-      assert.shallowDeepEqual(el.getDOMAttribute('material'), {});
+      assert.equal(el.getDOMAttribute('material'), undefined);
     });
 
     test('returns partial component data', function () {


### PR DESCRIPTION
**Description:**

That was discussed in https://github.com/aframevr/aframe-inspector/issues/741#issuecomment-2284890160
since the big refactoring and optimization of getDOMAttribute/getAttribute, that particular getDOMAttribute test wrongly passes because `shallowDeepEqual(undefined, {})` is true.

**Changes proposed:**
- Fix the test to use assert.equal and change the expected value.