### PR TITLE
Update attribute mapping tables in the docs for mesh primitives

### DIFF
--- a/docs/primitives/a-box.md
+++ b/docs/primitives/a-box.md
@@ -29,32 +29,55 @@ The box primitive creates shapes such as boxes, cubes, or walls.
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
 | depth                            | geometry.depth                         | 1             |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | geometry.height                        | 1             |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
 | segments-depth                   | geometry.segmentsDepth                 | 1             |
 | segments-height                  | geometry.segmentsHeight                | 1             |
 | segments-width                   | geometry.segmentsWidth                 | 1             |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | geometry.width                         | 1             |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-circle.md
+++ b/docs/primitives/a-circle.md
@@ -29,32 +29,55 @@ component with the type set to `circle`.
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
 | segments                         | geometry.segments                      | 32            |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 360           |
 | theta-start                      | geometry.thetaStart                    | 0             |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-cone.md
+++ b/docs/primitives/a-cone.md
@@ -24,38 +24,60 @@ The cone primitive creates a cone shape.
 
 ## Attributes
 
-
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | geometry.height                        | 1             |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | open-ended                       | geometry.openEnded                     | false         |
 | radius-bottom                    | geometry.radiusBottom                  | 1             |
-| radius-top                       | geometry.radiusTop                     | 0.8           |
+| radius-top                       | geometry.radiusTop                     | 0.01          |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
 | segments-height                  | geometry.segmentsHeight                | 18            |
 | segments-radial                  | geometry.segmentsRadial                | 36            |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 360           |
 | theta-start                      | geometry.thetaStart                    | 0             |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-cylinder.md
+++ b/docs/primitives/a-cylinder.md
@@ -38,34 +38,57 @@ Also, we can create a tube by making the cylinder open-ended, which removes the 
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | geometry.height                        | 1             |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | open-ended                       | geometry.openEnded                     | false         |
 | radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
 | segments-height                  | geometry.segmentsHeight                | 18            |
 | segments-radial                  | geometry.segmentsRadial                | 36            |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 360           |
 | theta-start                      | geometry.thetaStart                    | 0             |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-dodecahedron.md
+++ b/docs/primitives/a-dodecahedron.md
@@ -16,35 +16,53 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
+| detail                           | geometry.detail                        | 0             |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| open-ended                       | geometry.openEnded                     | false         |
-| radius-bottom                    | geometry.radiusBottom                  | 1             |
-| radius-top                       | geometry.radiusTop                     | 0.8           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
+| radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
-| segments-height                  | geometry.segmentsHeight                | 18            |
-| segments-radial                  | geometry.segmentsRadial                | 36            |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
-| theta-length                     | geometry.thetaLength                   | 360           |
-| theta-start                      | geometry.thetaStart                    | 0             |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-icosahedron.md
+++ b/docs/primitives/a-icosahedron.md
@@ -16,30 +16,53 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | detail                           | geometry.detail                        | 0             |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-octahedron.md
+++ b/docs/primitives/a-octahedron.md
@@ -16,30 +16,53 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | detail                           | geometry.detail                        | 0             |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-plane.md
+++ b/docs/primitives/a-plane.md
@@ -31,30 +31,53 @@ component with the type set to `plane`.
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | geometry.height                        | 1             |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
 | segments-height                  | geometry.segmentsHeight                | 1             |
 | segments-width                   | geometry.segmentsWidth                 | 1             |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | geometry.width                         | 1             |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-ring.md
+++ b/docs/primitives/a-ring.md
@@ -26,34 +26,57 @@ The ring primitive creates a ring or disc shape.
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | radius-inner                     | geometry.radiusInner                   | 0.8           |
 | radius-outer                     | geometry.radiusOuter                   | 1.2           |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
 | segments-phi                     | geometry.segmentsPhi                   | 10            |
 | segments-theta                   | geometry.segmentsTheta                 | 32            |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 360           |
 | theta-start                      | geometry.thetaStart                    | 0             |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-sphere.md
