### PR TITLE
Set raycaster.camera to the active camera in order to raycast against sprites

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -207,6 +207,7 @@
       <li><a href="primitives/torus/">Primitive: Torus</a></li>
       <li><a href="test/raycaster/">Raycaster</a></li>
       <li><a href="test/raycaster/simple.html">Raycaster (Simple)</a></li>
+      <li><a href="test/raycaster/sprite.html">Raycaster (Sprite)</a></li>
       <li><a href="test/shaders/">Shaders</a></li>
       <li><a href="test/shadows/">Shadows</a></li>
       <li><a href="test/text/">Text</a></li>

--- a/examples/test/raycaster/sprite.html
+++ b/examples/test/raycaster/sprite.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Raycaster - Sprites</title>
+    <meta name="description" content="Raycaster Sprites - A-Frame" />
+    <script src="../../../dist/aframe-master.js"></script>
+  </head>
+  <body>
+    <script>
+      AFRAME.registerComponent('sprite', {
+        schema: {
+          color: { type: 'color', default: '#69f' },
+          width: { type: 'number', default: 1 },
+          height: { type: 'number', default: 1 }
+        },
+
+        init: function () {
+          var data = this.data;
+          var material = new THREE.SpriteMaterial({ color: data.color });
+          var sprite = new THREE.Sprite(material);
+          sprite.scale.set(data.width, data.height, 1);
+          this.el.setObject3D('mesh', sprite);
+        },
+
+        update: function () {
+          var data = this.data;
+          var sprite = this.el.getObject3D('mesh');
+          if (!sprite) {
+            return;
+          }
+          sprite.material.color.set(data.color);
+          sprite.scale.set(data.width, data.height, 1);
+        },
+
+        remove: function () {
+          this.el.removeObject3D('mesh');
+        }
+      });
+
+      AFRAME.registerComponent('raycast-highlight', {
+        init: function () {
+          this.el.addEventListener('raycaster-intersected', function (evt) {
+            var el = evt.target;
+            var sprite = el.getObject3D('mesh');
+            if (sprite) {
+              sprite.material.color.set('#f44');
+            }
+          });
+
+          this.el.addEventListener('raycaster-intersected-cleared', function (evt) {
+            var el = evt.target;
+            var sprite = el.getObject3D('mesh');
+            if (sprite) {
+              sprite.material.color.set('#69f');
+            }
+          });
+        }
+      });
+    </script>
+    <p>Look at a sprite, it should turn red. Look away, it turns back to blue.</p>
+
+    <a-scene>
+      <a-entity camera look-controls wasd-controls raycaster="interval: 100; objects: [raycast-highlight]"></a-entity>
+
+      <a-entity sprite="color: #69f; width: 2; height: 2" position="-3 1.6 -5" raycast-highlight></a-entity>
+      <a-entity sprite="color: #69f; width: 1; height: 3" position="0 1.6 -5" raycast-highlight></a-entity>
+      <a-entity sprite="color: #69f; width: 3; height: 1" position="3 1.6 -5" raycast-highlight></a-entity>
+
+      <a-entity sprite="color: #69f; width: 1.5; height: 1.5" position="-2 3 -8" raycast-highlight></a-entity>
+      <a-entity sprite="color: #69f; width: 1.5; height: 1.5" position="2 3 -8" raycast-highlight></a-entity>
+    </a-scene>
+  </body>
+</html>

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -228,7 +228,9 @@ export var Component = registerComponent('raycaster', {
     // Raycast.
     this.updateOriginDirection();
     rawIntersections.length = 0;
+    this.raycaster.camera = this.el.sceneEl.camera;
     this.raycaster.intersectObjects(this.objects, true, rawIntersections);
+    this.raycaster.camera = null;
 
     // Only keep intersections against objects that have a reference to an entity.
     intersections.length = 0;

--- a/tests/components/raycaster.test.js
+++ b/tests/components/raycaster.test.js
@@ -394,6 +394,47 @@ suite('raycaster', function () {
     });
   });
 
+  suite('sprite raycasting', function () {
+    var spriteEl;
+
+    setup(function (done) {
+      spriteEl = document.createElement('a-entity');
+      el.setAttribute('position', '0 0 1');
+      el.setAttribute('raycaster', {near: 0.1, far: 10});
+
+      spriteEl.addEventListener('loaded', function () {
+        var material = new THREE.SpriteMaterial({color: 0x6699ff});
+        var sprite = new THREE.Sprite(material);
+        spriteEl.setObject3D('mesh', sprite);
+        spriteEl.object3D.position.set(0, 0, -1);
+        setTimeout(() => { done(); });
+      });
+      sceneEl.appendChild(spriteEl);
+    });
+
+    test('can intersect sprites', function (done) {
+      spriteEl.addEventListener('raycaster-intersected', function () {
+        done();
+      });
+      sceneEl.object3D.updateMatrixWorld();
+      component.refreshObjects();
+      component.tock();
+    });
+
+    test('emits intersection-cleared when looking away from sprite', function (done) {
+      spriteEl.addEventListener('raycaster-intersected', function () {
+        el.setAttribute('rotation', '90 0 0');
+        spriteEl.addEventListener('raycaster-intersected-cleared', function () {
+          done();
+        }, {once: true});
+        component.tock();
+      }, {once: true});
+      sceneEl.object3D.updateMatrixWorld();
+      component.refreshObjects();
+      component.tock();
+    });
+  });
+
   suite('updateOriginDirection', function () {
     test('updates ray origin if position changes', function () {
       var origin;


### PR DESCRIPTION
**Description:**

Set raycaster.camera to the active camera in order to raycast against sprites.

**Changes proposed:**
- Set `raycaster.camera` before calling `raycaster.intersectObjects`, set it back to null afterwards to be sure to not keep eventually a removed camera on it

I need that for the inspector to not give an error when hovering over some flame I got from the [webgpu_tsl_vfx_flames](https://github.com/mrdoob/three.js/blob/dev/examples/webgpu_tsl_vfx_flames.html) example
<img width="445" height="515" alt="Capture d’écran du 2026-03-30 19-15-34" src="https://github.com/user-attachments/assets/5fd79503-14f5-470b-9d0c-cf44bf4580da" />
otherwise you get the error `Sprite: "Raycaster.camera" needs to be set in order to raycast against sprites.` from https://github.com/mrdoob/three.js/blob/87c407b70235a6cdf64f96fa3f74d6fb9b0ccbbc/src/objects/Sprite.js#L133