### PR TITLE
Enable eslint indent rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,8 @@
     "ecmaVersion": 12
   },
   "rules": {
+    "indent": ["error", 2, { "SwitchCase": 1, "ignoreComments": true, "CallExpression": { "arguments": "first" } }],
+
     /* To work towards no-build. */
     "import/extensions": ["warn", "always", { "js": "always" }],
 
@@ -26,7 +28,6 @@
        careful co-ordination is needed in adopting the rule to avoid
        creating merge issues for other PRs. */
     "dot-notation": "off",
-    "indent": "off",
     "no-multi-spaces": "off",
     "object-curly-spacing": "off",
     "quote-props": "off"

--- a/examples/js/spatial-ui/spatial-close-button.js
+++ b/examples/js/spatial-ui/spatial-close-button.js
@@ -32,7 +32,7 @@ AFRAME.registerComponent('spatial-close-button', {
     });
 
     var texture = new THREE.TextureLoader().load('./close-button.png', function () {
-       // material.needsUpdate = true;
+      // material.needsUpdate = true;
     });
     planeMaterial.map = texture;
     texture.colorSpace = THREE.SRGBColorSpace;

--- a/examples/js/spatial-ui/spatial-utils.js
+++ b/examples/js/spatial-ui/spatial-utils.js
@@ -269,9 +269,7 @@ SPATIAL.utils = {
       uc = i < s || i >= 3 * s ? ur : ul;
       vc = i < 2 * s ? vh : vl;
 
-      uvs.push(uc, vc,
-              uc + ul * cosa, vc + vl * sina,
-              uc + ul * cosb, vc + vl * sinb);
+      uvs.push(uc, vc, uc + ul * cosa, vc + vl * sina, uc + ul * cosb, vc + vl * sinb);
 
       phia = phib;
     }

--- a/examples/js/spatial-ui/spatial-utils.js
+++ b/examples/js/spatial-ui/spatial-utils.js
@@ -170,7 +170,9 @@ SPATIAL.utils = {
       xc = i < s || i >= 3 * s ? wi : -wi;
       yc = i < 2 * s ? hi : -hi;
 
-      positions.push(xc, yc, 0, xc + r * cosa, yc + r * sina, 0, xc + r * cosb, yc + r * sinb, 0);
+      positions.push(xc, yc, 0,
+                     xc + r * cosa, yc + r * sina, 0,
+                     xc + r * cosb, yc + r * sinb, 0);
 
       normals.push(0, 0, 1);
       normals.push(0, 0, 1);
@@ -179,7 +181,9 @@ SPATIAL.utils = {
       uc = i < s || i >= 3 * s ? ur : ul;
       vc = i < 2 * s ? vh : vl;
 
-      uvs.push(uc, vc, uc + ul * cosa, vc + vl * sina, uc + ul * cosb, vc + vl * sinb);
+      uvs.push(uc, vc,
+               uc + ul * cosa, vc + vl * sina,
+               uc + ul * cosb, vc + vl * sinb);
 
       phia = phib;
     }
@@ -260,7 +264,9 @@ SPATIAL.utils = {
       xc = i < s || i >= 3 * s ? wi : -wi;
       yc = i < 2 * s ? hi : -hi;
 
-      positions.push(xc, yc, 0, xc + r * cosa, yc + r * sina, 0, xc + r * cosb, yc + r * sinb, 0);
+      positions.push(xc, yc, 0,
+                     xc + r * cosa, yc + r * sina, 0,
+                     xc + r * cosb, yc + r * sinb, 0);
 
       normals.push(0, 0, 1);
       normals.push(0, 0, 1);
@@ -269,7 +275,9 @@ SPATIAL.utils = {
       uc = i < s || i >= 3 * s ? ur : ul;
       vc = i < 2 * s ? vh : vl;
 
-      uvs.push(uc, vc, uc + ul * cosa, vc + vl * sina, uc + ul * cosb, vc + vl * sinb);
+      uvs.push(uc, vc,
+               uc + ul * cosa, vc + vl * sina,
+               uc + ul * cosb, vc + vl * sinb);
 
       phia = phib;
     }

--- a/examples/mixed-reality/watch/hand-menu.js
+++ b/examples/mixed-reality/watch/hand-menu.js
@@ -191,8 +191,8 @@ AFRAME.registerComponent('hand-menu', {
       this.menuEl.emit('open');
       function lookAtVector (sourcePoint, destPoint) {
         return auxQuaternion.setFromRotationMatrix(
-            auxMatrix.identity()
-            .lookAt(sourcePoint, destPoint, new THREE.Vector3(0, 1, 0)));
+          auxMatrix.identity().lookAt(sourcePoint, destPoint, new THREE.Vector3(0, 1, 0))
+        );
       }
 
       var cameraEl = this.el.sceneEl.querySelector('[camera]');

--- a/examples/mixed-reality/watch/time.js
+++ b/examples/mixed-reality/watch/time.js
@@ -2,8 +2,10 @@
 AFRAME.registerComponent('time', {
   tick: function () {
     var date = new Date();
-    this.el.setAttribute('text', 'value',
+    this.el.setAttribute(
+      'text', 'value',
       date.getHours().toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping: false}) +
-      ':' + date.getMinutes().toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping: false}));
+      ':' + date.getMinutes().toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping: false})
+    );
   }
 });

