### PR TITLE
Fix inline link check in docsLint.js script

### DIFF
--- a/scripts/docsLint.js
+++ b/scripts/docsLint.js
@@ -28,7 +28,9 @@ pages.forEach(function checkPage (pagePath) {
   let inlineLinkRegex = /\[.*?\]\((.*?)\)/g;
   match = inlineLinkRegex.exec(content);
   while (match !== null) {
-    checkLink(pagePath, match[1], 'Page does not exist');
+    if (!checkLink(pagePath, match[1])) {
+      addError(pagePath, match[0], 'Page does not exist');
+    }
     match = inlineLinkRegex.exec(content);
   }
 


### PR DESCRIPTION
**Description:**
The `docsLint.js` script checks relative links to see if the file they point to exists. For inline links this check wasn't performed correctly, causing issue to go unreported. This PR fixes the script.

Fixes for incorrect links are incorporated in #5730 

**Changes proposed:**
- Properly handle outcome of link checking for inline links to report any errors
