### PR TITLE
Fix some jsdoc errors found with eslint valid-jsdoc rule

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -163,9 +163,7 @@ export var Component = registerComponent('material', {
    * (Re)create new material. Has side-effects of setting `this.material` and updating
    * material registration in scene.
    *
-   * @param {object} data - Material component data.
-   * @param {object} type - Material type to create.
-   * @returns {object} Material.
+   * @param {THREE.Material} material - Material to register.
    */
   setMaterial: function (material) {
     var el = this.el;

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -311,7 +311,7 @@ export var Component = registerComponent('raycaster', {
   /**
    * Return the most recent intersection details for a given entity, if any.
    * @param {AEntity} el
-   * @return {Object}
+   * @returns {object|null}
    */
   getIntersection: function (el) {
     var i;
@@ -405,8 +405,8 @@ export var Component = registerComponent('raycaster', {
    * Only push children defined as component attachments (e.g., setObject3D),
    * NOT actual children in the scene graph hierarchy.
    *
-   * @param  {Array<Element>} els
-   * @return {Array<THREE.Object3D>}
+   * @param {Array<Element>} els
+   * @returns {Array<THREE.Object3D>}
    */
   flattenObject3DMaps: function (els) {
     var key;

--- a/src/components/scene/ar-hit-test.js
+++ b/src/components/scene/ar-hit-test.js
@@ -47,7 +47,7 @@ applyPose.tempFakePose = {
  * will always be a transient input and as of 08/2021 all transient inputs are 'generic-touchscreen'
  *
  * @param {WebGLRenderer} renderer THREE.JS Renderer
- * @param {} hitTestSourceDetails The source information either as the information for a transient hit-test or a regular hit-test
+ * @param {object} hitTestSourceDetails The source information either as the information for a transient hit-test or a regular hit-test
  */
 function HitTest (renderer, hitTestSourceDetails) {
   this.renderer = renderer;
@@ -101,7 +101,6 @@ HitTest.prototype.sessionStart = function sessionStart (hitTestSourceDetails) {
  *
  * @param {Object3D} object3D object to track
  * @param {Vector3} offset offset of the object from the origin that gets subtracted
- * @returns
  */
 HitTest.prototype.anchorFromLastHitTestResult = function (object3D, offset) {
   var hitTest = this.lastHitTest;

--- a/src/components/scene/device-orientation-permission-ui.js
+++ b/src/components/scene/device-orientation-permission-ui.js
@@ -102,6 +102,9 @@ export var Component = registerComponent('device-orientation-permission-ui', {
 /**
  * Create a modal dialog that request users permission to access the Device Motion API.
  *
+ * @param {string} denyText
+ * @param {string} allowText
+ * @param {string} dialogText
  * @param {function} onAllowClicked - click event handler
  * @param {function} onDenyClicked - click event handler
  *

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -143,8 +143,6 @@ export var Component = registerComponent('sound', {
 
   /**
    * Removes current sound object, creates new sound object, adds to entity.
-   *
-   * @returns {object} sound
    */
   setupSound: function () {
     var el = this.el;

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -205,7 +205,7 @@ function fixUpMediaElement (mediaEl) {
  * If it is not defined, we must create and re-append a new media element <img> and
  * have the browser re-request it with `crossorigin` set.
  *
- * @param {Element} Media element (e.g., <img>, <audio>, <video>).
+ * @param {Element} mediaEl - Media element (e.g., <img>, <audio>, <video>).
  * @returns {Element} Media element to be used to listen to for loaded events.
  */
 function setCrossOrigin (mediaEl) {

--- a/src/core/a-cubemap.js
+++ b/src/core/a-cubemap.js
@@ -40,7 +40,7 @@ class ACubeMap extends HTMLElement {
    * Checks for exactly six elements with [src].
    * When <img>s are used they will be prefetched.
    *
-   * @returns {Array|null} - six URLs or <img> elements if valid, else null.
+   * @returns {Array<string|Element>|undefined} - six URLs or <img> elements if valid, else undefined.
    */
   validate () {
     var elements = this.querySelectorAll('[src]');

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -621,9 +621,9 @@ export class AEntity extends ANode {
    * 4. Set a value for a single-property component, mixin, or normal HTML attribute.
    *
    * @param {string} attrName - Component or attribute name.
-   * @param {*} arg1 - Can be a value, property name, CSS-style property string, or
+   * @param {any} arg1 - Can be a value, property name, CSS-style property string, or
    *   object of properties.
-   * @param {*|bool} arg2 - If arg1 is a property name, this should be a value. Otherwise,
+   * @param {any} arg2 - If arg1 is a property name, this should be a value. Otherwise,
    *   it is a boolean indicating whether to clobber previous values (defaults to false).
    */
   setAttribute (attrName, arg1, arg2) {
@@ -681,7 +681,7 @@ export class AEntity extends ANode {
   /**
    * Reflect component data in the DOM (as seen from the browser DOM Inspector).
    *
-   * @param {bool} recursive - Also flushToDOM on the children.
+   * @param {boolean} recursive - Also flushToDOM on the children.
    **/
   flushToDOM (recursive) {
     var components = this.components;

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -17,10 +17,10 @@ var ONCE = {once: true};
  *
  * To be able to take components, the scene element inherits from the entity definition.
  *
- * @member {object} components - entity's currently initialized components.
- * @member {object} object3D - three.js object.
- * @member {array} states.
- * @member {boolean} isPlaying - false if dynamic behavior of the entity is paused.
+ * @property {object} components - entity's currently initialized components.
+ * @property {THREE.Object3D} object3D - three.js object.
+ * @property {string[]} states.
+ * @property {boolean} isPlaying - false if dynamic behavior of the entity is paused.
  */
 export class AEntity extends ANode {
   constructor () {
@@ -247,7 +247,7 @@ export class AEntity extends ANode {
   }
 
   /**
-   * @returns {array} Direct children that are entities.
+   * @returns {Array<Element>} Direct children that are entities.
    */
   getChildEntities () {
     var children = this.children;
@@ -381,7 +381,7 @@ export class AEntity extends ANode {
    * Build data using initial components, defined attributes, mixins, and defaults.
    * Update default components before the rest.
    *
-   * @member {function} getExtraComponents - Can be implemented to include component data
+   * @property {function} getExtraComponents - Can be implemented to include component data
    *   from other sources (e.g., implemented by primitives).
    */
   updateComponents () {
@@ -804,7 +804,7 @@ function checkComponentDefined (el, name) {
  * Check if any mixins contains a component.
  *
  * @param {string} name - Component name.
- * @param {array} mixinEls - Array of <a-mixin>s.
+ * @param {Array<Element>} mixinEls - Array of <a-mixin>s.
  */
 function isComponentMixedIn (name, mixinEls) {
   var i;

--- a/src/core/a-mixin.js
+++ b/src/core/a-mixin.js
@@ -7,9 +7,9 @@ import * as styleParser from '../utils/styleParser.js';
 var MULTIPLE_COMPONENT_DELIMITER = '__';
 
 /**
- * @member {object} componentCache - Cache of pre-parsed values. An object where the keys
+ * @property {object} componentCache - Cache of pre-parsed values. An object where the keys
  *         are component names and the values are already parsed by the component.
- * @member {object} rawAttributeCache - Cache of the raw attribute values.
+ * @property {object} rawAttributeCache - Cache of the raw attribute values.
  */
 class AMixin extends ANode {
   constructor () {

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -44,9 +44,10 @@ var attrValueProxyHandler = {
  * by adding, removing, or updating components. Entities do not share instances
  * of components.
  *
- * @member {object} el - Reference to the entity element.
- * @member {string} attrValue - Value of the corresponding HTML attribute.
- * @member {string} id - Optional id for differentiating multiple instances on the same entity.
+ * @constructor
+ * @param {object} el - Reference to the entity element.
+ * @param {string} attrValue - Value of the corresponding HTML attribute.
+ * @param {string} id - Optional id for differentiating multiple instances on the same entity.
  */
 export var Component = function (el, attrValue, id) {
   var self = this;
@@ -713,7 +714,8 @@ function hasBehavior (component) {
  * Wrapper for defined pause method.
  * Pause component by removing tick behavior and calling user's pause method.
  *
- * @param pauseMethod {function}
+ * @param {function} pauseMethod
+ * @returns {function}
  */
 function wrapPause (pauseMethod) {
   return function pause () {
@@ -732,7 +734,8 @@ function wrapPause (pauseMethod) {
  * Wrapper for defined play method.
  * Play component by adding tick behavior and calling user's play method.
  *
- * @param playMethod {function}
+ * @param {function} playMethod
+ * @returns {function}
  */
 function wrapPlay (playMethod) {
   return function play () {

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -269,7 +269,7 @@ Component.prototype = {
 
   /**
    * @param {string|object} attrValue - Passed argument from setAttribute.
-   * @param {bool} clobber - Whether or not to overwrite previous data by the attrValue.
+   * @param {boolean} clobber - Whether or not to overwrite previous data by the attrValue.
    */
   updateData: function (attrValue, clobber) {
     // Single property (including object based single property)

--- a/src/core/propertyTypes.js
+++ b/src/core/propertyTypes.js
@@ -31,12 +31,11 @@ registerPropertyType('vec4', {x: 0, y: 0, z: 0, w: 1}, vecParse, coordinates.str
  * `schema.process` will set the property `parse` and `stringify`.
  *
  * @param {string} type - Type name.
- * @param [defaultValue=null] -
- *   Default value to use if component does not define default value.
+ * @param {any} [defaultValue=null] - Default value to use if component does not define default value.
  * @param {function} [parse=defaultParse] - Parse string function.
  * @param {function} [stringify=defaultStringify] - Stringify to DOM function.
  * @param {function} [equals=defaultEquals] - Equality comparator.
- * @param {boolean} [cachable=false] - Whether or not the parsed value of a property can be cached.
+ * @param {boolean} [cacheable=false] - Whether or not the parsed value of a property can be cached.
  */
 export function registerPropertyType (type, defaultValue, parse, stringify, equals, cacheable) {
   if (type in propertyTypes) {

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -696,7 +696,7 @@ export class AScene extends AEntity {
  * constraints into account.
  *
  * @param {object} components - The components to order
- * @param {array} array - Optional array to use as output
+ * @param {Array} array - Optional array to use as output
  */
 export function determineComponentBehaviorOrder (components, array) {
   var graph = {};
@@ -807,10 +807,11 @@ customElements.define('a-scene', AScene);
  * The parent size will be returned in that case.
  * the returned size will be constrained to the maxSize maintaining aspect ratio.
  *
- * @param {object} canvasEl - the canvas element
+ * @param {Element} canvasEl - the canvas element
  * @param {boolean} embedded - Is the scene embedded?
- * @param {object} max - Max size parameters
+ * @param {object} maxSize - Max size parameters
  * @param {boolean} isVR - If in VR
+ * @returns {number} Max size
  */
 function getCanvasSize (canvasEl, embedded, maxSize, isVR) {
   if (!canvasEl.parentElement) { return {height: 0, width: 0}; }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -24,15 +24,15 @@ var isWebXRAvailable = utils.device.isWebXRAvailable;
 /**
  * Scene element, holds all entities.
  *
- * @member {array} behaviors - Component instances that have registered themselves to be
+ * @member {Array} behaviors - Component instances that have registered themselves to be
            updated on every tick.
  * @member {object} camera - three.js Camera object.
  * @member {object} canvas
- * @member {bool} isScene - Differentiates as scene entity as opposed to other entities.
- * @member {bool} isMobile - Whether browser is mobile (via UA detection).
+ * @member {boolean} isScene - Differentiates as scene entity as opposed to other entities.
+ * @member {boolean} isMobile - Whether browser is mobile (via UA detection).
  * @member {object} object3D - Root three.js Scene object.
  * @member {object} renderer
- * @member {bool} renderStarted
+ * @member {boolean} renderStarted
  * @member {object} systems - Registered instantiated systems.
  * @member {number} time
  */
@@ -253,7 +253,7 @@ export class AScene extends AEntity {
    * Call `requestFullscreen` on desktop.
    * Handle events, states, fullscreen styles.
    *
-   * @param {bool?} useAR - if true, try immersive-ar mode
+   * @param {?boolean} useAR - if true, try immersive-ar mode
    * @returns {Promise}
    */
   enterVR (useAR, useOfferSession) {

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -21,8 +21,9 @@ export var systems = {};  // Keep track of registered systems.
  * and some pieces are missing from the Component facilities (e.g., attribute caching,
  * setAttribute behavior).
  *
- * @member {string} name - Name that system is registered under.
- * @member {Element} sceneEl - Handle to the scene element where system applies to.
+ * @constructor
+ * @param {Element} sceneEl - Handle to the scene element where system applies to.
+ * @property {string} name - Name that system is registered under.
  */
 export var System = function (sceneEl) {
   var component = components && components.components[this.name];
@@ -120,7 +121,6 @@ System.prototype = {
  *
  * @param {string} name - Component name.
  * @param {object} definition - Component property and methods.
- * @returns {object} Component.
  */
 export function registerSystem (name, definition) {
   var i;

--- a/src/shaders/standard.js
+++ b/src/shaders/standard.js
@@ -76,7 +76,6 @@ export var Shader = registerShader('standard', {
    * Updating existing material.
    *
    * @param {object} data - Material component data.
-   * @returns {object} Material.
    */
   updateMaterial: function (data) {
     var key;

--- a/src/systems/geometry.js
+++ b/src/systems/geometry.js
@@ -26,7 +26,7 @@ export var System = registerSystem('geometry', {
   /**
    * Attempt to retrieve from cache.
    *
-   * @returns {Object|null} A geometry if it exists, else null.
+   * @returns {object|null} A geometry if it exists, else null.
    */
   getOrCreateGeometry: function (data) {
     var cache = this.cache;

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -111,7 +111,7 @@ export var System = registerSystem('material', {
   /**
    * High-level function for loading image textures (THREE.Texture).
    *
-   * @param {Element|string} src - Texture source.
+   * @param {string|Element} src - Texture source.
    * @param {function} cb - Callback to pass texture to.
    */
   loadImage: function (src, cb) {
@@ -130,7 +130,7 @@ export var System = registerSystem('material', {
    * Note that creating a video texture is synchronous unlike loading an image texture.
    * Made asynchronous to be consistent with image textures.
    *
-   * @param {Element|string} src - Texture source.
+   * @param {string|Element} src - Texture source.
    * @param {function} cb - Callback to pass texture to.
    */
   loadVideo: function (src, cb) {

--- a/src/systems/material.js
+++ b/src/systems/material.js
@@ -28,7 +28,7 @@ export var System = registerSystem('material', {
   /**
    * Loads and creates a texture for a given `src`.
    *
-   * @param {string, or element} src - URL or element
+   * @param {string|Element} src - URL or element
    * @param {object} data - Relevant texture properties
    * @param {function} cb - Callback to pass texture to
    */
@@ -43,7 +43,7 @@ export var System = registerSystem('material', {
   /**
    * Determine whether `src` is an image or video. Then try to load the asset, then call back.
    *
-   * @param {string, or element} src - URL or element.
+   * @param {string|Element} src - URL or element.
    * @param {function} cb - Callback to pass texture source to.
    */
   loadTextureSource: function (src, cb) {
@@ -78,7 +78,7 @@ export var System = registerSystem('material', {
   /**
    * Load the six individual sides and construct a cube texture, then call back.
    *
-   * @param {Array} srcs - Array of six texture URLs or elements.
+   * @param {Array<string|Element>} srcs - Array of six texture URLs or elements.
    * @param {function} cb - Callback to pass cube texture to.
    */
   loadCubeMapTexture: function (srcs, cb) {

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -15,7 +15,7 @@ var whitespaceRegex = /\s+/g;
  * Parses coordinates from an "x y z" string.
  * Example: "3 10 -5" to {x: 3, y: 10, z: -5}.
  *
- * @param {string} val - An "x y z" string.
+ * @param {string} value - An "x y z" string.
  * @param {string} defaultVec - fallback value.
  * @param {object} target - Optional target object for coordinates.
  * @returns {object} An object with keys [x, y, z].

--- a/src/utils/coordinates.js
+++ b/src/utils/coordinates.js
@@ -92,7 +92,8 @@ export function equals (a, b) {
 }
 
 /**
- * @returns {bool}
+ * @param {string} value
+ * @returns {boolean}
  */
 export function isCoordinates (value) {
   return regex.test(value);

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -54,9 +54,9 @@ function formatArgs (args) {
 /**
  * Returns the type of the namespace (e.g., `error`, `warn`).
  *
- * @param {String} namespace
+ * @param {string} namespace
  *   The debug logger's namespace (e.g., `components:geometry:warn`).
- * @returns {String} The type of the namespace (e.g., `warn`).
+ * @returns {string} The type of the namespace (e.g., `warn`).
  * @api private
  */
 function getDebugNamespaceType (namespace) {
@@ -68,9 +68,9 @@ function getDebugNamespaceType (namespace) {
 /**
  * Returns the color of the namespace (e.g., `orange`).
  *
- * @param {String} namespace
+ * @param {string} namespace
  *   The debug logger's namespace (e.g., `components:geometry:warn`).
- * @returns {String} The color of the namespace (e.g., `orange`).
+ * @returns {string} The color of the namespace (e.g., `orange`).
  * @api private
  */
 function getDebugNamespaceColor (namespace) {

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -64,7 +64,7 @@ export function checkVRSupport () { return supportsVRSession; }
 
 /**
  * Checks if browser is mobile and not stand-alone dedicated vr device.
- * @return {Boolean} True if mobile browser detected.
+ * @returns {boolean} True if mobile browser detected.
  */
 export var isMobile = (function () {
   var _isMobile = false;
@@ -159,7 +159,7 @@ export function isR7 () {
 
 /**
  * Checks mobile device orientation.
- * @return {Boolean} True if landscape orientation.
+ * @returns {boolean} True if landscape orientation.
  */
 export function isLandscape () {
   var orientation = window.orientation;

--- a/src/utils/entity.js
+++ b/src/utils/entity.js
@@ -9,7 +9,7 @@ import { split } from './split.js';
  *
  * @param {string} str - e.g., `material.opacity`.
  * @param {string} delimiter - e.g., `.`.
- * @returns {array} e.g., `['material', 'opacity']`.
+ * @returns {string[]} e.g., `['material', 'opacity']`.
  */
 export function getComponentPropertyPath (str, delimiter) {
   delimiter = delimiter || '.';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -139,7 +139,7 @@ export function throttleTick (functionToThrottle, minimumInterval, optionalConte
 /**
  * Returns debounce function that gets called only once after a set of repeated calls.
  *
- * @param {function} functionToDebounce
+ * @param {function} func - function to debounce
  * @param {number} wait - Time to wait for repeated function calls (milliseconds).
  * @param {boolean} immediate - Calls the function immediately regardless of if it should be waiting.
  * @returns {function} Debounced function.
@@ -294,7 +294,7 @@ export var diff = (function () {
 /**
  * Returns whether we should capture this keyboard event for keyboard shortcuts.
  * @param {Event} event Event object.
- * @returns {Boolean} Whether the key event should be captured.
+ * @returns {boolean} Whether the key event should be captured.
  */
 export function shouldCaptureKeyEvent (event) {
   if (event.metaKey) { return false; }
@@ -304,9 +304,9 @@ export function shouldCaptureKeyEvent (event) {
 /**
  * Splits a string into an array based on a delimiter.
  *
- * @param   {string=} [str='']        Source string
- * @param   {string=} [delimiter=' '] Delimiter to use
- * @returns {array}                   Array of delimited strings
+ * @param   {string} [str='']        Source string
+ * @param   {string} [delimiter=' '] Delimiter to use
+ * @returns {string[]}               Array of delimited strings
  */
 export function splitString (str, delimiter) {
   if (typeof delimiter === 'undefined') { delimiter = ' '; }
@@ -320,9 +320,9 @@ export function splitString (str, delimiter) {
 /**
  * Extracts data from the element given an object that contains expected keys.
  *
- * @param {Element} Source element.
- * @param {Object} [defaults={}] Object of default key-value pairs.
- * @returns {Object}
+ * @param {Element} el - Source element.
+ * @param {object} [defaults={}] - Object of default key-value pairs.
+ * @returns {object}
  */
 export function getElData (el, defaults) {
   defaults = defaults || {};
@@ -338,8 +338,8 @@ export function getElData (el, defaults) {
 
 /**
  * Retrieves querystring value.
- * @param  {String} name Name of querystring key.
- * @return {String}      Value
+ * @param {string} name Name of querystring key.
+ * @returns {string} Value
  */
 export function getUrlParameter (name) {
   // eslint-disable-next-line no-useless-escape

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -14,6 +14,7 @@ var COLOR_MAPS = new Set([
 /**
  * Set texture properties such as repeat and offset.
  *
+ * @param {THREE.Texture} texture - a Texture instance.
  * @param {object} data - With keys like `repeat`.
  */
 export function setTextureProperties (texture, data) {
@@ -61,6 +62,8 @@ export function setTextureProperties (texture, data) {
  * Update `material` texture property (usually but not always `map`)
  * from `data` property (usually but not always `src`).
  *
+ * @param {string} materialName
+ * @param {string} dataName
  * @param {object} shader - A-Frame shader instance.
  * @param {object} data
  */

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -3,7 +3,7 @@
  * @param {THREE.Vector3} positionOnPlane any point on the plane.
  * @param {THREE.Vector3} planeNormal the normal of the plane
  * @param {THREE.Vector3} pointToTest point to test
- * @returns Number
+ * @returns {number}
  */
  export function distanceOfPointFromPlane (positionOnPlane, planeNormal, pointToTest) {
   // the d value in the plane equation a*x + b*y + c*z=d
@@ -19,7 +19,7 @@
  * @param {THREE.Vector3} planeNormal the normal of the plane
  * @param {THREE.Vector3} pointToTest point to test
  * @param {THREE.Vector3} resultPoint where to store the result.
- * @returns
+ * @returns {THREE.Vector3}
  */
  export function nearestPointInPlane (positionOnPlane, planeNormal, pointToTest, resultPoint) {
    var t = distanceOfPointFromPlane(positionOnPlane, planeNormal, pointToTest);

--- a/src/utils/src-loader.js
+++ b/src/utils/src-loader.js
@@ -10,9 +10,9 @@ var warn = debug('utils:src-loader:warn');
  *
  * `src` will be passed into the callback
  *
- * @params {string|Element} src - URL or media element.
- * @params {function} isImageCb - callback if texture is an image.
- * @params {function} isVideoCb - callback if texture is a video.
+ * @param {string|Element} src - URL or media element.
+ * @param {function} isImageCb - callback if texture is an image.
+ * @param {function} isVideoCb - callback if texture is a video.
  */
 export function validateSrc (src, isImageCb, isVideoCb) {
   checkIsImage(src, function isAnImageUrl (isImage) {
@@ -108,7 +108,7 @@ export function validateCubemapSrc (src, cb) {
 /**
  * Parses src from `url(src)`.
  * @param  {string} src - String to parse.
- * @return {string} The parsed src, if parseable.
+ * @returns {string} The parsed src, if parseable.
  */
 export function parseUrl (src) {
   var parsedSrc = src.match(/url\((.+)\)/);
@@ -166,10 +166,10 @@ function checkIsImageFallback (src, onResult) {
 /**
  * Query and validate a query selector,
  *
- * @param  {string} selector - DOM selector.
- * @return {object|null|undefined} Selected DOM element if exists.
-           null if query yields no results.
-           undefined if `selector` is not a valid selector.
+ * @param {string} selector - DOM selector.
+ * @returns {object|null|undefined} Selected DOM element if exists.
+ *          null if query yields no results.
+ *          undefined if `selector` is not a valid selector.
  */
 function validateAndGetQuerySelector (selector) {
   try {

--- a/src/utils/src-loader.js
+++ b/src/utils/src-loader.js
@@ -29,8 +29,8 @@ export function validateSrc (src, isImageCb, isVideoCb) {
  *
  * @param {string} src - A selector, image URL or comma-separated image URLs. Image URLS
           must be wrapped by `url()`.
- * @param {*} isCubemapCb - callback if src is a cubemap.
- * @param {*} isEquirectCb - callback is src is a singular equirectangular image.
+ * @param {function} isCubemapCb - callback if src is a cubemap.
+ * @param {function} isEquirectCb - callback if src is a singular equirectangular image.
  */
 export function validateEnvMapSrc (src, isCubemapCb, isEquirectCb) {
   var el;

--- a/src/utils/styleParser.js
+++ b/src/utils/styleParser.js
@@ -36,7 +36,7 @@ export function stringify (data) {
  * Converts string from hyphen to camelCase.
  *
  * @param {string} str - String to camelCase.
- * @return {string} CamelCased string.
+ * @returns {string} CamelCased string.
  */
 export function toCamelCase (str) {
   return str.replace(DASH_REGEX, upperCase);

--- a/src/utils/tracked-controls.js
+++ b/src/utils/tracked-controls.js
@@ -38,6 +38,7 @@ export function checkControllerPresentAndSetup (component, idPrefix, queryObject
 /**
  *
  * @param {object} component - Tracked controls component.
+ * @returns {boolean} True if a controller is present.
  */
 export function isControllerPresentWebXR (component, id, queryObject) {
   var controllers;
@@ -91,7 +92,7 @@ export function findMatchingControllerWebXR (controllers, idPrefix, handedness, 
  * Emit specific `moved` event(s) if axes changed based on original axismove event.
  *
  * @param {object} component - Controller component in use.
- * @param {array} axesMapping - For example `{thumbstick: [0, 1]}`.
+ * @param {object} axesMapping - For example `{thumbstick: [0, 1]}`.
  * @param {object} evt - Event to process.
  */
 export function emitIfAxesChanged (component, axesMapping, evt) {


### PR DESCRIPTION
Fix some jsdoc errors found with eslint valid-jsdoc rule and also uniformize style.

Tested with 
```
    "valid-jsdoc": [
      "error",
      {
        "requireReturn": false,
        "requireReturnType": true,
        "requireParamDescription": false,
        "requireReturnDescription": false,
        "requireParamType": true,
        "prefer": {
          "params": "param",
          "return": "returns"
        },
        "preferType": {
          "Any": "any",
          "array": "Array",
          "bool": "boolean",
          "Boolean": "boolean",
          "Number": "number",
          "Object": "object",
          "String": "string"
        }
      }
    ],
```

in rules in `.eslintrc.json`

I didn't enable the rule because there is still 220 problems of `Missing JSDoc for parameter 'x'` and `Missing JSDoc @returns for function.`