### PR TITLE
Use defer to load any umd script

### DIFF
--- a/examples/showcase/webgpu/index.html
+++ b/examples/showcase/webgpu/index.html
@@ -86,8 +86,8 @@
       });
     </script>
     <script
+      defer
       src="https://cdn.jsdelivr.net/npm/aframe-orbit-controls@1.3.2/dist/aframe-orbit-controls.min.js"
-      type="module"
     ></script>
     <script src="../../js/info-message.js" type="module"></script>
   </head>


### PR DESCRIPTION
**Description:**

Loading a umd script should be loaded with `defer`, not `type="module"`. You can have weird issues otherwise if two umd builds are wrongly loaded with `type="module"` and the first one is loading additional assets (using publicPath: 'auto' or undefined in webpack). Found that in https://github.com/c-frame/aframe-gltf-model-plus/issues/72

**Changes proposed:**
- Use defer when loading any built js