### PR TITLE
Fix link syntax to community page in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Glitch and update the `src` URL.
 
 ## On Discord
 
-1. [Invite yourself][https://aframe.io/community/] to Discord.
+1. [Invite yourself](https://aframe.io/community/) to Discord.
 2. Help answer questions that people might have and welcome new people.
 3. Redirect or cross-post questions to the [Stack Overflow A-Frame tag][stackoverflow].
 


### PR DESCRIPTION
**Description:**

The markdown syntax was wrong since my changes in https://github.com/aframevr/aframe/commit/95ad38c359c1508bc6e68b43f000e301937f7d1b

**Changes proposed:**
- Fix link syntax to community page in CONTRIBUTING.md