### PR TITLE
Only update shadow properties of lights that support shadows

### DIFF
--- a/src/components/light.js
+++ b/src/components/light.js
@@ -199,6 +199,9 @@ export var Component = registerComponent('light', {
     if (newLight) {
       if (this.light) {
         el.removeObject3D('light');
+        if (el.getObject3D('cameraHelper')) {
+          el.removeObject3D('cameraHelper');
+        }
       }
 
       this.light = newLight;
@@ -232,18 +235,20 @@ export var Component = registerComponent('light', {
     var data = this.data;
     var light = this.light;
 
-    light.castShadow = data.castShadow;
+    // Cast shadows if enabled and light type supports shadows.
+    light.castShadow = data.castShadow && light.shadow;
 
     // Shadow camera helper.
     var cameraHelper = el.getObject3D('cameraHelper');
-    if (data.shadowCameraVisible && !cameraHelper) {
+    var shadowCameraVisible = data.shadowCameraVisible && light.shadow;
+    if (shadowCameraVisible && !cameraHelper) {
       cameraHelper = new THREE.CameraHelper(light.shadow.camera);
       el.setObject3D('cameraHelper', cameraHelper);
-    } else if (!data.shadowCameraVisible && cameraHelper) {
+    } else if (!shadowCameraVisible && cameraHelper) {
       el.removeObject3D('cameraHelper');
     }
 
-    if (!data.castShadow) { return light; }
+    if (!light.castShadow) { return light; }
 
     // Shadow appearance.
     light.shadow.bias = data.shadowBias;


### PR DESCRIPTION
**Description:**
Fixes #5747.

The `light` component would unconditionally update the properties of `light.shadow` when `castShadow` was enabled. However, not all light types support shadows, causing an error when switching the light type and/or enabling `castShadow` for an incompatible light type.

Additionally I noticed that the `CameraHelper` for the shadow camera would not update when changing light type. By removing the camera helper when the light type changes, it's guaranteed to be recreated for the correct camera (if needed).

**Changes proposed:**
- Only update `light.shadow` properties if the light type supports shadows
- Remove shadow camera helper when light type changes
