### PR TITLE
Fix condition that check that XRWebGLBinding is defined in layer component

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -361,7 +361,8 @@ export var Component = registerComponent('layer', {
   onEnterVR: function () {
     var sceneEl = this.el.sceneEl;
     var xrSession = sceneEl.xrSession;
-    if (!sceneEl.hasWebXR || !XRWebGLBinding || !xrSession) {
+    if (this.data.src.play) { this.data.src.play(); }
+    if (!sceneEl.hasWebXR || typeof XRWebGLBinding === 'undefined' || !xrSession) {
       warn('The layer component requires WebXR and the layers API enabled');
       return;
     }
@@ -370,7 +371,6 @@ export var Component = registerComponent('layer', {
     if (this.quadPanelEl) {
       this.quadPanelEl.object3D.visible = false;
     }
-    if (this.data.src.play) { this.data.src.play(); }
   },
 
   onExitVR: function () {


### PR DESCRIPTION
**Description:**

Fix condition that check that XRWebGLBinding is defined, also be sure to play the video even if layers is not supported.
Indeed if XRWebGLBinding is really undefined it would give an error. @dmarcos if you can verify on your AVP with some console.log if XRWebGLBinding is really undefined and also XRMediaBinding, that would be great.

I want that layer component to work on both Quest and AVP with the fallback to plane or spheres if layers is not supported currently on AVP. For this I think layers should be in webxr optionalFeatures and not requiredFeatures but using optionalFeatures with 'layers' just give an invisible layer without error on Quest it seems, that's another issue to be reported. So the changes here are only half the changes for the layer component to work on AVP.

**Changes proposed:**
- change condition from `!XRWebGLBinding` to `typeof XRWebGLBinding === 'undefined'`
- move the src.play() line above that condition
