### PR TITLE
Add minFilter and magFilter to material component replacing npot

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -64,10 +64,11 @@ depending on the material type applied.
 | alphaTest    | Alpha test threshold for transparency.                                                                                                            | 0             |
 | depthTest    | Whether depth testing is enabled when rendering the material.                                                                                     | true          |
 | flatShading  | Use `THREE.FlatShading` rather than `THREE.StandardShading`.                                                                                      | false         |
-| npot         | Use settings for non-power-of-two (NPOT) texture.                                                                                                 | false         |
 | offset       | Texture offset to be used.                                                                                                                        | {x: 0, y: 0}  |
 | opacity      | Extent of transparency. If the `transparent` property is not `true`, then the material will remain opaque and `opacity` will only affect color.   | 1.0           |
 | repeat       | Texture repeat to be used.                                                                                                                        | {x: 1, y: 1}  |
+| magFilter    | Which magnifying filter to use when sampling textures. Can be one of `linear` or `nearest`.                                                       | `linear`      |
+| minFilter    | Which minifying filter to use when sampling textures. Can be one of `linear`, `linear-mipmap-nearest`, `linear-mipmap-linear`, `nearest`, `nearest-mipmap-nearest` or `nearest-mipmap-linear`. | `linear-mipmap-linear` |
 | shader       | Which material to use. Defaults to the [standard material][standard]. Can be set to the [flat material][flat] or to a registered custom shader material. | standard      |
 | side         | Which sides of the mesh to render. Can be one of `front`, `back`, or `double`.                                                                    | front         |
 | transparent  | Whether material is transparent. Transparent entities are rendered after non-transparent entities.                                                | false         |

--- a/docs/primitives/a-box.md
+++ b/docs/primitives/a-box.md
@@ -27,57 +27,58 @@ The box primitive creates shapes such as boxes, cubes, or walls.
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth                            | geometry.depth                         | 1             |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | geometry.height                        | 1             |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| segments-depth                   | geometry.segmentsDepth                 | 1             |
-| segments-height                  | geometry.segmentsHeight                | 1             |
-| segments-width                   | geometry.segmentsWidth                 | 1             |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | geometry.width                         | 1             |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth                            | geometry.depth                         | 1                    |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| height                           | geometry.height                        | 1                    |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| segments-depth                   | geometry.segmentsDepth                 | 1                    |
+| segments-height                  | geometry.segmentsHeight                | 1                    |
+| segments-width                   | geometry.segmentsWidth                 | 1                    |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| width                            | geometry.width                         | 1                    |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-circle.md
+++ b/docs/primitives/a-circle.md
@@ -27,60 +27,59 @@ component with the type set to `circle`.
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| radius                           | geometry.radius                        | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| segments                         | geometry.segments                      | 32            |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| theta-length                     | geometry.thetaLength                   | 360           |
-| theta-start                      | geometry.thetaStart                    | 0             |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| radius                           | geometry.radius                        | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| segments                         | geometry.segments                      | 32                   |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| theta-length                     | geometry.thetaLength                   | 360                  |
+| theta-start                      | geometry.thetaStart                    | 0                    |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |
 
 ## Parallelizing to the Ground
 

