### PR TITLE
Add trigger-deploy workflow for docs changes

### DIFF
--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'docs/**'
 
+permissions: {}
+
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -2,7 +2,9 @@ name: Trigger site deploy
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - 'docs-v*'
     paths:
       - 'docs/**'
 

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -1,0 +1,18 @@
+name: Trigger site deploy
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger aframevr.github.io deploy
+        run: |
+          gh api repos/aframevr/aframevr.github.io/dispatches \
+            -f event_type=deploy
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_PAT }}


### PR DESCRIPTION
Add `.github/workflows/trigger-deploy.yml` that sends a `repository_dispatch` event
to `aframevr/aframevr.github.io` when `docs/**` files are pushed to master.

This is part of the full site build pipeline migration to GitHub Actions.
See the companion PR https://github.com/aframevr/aframevr.github.io/pull/11 for the full context.