### PR TITLE
Creating 6 loading canvas is not needed for a quad layer

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -253,7 +253,6 @@ export var Component = registerComponent('layer', {
       height: this.data.height / 2 || this.texture.image.height / 1000,
       width: this.data.width / 2 || this.texture.image.width / 1000
     });
-    this.initLoadingScreenImages();
     sceneEl.renderer.xr.addLayer(this.layer);
   },
 


### PR DESCRIPTION
**Description:**

Creating 6 loading canvas is not needed for a quad layer, `this.loadingScreenImages` is only used in `loadCubeMapImage`

**Changes proposed:**
- Remove the `this.initLoadingScreenImages()` line in `initQuadLayer()`