--- a/docs/primitives/a-cone.md
+++ b/docs/primitives/a-cone.md
@@ -24,60 +24,60 @@ The cone primitive creates a cone shape.
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | geometry.height                        | 1             |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| open-ended                       | geometry.openEnded                     | false         |
-| radius-bottom                    | geometry.radiusBottom                  | 1             |
-| radius-top                       | geometry.radiusTop                     | 0.01          |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| segments-height                  | geometry.segmentsHeight                | 18            |
-| segments-radial                  | geometry.segmentsRadial                | 36            |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| theta-length                     | geometry.thetaLength                   | 360           |
-| theta-start                      | geometry.thetaStart                    | 0             |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| height                           | geometry.height                        | 1                    |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| open-ended                       | geometry.openEnded                     | false                |
+| radius-bottom                    | geometry.radiusBottom                  | 1                    |
+| radius-top                       | geometry.radiusTop                     | 0.01                 |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| segments-height                  | geometry.segmentsHeight                | 18                   |
+| segments-radial                  | geometry.segmentsRadial                | 36                   |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| theta-length                     | geometry.thetaLength                   | 360                  |
+| theta-start                      | geometry.thetaStart                    | 0                    |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-cylinder.md
+++ b/docs/primitives/a-cylinder.md
@@ -36,59 +36,59 @@ Also, we can create a tube by making the cylinder open-ended, which removes the 
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | geometry.height                        | 1             |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| open-ended                       | geometry.openEnded                     | false         |
-| radius                           | geometry.radius                        | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| segments-height                  | geometry.segmentsHeight                | 18            |
-| segments-radial                  | geometry.segmentsRadial                | 36            |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| theta-length                     | geometry.thetaLength                   | 360           |
-| theta-start                      | geometry.thetaStart                    | 0             |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| height                           | geometry.height                        | 1                    |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| open-ended                       | geometry.openEnded                     | false                |
+| radius                           | geometry.radius                        | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| segments-height                  | geometry.segmentsHeight                | 18                   |
+| segments-radial                  | geometry.segmentsRadial                | 36                   |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| theta-length                     | geometry.thetaLength                   | 360                  |
+| theta-start                      | geometry.thetaStart                    | 0                    |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-dodecahedron.md
+++ b/docs/primitives/a-dodecahedron.md
@@ -14,55 +14,54 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| detail                           | geometry.detail                        | 0             |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| radius                           | geometry.radius                        | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| detail                           | geometry.detail                        | 0                    |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| radius                           | geometry.radius                        | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-icosahedron.md
+++ b/docs/primitives/a-icosahedron.md
@@ -14,55 +14,54 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| detail                           | geometry.detail                        | 0             |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| radius                           | geometry.radius                        | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| detail                           | geometry.detail                        | 0                    |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| radius                           | geometry.radius                        | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-octahedron.md
+++ b/docs/primitives/a-octahedron.md
@@ -14,55 +14,54 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| detail                           | geometry.detail                        | 0             |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| radius                           | geometry.radius                        | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| detail                           | geometry.detail                        | 0                    |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| radius                           | geometry.radius                        | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-plane.md
+++ b/docs/primitives/a-plane.md
@@ -29,58 +29,59 @@ component with the type set to `plane`.
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | geometry.height                        | 1             |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| segments-height                  | geometry.segmentsHeight                | 1             |
-| segments-width                   | geometry.segmentsWidth                 | 1             |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | geometry.width                         | 1             |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| height                           | geometry.height                        | 1                    |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| segments-height                  | geometry.segmentsHeight                | 1                    |
+| segments-width                   | geometry.segmentsWidth                 | 1                    |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| width                            | geometry.width                         | 1                    |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |
 
 ## Parallelizing to the Ground
 

