### PR TITLE
Set material npot to true for quadPanelEl for better quality when layer disabled

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -323,6 +323,7 @@ export var Component = registerComponent('layer', {
 
     quadPanelEl.setAttribute('material', {
       shader: 'flat',
+      npot: true,
       src: this.data.src,
       transparent: true
     });


### PR DESCRIPTION
**Description:**

Set material npot (not power of two) to true for quadPanelEl for better quality when layer is disabled.

**Changes proposed:**
- Setting npot to true similar to what we have for a-videosphere and a-sky

Tested on the https://aframe.io/aframe/examples/test/layer/ example

layer disabled, without npot
![npotfalse](https://github.com/user-attachments/assets/1f3fca67-b7ee-4a97-b528-4d98077e6ac7)

layer disabled, with npot: true (not necessary visible on the jpg here, but trust me it changes the quality)
![npottrue](https://github.com/user-attachments/assets/b28ad72c-8fb2-410c-89bf-5eabe2ba0c31)

with layer enabled
![quadlayer](https://github.com/user-attachments/assets/e70b2496-8801-477c-9a62-8b28ef3c07e1)
