### PR TITLE
Update aframe-environment-component to 1.5.0 in examples and docs

### DIFF
--- a/docs/guides/building-a-basic-scene.md
+++ b/docs/guides/building-a-basic-scene.md
@@ -224,7 +224,7 @@ First, include the environment component using a script tag after A-Frame:
 ```html
 <head>
   <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-environment-component@1.3.x/dist/aframe-environment-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
 </head>
 ```
 

--- a/examples/boilerplate/webxr-ar-lighting/index.html
+++ b/examples/boilerplate/webxr-ar-lighting/index.html
@@ -3,7 +3,7 @@
 <head>
 	<script src="../../../dist/aframe-master.js"></script>
 	<script src="ar-shadow-helper.js"></script>
-	<script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+	<script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
 	<title>AFRame Total WebXR AR Demo</title>
 	<style>
 		body {

--- a/examples/docs/basic-scene/index.html
+++ b/examples/docs/basic-scene/index.html
@@ -7,7 +7,7 @@
     <script src="https://aframe.io/releases/<release_number>/aframe.min.js"></script>
     -->
     <script src="../../../dist/aframe-master.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.3.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
   </head>
   <body>
     <a-scene>
@@ -46,7 +46,7 @@
       <a-entity environment="preset: forest; dressingAmount: 500"></a-entity>
       <!-- Try changing the preset to one of default, contact, egypt, checkerboard, forest, goaland, yavapai, goldmine, 
          threetowers, poison, arches, tron, japan, dream, volcano, starry, osiris. -->
-      <!-- See more environment options: https://github.com/feiss/aframe-environment-component#parameters -->
+      <!-- See more environment options: https://github.com/supermedium/aframe-environment-component#parameters -->
     </a-scene>
   </body>
 </html>

--- a/examples/mixed-reality/watch/index.html
+++ b/examples/mixed-reality/watch/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Hand Menu (Mixed Reality) • A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
     <script src="../../js/info-message.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="time.js"></script>
     <script src="button.js"></script>
     <script src="hand-menu.js"></script>

--- a/examples/showcase/hand-tracking-grab-controls/index.html
+++ b/examples/showcase/hand-tracking-grab-controls/index.html
@@ -9,7 +9,7 @@
     <script src="../../js/spatial-ui/spatial-modal.js"></script>
     <script src="../../js/spatial-ui/spatial-hero-image.js"></script>
     <script src="../../js/info-message.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="hover.js"></script>
   </head>
   <body>

--- a/examples/showcase/hand-tracking/index.html
+++ b/examples/showcase/hand-tracking/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Hand Tracking! • A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
     <script src="../../js/info-message.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="pinchable.js"></script>
     <script src="color-change.js"></script>
     <script src="slider.js"></script>

--- a/examples/showcase/link-traversal/egypt.html
+++ b/examples/showcase/link-traversal/egypt.html
@@ -8,7 +8,7 @@
     <script src="js/components/aframe-tooltip-component.js"></script>
     <script src="js/components/camera-position.js"></script>
     <script src="js/components/link-controls.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="../../js/info-message.js"></script>
   </head>
   <body>

--- a/examples/showcase/link-traversal/forest.html
+++ b/examples/showcase/link-traversal/forest.html
@@ -8,7 +8,7 @@
     <script src="js/components/aframe-tooltip-component.js"></script>
     <script src="js/components/camera-position.js"></script>
     <script src="js/components/link-controls.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="../../js/info-message.js"></script>
   </head>
   <body>

--- a/examples/showcase/link-traversal/index.html
+++ b/examples/showcase/link-traversal/index.html
@@ -8,7 +8,7 @@
     <script src="js/components/aframe-tooltip-component.js"></script>
     <script src="js/components/camera-position.js"></script>
     <script src="js/components/link-controls.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="../../js/info-message.js"></script>
   </head>
   <body>

--- a/examples/showcase/link-traversal/japan.html
+++ b/examples/showcase/link-traversal/japan.html
@@ -8,7 +8,7 @@
     <script src="js/components/aframe-tooltip-component.js"></script>
     <script src="js/components/camera-position.js"></script>
     <script src="js/components/link-controls.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="../../js/info-message.js"></script>
   </head>
   <body>

--- a/examples/showcase/painter/index.html
+++ b/examples/showcase/painter/index.html
@@ -5,7 +5,7 @@
     <title>Painter (Logitech MX INK) • A-Frame</title>
     <meta name="description" content="Hand Tracking! • A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="stroke-geometry.js"></script>
     <script src="components/brush.js"></script>
     <script src="systems/brush.js"></script>

--- a/examples/showcase/ui/index.html
+++ b/examples/showcase/ui/index.html
@@ -5,7 +5,7 @@
     <title>Laser input UI</title>
     <meta name="description" content="Laser input UI • A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="../../js/info-message.js"></script>
     <script src="highlight.js"></script>
     <script src="info-panel.js"></script>

--- a/examples/test/layer/index.html
+++ b/examples/test/layer/index.html
@@ -5,7 +5,7 @@
     <title>Compositor Layer Example • A-Frame</title>
     <meta name="description" content="Hello, World! • A-Frame">
     <script src="../../../dist/aframe-master.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.4.x/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.5.x/dist/aframe-environment-component.min.js"></script>
     <script src="page-turn.js"></script>
     <script src="toggle-layer.js"></script>
     <script src="button.js"></script>


### PR DESCRIPTION
Update aframe-environment-component to 1.4.0 in docs.
I changed it in examples last time, but forgot to change it in docs it seems.