### PR TITLE
Fix out-by-one error

### DIFF
--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -236,10 +236,12 @@ export var Component = registerComponent('screenshot', {
     var flippedPixels = pixels.slice(0);
     for (var x = 0; x < width; ++x) {
       for (var y = 0; y < height; ++y) {
-        flippedPixels[x * 4 + y * width * 4] = pixels[x * 4 + (height - y) * width * 4];
-        flippedPixels[x * 4 + 1 + y * width * 4] = pixels[x * 4 + 1 + (height - y) * width * 4];
-        flippedPixels[x * 4 + 2 + y * width * 4] = pixels[x * 4 + 2 + (height - y) * width * 4];
-        flippedPixels[x * 4 + 3 + y * width * 4] = pixels[x * 4 + 3 + (height - y) * width * 4];
+        var from = x * 4 + (height - y - 1) * width * 4;
+        var to = x * 4 + y * width * 4;
+        flippedPixels[to] = pixels[from];
+        flippedPixels[to + 1] = pixels[from + 1];
+        flippedPixels[to + 2] = pixels[from + 2];
+        flippedPixels[to + 3] = pixels[from + 3];
       }
     }
     return flippedPixels;


### PR DESCRIPTION
**Description:**

As described in issue #5789

**Changes proposed:**

Fix out by 1 error, so pixel row 0 swaps with row (height -1) not (height) and vice-versa.
Also simplified code & reduced calculations by pre-computing the start and end indices.

Testing
- "screenshot" UTs run clean.  They don't test in enough detail to notice any change.
- Live.

Before fix: I took a screenshot from the Anime UI example and opened in Paint.  You can see a single layer of blank pixels at the top of the image:

<img width="1310" height="120" alt="image" src="https://github.com/user-attachments/assets/bbd05bb0-db93-446b-8354-8cc924b2bd64" />

After fix: no blank row of pixels at the top or bottom of the image:

<img width="1008" height="131" alt="image" src="https://github.com/user-attachments/assets/e12eb74e-5bed-4efc-931a-19bdfa836823" />
<img width="900" height="120" alt="image" src="https://github.com/user-attachments/assets/d069d8d0-fbff-40fc-bc73-5c578ce6e381" />




