### PR TITLE
Put back the process.browser === true check in isBrowserEnvironment

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -171,8 +171,9 @@ export function isLandscape () {
  * Check if running in a browser or spoofed browser (bundler).
  * We need to check a node api that isn't mocked on either side.
  * `require` and `module.exports` are mocked in browser by bundlers.
+ * process is polyfilled with process.browser true by Next.js with "use client".
  */
-export var isBrowserEnvironment = typeof process === 'undefined';
+export var isBrowserEnvironment = typeof process === 'undefined' || process.browser === true;
 
 /**
  * Check if running in node on the server.


### PR DESCRIPTION
**Description:**

NextJS client rendered don't show the styles in A-Frame 1.7.0 because of my commit https://github.com/aframevr/aframe/commit/84d4607ef2d84d9349badfccf211d0e54fcfe838 It worked on 1.6.0.
I didn't know that framework polyfilled process with process.browser when rendering client side.

This fixes #5679

**Changes proposed:**

- Put back the `process.browser === true` check in `isBrowserEnvironment` for Next.js with "use client" to have the styles
