### PR TITLE
Fix crash setting transform on undefined when layer is pending recreation

### DIFF
--- a/src/components/layer.js
+++ b/src/components/layer.js
@@ -222,6 +222,8 @@ export var Component = registerComponent('layer', {
     if (!this.el.sceneEl.xrSession) { return; }
     if (!this.referenceSpace) { return; }
     if (this.layerEnabled && !this.layer && (this.el.sceneEl.is('vr-mode') || this.el.sceneEl.is('ar-mode'))) { this.initLayer(); }
+    // initLayer may not have created the layer if the texture is not loaded yet
+    if (!this.layer) { return; }
     this.updateTransform();
     if (this.data.src.complete && (this.pendingCubeMapUpdate || this.loadingScreen || this.visibilityChanged)) { this.loadCubeMapImages(); }
     if (!this.needsRedraw && !this.layer.needsRedraw) { return; }


### PR DESCRIPTION
**Description:**

Fix crash setting transform on undefined when layer is destroyed in updateSrc and layer is not yet recreated because image has not loaded yet (this.texture is undefined).
Crash reproduced on the Comic book example while in VR switch to the next image. I didn't have the issue on the other layer quad example.
In https://github.com/aframevr/aframe/commit/a59273715b16918f132d7fcaf6fa92c7036270b3 I had changed updateSrc to  destroy the layer on src change, not sure if I tested again that example after that change or the issue appears now because of my connection, anyway this PR fixes it. 

**Changes proposed:**
- if this.layer is undefined after initLayer, return