### PR TITLE
Remove stats div from the DOM when removing stats component

### DIFF
--- a/src/components/scene/stats.js
+++ b/src/components/scene/stats.js
@@ -25,6 +25,10 @@ registerComponent('stats', {
     return (!this.data) ? this.hide() : this.show();
   },
 
+  remove: function () {
+    this.stats.dom.remove();
+  },
+
   hide: function () {
     this.stats.dom.classList.add(HIDDEN_CLASS);
   },


### PR DESCRIPTION
**Description:**

#5700 changes didn't properly remove the added div when the stats component is removed.

**Changes proposed:**
- Remove stats div from the DOM when removing stats component