### PR TITLE
Fixed the anchored documentation error

### DIFF
--- a/docs/components/anchored.md
+++ b/docs/components/anchored.md
@@ -11,7 +11,7 @@ examples: []
 
 It requires a browser supporting the [WebXR Anchors module][webxranchors].
 
-Fix any entity to a position and rotation in the real world. Apply the anchored component to an entity and call the method `el.components.createAnchor(position, quaternion)` to anchor it to a position and rotation corresponding to real world coordinates. If `creatorAnchor` is not called the entity is anchored to its initial position and rotation. The anchoring only applies when in immersive mode.
+Fix any entity to a position and rotation in the real world. Apply the anchored component to an entity and call the method `el.components.anchored.createAnchor(position, quaternion)` to anchor it to a position and rotation corresponding to real world coordinates. If `creatorAnchor` is not called the entity is anchored to its initial position and rotation. The anchoring only applies when in immersive mode.
 
 
 ## Example


### PR DESCRIPTION
**Description:**
As suggested by #5705, I replaced the function el.components.createAnchor(position, quaternion) with el.components.anchored.createAnchor(position, quaternion) instead.

**Changes proposed:**
-Made the change in the function as mentioned above
-
-