+++ b/docs/primitives/a-sphere.md
@@ -18,35 +18,58 @@ The sphere primitive creates a spherical or polyhedron shapes. It wraps an entit
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | phi-length                       | geometry.phiLength                     | 360           |
 | phi-start                        | geometry.phiStart                      | 0             |
 | radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
 | segments-height                  | geometry.segmentsHeight                | 18            |
 | segments-width                   | geometry.segmentsWidth                 | 36            |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
 | theta-length                     | geometry.thetaLength                   | 180           |
 | theta-start                      | geometry.thetaStart                    | 0             |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-tetrahedron.md
+++ b/docs/primitives/a-tetrahedron.md
@@ -16,30 +16,53 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | detail                           | geometry.detail                        | 0             |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | radius                           | geometry.radius                        | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-torus-knot.md
+++ b/docs/primitives/a-torus-knot.md
@@ -21,34 +21,57 @@ component with the type set to `torusKnot`.
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | p                                | geometry.p                             | 2             |
 | q                                | geometry.q                             | 3             |
 | radius                           | geometry.radius                        | 1             |
 | radius-tubular                   | geometry.radiusTubular                 | 0.2           |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
 | segments-radial                  | geometry.segmentsRadial                | 8             |
 | segments-tubular                 | geometry.segmentsTubular               | 100           |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-torus.md
+++ b/docs/primitives/a-torus.md
@@ -21,33 +21,56 @@ component with the type set to `torus`.
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
 | arc                              | geometry.arc                           | 360           |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | radius                           | geometry.radius                        | 1             |
 | radius-tubular                   | geometry.radiusTubular                 | 0.2           |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
 | segments-radial                  | geometry.segmentsRadial                | 36            |
 | segments-tubular                 | geometry.segmentsTubular               | 32            |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
+| transparent                      | material.transparent                   | false         |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/docs/primitives/a-triangle.md
+++ b/docs/primitives/a-triangle.md
@@ -29,31 +29,54 @@ component with the type set to `triangle`.
 
 | Attribute                        | Component Mapping                      | Default Value |
 | --------                         | -----------------                      | ------------- |
+| alpha-test                       | material.alphaTest                     | 0             |
 | ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
 | ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
 | ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
 | ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
+| anisotropy                       | material.anisotropy                    | 0             |
+| blending                         | material.blending                      | normal        |
 | color                            | material.color                         | #FFF          |
+| depth-test                       | material.depthTest                     | true          |
+| depth-write                      | material.depthWrite                    | true          |
 | displacement-bias                | material.displacementBias              | 0.5           |
 | displacement-map                 | material.displacementMap               | None          |
 | displacement-scale               | material.displacementScale             | 1             |
 | displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
 | displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
+| dithering                        | material.dithering                     | true          |
+| emissive                         | material.emissive                      | #000          |
+| emissive-intensity               | material.emissiveIntensity             | 1             |
 | env-map                          | material.envMap                        | None          |
-| fog                              | material.fog                           | true          |
+| flat-shading                     | material.flatShading                   | false         |
 | height                           | material.height                        | 256           |
+| material-fog                     | material.fog                           | true          |
+| material-visible                 | material.visible                       | true          |
 | metalness                        | material.metalness                     | 0             |
+| metalness-map                    | material.metalnessMap                  | None          |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
 | normal-map                       | material.normalMap                     | None          |
 | normal-scale                     | material.normalScale                   | 1 1           |
 | normal-texture-offset            | material.normalTextureOffset           | 0 0           |
 | normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
+| npot                             | material.npot                          | false         |
+| offset                           | material.offset                        | 0 0           |
+| opacity                          | material.opacity                       | 1             |
 | repeat                           | material.repeat                        | 1 1           |
 | roughness                        | material.roughness                     | 0.5           |
