### PR TITLE
Fix a-assets image onload crash from loop-variable closure

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -57,18 +57,21 @@ class AAssets extends ANode {
     for (i = 0; i < imgEls.length; i++) {
       imgEl = fixUpMediaElement(imgEls[i]);
       loaded.push(new Promise(function (resolve, reject) {
+        // Bind the current img to a local so onload below does not close
+        // over the shared outer loop variable.
+        var el = imgEl;
         // Set in cache because we won't be needing to call three.js loader if we have.
         // a loaded media element.
-        if (imgEl.complete) {
-          THREE.Cache.add('image:' + imgEls[i].getAttribute('src'), imgEl);
+        if (el.complete) {
+          THREE.Cache.add('image:' + el.getAttribute('src'), el);
           resolve();
           return;
         }
-        imgEl.onload = function () {
-          THREE.Cache.add('image:' + imgEls[i].getAttribute('src'), imgEl);
+        el.onload = function () {
+          THREE.Cache.add('image:' + el.getAttribute('src'), el);
           resolve();
         };
-        imgEl.onerror = reject;
+        el.onerror = reject;
       }));
     }
 

--- a/tests/core/a-assets.test.js
+++ b/tests/core/a-assets.test.js
@@ -88,6 +88,34 @@ suite('a-assets', function () {
     document.body.appendChild(sceneEl);
   });
 
+  test('caches image loaded asynchronously alongside media element', function (done) {
+    var assetsEl = this.el;
+    var sceneEl = this.scene;
+
+    // Use a cache-busted src so the browser has to actually fetch, making
+    // imgEl.complete false when the Promise executor runs and forcing the
+    // onload path to be exercised.
+    var src = IMG_SRC + '?async-load-test';
+    THREE.Cache.remove('image:' + src);
+
+    var img = document.createElement('img');
+    img.setAttribute('src', src);
+    assetsEl.appendChild(img);
+
+    // A sibling media element ensures the image onload callback is
+    // verified alongside a non-trivial asset list.
+    var audio = document.createElement('audio');
+    audio.setAttribute('src', '');
+    assetsEl.appendChild(audio);
+
+    sceneEl.addEventListener('loaded', function () {
+      assert.equal(THREE.Cache.get('image:' + src), img);
+      done();
+    });
+
+    document.body.appendChild(sceneEl);
+  });
+
   test('does not wait for media element without preload attribute', function (done) {
     var el = this.el;
     var scene = this.scene;


### PR DESCRIPTION
## Summary

- Fixes `TypeError: Cannot read properties of undefined (reading 'getAttribute')` at `a-assets.js:68` when an `<img>` in `<a-assets>` finishes loading asynchronously.
- Regression introduced in 835aac4 (#5778), which moved `THREE.Cache.add` into the `imgEl.onload` handler. Before that commit the cache call ran synchronously inside the Promise executor, so the current-iteration `imgEl` / `imgEls[i]` were still in scope and there was no crash — but the cache was populated before the image actually finished loading, which is what #5778 correctly set out to fix.
- Once the call was moved into `onload`, the callback closed over the shared outer `var i` / `var imgEl`. Because `var` is function-scoped, by the time the handler fired `i` had already advanced past the end of the images loop (typically to `mediaEls.length`), so `imgEls[i]` was `undefined` and `.getAttribute('src')` threw.
- Note: using `imgEls[i]` would also be semantically off when `fixUpMediaElement` clones the element, since `imgEls[i]` is then the pre-clone element that has been detached from the DOM. That part alone wouldn't crash — detached elements still respond to `getAttribute` — and the src string happens to match the clone's, so the cache key would still be correct. The actual crash is purely the closure/indexing bug above.
- Fix: bind the current `imgEl` to a local `var el` inside the Promise executor and use it in both the `.complete` and `onload` branches.

## Test plan

- [x] Added `caches image loaded asynchronously alongside media element` in `tests/core/a-assets.test.js`. It uses a cache-busted src (so `imgEl.complete` is false and the onload path is taken) plus a sibling `<audio>` element, which reliably reproduces the crash before the fix.
- [x] Verified the new test fails on master with the exact `TypeError` from the bug report, and passes with the fix applied.
- [x] Full `a-assets` test suite passes (29 tests).