### PR TITLE
Add bump-dist CI workflow to replace a-frobot AWS instance

### DIFF
--- a/.github/workflows/bump-dist.yml
+++ b/.github/workflows/bump-dist.yml
@@ -1,0 +1,91 @@
+name: Bump dist builds
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'vendor/**'
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: write
+
+jobs:
+  bump-dist:
+    name: Bump aframe-master dist builds
+    runs-on: ubuntu-latest
+    # Skip if the push was made by this workflow (avoid infinite loop).
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need history to find the previous dist bump commit.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dist
+        run: npm run dist
+
+      - name: Check for dist changes
+        id: check
+        run: |
+          if git diff --quiet dist/ src/index.js; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find previous dist bump commit
+        if: steps.check.outputs.changed == 'true'
+        id: prev
+        run: |
+          # Find the commit hash referenced in the previous "Bump aframe-master dist/ builds" commit.
+          PREV_BUMP=$(git log --all --format="%H" --author="a-frobot\|github-actions\[bot\]" --grep="Bump aframe-master dist/ builds" -1 2>/dev/null || true)
+          if [ -n "$PREV_BUMP" ]; then
+            # The compare range starts from the parent of the previous bump.
+            PREV_PARENT=$(git rev-parse "${PREV_BUMP}^" 2>/dev/null || true)
+            if [ -n "$PREV_PARENT" ]; then
+              echo "hash=${PREV_PARENT:0:12}" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          # Current HEAD short hash (the triggering commit).
+          echo "current=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit dist builds
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          PREV="${{ steps.prev.outputs.hash }}"
+          CURRENT="${{ steps.prev.outputs.current }}"
+
+          if [ -n "$PREV" ]; then
+            COMPARE="(https://github.com/${{ github.repository }}/compare/${PREV}...${CURRENT})"
+          else
+            COMPARE=""
+          fi
+
+          git add dist/ src/index.js
+          git commit -m "Bump aframe-master dist/ builds. ${COMPARE}"
+
+          # Now update the CDN URL in dist/README.md.
+          DIST_HASH=$(git rev-parse HEAD)
+          CDN_URL="https://cdn.jsdelivr.net/gh/${{ github.repository }}@${DIST_HASH}/dist/aframe-master.min.js"
+          sed -i "s|https://cdn.jsdelivr.net/gh/aframevr/aframe@[^/]*/dist/aframe-master.min.js|${CDN_URL}|g" dist/README.md
+
+          git add dist/README.md
+          git commit -m "Update master CDN URL. (${CDN_URL})"
+
+          git push


### PR DESCRIPTION
## Summary

Migrate the automated `dist/` build process from the a-frobot AWS instance to a GitHub Actions workflow (`.github/workflows/bump-dist.yml`).

Previously, an AWS instance running [a-frobot](https://github.com/supermedium/a-frobot/blob/master/lib/bumpAframeDist.js) would listen for pushes to master, rebuild the dist files, and commit them back. This PR replaces that with a native GitHub CI workflow.

### What the workflow does

On every push to `master` that touches `src/`, `vendor/`, `package.json`, or `package-lock.json`:

1. Checks out the repo with full history
2. Installs dependencies with `npm ci` (strict lockfile install, reproducible builds)
3. Runs `npm run dist` to build `aframe-master.js`, `aframe-master.min.js`, and `aframe-master.module.min.js` with source maps
4. If dist files changed, commits them as **"Bump aframe-master dist/ builds."** with a GitHub compare link showing what source changes are included
5. Updates the CDN URL in `dist/README.md` to point to the new commit hash
6. Commits as **"Update master CDN URL."** with the jsdelivr CDN link
7. Pushes both commits to master

The commit messages and format are identical to what a-frobot produced.

### Changes compared to the a-frobot setup

- **`package-lock.json` changes now trigger a rebuild** - dependency updates that could affect the build output are no longer missed.
- **`npm ci` instead of `npm install`** - ensures reproducible builds from the lockfile rather than potentially resolving new versions.
- **Infinite loop prevention** - the workflow skips runs where `github.actor` is `github-actions[bot]`, so the bot's own dist commits don't re-trigger a build.
- **No external infrastructure** - no AWS instance or GitHub webhook to maintain.

### Configuration required (for repo owner)

1. **Actions workflow permissions**: Go to **Settings > Actions > General > Workflow permissions** and select **"Read and write permissions"**. The workflow needs `contents: write` to push commits back to master.

2. **Branch protection rules** (if any): If master has branch protection enabled, the default `GITHUB_TOKEN` cannot bypass it. You would need to:
   - Create a fine-grained PAT scoped to `aframevr/aframe` with **Contents: Read and write** permission
   - Add it as a repository secret (e.g. `BUMP_DIST_PAT`)
   - Update the checkout step in the workflow to use `token: ${{ secrets.BUMP_DIST_PAT }}`
   
   Note: the existing `DEPLOY_PAT` secret is scoped to `aframevr/aframevr.github.io` for triggering site deploys, so it cannot be reused here.

3. **Retire a-frobot**: Once the workflow is verified working, disable the a-frobot webhook/AWS instance for the dist bump task.