--- a/docs/primitives/a-ring.md
+++ b/docs/primitives/a-ring.md
@@ -24,59 +24,58 @@ The ring primitive creates a ring or disc shape.
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| radius-inner                     | geometry.radiusInner                   | 0.8           |
-| radius-outer                     | geometry.radiusOuter                   | 1.2           |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| segments-phi                     | geometry.segmentsPhi                   | 10            |
-| segments-theta                   | geometry.segmentsTheta                 | 32            |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| theta-length                     | geometry.thetaLength                   | 360           |
-| theta-start                      | geometry.thetaStart                    | 0             |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| radius-inner                     | geometry.radiusInner                   | 0.8                  |
+| radius-outer                     | geometry.radiusOuter                   | 1.2                  |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| segments-phi                     | geometry.segmentsPhi                   | 10                   |
+| segments-theta                   | geometry.segmentsTheta                 | 32                   |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| theta-length                     | geometry.thetaLength                   | 360                  |
+| theta-start                      | geometry.thetaStart                    | 0                    |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-sphere.md
+++ b/docs/primitives/a-sphere.md
@@ -16,60 +16,59 @@ The sphere primitive creates a spherical or polyhedron shapes. It wraps an entit
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| phi-length                       | geometry.phiLength                     | 360           |
-| phi-start                        | geometry.phiStart                      | 0             |
-| radius                           | geometry.radius                        | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| segments-height                  | geometry.segmentsHeight                | 18            |
-| segments-width                   | geometry.segmentsWidth                 | 36            |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| theta-length                     | geometry.thetaLength                   | 180           |
-| theta-start                      | geometry.thetaStart                    | 0             |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| phi-length                       | geometry.phiLength                     | 360                  |
+| phi-start                        | geometry.phiStart                      | 0                    |
+| radius                           | geometry.radius                        | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| segments-height                  | geometry.segmentsHeight                | 18                   |
+| segments-width                   | geometry.segmentsWidth                 | 36                   |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| theta-length                     | geometry.thetaLength                   | 180                  |
+| theta-start                      | geometry.thetaStart                    | 0                    |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-tetrahedron.md
+++ b/docs/primitives/a-tetrahedron.md
@@ -14,55 +14,54 @@ source_code: src/extras/primitives/primitives/meshPrimitives.js
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| detail                           | geometry.detail                        | 0             |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| radius                           | geometry.radius                        | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| detail                           | geometry.detail                        | 0                    |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| radius                           | geometry.radius                        | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-torus-knot.md
+++ b/docs/primitives/a-torus-knot.md
@@ -19,59 +19,58 @@ component with the type set to `torusKnot`.
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| p                                | geometry.p                             | 2             |
-| q                                | geometry.q                             | 3             |
-| radius                           | geometry.radius                        | 1             |
-| radius-tubular                   | geometry.radiusTubular                 | 0.2           |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| segments-radial                  | geometry.segmentsRadial                | 8             |
-| segments-tubular                 | geometry.segmentsTubular               | 100           |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| p                                | geometry.p                             | 2                    |
+| q                                | geometry.q                             | 3                    |
+| radius                           | geometry.radius                        | 1                    |
+| radius-tubular                   | geometry.radiusTubular                 | 0.2                  |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| segments-radial                  | geometry.segmentsRadial                | 8                    |
+| segments-tubular                 | geometry.segmentsTubular               | 100                  |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-torus.md
+++ b/docs/primitives/a-torus.md
@@ -19,58 +19,57 @@ component with the type set to `torus`.
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| arc                              | geometry.arc                           | 360           |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| radius                           | geometry.radius                        | 1             |
-| radius-tubular                   | geometry.radiusTubular                 | 0.2           |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| segments-radial                  | geometry.segmentsRadial                | 36            |
-| segments-tubular                 | geometry.segmentsTubular               | 32            |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| transparent                      | material.transparent                   | false         |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| arc                              | geometry.arc                           | 360                  |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| radius                           | geometry.radius                        | 1                    |
+| radius-tubular                   | geometry.radiusTubular                 | 0.2                  |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| segments-radial                  | geometry.segmentsRadial                | 36                   |
+| segments-tubular                 | geometry.segmentsTubular               | 32                   |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| transparent                      | material.transparent                   | false                |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |

--- a/docs/primitives/a-triangle.md
+++ b/docs/primitives/a-triangle.md
@@ -27,59 +27,58 @@ component with the type set to `triangle`.
 
 ## Attributes
 
