### PR TITLE
Fix ar-hit-test component not working since A-Frame 1.6.0

### DIFF
--- a/src/components/scene/ar-hit-test.js
+++ b/src/components/scene/ar-hit-test.js
@@ -270,7 +270,8 @@ export var Component = register('ar-hit-test', {
       this.hitTest = null;
     }.bind(this));
 
-    this.el.sceneEl.renderer.xr.addEventListener('sessionstart', function () {
+    // Use enter-vr event instead of sessionstart so that ar-mode is set before this is called
+    this.el.sceneEl.addEventListener('enter-vr', function () {
       // Don't request Hit Test unless AR (breaks WebXR Emulator)
       if (!this.el.is('ar-mode')) { return; }
 


### PR DESCRIPTION
**Description:**

Testing on https://aframe-xr-starterkit.glitch.me/ AR mode where we had the shadow of the piano in A-Frame 1.5.0
with a message at the bottom ["Scanning environment, finding surface."](https://github.com/AdaRoseCannon/aframe-xr-boilerplate/blob/6c4b317910f17ba6e0242c07086d7cd3dd226954/main.js#L245)
It doesn't work since A-Frame 1.6.0 because of commit https://github.com/aframevr/aframe/commit/77af389876de2c3fe10ff6ae82a0a06b46474fd6 that changed the order of setting the `ar-mode` state so that particular check in the `ar-hit-test` component https://github.com/aframevr/aframe/blob/388eb8ca603d23ad117bcc9090622f2f02af8890/src/components/scene/ar-hit-test.js#L273-L275
broke because `ar-mode` state is not set at the time this `sessionstart` listener is called.

**Changes proposed:**

The fix is here to change
`this.el.sceneEl.renderer.xr.addEventListener('sessionstart'`
to  
`this.el.addEventListener('enter-vr'`
similar to what we do in the `reflection` or `hide-on-enter-ar` components.