### PR TITLE
repairing the axisMeshNames for TOUCHPAD_TOUCH on Y

### DIFF
--- a/src/components/windows-motion-controls.js
+++ b/src/components/windows-motion-controls.js
@@ -23,7 +23,7 @@ var INPUT_MAPPING = {
   // the mesh corresponding to axis 0 is in this array index 0.
   axisMeshNames: [
     'TOUCHPAD_TOUCH_X',
-    'TOUCHPAD_TOUCH_X',
+    'TOUCHPAD_TOUCH_Y',
     'THUMBSTICK_X',
     'THUMBSTICK_Y'
   ],


### PR DESCRIPTION
**Description:**

**Changes proposed:**
lines 24 to 29
from the following to the later:
```
  axisMeshNames: [
    'TOUCHPAD_TOUCH_X',
    'TOUCHPAD_TOUCH_X',
    'THUMBSTICK_X',
    'THUMBSTICK_Y'
  ],
  ```
  ```
  axisMeshNames: [
    'TOUCHPAD_TOUCH_X',
    'TOUCHPAD_TOUCH_Y',
    'THUMBSTICK_X',
    'THUMBSTICK_Y'
  ],
```