### PR TITLE
Add prettier config for html files only

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+# prettier is enabled only for html files in the examples folder
+*.cjs
+*.js
+*.json
+*.md
+*.yml
+build
+dist
+docs
+gh-pages
+scripts
+src
+tests
+vendor

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "printWidth": 120,
+  "singleQuote": true,
+  "trailingComma": "none"
+}


### PR DESCRIPTION
**Description:**

For those using vscode with prettier addon to format the html files, add a prettier config so the js embed in the html file match the repo style with single quote and no trailing comma.
The config only applies to html files in the examples directory.

If you want to reformat all files
```
npm install -D prettier
npx prettier --write 'examples/**/index.html'
```
but that does lots of changes.