### PR TITLE
Fix joints in hand-tracking-controls not having the correct world position

### DIFF
--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -363,6 +363,7 @@ export var Component = registerComponent('hand-tracking-controls', {
         primitive: 'sphere',
         radius: 1.0
       });
+      jointEl.isJointDot = true;
       jointEl.object3D.visible = false;
       this.el.appendChild(jointEl);
       this.jointEls.push(jointEl);
@@ -405,6 +406,7 @@ export var Component = registerComponent('hand-tracking-controls', {
 
   addChildEntity: function (childEl) {
     if (!(childEl instanceof AEntity)) { return; }
+    if (childEl.isJointDot) { return; }
     this.wristObject3D.add(childEl.object3D);
   }
 });

--- a/src/components/hand-tracking-controls.js
+++ b/src/components/hand-tracking-controls.js
@@ -363,7 +363,7 @@ export var Component = registerComponent('hand-tracking-controls', {
         primitive: 'sphere',
         radius: 1.0
       });
-      jointEl.isJointDot = true;
+      jointEl.isHandJoint = true;
       jointEl.object3D.visible = false;
       this.el.appendChild(jointEl);
       this.jointEls.push(jointEl);
@@ -406,7 +406,7 @@ export var Component = registerComponent('hand-tracking-controls', {
 
   addChildEntity: function (childEl) {
     if (!(childEl instanceof AEntity)) { return; }
-    if (childEl.isJointDot) { return; }
+    if (childEl.isHandJoint) { return; }
     this.wristObject3D.add(childEl.object3D);
   }
 });


### PR DESCRIPTION
**Description:**
Component hand-tracking-controls with the "dots" modelStyle has not been displaying correctly since A-Frame 1.6.0. This is because "wristObject3D" is introduced, and all child elements of the hand, including jointEl, are reparented to be the children of "wristObject3D" through addChildEntity(). However, setting the correct position of jointEl is handled in updateHandDotsModel(), so it's not necessary to attach them to wristObject3D.

**Changes proposed:**
- Add a flag to each jointEl to prevent them from reparenting.
