### PR TITLE
Fix jsdoc for parse and styleParse in styleParser.js, second param obj is optional

### DIFF
--- a/src/utils/styleParser.js
+++ b/src/utils/styleParser.js
@@ -9,7 +9,7 @@ var DASH_REGEX = /-([a-z])/g;
  * Deserialize style-like string into an object of properties.
  *
  * @param {string} value - HTML attribute value.
- * @param {object} obj - Reused object for object pooling.
+ * @param {object} [obj] - Reused object for object pooling.
  * @returns {object} Property data.
  */
 export function parse (value, obj) {
@@ -83,7 +83,7 @@ var getKeyValueChunks = (function () {
  * Convert a style attribute string to an object.
  *
  * @param {object} str - Attribute string.
- * @param {object} obj - Object to reuse as a base, else a new one will be allocated.
+ * @param {object} [obj] - Object to reuse as a base, else a new one will be allocated.
  */
 function styleParse (str, obj) {
   var chunks;


### PR DESCRIPTION
**Description:**

I got a typescript error in my project copying that parse and styleParse functions and using only one param, properly marking the second param as optional fixed it.
Note that if you're using `AFRAME.utils.styleParser.parse(astring)` directly there is no error because only the first param is in the `@types/aframe` types defined in https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3829c3cb5e731141ebf73816117e5a5a6866be17/types/aframe/index.d.ts#L340