### PR TITLE
Make layers feature optional for type quad so it works on devices not supporting WebXR layers

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -285,7 +285,7 @@ export class AScene extends AEntity {
                 self.usedOfferSession = false;
               }
 
-              vrManager.layersEnabled = xrInit.requiredFeatures.indexOf('layers') !== -1;
+              vrManager.layersEnabled = xrSession.enabledFeatures ? xrSession.enabledFeatures.indexOf('layers') !== -1 : true;
               vrManager.setSession(xrSession).then(function () {
                 vrManager.setFoveation(rendererSystem.foveationLevel);
                 self.xrSession = xrSession;


### PR DESCRIPTION
**Description:**

Make layers feature optional for type quad so it works on devices not supporting WebXR layers. Please confirm @dmarcos that the Layer Quad example is working with the fallback to a plane on AVP.

**Changes proposed:**
- Use optionalFeatures layers for types that have a fallback, requiredFeatures for types that don't have a fallback
- Add this.layerEnabled in the condition to initLayer(), layerEnabled is false for devices not defining XRWebGLBinding or XRMediaBinding (when I tested the VR button on Chrome desktop, XRWebGLBinding was defined, XRMediaBinding was undefined)
