### PR TITLE
Bunny video shouldn't autoplay in Layer Quad example

### DIFF
--- a/examples/test/layer/index.html
+++ b/examples/test/layer/index.html
@@ -19,7 +19,7 @@
           Author: Blender Institute
           URL:    https://peach.blender.org/
         -->
-        <video id="bunny" autoplay preload="auto" loop crossorigin="anonymous" width="1920" height="1080">
+        <video id="bunny" preload="auto" loop crossorigin="anonymous" width="1920" height="1080">
           <source src="https://cdn.aframe.io/videos/bunny.mp4">
         </video>
         <img id="panel" crossOrigin="anonymous" src="panel.png">


### PR DESCRIPTION
**Description:**

Sometimes when loading the test/layer example, I would hear the video sound, that video shouldn't autoplay, it should play only after clicking twice on Next.

**Changes proposed:**
- Remove autoplay attribute
