### PR TITLE
Remove setting look-controls userHeight in tests

### DIFF
--- a/tests/components/look-controls.test.js
+++ b/tests/components/look-controls.test.js
@@ -98,7 +98,6 @@ suite('look-controls', function () {
       var cameraEl = sceneEl.camera.el;
       var lookControlsComponent = cameraEl.components['look-controls'];
       lookControlsComponent.hasPositionalTracking = true;
-      cameraEl.setAttribute('look-controls', {userHeight: 0});
       cameraEl.setAttribute('position', '3 3 3');
       sceneEl.xrSession = {addEventListener: function () {}};
       sceneEl.emit('enter-vr');


### PR DESCRIPTION
**Description:**

Remove setting look-controls userHeight in tests, that property doesn't exist.
The tests pass with three 177