### PR TITLE
Handle tock in AScene.render instead of onAfterRender

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -49,10 +49,6 @@ export class AScene extends AEntity {
     self.isAR = false;
     self.isScene = true;
     self.object3D = new THREE.Scene();
-    self.object3D.onAfterRender = function (renderer, scene, camera) {
-      // THREE may swap the camera used for the rendering if in VR, so we pass it to tock
-      if (self.isPlaying) { self.tock(self.time, self.delta, camera); }
-    };
     self.resize = self.resize.bind(self);
     self.render = self.render.bind(self);
     self.systems = {};
@@ -667,6 +663,10 @@ export class AScene extends AEntity {
     renderer.render(this.object3D, this.camera);
     if (savedBackground) {
       this.object3D.background = savedBackground;
+    }
+    if (this.isPlaying) {
+      var renderCamera = renderer.xr.isPresenting ? renderer.xr.getCamera() : this.camera;
+      this.tock(this.time, this.delta, renderCamera);
     }
   }
 

--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -36,12 +36,11 @@ setup(function (done) {
     // Mock renderer.
     AScene.prototype.renderer = {
       xr: {
-        getDevice: function () { return {requestPresent: function () {}}; },
         isPresenting: function () { return true; },
-        setDevice: function () {},
         setSession: function () { return Promise.resolve(); },
         setFoveation: function () {},
         setPoseTarget: function () {},
+        getCamera: function () {},
         dispose: function () {},
         setReferenceSpaceType: function () {},
         enabled: false


### PR DESCRIPTION
**Description:**
Currently the `tock` logic is handled in the `onAfterRender` callback on the scene. However, in case of post-processing or when multiple scene renders happen in one frame, this would fire tock at incorrect times or even multiple times.

This PR moves the `tock` handling logic into the `AScene.render` method, similar to how `tick` is handled. Care is taken to preserve the correct `camera` parameter. Although, I propose we deprecate this parameter, as I fail to see why its needed.

**Changes proposed:**
- Move `tock` handling into `AScene.render`
