### PR TITLE
Remove unused width and height properties from flat and standard shaders

### DIFF
--- a/src/shaders/flat.js
+++ b/src/shaders/flat.js
@@ -9,11 +9,9 @@ export var Shader = registerShader('flat', {
   schema: {
     color: {type: 'color'},
     fog: {default: true},
-    height: {default: 256},
     offset: {type: 'vec2', default: {x: 0, y: 0}},
     repeat: {type: 'vec2', default: {x: 1, y: 1}},
     src: {type: 'map'},
-    width: {default: 512},
     wireframe: {default: false},
     wireframeLinewidth: {default: 2},
     toneMapped: {default: true}

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -26,7 +26,6 @@ export var Shader = registerShader('standard', {
     envMap: {default: ''},
 
     fog: {default: true},
-    height: {default: 256},
 
     metalness: {default: 0.0, min: 0.0, max: 1.0},
     metalnessMap: {type: 'map'},
@@ -48,7 +47,6 @@ export var Shader = registerShader('standard', {
 
     sphericalEnvMap: {type: 'map'},
     src: {type: 'map'},
-    width: {default: 512},
     wireframe: {default: false},
     wireframeLinewidth: {default: 2}
   },

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -212,10 +212,8 @@ suite('material', function () {
       el.components.material.updateSchema({shader: 'flat'});
       assert.ok(el.components.material.schema.color);
       assert.ok(el.components.material.schema.fog);
-      assert.ok(el.components.material.schema.height);
       assert.ok(el.components.material.schema.repeat);
       assert.ok(el.components.material.schema.src);
-      assert.ok(el.components.material.schema.width);
       assert.notOk(el.components.material.schema.metalness);
       assert.notOk(el.components.material.schema.roughness);
       assert.notOk(el.components.material.schema.envMap);


### PR DESCRIPTION
**Description:**
The `flat` and `standard` shaders both list a `width` and `height` property. These properties go unused and can thus be removed. Originally they seemed to have been used for video textures to indicate the dimensions of the video element, however this is no longer the case. The only reference I could find was in a material unit test.

This PR simply removes the properties. A good indicator that it isn't needed might be the `phong` shader which never had them to begin with, but supports video textures in the same way as `flat` and `standard` do.

**Changes proposed:**
- Remove `width` and `height` properties from `flat` and `standard` shaders