### PR TITLE
added 'controllermodelready'-event 

### DIFF
--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -388,6 +388,11 @@ export var Component = registerComponent('hand-tracking-controls', {
     this.updateModelMaterial();
     this.setupChildrenEntities();
     this.el.setObject3D('mesh', mesh);
+    this.el.emit('controllermodelready', {
+      name: 'hand-tracking-controls',
+      model: this.data.model,
+      rayOrigin: new THREE.Vector3(0, 0, 0)
+    });
   },
 
   setupChildrenEntities: function () {


### PR DESCRIPTION
> NOTE: I need to lint this PR (but before bothering, I would love a pre-blessing of this PR)

This adds the `controllermodelready` event to hand-tracking-controls, so it behaves like the others controllermodels.
I've also added a [examples/showcase/multi-input-anchors](https://github.com/coderofsalvation/aframe/blob/fix/controller-specific-anchors/examples/showcase/controller-specific-anchors/index.html) demo, to see it in action:

https://github.com/user-attachments/assets/75ae0744-246d-46f2-a838-f5a3aa854120

https://github.com/user-attachments/assets/11988265-2d21-4fee-ad92-90cdd5f33260

> NOTE: Quest 2 and Webxr-emulator was used for testing (other controllers can be added in similar fashion)

Its [wearable](https://github.com/coderofsalvation/aframe/blob/fix/controller-specific-anchors/examples/showcase/controller-specific-anchors/wearable.js)-component gives others a huge headstart, without having to worry about:

* controller-models (not) wiping/re-attaching their children after a controller-switch
* anchoring objects to specific legacy.future controllers
* the tricky when & why behind  `model-loaded`, `controllersupdated`-, `controllermodelready`-, and `controllerconnected`-events.
