### PR TITLE
Use webpack 5.95.0 to have a correct module build

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "standardx": "^7.0.0",
     "style-loader": "^4.0.0",
     "too-wordy": "ngokevin/too-wordy",
-    "webpack": "^5.91.0",
+    "webpack": "5.95.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "~5.0.4",
     "write-good": "^1.0.8"


### PR DESCRIPTION
**Description:**

webpack 5.96.0-5.98.0 versions break the `aframe-master.module.min.js` build because using `import.meta.url`, see #5691

**Changes proposed:**
- Specify an exact version of webpack in `package.json`, latest working version was 5.95.0