### PR TITLE
Fix all controls to use id instead of idPrefix on tracked-controls

### DIFF
--- a/src/components/generic-tracked-controller-controls.js
+++ b/src/components/generic-tracked-controller-controls.js
@@ -127,7 +127,7 @@ export var Component = registerComponent('generic-tracked-controller-controls', 
     }
     el.setAttribute('tracked-controls', {
       hand: data.hand,
-      idPrefix: GAMEPAD_ID_PREFIX,
+      id: GAMEPAD_ID_PREFIX,
       iterateControllerProfiles: true
     });
     if (!this.data.defaultModel) { return; }

--- a/src/components/hp-mixed-reality-controls.js
+++ b/src/components/hp-mixed-reality-controls.js
@@ -117,7 +117,7 @@ export var Component = registerComponent('hp-mixed-reality-controls', {
 
     el.setAttribute('tracked-controls', {
       // TODO: verify expected behavior between reserved prefixes.
-      idPrefix: GAMEPAD_ID,
+      id: GAMEPAD_ID,
       hand: data.hand,
       controller: this.controllerIndex
     });

--- a/src/components/magicleap-controls.js
+++ b/src/components/magicleap-controls.js
@@ -112,7 +112,7 @@ export var Component = registerComponent('magicleap-controls', {
 
     el.setAttribute('tracked-controls', {
       // TODO: verify expected behavior between reserved prefixes.
-      idPrefix: GAMEPAD_ID_COMPOSITE,
+      id: GAMEPAD_ID_COMPOSITE,
       hand: data.hand,
       controller: this.controllerIndex
     });

--- a/src/components/oculus-go-controls.js
+++ b/src/components/oculus-go-controls.js
@@ -103,7 +103,7 @@ export var Component = registerComponent('oculus-go-controls', {
     var data = this.data;
     el.setAttribute('tracked-controls', {
       hand: data.hand,
-      idPrefix: GAMEPAD_ID_PREFIX
+      id: GAMEPAD_ID_PREFIX
     });
     if (!this.data.model) { return; }
     this.el.setAttribute('gltf-model', OCULUS_GO_CONTROLLER_MODEL_URL);

--- a/src/components/pico-controls.js
+++ b/src/components/pico-controls.js
@@ -110,7 +110,7 @@ export var Component = registerComponent('pico-controls', {
     var data = this.data;
     el.setAttribute('tracked-controls', {
       // TODO: verify expected behavior between reserved prefixes.
-      idPrefix: GAMEPAD_ID,
+      id: GAMEPAD_ID,
       hand: data.hand,
       controller: this.controllerIndex
     });

--- a/src/components/tracked-controls.js
+++ b/src/components/tracked-controls.js
@@ -69,7 +69,7 @@ export var Component = registerComponent('tracked-controls', {
   },
 
   /**
-   * Handle update controller match criteria (such as `id`, `idPrefix`, `hand`, `controller`)
+   * Handle update controller match criteria (such as `id`, `hand`, `controller`)
    */
   updateController: function () {
     this.controller = controllerUtils.findMatchingControllerWebXR(

--- a/src/components/valve-index-controls.js
+++ b/src/components/valve-index-controls.js
@@ -118,7 +118,7 @@ export var Component = registerComponent('valve-index-controls', {
 
     // If we have an OpenVR Gamepad, use the fixed mapping.
     el.setAttribute('tracked-controls', {
-      idPrefix: GAMEPAD_ID_PREFIX,
+      id: GAMEPAD_ID_PREFIX,
       // Hand IDs: 1 = right, 0 = left, 2 = anything else.
       controller: data.hand === 'right' ? 1 : data.hand === 'left' ? 0 : 2,
       hand: data.hand

--- a/src/components/vive-controls.js
+++ b/src/components/vive-controls.js
@@ -121,7 +121,7 @@ export var Component = registerComponent('vive-controls', {
 
     // If we have an OpenVR Gamepad, use the fixed mapping.
     el.setAttribute('tracked-controls', {
-      idPrefix: GAMEPAD_ID_PREFIX,
+      id: GAMEPAD_ID_PREFIX,
       hand: data.hand,
       controller: this.controllerIndex
     });

--- a/src/components/vive-focus-controls.js
+++ b/src/components/vive-focus-controls.js
@@ -99,7 +99,7 @@ export var Component = registerComponent('vive-focus-controls', {
   injectTrackedControls: function () {
     var el = this.el;
     el.setAttribute('tracked-controls', {
-      idPrefix: GAMEPAD_ID_PREFIX
+      id: GAMEPAD_ID_PREFIX
     });
     if (!this.data.model) { return; }
     this.el.setAttribute('gltf-model', VIVE_FOCUS_CONTROLLER_MODEL_URL);

--- a/src/components/windows-motion-controls.js
+++ b/src/components/windows-motion-controls.js
@@ -173,7 +173,7 @@ export var Component = registerComponent('windows-motion-controls', {
   injectTrackedControls: function () {
     var data = this.data;
     this.el.setAttribute('tracked-controls', {
-      idPrefix: GAMEPAD_ID_PREFIX,
+      id: GAMEPAD_ID_PREFIX,
       controller: data.pair,
       hand: data.hand
     });


### PR DESCRIPTION
**Description:**

Fix all controls to use id instead of idPrefix when setting the tracked-controls component, only logitech-mx-ink-controls and meta-touch-controls were correct (fix #5772)

The tests pass with three 177