--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -354,7 +354,7 @@ export var Component = registerComponent('hand-tracking-controls', {
   },
 
   initDotsModel: function () {
-     // Add models just once.
+    // Add models just once.
     if (this.jointEls.length !== 0) { return; }
     for (var i = 0; i < JOINTS.length; ++i) {
       var jointEl = this.jointEl = document.createElement('a-entity');

--- a/src/components/oculus-go-controls.js
+++ b/src/components/oculus-go-controls.js
@@ -85,7 +85,7 @@ export var Component = registerComponent('oculus-go-controls', {
 
   checkIfControllerPresent: function () {
     checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX,
-                                        this.data.hand ? {hand: this.data.hand} : {});
+                                   this.data.hand ? {hand: this.data.hand} : {});
   },
 
   play: function () {

--- a/src/components/scene/ar-hit-test.js
+++ b/src/components/scene/ar-hit-test.js
@@ -81,17 +81,17 @@ HitTest.prototype.sessionStart = function sessionStart (hitTestSourceDetails) {
   }
   if (hitTestSourceDetails.space) {
     this.session.requestHitTestSource(hitTestSourceDetails)
-    .then(function (xrHitTestSource) {
-      this.xrHitTestSource = xrHitTestSource;
-    }.bind(this))
-    .catch(warnAboutHitTest);
+      .then(function (xrHitTestSource) {
+        this.xrHitTestSource = xrHitTestSource;
+      }.bind(this))
+      .catch(warnAboutHitTest);
   } else if (hitTestSourceDetails.profile) {
     this.session.requestHitTestSourceForTransientInput(hitTestSourceDetails)
-    .then(function (xrHitTestSource) {
-      this.xrHitTestSource = xrHitTestSource;
-      this.transient = true;
-    }.bind(this))
-    .catch(warnAboutHitTest);
+      .then(function (xrHitTestSource) {
+        this.xrHitTestSource = xrHitTestSource;
+        this.transient = true;
+      }.bind(this))
+      .catch(warnAboutHitTest);
   }
 };
 
@@ -113,24 +113,24 @@ HitTest.prototype.anchorFromLastHitTestResult = function (object3D, offset) {
   };
 
   Array.from(this.anchorToObject3D.entries())
-  .forEach(function (entry) {
-    var entryObject = entry[1].object3D;
-    var anchor = entry[0];
-    if (entryObject === object3D) {
-      this.anchorToObject3D.delete(anchor);
-      anchor.delete();
-    }
-  }.bind(this));
+    .forEach(function (entry) {
+      var entryObject = entry[1].object3D;
+      var anchor = entry[0];
+      if (entryObject === object3D) {
+        this.anchorToObject3D.delete(anchor);
+        anchor.delete();
+      }
+    }.bind(this));
 
   if (hitTest.createAnchor) {
     hitTest.createAnchor()
-    .then(function (anchor) {
-      this.anchorToObject3D.set(anchor, object3DOptions);
-    }.bind(this))
-    .catch(function (e) {
-      console.warn(e.message);
-      console.warn('Cannot create anchor, are you missing: webxr="optionalFeatures: anchors;" from <a-scene>?');
-    });
+      .then(function (anchor) {
+        this.anchorToObject3D.set(anchor, object3DOptions);
+      }.bind(this))
+      .catch(function (e) {
+        console.warn(e.message);
+        console.warn('Cannot create anchor, are you missing: webxr="optionalFeatures: anchors;" from <a-scene>?');
+      });
   }
 };
 
@@ -283,13 +283,13 @@ export var Component = register('ar-hit-test', {
 
       // Default to selecting through the face
       session.requestReferenceSpace('viewer')
-      .then(function (viewerSpace) {
-        this.viewerHitTest = this.hitTest = new HitTest(renderer, {
-          space: viewerSpace
-        });
+        .then(function (viewerSpace) {
+          this.viewerHitTest = this.hitTest = new HitTest(renderer, {
+            space: viewerSpace
+          });
 
-        this.el.emit('ar-hit-test-start');
-      }.bind(this));
+          this.el.emit('ar-hit-test-start');
+        }.bind(this));
 
       // If a tracked controller is available, selects via that instead of the headset
       var arHitTestComp = this;

--- a/src/components/scene/reflection.js
+++ b/src/components/scene/reflection.js
@@ -5,8 +5,8 @@ import { registerComponent as register } from '../../core/component.js';
 function updateLights (estimate, probeLight, directionalLight, directionalLightPosition) {
   var intensityScalar =
     Math.max(estimate.primaryLightIntensity.x,
-      Math.max(estimate.primaryLightIntensity.y,
-        estimate.primaryLightIntensity.z));
+             Math.max(estimate.primaryLightIntensity.y,
+                      estimate.primaryLightIntensity.z));
 
   probeLight.sh.fromArray(estimate.sphericalHarmonicsCoefficients);
   probeLight.intensity = 3.14;

--- a/src/components/scene/xr-mode-ui.js
+++ b/src/components/scene/xr-mode-ui.js
@@ -198,7 +198,7 @@ function createEnterVRButton (onClick) {
   vrButton = document.createElement('button');
   vrButton.className = ENTER_VR_BTN_CLASS;
   vrButton.setAttribute('title',
-    'Enter VR mode with a headset or fullscreen without');
+                        'Enter VR mode with a headset or fullscreen without');
   vrButton.setAttribute(constants.AFRAME_INJECTED, '');
   if (utils.device.isMobile()) { applyStickyHoverFix(vrButton); }
   // Insert elements.
@@ -230,7 +230,7 @@ function createEnterARButton (onClick, xrMode) {
   arButton = document.createElement('button');
   arButton.className = ENTER_AR_BTN_CLASS;
   arButton.setAttribute('title',
-    'Enter AR mode with a headset or handheld device.');
+                        'Enter AR mode with a headset or handheld device.');
   arButton.setAttribute(constants.AFRAME_INJECTED, '');
   if (utils.device.isMobile()) { applyStickyHoverFix(arButton); }
   // Insert elements.

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -367,7 +367,7 @@ export var Component = registerComponent('text', {
         ? data.lineHeight
         : font.common.lineHeight;
       geometryUpdateData.text = data.value.toString().replace(newLineRegex, '\n')
-                                                     .replace(tabRegex, '\t');
+        .replace(tabRegex, '\t');
       geometryUpdateData.width = computeWidth(data.wrapPixels, data.wrapCount,
                                               font.widthFactor);
       geometry.update(utils.extend(geometryUpdateBase, data, geometryUpdateData));

--- a/src/components/vive-focus-controls.js
+++ b/src/components/vive-focus-controls.js
@@ -83,7 +83,7 @@ export var Component = registerComponent('vive-focus-controls', {
 
   checkIfControllerPresent: function () {
     checkControllerPresentAndSetup(this, GAMEPAD_ID_PREFIX,
-                                        this.data.hand ? {hand: this.data.hand} : {});
+                                   this.data.hand ? {hand: this.data.hand} : {});
   },
 
   play: function () {

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -342,7 +342,7 @@ export class AScene extends AEntity {
     }
   }
 
-   /**
+  /**
    * Call `exitPresent` if WebVR / WebXR or WebVR polyfill.
    * Handle events, states, fullscreen styles.
    *

--- a/src/geometries/cone.js
+++ b/src/geometries/cone.js
@@ -17,8 +17,8 @@ registerGeometry('cone', {
 
   init: function (data) {
     this.geometry = new THREE.CylinderGeometry(
-        data.radiusTop, data.radiusBottom, data.height, data.segmentsRadial,
-        data.segmentsHeight, data.openEnded, degToRad(data.thetaStart),
-        degToRad(data.thetaLength));
+      data.radiusTop, data.radiusBottom, data.height, data.segmentsRadial,
+      data.segmentsHeight, data.openEnded, degToRad(data.thetaStart),
+      degToRad(data.thetaLength));
   }
 });

--- a/src/geometries/cylinder.js
+++ b/src/geometries/cylinder.js
@@ -16,7 +16,7 @@ registerGeometry('cylinder', {
 
   init: function (data) {
     this.geometry = new THREE.CylinderGeometry(
-        data.radius, data.radius, data.height, data.segmentsRadial, data.segmentsHeight,
-        data.openEnded, degToRad(data.thetaStart), degToRad(data.thetaLength));
+      data.radius, data.radius, data.height, data.segmentsRadial, data.segmentsHeight,
+      data.openEnded, degToRad(data.thetaStart), degToRad(data.thetaLength));
   }
 });

--- a/src/geometries/ring.js
+++ b/src/geometries/ring.js
@@ -15,7 +15,7 @@ registerGeometry('ring', {
 
   init: function (data) {
     this.geometry = new THREE.RingGeometry(
-        data.radiusInner, data.radiusOuter, data.segmentsTheta, data.segmentsPhi,
-        degToRad(data.thetaStart), degToRad(data.thetaLength));
+      data.radiusInner, data.radiusOuter, data.segmentsTheta, data.segmentsPhi,
+      degToRad(data.thetaStart), degToRad(data.thetaLength));
   }
 });

--- a/src/shaders/sdf.js
+++ b/src/shaders/sdf.js
@@ -96,16 +96,16 @@ export var Shader = registerShader('sdf', {
   fragmentShader: FRAGMENT_SHADER,
 
   init: function () {
-     this.uniforms = UniformsUtils.merge([
-       UniformsLib.fog,
-       this.initUniforms()
-     ]);
-     this.material = new THREE.ShaderMaterial({
-       uniforms: this.uniforms,
-       vertexShader: this.vertexShader,
-       fragmentShader: this.fragmentShader,
-       fog: true
-     });
-     return this.material;
-   }
+    this.uniforms = UniformsUtils.merge([
+      UniformsLib.fog,
+      this.initUniforms()
+    ]);
+    this.material = new THREE.ShaderMaterial({
+      uniforms: this.uniforms,
+      vertexShader: this.vertexShader,
+      fragmentShader: this.fragmentShader,
+      fog: true
+    });
+    return this.material;
+  }
 });

--- a/src/systems/tracked-controls.js
+++ b/src/systems/tracked-controls.js
@@ -35,8 +35,8 @@ export var System = registerSystem('tracked-controls', {
       self.referenceSpace = referenceSpace;
     }).catch(function (err) {
       self.el.sceneEl.systems.webxr.warnIfFeatureNotRequested(
-          refspace,
-          'tracked-controls uses reference space "' + refspace + '".');
+        refspace,
+        'tracked-controls uses reference space "' + refspace + '".');
       throw err;
     });
 

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -5,13 +5,13 @@
  * @param {THREE.Vector3} pointToTest point to test
  * @returns {number}
  */
- export function distanceOfPointFromPlane (positionOnPlane, planeNormal, pointToTest) {
+export function distanceOfPointFromPlane (positionOnPlane, planeNormal, pointToTest) {
   // the d value in the plane equation a*x + b*y + c*z=d
-   var d = planeNormal.dot(positionOnPlane);
+  var d = planeNormal.dot(positionOnPlane);
 
   // distance of point from plane
-   return (d - planeNormal.dot(pointToTest)) / planeNormal.length();
- }
+  return (d - planeNormal.dot(pointToTest)) / planeNormal.length();
+}
 
 /**
  * Find the point on a plane that lies closest to
@@ -21,11 +21,11 @@
  * @param {THREE.Vector3} resultPoint where to store the result.
  * @returns {THREE.Vector3}
  */
- export function nearestPointInPlane (positionOnPlane, planeNormal, pointToTest, resultPoint) {
-   var t = distanceOfPointFromPlane(positionOnPlane, planeNormal, pointToTest);
+export function nearestPointInPlane (positionOnPlane, planeNormal, pointToTest, resultPoint) {
+  var t = distanceOfPointFromPlane(positionOnPlane, planeNormal, pointToTest);
   // closest point on the plane
-   resultPoint.copy(planeNormal);
-   resultPoint.multiplyScalar(t);
-   resultPoint.add(pointToTest);
-   return resultPoint;
- }
+  resultPoint.copy(planeNormal);
+  resultPoint.multiplyScalar(t);
+  resultPoint.add(pointToTest);
+  return resultPoint;
+}

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -27,7 +27,7 @@ suite('material', function () {
     test('updates material', function () {
       el.setAttribute('material', 'color: #F0F; side: double');
       assert.shallowDeepEqual(el.getObject3D('mesh').material.color,
-                             {r: 1, g: 0, b: 1});
+                              {r: 1, g: 0, b: 1});
       assert.shallowDeepEqual(el.getObject3D('mesh').material.side, THREE.DoubleSide);
     });
 

--- a/tests/components/tracked-controls.test.js
+++ b/tests/components/tracked-controls.test.js
@@ -43,7 +43,7 @@ suite('tracked-controls', function () {
       system.controllers = [controller];
       assert.strictEqual(component.controller, undefined);
       el.setAttribute('tracked-controls',
-        {id: 'generic', hand: 'left', iterateControllerProfiles: true});
+                      {id: 'generic', hand: 'left', iterateControllerProfiles: true});
       component.updateController();
       assert.equal(component.controller, controller);
     });

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -77,8 +77,8 @@ suite('a-scene (without renderer) - WebXR', function () {
       assert.ok(sceneEl.renderer);
       // Mock renderer is not a real WebGLRenderer.
       assert.notOk(
-          (THREE.WebGLRenderer && sceneEl.renderer instanceof THREE.WebGLRenderer) ||
-          (THREE.WebGPURenderer && sceneEl.renderer instanceof THREE.WebGPURenderer));
+        (THREE.WebGLRenderer && sceneEl.renderer instanceof THREE.WebGLRenderer) ||
+        (THREE.WebGPURenderer && sceneEl.renderer instanceof THREE.WebGPURenderer));
     });
   });
 

--- a/tests/shaders/phong.test.js
+++ b/tests/shaders/phong.test.js
@@ -98,18 +98,18 @@ suite('phong material', function () {
     { dataName: 'ambientOcclusionMap', materialName: 'aoMap' },
     { dataName: 'bumpMap', materialName: 'bumpMap' }
   ].forEach(function (names) {
-      test(`can unset ${names.dataName}`, function (done) {
-        var el = this.el;
-        var imageUrl = 'base/tests/assets/test.png';
+    test(`can unset ${names.dataName}`, function (done) {
+      var el = this.el;
+      var imageUrl = 'base/tests/assets/test.png';
+      assert.isNull(el.getObject3D('mesh').material[names.materialName]);
+      el.setAttribute('material', names.dataName, `url(${imageUrl})`);
+      el.addEventListener('materialtextureloaded', function (evt) {
+        assert.equal(el.getObject3D('mesh').material[names.materialName], evt.detail.texture);
+        el.setAttribute('material', names.dataName, '');
         assert.isNull(el.getObject3D('mesh').material[names.materialName]);
-        el.setAttribute('material', names.dataName, `url(${imageUrl})`);
-        el.addEventListener('materialtextureloaded', function (evt) {
-          assert.equal(el.getObject3D('mesh').material[names.materialName], evt.detail.texture);
-          el.setAttribute('material', names.dataName, '');
-          assert.isNull(el.getObject3D('mesh').material[names.materialName]);
-          done();
-        });
+        done();
       });
+    });
   });
 
   test('can use spherical env maps', function (done) {

--- a/tests/shaders/standard.test.js
+++ b/tests/shaders/standard.test.js
@@ -85,18 +85,18 @@ suite('standard material', function () {
     { dataName: 'metalnessMap', materialName: 'metalnessMap' },
     { dataName: 'roughnessMap', materialName: 'roughnessMap' }
   ].forEach(function (names) {
-      test(`can unset ${names.dataName}`, function (done) {
-        var el = this.el;
-        var imageUrl = 'base/tests/assets/test.png';
+    test(`can unset ${names.dataName}`, function (done) {
+      var el = this.el;
+      var imageUrl = 'base/tests/assets/test.png';
+      assert.isNull(el.getObject3D('mesh').material[names.materialName]);
+      el.setAttribute('material', names.dataName, `url(${imageUrl})`);
+      el.addEventListener('materialtextureloaded', function (evt) {
+        assert.equal(el.getObject3D('mesh').material[names.materialName], evt.detail.texture);
+        el.setAttribute('material', names.dataName, '');
         assert.isNull(el.getObject3D('mesh').material[names.materialName]);
-        el.setAttribute('material', names.dataName, `url(${imageUrl})`);
-        el.addEventListener('materialtextureloaded', function (evt) {
-          assert.equal(el.getObject3D('mesh').material[names.materialName], evt.detail.texture);
-          el.setAttribute('material', names.dataName, '');
-          assert.isNull(el.getObject3D('mesh').material[names.materialName]);
-          done();
-        });
+        done();
       });
+    });
   });
 
   test('can use spherical env maps', function (done) {

--- a/tests/systems/material.test.js
+++ b/tests/systems/material.test.js
@@ -158,7 +158,7 @@ suite('material system', function () {
         var system = this.system;
 
         videoEl.insertAdjacentHTML('beforeend',
-          '<source src="' + VIDEO1 + '"></source>');
+                                   '<source src="' + VIDEO1 + '"></source>');
         system.loadTextureSource(videoEl, function (source) {
           var hash = Object.keys(system.sourceCache)[0];
           assert.equal(source.data, videoEl);


### PR DESCRIPTION
**Description:**

I added a prettier config in #5665 that applies 2 spaces indent only for html and js inside the html for new contributed examples.
For js files that 2 spaces indent wasn't enforced.

**Changes proposed:**
- Enable the eslint indent rule to use 2 spaces in js files, use proper options to minimize code changes
- Fix all indent errors
