### PR TITLE
Replace Clock instance by Timer instance (three r183+)

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -42,7 +42,7 @@ export class AScene extends AEntity {
     var self;
     super();
     self = this;
-    self.clock = new THREE.Clock();
+    self.timer = new THREE.Timer();
     self.isIOS = isIOS;
     self.isMobile = isMobile;
     self.hasWebXR = isWebXRAvailable;
@@ -688,8 +688,9 @@ export class AScene extends AEntity {
     var renderer = this.renderer;
 
     this.frame = frame;
-    this.delta = this.clock.getDelta() * 1000;
-    this.time = this.clock.elapsedTime * 1000;
+    this.timer.update();
+    this.delta = this.timer.getDelta() * 1000;
+    this.time = this.timer.getElapsed() * 1000;
 
     if (this.isPlaying) { this.tick(this.time, this.delta); }
     var savedBackground = null;

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -42,7 +42,8 @@ export class AScene extends AEntity {
     var self;
     super();
     self = this;
-    self.clock = new THREE.Clock();
+    self.timer = new THREE.Timer();
+    self.timer.connect(document);
     self.isIOS = isIOS;
     self.isMobile = isMobile;
     self.hasWebXR = isWebXRAvailable;
@@ -217,6 +218,7 @@ export class AScene extends AEntity {
     window.removeEventListener('sessionend', this.resize);
     this.removeFullScreenStyles();
     this.renderer.dispose();
+    this.timer.dispose();
   }
 
   /**
@@ -688,8 +690,9 @@ export class AScene extends AEntity {
     var renderer = this.renderer;
 
     this.frame = frame;
-    this.delta = this.clock.getDelta() * 1000;
-    this.time = this.clock.elapsedTime * 1000;
+    this.timer.update();
+    this.delta = this.timer.getDelta() * 1000;
+    this.time = this.timer.getElapsed() * 1000;
 
     if (this.isPlaying) { this.tick(this.time, this.delta); }
     var savedBackground = null;

--- a/src/core/scene/loadingScreen.js
+++ b/src/core/scene/loadingScreen.js
@@ -24,7 +24,7 @@ export function setup (el, getCanvasSize) {
   var sphereMesh2;
   var sphereMesh3;
   var camera;
-  var clock;
+  var timer;
   var time;
   var render;
 
@@ -38,11 +38,12 @@ export function setup (el, getCanvasSize) {
   sphereMesh2 = sphereMesh1.clone();
   sphereMesh3 = sphereMesh1.clone();
   camera = new THREE.PerspectiveCamera(80, window.innerWidth / window.innerHeight, 0.0005, 10000);
-  clock = new THREE.Clock();
+  timer = new THREE.Timer();
   time = 0;
   render = function () {
     sceneEl.renderer.render(loaderScene, camera);
-    time = clock.getElapsedTime() % 4;
+    timer.update();
+    time = timer.getElapsed() % 4;
     sphereMesh1.visible = time >= 1;
     sphereMesh2.visible = time >= 2;
     sphereMesh3.visible = time >= 3;

--- a/tests/core/scene/a-scene.test.js
+++ b/tests/core/scene/a-scene.test.js
@@ -716,20 +716,6 @@ helpers.getSkipCISuite()('a-scene (with renderer)', function () {
     sinon.assert.called(Component.tock);
     sinon.assert.calledWith(Component.tock, scene.time);
   });
-
-  test.skip('clock', function () {
-    var scene = this.el;
-
-    assert.isAbove(scene.time, 0);
-    var prevTime = scene.time;
-    assert.ok(scene.time, scene.clock.elapsedTime);
-    for (var i = 0; i < 10; i++) {
-      scene.render();
-      assert.isAbove(scene.time, prevTime);
-      assert.ok(scene.time, scene.clock.elapsedTime);
-      prevTime = scene.time;
-    }
-  });
 });
 
 suite('scenes', function () {


### PR DESCRIPTION
Replace Clock instance by Timer instance. Clock is deprecated in three r183.
To be merged after the repo is updated to three r183+

I didn't call `self.timer.connect(document);` 
The `connect(document)` call on the timer leverages the Page Visibility API similar to Clock to prevent large time jumps when the browser tab is inactive.
I don't think we want it?

FYI networked-aframe accessed that clock instance so I did some changes in https://github.com/networked-aframe/networked-aframe/pull/521 That's the only occurrence of it I saw in community components.