### PR TITLE
Remove bad code in meta-touch-controls for thumbstick rotation

### DIFF
--- a/src/components/meta-touch-controls.js
+++ b/src/components/meta-touch-controls.js
@@ -423,13 +423,6 @@ var componentConfig = {
       this.updateThumbstickTouchV3orPROorPlus(evt);
       return;
     }
-    for (var axis in evt.detail) {
-      this.buttonObjects.thumbstick.rotation[this.axisMap[axis]] =
-        this.buttonRanges.thumbstick.originalRotation[this.axisMap[axis]] -
-        (Math.PI / 8) *
-        evt.detail[axis] *
-        (axis === 'y' || this.data.hand === 'right' ? -1 : 1);
-    }
   },
   axisMap: {
     y: 'x',


### PR DESCRIPTION
**Description:**

Remove bad code in meta-touch-controls for thumbstick rotation that gives error with Rift controllers.
That was reported on discord for aframe 1.7.1 
https://discord.com/channels/479784974917042186/479787777949433900/1428015046046257213

For context, that code with originalRotation was originally written in https://github.com/aframevr/aframe/commit/efb5c3a5979b1ade36898a6c41551526844d5d0d to support button highlighting for Oculus 2 controllers, that part of the code wasn't properly checking for isOculusTouchV3. And that code was later modified in https://github.com/aframevr/aframe/commit/97b8a2bcaced7175b3699b22dc9e0647bb2e7dbe to support Meta Quest Pro, removing this originalRotation, adding a specific code path for isTouchV3orPROorPlus so making that block of code really dead.