-| Attribute                        | Component Mapping                      | Default Value |
-| --------                         | -----------------                      | ------------- |
-| alpha-test                       | material.alphaTest                     | 0             |
-| ambient-occlusion-map            | material.ambientOcclusionMap           | None          |
-| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1             |
-| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0           |
-| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1           |
-| anisotropy                       | material.anisotropy                    | 0             |
-| blending                         | material.blending                      | normal        |
-| color                            | material.color                         | #FFF          |
-| depth-test                       | material.depthTest                     | true          |
-| depth-write                      | material.depthWrite                    | true          |
-| displacement-bias                | material.displacementBias              | 0.5           |
-| displacement-map                 | material.displacementMap               | None          |
-| displacement-scale               | material.displacementScale             | 1             |
-| displacement-texture-offset      | material.displacementTextureOffset     | 0 0           |
-| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1           |
-| dithering                        | material.dithering                     | true          |
-| emissive                         | material.emissive                      | #000          |
-| emissive-intensity               | material.emissiveIntensity             | 1             |
-| env-map                          | material.envMap                        | None          |
-| flat-shading                     | material.flatShading                   | false         |
-| height                           | material.height                        | 256           |
-| material-fog                     | material.fog                           | true          |
-| material-visible                 | material.visible                       | true          |
-| metalness                        | material.metalness                     | 0             |
-| metalness-map                    | material.metalnessMap                  | None          |
-| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0           |
-| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1           |
-| normal-map                       | material.normalMap                     | None          |
-| normal-scale                     | material.normalScale                   | 1 1           |
-| normal-texture-offset            | material.normalTextureOffset           | 0 0           |
-| normal-texture-repeat            | material.normalTextureRepeat           | 1 1           |
-| npot                             | material.npot                          | false         |
-| offset                           | material.offset                        | 0 0           |
-| opacity                          | material.opacity                       | 1             |
-| repeat                           | material.repeat                        | 1 1           |
-| roughness                        | material.roughness                     | 0.5           |
-| roughness-map                    | material.roughnessMap                  | None          |
-| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0           |
-| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1           |
-| shader                           | material.shader                        | standard      |
-| side                             | material.side                          | front         |
-| spherical-env-map                | material.sphericalEnvMap               | None          |
-| src                              | material.src                           | None          |
-| transparent                      | material.transparent                   | false         |
-| vertex-a                         | geometry.vertexA                       | 0 0.5 0       |
-| vertex-b                         | geometry.vertexB                       | -0.5 -0.5 0   |
-| vertex-c                         | geometry.vertexC                       | 0.5 -0.5 0    |
-| vertex-colors-enabled            | material.vertexColorsEnabled           | false         |
-| width                            | material.width                         | 512           |
-| wireframe                        | material.wireframe                     | false         |
-| wireframe-linewidth              | material.wireframeLinewidth            | 2             |
+| Attribute                        | Component Mapping                      | Default Value        |
+| --------                         | -----------------                      | -------------        |
+| alpha-test                       | material.alphaTest                     | 0                    |
+| ambient-occlusion-map            | material.ambientOcclusionMap           | None                 |
+| ambient-occlusion-map-intensity  | material.ambientOcclusionMapIntensity  | 1                    |
+| ambient-occlusion-texture-offset | material.ambientOcclusionTextureOffset | 0 0                  |
+| ambient-occlusion-texture-repeat | material.ambientOcclusionTextureRepeat | 1 1                  |
+| anisotropy                       | material.anisotropy                    | 0                    |
+| blending                         | material.blending                      | normal               |
+| color                            | material.color                         | #FFF                 |
+| depth-test                       | material.depthTest                     | true                 |
+| depth-write                      | material.depthWrite                    | true                 |
+| displacement-bias                | material.displacementBias              | 0.5                  |
+| displacement-map                 | material.displacementMap               | None                 |
+| displacement-scale               | material.displacementScale             | 1                    |
+| displacement-texture-offset      | material.displacementTextureOffset     | 0 0                  |
+| displacement-texture-repeat      | material.displacementTextureRepeat     | 1 1                  |
+| dithering                        | material.dithering                     | true                 |
+| emissive                         | material.emissive                      | #000                 |
+| emissive-intensity               | material.emissiveIntensity             | 1                    |
+| env-map                          | material.envMap                        | None                 |
+| flat-shading                     | material.flatShading                   | false                |
+| mag-filter                       | material.magFilter                     | linear               |
+| material-fog                     | material.fog                           | true                 |
+| material-visible                 | material.visible                       | true                 |
+| metalness                        | material.metalness                     | 0                    |
+| metalness-map                    | material.metalnessMap                  | None                 |
+| metalness-texture-offset         | material.metalnessTextureOffset        | 0 0                  |
+| metalness-texture-repeat         | material.metalnessTextureRepeat        | 1 1                  |
+| min-filter                       | material.minFilter                     | linear-mipmap-linear |
+| normal-map                       | material.normalMap                     | None                 |
+| normal-scale                     | material.normalScale                   | 1 1                  |
+| normal-texture-offset            | material.normalTextureOffset           | 0 0                  |
+| normal-texture-repeat            | material.normalTextureRepeat           | 1 1                  |
+| offset                           | material.offset                        | 0 0                  |
+| opacity                          | material.opacity                       | 1                    |
+| repeat                           | material.repeat                        | 1 1                  |
+| roughness                        | material.roughness                     | 0.5                  |
+| roughness-map                    | material.roughnessMap                  | None                 |
+| roughness-texture-offset         | material.roughnessTextureOffset        | 0 0                  |
+| roughness-texture-repeat         | material.roughnessTextureRepeat        | 1 1                  |
+| shader                           | material.shader                        | standard             |
+| side                             | material.side                          | front                |
+| spherical-env-map                | material.sphericalEnvMap               | None                 |
+| src                              | material.src                           | None                 |
+| transparent                      | material.transparent                   | false                |
+| vertex-a                         | geometry.vertexA                       | 0 0.5 0              |
+| vertex-b                         | geometry.vertexB                       | -0.5 -0.5 0          |
+| vertex-c                         | geometry.vertexC                       | 0.5 -0.5 0           |
+| vertex-colors-enabled            | material.vertexColorsEnabled           | false                |
+| wireframe                        | material.wireframe                     | false                |
+| wireframe-linewidth              | material.wireframeLinewidth            | 2                    |
 
 ## Parallelizing to the Ground
 

