### PR TITLE
Update installation.md Python 3 command to `python3`

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -55,10 +55,10 @@ editors. Both support remixing or forking:
 For the options below, we should develop projects using a local server so that
 files are properly served. Options of local servers include:
 
-- Running `npm i -g five-server@latest && five-server --port=8000` in a terminal
+- Run `npm i -g five-server@latest && five-server --port=8000` in a terminal
   in the same directory as your HTML file.
-- Running `python -m SimpleHTTPServer` (or `python3 -m http.server` for Python 3)
-  in a terminal in the same directory as your HTML file.
+- Run `python3 -m http.server` in a terminal in the same directory as your
+  HTML file.
 
 Once we are running our server, we can open our project in the browser using
 the local URL and port which the server is running on (e.g.,

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -57,7 +57,7 @@ files are properly served. Options of local servers include:
 
 - Running `npm i -g five-server@latest && five-server --port=8000` in a terminal
   in the same directory as your HTML file.
-- Running `python -m SimpleHTTPServer` (or `python -m http.server` for Python 3)
+- Running `python -m SimpleHTTPServer` (or `python3 -m http.server` for Python 3)
   in a terminal in the same directory as your HTML file.
 
 Once we are running our server, we can open our project in the browser using


### PR DESCRIPTION
**Description:**

When following the instructions on macOS 15.4, after installing the recommended version of Python from python.org, I found that the Python 3 executable is `python3`, not `python`.

Some quick internet searching suggests that `python3` is probably the most reliable command to run across multiple OSes.

I confirmed the command seems to work as expected:
```
% python3 -m http.server
Serving HTTP on :: port 8000 (http://[::]:8000/) ...
::1 - - [04/May/2025 23:10:46] "GET /my-test-vr.html HTTP/1.1" 200 -
```

**Changes proposed:**

Simple docs change from `python` to `python3`.