### PR TITLE
Fix race condition in gltf-model when changing src while loading

### DIFF
--- a/src/components/gltf-model.js
+++ b/src/components/gltf-model.js
@@ -36,12 +36,13 @@ export var Component = registerComponent('gltf-model', {
     var el = this.el;
     var src = this.data;
 
-    if (!src) { return; }
-
     this.remove();
+
+    if (!src) { return; }
 
     this.ready.then(function () {
       self.loader.load(src, function gltfLoaded (gltfModel) {
+        if (src !== self.data) { return; }
         self.model = gltfModel.scene || gltfModel.scenes[0];
         self.model.animations = gltfModel.animations;
 
@@ -58,5 +59,6 @@ export var Component = registerComponent('gltf-model', {
   remove: function () {
     if (!this.model) { return; }
     this.el.removeObject3D('mesh');
+    this.model = null;
   }
 });


### PR DESCRIPTION
**Description:**
The `gltf-model` component would unconditionally change the model in the `gltfLoad` callback. However, it's possible for the `src` value to have changed in the meantime. In case the second model finishes loading before the first one, the component would incorrectly end up showing the first model (once it finishes loading as well).

This PR adds a check to ensure that the `src` hasn't changed (similar to what is done for textures).

**Changes proposed:**
- Check if `src` changed while loading model to avoid showing the wrong model
- Always remove previous model, even when setting to an empty value
- Add unit tests covering the `src` change and removal logic.
