### PR TITLE
Rename tracked-controls-webxr to tracked-controls in docs and examples

### DIFF
--- a/docs/components/tracked-controls.md
+++ b/docs/components/tracked-controls.md
@@ -21,11 +21,6 @@ This component elects the appropriate controller, applies pose to
 the entity, observes buttons state and emits appropriate events.  For non-6DOF controllers,
 a primitive arm model is used to emulate positional data.
 
-tracked-controls sets two components that handles different Web API versions for VR:
-
-- tracked-controls-webvr
-- tracked-controls-webxr
-
 ## Example
 
 Note that due to recent browser-specific changes, Vive controllers may be returned

--- a/docs/components/webxr.md
+++ b/docs/components/webxr.md
@@ -60,7 +60,7 @@ important that the viewer (camera) and controllers are consistent.
 For consistency when used in components, this name is available as
 `sceneEl.systems.webxr.sessionReferenceSpaceType`, and the corresponding
 reference space object is available during the XR session as
-`sceneEl.systems['tracked-controls-webxr'].referenceSpace`.
+`sceneEl.systems['tracked-controls'].referenceSpace`.
 
 ### requiredFeatures
 

--- a/examples/showcase/layer-cubemap/cubemap-switcher.js
+++ b/examples/showcase/layer-cubemap/cubemap-switcher.js
@@ -159,8 +159,8 @@ AFRAME.registerComponent('cubemap-switcher', {
   },
 
   checkInput: function () {
-    var leftHandControls = this.leftHandEl.components['tracked-controls-webxr'];
-    var rightHandControls = this.rightHandEl.components['tracked-controls-webxr'];
+    var leftHandControls = this.leftHandEl.components['tracked-controls'];
+    var rightHandControls = this.rightHandEl.components['tracked-controls'];
     if (leftHandControls) { leftHandControls.updateButtons(); }
     if (rightHandControls) { rightHandControls.updateButtons(); }
   },

--- a/examples/showcase/tracked-controls/components/ar-controls.js
+++ b/examples/showcase/tracked-controls/components/ar-controls.js
@@ -11,7 +11,7 @@ AFRAME.registerComponent('ar-controls', {
   },
 
   updateControllers: function () {
-    var controllers = this.el.systems['tracked-controls-webxr'].controllers;
+    var controllers = this.el.systems['tracked-controls'].controllers;
     var i;
     var xrSession = this.el.xrSession;
     if (!xrSession) { return; }

--- a/examples/showcase/tracked-controls/components/grab.js
+++ b/examples/showcase/tracked-controls/components/grab.js
@@ -6,7 +6,7 @@
 * Updates its position to move along the controller.
 */
 AFRAME.registerComponent('grab', {
-  after: ['tracked-controls-webxr'],
+  after: ['tracked-controls'],
   before: ['aabb-collider'],
   init: function () {
     this.GRABBED_STATE = 'grabbed';


### PR DESCRIPTION
Rename tracked-controls-webxr to tracked-controls in docs and example scripts that were missed in 1.7.0 release