### PR TITLE
In layer component enableCompositorLayer verify this.quadPanelEl exists before toggling the visibility

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -311,7 +311,9 @@ export var Component = registerComponent('layer', {
 
   enableCompositorLayer: function (enable) {
     this.layerEnabled = enable;
-    this.quadPanelEl.object3D.visible = !this.layerEnabled;
+    if (this.quadPanelEl) {
+      this.quadPanelEl.object3D.visible = !this.layerEnabled;
+    }
   },
 
   updateQuadPanel: function () {


### PR DESCRIPTION
**Description:**

In layer component `enableCompositorLayer` verify `this.quadPanelEl` exists before toggling the visibility.

**Changes proposed:**
- Add a if condition, similar to other places in the code. Also we may have a similar condition here to toggle a sphereEl visibility when we'll add support for equirect layer.
