### PR TITLE
Remove renderer colorManagement: true in examples, that's the default

### DIFF
--- a/examples/animation/aframe-logo/index.html
+++ b/examples/animation/aframe-logo/index.html
@@ -9,8 +9,7 @@
   </head>
   <body>
     <a-scene xr-mode-ui="enabled: false;"
-             background="color: #24CAFF;"
-             renderer="colorManagement: true;">
+             background="color: #24CAFF;">
       <a-assets>
         <a-asset-item id="treeModel" src="../../assets/models/tree1.glb"></a-asset-item>
         <a-mixin

--- a/examples/boilerplate/ar-hello-world/index.html
+++ b/examples/boilerplate/ar-hello-world/index.html
@@ -22,7 +22,7 @@
     <a-scene
       reflection="directionalLight: a-light[type=directional]"
       ar-hit-test="target: #objects;"
-      renderer="colorManagement: true; exposure: 1; toneMapping: ACESFilmic"
+      renderer="exposure: 1; toneMapping: ACESFilmic"
       shadow="type: pcfsoft"
       xr-mode-ui="XRMode: xr"
     >

--- a/examples/mixed-reality/anchor/index.html
+++ b/examples/mixed-reality/anchor/index.html
@@ -13,7 +13,6 @@
   <body>
     <a-scene
       obb-collider="showColliders: false"
-      renderer="colorManagement: true;"
       button
       xr-mode-ui="XRMode: ar"
       info-message="htmlSrc: #messageText">

--- a/examples/mixed-reality/real-world-meshing/index.html
+++ b/examples/mixed-reality/real-world-meshing/index.html
@@ -14,7 +14,6 @@
     <a-scene
       real-world-meshing="filterLabels: table; meshesEnabled: false; planeMixin: xrplane"
       obb-collider="showColliders: false"
-      renderer="colorManagement: true;"
       xr-mode-ui="XRMode: ar"
       info-message="htmlSrc: #messageText">
       <a-assets>

--- a/examples/mixed-reality/watch/index.html
+++ b/examples/mixed-reality/watch/index.html
@@ -18,7 +18,7 @@
     <a-scene
       button
       obb-collider="showColliders: false"
-      renderer="colorManagement: true; sortTransparentObjects: true"
+      renderer="sortTransparentObjects: true"
       xr-mode-ui="XRMode: xr"
       info-message="htmlSrc: #messageText; startOpened: true">
       <a-assets  timeout="10000">

--- a/examples/primitives/models/index.html
+++ b/examples/primitives/models/index.html
@@ -7,7 +7,7 @@
     <script src="../../../dist/aframe-master.js"></script>
   </head>
   <body>
-    <a-scene renderer="colorManagement: true;">
+    <a-scene>
       <a-assets>
         <a-asset-item id="tree1" src="../../assets/models/tree1.glb"></a-asset-item>
         <a-asset-item id="tree2" src="../../assets/models/tree2.glb"></a-asset-item>

--- a/examples/showcase/anime-UI/index.html
+++ b/examples/showcase/anime-UI/index.html
@@ -8,7 +8,7 @@
     <script src="https://unpkg.com/aframe-event-set-component@5.x.x/dist/aframe-event-set-component.min.js"></script>
   </head>
   <body>
-    <a-scene renderer="colorManagement: true;" xr-mode-ui="XRMode: xr">
+    <a-scene xr-mode-ui="XRMode: xr">
       <a-assets>
         <a-asset-item id="engine" src="models/engine.glb"></a-asset-item>
         <a-mixin id="image" geometry="height: 2; width: 2"></a-mixin>

--- a/examples/showcase/composite/index.html
+++ b/examples/showcase/composite/index.html
@@ -7,7 +7,7 @@
     <script src="../../../dist/aframe-master.js"></script>
   </head>
   <body>
-    <a-scene renderer="colorManagement: true;">
+    <a-scene>
       <a-assets>
         <img id="lake" src="lake.jpg">
         <img id="pdx" src="portland.png">

--- a/examples/showcase/model-viewer/index.html
+++ b/examples/showcase/model-viewer/index.html
@@ -15,7 +15,6 @@
 <body>
 
 <a-scene
-  renderer="colorManagement: true;"
   info-message="htmlSrc: #messageText"
   model-viewer="gltfModel: #triceratops; title: Triceratops"
   xr-mode-ui="XRMode: xr">

--- a/examples/showcase/shopping/index.html
+++ b/examples/showcase/shopping/index.html
@@ -7,7 +7,7 @@
     <script src="../../../dist/aframe-master.js"></script>
   </head>
   <body>
-    <a-scene background="color: #ECECEC" renderer="colorManagement: true;">
+    <a-scene background="color: #ECECEC">
       <a-assets>
         <a-asset-item id="why-male-models" src="man.glb"></a-asset-item>
         <img id="fall" src="fall.png">

--- a/examples/showcase/tracked-controls/index.html
+++ b/examples/showcase/tracked-controls/index.html
@@ -13,7 +13,6 @@
   </head>
   <body>
     <a-scene
-      renderer="colorManagement: true;"
       cursor="rayOrigin: mouse"
       raycaster="objects: [cube]" fog="color: #bc483e; near: 0; far: 65;">
       <a-assets>

--- a/examples/test/model/index.html
+++ b/examples/test/model/index.html
@@ -7,7 +7,7 @@
     <script src="../../../dist/aframe-master.js"></script>
   </head>
   <body>
-    <a-scene gltf-model="basisTranscoderPath:https://cdn.jsdelivr.net/npm/three@0.154.0/examples/jsm/libs/basis/;" background="color: #FAFAFA" renderer="colorManagement: true;" stats>
+    <a-scene gltf-model="basisTranscoderPath:https://cdn.jsdelivr.net/npm/three@0.154.0/examples/jsm/libs/basis/;" background="color: #FAFAFA" stats>
       <a-assets>
         <a-asset-item id="crate-obj" src="../../assets/models/crate/crate.obj"></a-asset-item>
         <a-asset-item id="crate-mtl" src="../../assets/models/crate/crate.mtl"></a-asset-item>


### PR DESCRIPTION
Remove renderer colorManagement: true in examples, that's the default.
This is to avoid unnecessary copy and paste from users looking at the examples code.
