### PR TITLE
Fix the npm link to really search for aframe-component tag

### DIFF
--- a/docs/guides/building-a-360-image-gallery.md
+++ b/docs/guides/building-a-360-image-gallery.md
@@ -140,7 +140,7 @@ Now we have a textured plane that plays a click sound when clicked.
 
 ## Using Community Components
 
-[npm]: https://www.npmjs.com/search?q=aframe-component&page=1&ranking=optimal
+[npm]: https://www.npmjs.com/search?q=keywords:aframe-component
 
 A-Frame comes with a small core of standard components, but lot of magic comes
 from the large number of open source community components in the A-Frame

--- a/docs/introduction/entity-component-system.md
+++ b/docs/introduction/entity-component-system.md
@@ -322,12 +322,16 @@ channels to share!
 
 #### npm
 
-[search]: https://www.npmjs.com/search?q=aframe-component
+[search]: https://www.npmjs.com/search?q=keywords:aframe-component
+[directory]: https://aframe.wiki/en/#!pages/component-directory.md
 
 Most A-Frame components are published on npm as well as GitHub. We can use
-[npm's search to search for `aframe-components`][search]. npm lets us sort by
-quality, popularity, and maintenance. This is a great place to look for a more
-complete list of components.
+[npm's search to search for packages tagged with `aframe-component`][search].
+This is a great place to look for a more complete list of components.
+
+For a list of components with the A-Frame version that the component
+was last tested with, check out the community-maintained [Component Directory][directory]
+on the [A-Frame Wiki](#a-frame-wiki).
 
 #### GitHub Projects
 


### PR DESCRIPTION
Fix the npm search link and mention the A-Frame Wiki for a community-maintained list of components

Same change on the site in https://github.com/aframevr/aframe-site/pull/555