### PR TITLE
Expose premultipliedAlpha on material component

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -64,6 +64,7 @@ depending on the material type applied.
 | flatShading  | Use `THREE.FlatShading` rather than `THREE.StandardShading`.                                                                                      | false         |
 | offset       | Texture offset to be used.                                                                                                                        | {x: 0, y: 0}  |
 | opacity      | Extent of transparency. If the `transparent` property is not `true`, then the material will remain opaque and `opacity` will only affect color.   | 1.0           |
+| premultipliedAlpha | Whether the material's RGB channels are premultiplied by its alpha channel. Automatically forced to `true` when `blending` is `multiply`.   | false         |
 | repeat       | Texture repeat to be used.                                                                                                                        | {x: 1, y: 1}  |
 | magFilter    | Which magnifying filter to use when sampling textures. Can be one of `linear` or `nearest`.                                                       | `linear`      |
 | minFilter    | Which minifying filter to use when sampling textures. Can be one of `linear`, `linear-mipmap-nearest`, `linear-mipmap-linear`, `nearest`, `nearest-mipmap-nearest` or `nearest-mipmap-linear`. | `linear-mipmap-linear` |

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -20,6 +20,7 @@ export var Component = registerComponent('material', {
     flatShading: {default: false},
     offset: {type: 'vec2', default: {x: 0, y: 0}},
     opacity: {default: 1.0, min: 0.0, max: 1.0},
+    premultipliedAlpha: {default: false},
     repeat: {type: 'vec2', default: {x: 1, y: 1}},
     magFilter: {default: 'linear', oneOf: ['nearest', 'linear']},
     minFilter: {
@@ -139,6 +140,9 @@ export var Component = registerComponent('material', {
     material.vertexColors = data.vertexColorsEnabled;
     material.visible = data.visible;
     material.blending = parseBlending(data.blending);
+    // three.js r178+ requires premultipliedAlpha for MultiplyBlending,
+    // so force it on regardless of the user-supplied value.
+    material.premultipliedAlpha = data.blending === 'multiply' ? true : data.premultipliedAlpha;
     material.dithering = data.dithering;
 
     // Check if material needs update.

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -394,6 +394,26 @@ suite('material', function () {
       el.setAttribute('material', 'blending', 'multiply');
       assert.equal(el.components.material.material.blending, THREE.MultiplyBlending);
     });
+
+    test('forces premultipliedAlpha when blending is multiply', function () {
+      el.setAttribute('material', 'blending: multiply; transparent: true');
+      assert.strictEqual(el.components.material.material.premultipliedAlpha, true);
+    });
+
+    test('forces premultipliedAlpha even if user sets it to false with multiply', function () {
+      el.setAttribute('material', 'blending: multiply; transparent: true; premultipliedAlpha: false');
+      assert.strictEqual(el.components.material.material.premultipliedAlpha, true);
+    });
+
+    test('premultipliedAlpha defaults to false for other blending modes', function () {
+      el.setAttribute('material', 'blending: additive; transparent: true');
+      assert.strictEqual(el.components.material.material.premultipliedAlpha, false);
+    });
+
+    test('respects user-supplied premultipliedAlpha for non-multiply blending', function () {
+      el.setAttribute('material', 'blending: additive; transparent: true; premultipliedAlpha: true');
+      assert.strictEqual(el.components.material.material.premultipliedAlpha, true);
+    });
   });
 
   suite('anisotropy', function () {


### PR DESCRIPTION
## Summary

Since three.js r178 ([mrdoob/three.js#31246](https://github.com/mrdoob/three.js/pull/31246)), `THREE.MultiplyBlending` emits a repeated console warning unless the material has `premultipliedAlpha = true`:

```
THREE.WebGLState: MultiplyBlending requires material.premultipliedAlpha = true
```

A-Frame's `material` component exposes `blending: multiply` but does not expose `premultipliedAlpha`, so users had no way to silence the warning from markup alone.

This PR:

- Adds `premultipliedAlpha` to the `material` schema (default `false`), giving users direct control from markup.
- Forces `premultipliedAlpha = true` whenever `blending` is `multiply`, regardless of the user-supplied value, so the three.js warning cannot accidentally be triggered through the component's public API.

## Changes

- `src/components/material.js` — add `premultipliedAlpha` schema property; force it on for `blending: multiply`, otherwise pass through the user value.
- `docs/components/material.md` — document the new property.
- `tests/components/material.test.js` — four tests in the `blending` suite covering:
  - forced on when blending is multiply
  - forced on even when user sets it to false with multiply
  - defaults to false for non-multiply blending
  - respects user value for non-multiply blending

## Test plan

- [x] `npm test` — all tests pass.
- [x] Manually verified the warning no longer appears on an entity using `material="blending: multiply; transparent: true"`.