### PR TITLE
Show loading screen while downloading images assets

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -17,6 +17,24 @@ class AAssets extends ANode {
     this.timeout = null;
   }
 
+  /**
+   * Override connectedCallback to initialize at 'interactive' instead of 'complete'.
+   * This allows the timeout mechanism to work before loading the images.
+   * If we wait for 'complete', all resources (including images) are already loaded.
+   */
+  connectedCallback () {
+    var self = this;
+    if (document.readyState === 'interactive' || document.readyState === 'complete') {
+      this.doConnectedCallback();
+      return;
+    }
+    document.addEventListener('readystatechange', function onReadyStateChange () {
+      if (document.readyState !== 'interactive' && document.readyState !== 'complete') { return; }
+      document.removeEventListener('readystatechange', onReadyStateChange);
+      self.doConnectedCallback();
+    });
+  }
+
   doConnectedCallback () {
     var self = this;
     var i;


### PR DESCRIPTION
**Description:**

Set timeout mechanism and loading screen earlier at interactive state so we see the loading screen while images are loading.
That was a regression since https://github.com/aframevr/aframe/commit/0d9721884feeb59825dc8c0bebfe73efea34e670 where we changed everything to wait on complete state that includes DOM ready and resources like images loaded.

**Changes proposed:**
- Implements connectedCallback for a-assets to wait for interactive and similar in a-scene to set the renderer and loading screen earlier.

PR done with the help of Claude Code with Opus 4.5