+| roughness-map                    | material.roughnessMap                  | None          |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
+| shader                           | material.shader                        | standard      |
+| side                             | material.side                          | front         |
 | spherical-env-map                | material.sphericalEnvMap               | None          |
 | src                              | material.src                           | None          |
-| vertex-a                         | geometry.vertexA                       | 0  0.5 0   |
+| transparent                      | material.transparent                   | false         |
+| vertex-a                         | geometry.vertexA                       | 0 0.5 0       |
 | vertex-b                         | geometry.vertexB                       | -0.5 -0.5 0   |
-| vertex-c                         | geometry.vertexC                       |  0.5 -0.5 0   |
+| vertex-c                         | geometry.vertexC                       | 0.5 -0.5 0    |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
 | width                            | material.width                         | 512           |
 | wireframe                        | material.wireframe                     | false         |
 | wireframe-linewidth              | material.wireframeLinewidth            | 2             |

--- a/scripts/docs-primitives/index.html
+++ b/scripts/docs-primitives/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<script src="http://localhost:9000/build/aframe.js"></script>
+<script src="http://localhost:8080/dist/aframe-master.js"></script>
 </head>
 <body>
 <script>
@@ -18,19 +18,11 @@ geometryNames.forEach(function (geometryName) {
 
   var str = [];
   str.push('## Attributes\n');
-  str.push('| Attribute | Component Mapping | Default Value |');
-  str.push('| -------- | ----------------- | ------------- |');
-
-  // Compile geometry mappings.
-  var geometry = geometries[geometryName];
+  
+  // Header
   var rows = {};
-  Object.keys(geometry.schema).forEach(function addMapping (property) {
-    rows[unCamelCase(property)] = '|' + [
-      unCamelCase(property),
-      'geometry.' + property,
-      geometry.schema[property].stringify(geometry.schema[property].default)
-    ].join('|') + '|';
-  });
+  rows[0] = ['Attribute', 'Component Mapping', 'Default Value'];
+  rows[1] = ['--------', '-----------------', '-------------'];
 
   // Compile mesh mixin mappings.
   Object.keys(meshMappings).forEach(function addMapping (attribute) {
@@ -38,18 +30,36 @@ geometryNames.forEach(function (geometryName) {
     var property = mapping.split('.')[1];
     var materialProp = AFRAME.components.material.schema[property] ||
                        AFRAME.shaders.standard.schema[property];
-    rows[attribute] = '|' + [
+    rows[attribute] = [
       attribute,
       mapping,
       (materialProp.default === undefined || materialProp.default === null ||
        materialProp.default === '') ?
         'None' : materialProp.stringify(materialProp.default)
-    ].join('|') + '|';
+    ];
+  });
+
+  // Compile geometry mappings.
+  var geometry = geometries[geometryName];
+  Object.keys(geometry.schema).forEach(function addMapping (property) {
+    rows[unCamelCase(property)] = [
+      unCamelCase(property),
+      'geometry.' + property,
+      geometry.schema[property].stringify(geometry.schema[property].default)
+    ];
+  });
+  
+  // Measure required length for each column
+  var cols = [0, 0, 0];
+  Object.values(rows).forEach(function (row) {
+    for(var i = 0; i < cols.length; i++) {
+      cols[i] = Math.max(cols[i], row[i].length);
+    }
   });
 
   // Append rows.
   Object.keys(rows).sort().forEach(function (attribute) {
-    str.push(rows[attribute]);
+    str.push('| ' + rows[attribute].map((v, i) => v.padEnd(cols[i], ' ')).join(' | ') + ' |');
   });
 
   console.log(str.join('\n'));


### PR DESCRIPTION
**Description:**
The attribute mapping tables in the docs for the various mesh primitives was outdated. To remedy this, I've updated the script used to generate these to output pre-formatted tables.

**Changes proposed:**
- Update `scripts/docs-primitives` to output pre-formatted tables
- Update attribute tables for mesh primitive
