### PR TITLE
Fix quadPanelEl geometry width to take the texture width

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -332,7 +332,7 @@ export var Component = registerComponent('layer', {
     quadPanelEl.setAttribute('geometry', {
       primitive: 'plane',
       height: this.data.height || this.texture.image.height / 1000,
-      width: this.data.width || this.texture.image.height / 1000
+      width: this.data.width || this.texture.image.width / 1000
     });
   },
 


### PR DESCRIPTION
Fix quadPanelEl geometry width to take the texture width and not the height when width property is kept at 0
