### PR TITLE
Set texture.generateMipmaps according to specified minFilter

### DIFF
--- a/src/utils/material.js
+++ b/src/utils/material.js
@@ -52,6 +52,7 @@ export function setTextureProperties (texture, data) {
     texture.wrapT = wrapT;
     texture.magFilter = magFilter;
     texture.minFilter = minFilter;
+    texture.generateMipmaps = minFilter !== THREE.NearestFilter && minFilter !== THREE.LinearFilter;
     texture.anisotropy = anisotropy;
     texture.needsUpdate = true;
   }


### PR DESCRIPTION
**Description:**

Set `texture.generateMipmaps` according to specified `minFilter`.
Since https://github.com/mrdoob/three.js/pull/29677 that's included since three r170 you need to set `texture.generateMipmaps` to `false` explicitly if using `minFilter` 'linear' or 'nearest' to not generate mipmaps.

**Changes proposed:**
- add `texture.generateMipmaps = minFilter !== THREE.NearestFilter && minFilter !== THREE.LinearFilter;`