### PR TITLE
Remove https://dpdb.webvr.rocks from CSP

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -135,7 +135,6 @@ In your `index.html`, adjust as follows:
             https://ssl.gstatic.com 
             'unsafe-eval' 
             https://cdn.aframe.io         <-- required
-            https://dpdb.webvr.rocks      <-- required
             https://fonts.googleapis.com  <-- required
             https://cdn.jsdelivr.net      <-- your choice, see below
             ; 

--- a/docs/introduction/interactions-and-controllers.md
+++ b/docs/introduction/interactions-and-controllers.md
@@ -261,7 +261,7 @@ interact with objects with their hands.
 [gamepad]: https://developer.mozilla.org/docs/Web/API/Gamepad_API/Using_the_Gamepad_API
 
 A-Frame provides components for controllers across the spectrum as supported by
-their respective WebVR browsers through the [Gamepad Web API][gamepad]. There
+their respective WebXR browsers through the [Gamepad Web API][gamepad]. There
 are components for Vive, Oculus Touch, Meta Quest and Oculus Go controllers.
 
 To inspect the Gamepad object for poking around or to get the Gamepad ID, we
@@ -354,12 +354,12 @@ and Oculus Rift with Touch provide 6DoF and controllers for both hands. HTC
 Vive also provides trackers for tracking additional objects in the real world
 into VR.
 
-[rocks]: https://webvr.rocks
+[immersiveweb]: https://immersiveweb.dev
 [vivecomponent]: ../components/vive-controls.md
 
 To add controllers for HTC Vive, use the [vive-controls
-component][vivecomponent] for both hands. Then try it out on a [WebVR-enabled
-desktop browser][rocks]:
+component][vivecomponent] for both hands. Then try it out on a [WebXR-enabled
+desktop browser][immersiveweb]:
 
 ```html
 <a-entity vive-controls="hand: left"></a-entity>
@@ -369,8 +369,8 @@ desktop browser][rocks]:
 [metatouchcomponent]: ../components/meta-touch-controls.md
 
 To add controllers for Oculus Touch, use the [meta-touch-controls
-component][metatouchcomponent] for both hands. Then try it out on a [WebVR-enabled
-desktop browser][rocks]:
+component][metatouchcomponent] for both hands. Then try it out on a [WebXR-enabled
+browser][immersiveweb]:
 
 ```html
 <a-entity meta-touch-controls="hand: left"></a-entity>


### PR DESCRIPTION
**Description:**

**Changes proposed:**
- Remove https://dpdb.webvr.rocks from the CSP example, that link was the devices db for webvr-polyfill