### PR TITLE
Add migration instruction for npot: true to minFilter: linear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.8.0 (unreleased)
+
+### Deprecations
+
+- If you used material `npot: true` previously as a way to set `texture.minFilter = THREE.LinearFilter` for better image quality, you need to replace it with `minFilter: linear`. That change was introduced in #5717 that removed `npot` property that was legacy of WebGL1, new material properties `minFilter` and `magFilter` have been exposed instead.
+
 ### 1.7.1 (Apr 1, 2025)
 
 ### Bug fixes


### PR DESCRIPTION
Add a migration note in future changelog about removal of `npot: true` in #5717 that needs to be replaced by `minFilter: linear` in your own code.