--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -324,7 +324,7 @@ export var Component = registerComponent('layer', {
 
     quadPanelEl.setAttribute('material', {
       shader: 'flat',
-      npot: true,
+      minFilter: 'linear',
       src: this.data.src,
       transparent: true
     });

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -18,10 +18,14 @@ export var Component = registerComponent('material', {
     depthTest: {default: true},
     depthWrite: {default: true},
     flatShading: {default: false},
-    npot: {default: false},
     offset: {type: 'vec2', default: {x: 0, y: 0}},
     opacity: {default: 1.0, min: 0.0, max: 1.0},
     repeat: {type: 'vec2', default: {x: 1, y: 1}},
+    magFilter: {default: 'linear', oneOf: ['nearest', 'linear']},
+    minFilter: {
+      default: 'linear-mipmap-linear',
+      oneOf: ['nearest', 'nearest-mipmap-nearest', 'nearest-mipmap-linear', 'linear', 'linear-mipmap-nearest', 'linear-mipmap-linear']
+    },
     shader: {default: 'standard', oneOf: shaderNames, schemaChange: true},
     side: {default: 'front', oneOf: ['front', 'back', 'double']},
     transparent: {default: false},

--- a/src/extras/primitives/primitives/a-sky.js
+++ b/src/extras/primitives/primitives/a-sky.js
@@ -15,7 +15,7 @@ registerPrimitive('a-sky', utils.extendDeep({}, getMeshMixin(), {
       color: '#FFF',
       side: 'back',
       shader: 'flat',
-      npot: true
+      minFilter: 'linear'
     },
     scale: '-1 1 1'
   },

--- a/src/extras/primitives/primitives/a-videosphere.js
+++ b/src/extras/primitives/primitives/a-videosphere.js
@@ -14,7 +14,7 @@ registerPrimitive('a-videosphere', utils.extendDeep({}, getMeshMixin(), {
       color: '#FFF',
       shader: 'flat',
       side: 'back',
-      npot: true
+      minFilter: 'linear'
     },
     scale: '-1 1 1'
   },

--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -11,6 +11,15 @@ var COLOR_MAPS = new Set([
   'specularMap'
 ]);
 
+var FILTERING_TYPES = {
+  'nearest': THREE.NearestFilter,
+  'nearest-mipmap-nearest': THREE.NearestMipMapNearestFilter,
+  'nearest-mipmap-linear': THREE.NearestMipMapLinearFilter,
+  'linear': THREE.LinearFilter,
+  'linear-mipmap-nearest': THREE.LinearMipMapNearestFilter,
+  'linear-mipmap-linear': THREE.LinearMipmapLinearFilter
+};
+
 /**
  * Set texture properties such as repeat and offset.
  *
@@ -20,21 +29,11 @@ var COLOR_MAPS = new Set([
 export function setTextureProperties (texture, data) {
   var offset = data.offset || {x: 0, y: 0};
   var repeat = data.repeat || {x: 1, y: 1};
-  var npot = data.npot || false;
   var anisotropy = data.anisotropy || THREE.Texture.DEFAULT_ANISOTROPY;
   var wrapS = texture.wrapS;
   var wrapT = texture.wrapT;
-  var magFilter = texture.magFilter;
-  var minFilter = texture.minFilter;
-
-  // To support NPOT textures, wrap must be ClampToEdge (not Repeat),
-  // and filters must not use mipmaps (i.e. Nearest or Linear).
-  if (npot) {
-    wrapS = THREE.ClampToEdgeWrapping;
-    wrapT = THREE.ClampToEdgeWrapping;
-    magFilter = THREE.LinearFilter;
-    minFilter = THREE.LinearFilter;
-  }
+  var magFilter = FILTERING_TYPES[data.magFilter] || texture.magFilter;
+  var minFilter = FILTERING_TYPES[data.minFilter] || texture.minFilter;
 
   // Set wrap mode to repeat only if repeat isn't 1/1. Power-of-two is required to repeat.
   if (repeat.x !== 1 || repeat.y !== 1) {


### PR DESCRIPTION
**Description:**
As discussed in #5706 the `npot` property was only intended for working with non-power-of-two textures in WebGL 1. It's being used in several places to indirectly set the `minFilter` to `THREE.LinearFiltering`. This PR introduces `minFilter` and `magFilter` properties allowing the filtering methods to be set directly and explicitly.

**Changes proposed:**
- Add `minFilter` and `magFilter` properties to `material` component to set texture filtering.
- Remove `npot` property from `material` component
