### PR TITLE
Add support for equirect layer

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -6,8 +6,9 @@ var warn = utils.debug('components:layer:warn');
 
 export var Component = registerComponent('layer', {
   schema: {
-    type: {default: 'quad', oneOf: ['quad', 'monocubemap', 'stereocubemap']},
+    type: {default: 'quad', oneOf: ['mono-equirect', 'stereo-left-right-equirect', 'stereo-top-bottom-equirect', 'quad', 'monocubemap', 'stereocubemap']},
     src: {type: 'map'},
+    is180: {default: false, if: {type: ['mono-equirect', 'stereo-left-right-equirect', 'stereo-top-bottom-equirect']}},
     rotateCubemap: {default: false},
     width: {default: 0},
     height: {default: 0}
@@ -44,6 +45,11 @@ export var Component = registerComponent('layer', {
     this.destroyLayer();
     this.texture = undefined;
     this.textureIsVideo = this.data.src.tagName === 'VIDEO';
+    if (type.endsWith('equirect')) {
+      this.loadEquirectImage();
+      return;
+    }
+
     if (type === 'quad') {
       this.loadQuadImage();
       return;
@@ -87,6 +93,15 @@ export var Component = registerComponent('layer', {
       glayer = xrGLFactory.getSubImage(this.layer, frame, 'right');
       this.loadCubeMapImage(glayer.colorTexture, src, 6);
     }
+  },
+
+  loadEquirectImage: function () {
+    var src = this.data.src;
+    var self = this;
+    this.el.sceneEl.systems.material.loadTexture(src, {src: src}, function textureLoaded (texture) {
+      self.el.sceneEl.renderer.initTexture(texture);
+      self.texture = texture;
+    });
   },
 
   loadQuadImage: function () {
@@ -211,7 +226,7 @@ export var Component = registerComponent('layer', {
     if (this.data.src.complete && (this.pendingCubeMapUpdate || this.loadingScreen || this.visibilityChanged)) { this.loadCubeMapImages(); }
     if (!this.layer.needsRedraw) { return; }
     if (this.textureIsVideo) { return; }
-    if (this.data.type === 'quad') { this.draw(); }
+    if (this.data.type === 'quad' || this.data.type.endsWith('equirect')) { this.draw(); }
   },
 
   initLayer: function () {
@@ -222,6 +237,11 @@ export var Component = registerComponent('layer', {
       self.visibilityChanged = evt.session.visibilityState !== 'hidden';
     };
 
+    if (type.endsWith('equirect')) {
+      this.initEquirectLayer();
+      return;
+    }
+
     if (type === 'quad') {
       this.initQuadLayer();
       return;
@@ -231,6 +251,36 @@ export var Component = registerComponent('layer', {
       this.initCubeMapLayer();
       return;
     }
+  },
+
+  initEquirectLayer: function () {
+    if (!this.texture) { return; }
+    var sceneEl = this.el.sceneEl;
+    var eqrtIs180 = this.data.is180;
+    var eqrtRadius = 10;
+    var eqrtLayout = this.data.type.replace('-equirect', ''); // mono stereo-left-right stereo-top-bottom
+    if (this.textureIsVideo) {
+      var mediaBinding = new XRMediaBinding(sceneEl.xrSession);
+      this.layer = mediaBinding.createEquirectLayer(this.data.src, {
+        space: this.referenceSpace,
+        layout: eqrtLayout
+      });
+    } else {
+      var eqrtTextureWidth = this.texture.image.width;
+      var eqrtTextureHeight = this.texture.image.height;
+      var xrGLFactory = this.xrGLFactory = sceneEl.renderer.xr.getBinding();
+      this.layer = xrGLFactory.createEquirectLayer({
+        space: this.referenceSpace,
+        viewPixelWidth: eqrtTextureWidth / (eqrtLayout === 'stereo-left-right' ? 2 : 1),
+        viewPixelHeight: eqrtTextureHeight / (eqrtLayout === 'stereo-top-bottom' ? 2 : 1),
+        layout: eqrtLayout
+      });
+    }
+    this.layer.centralHorizontalAngle = Math.PI * (eqrtIs180 ? 1 : 2);
+    this.layer.upperVerticalAngle = Math.PI / 2.0;
+    this.layer.lowerVerticalAngle = -Math.PI / 2.0;
+    this.layer.radius = eqrtRadius;
+    sceneEl.renderer.xr.addLayer(this.layer);
   },
 
   initQuadLayer: function () {
@@ -340,11 +390,27 @@ export var Component = registerComponent('layer', {
     var gl = this.el.sceneEl.renderer.getContext();
     var sceneEl = this.el.sceneEl;
     var textureEl = this.data.src;
-    var glayer = this.xrGLFactory.getSubImage(this.layer, sceneEl.frame);
-    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
-    gl.bindTexture(gl.TEXTURE_2D, glayer.colorTexture);
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, textureEl.width, textureEl.height, gl.RGBA, gl.UNSIGNED_BYTE, textureEl);
-    gl.bindTexture(gl.TEXTURE_2D, null);
+    var glayer;
+
+    // Handle stereo rendering for img equirect layers
+    if (this.data.type.includes('stereo')) {
+      var pose = sceneEl.frame.getViewerPose(this.referenceSpace);
+      if (!pose) { return; }
+      for (var view of pose.views) {
+        glayer = this.xrGLFactory.getSubImage(this.layer, sceneEl.frame, view.eye);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+        gl.bindTexture(gl.TEXTURE_2D, glayer.colorTexture);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, textureEl.width, textureEl.height, gl.RGBA, gl.UNSIGNED_BYTE, textureEl);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+      }
+    } else {
+      // Handle img quad and img mono equirect layers
+      glayer = this.xrGLFactory.getSubImage(this.layer, sceneEl.frame);
+      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+      gl.bindTexture(gl.TEXTURE_2D, glayer.colorTexture);
+      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, textureEl.width, textureEl.height, gl.RGBA, gl.UNSIGNED_BYTE, textureEl);
+      gl.bindTexture(gl.TEXTURE_2D, null);
+    }
   },
 
   updateTransform: function () {


### PR DESCRIPTION
**Description:**

Add support for equirect layer, mono and stereo 180 and 360 videos and equirectangular image.

Remaining to do:
- [ ] Add an example of 180 stereo video, 360 stereo video and mono and stereo equirectangular image, probably use the videos from https://immersive-web.github.io/webxr-samples/layers-samples/eqrt-layer.html (180 video) and from https://immersive-web.github.io/webxr-samples/layers-samples/media-layer-sample.html
- [ ] sphere geometry with uv for mono and stereo 180 and 360 video (code from https://github.com/c-frame/aframe-stereo-component) for devices not supporting WebXR layers

**Changes proposed:**
- Add 'mono-equirect', 'stereo-left-right-equirect', 'stereo-top-bottom-equirect' types
- Add is180 property