### PR TITLE
Set explicit text color on dialog and buttons to prevent white-on-white with color-scheme dark

### DIFF
--- a/src/style/aframe.css
+++ b/src/style/aframe.css
@@ -323,6 +323,7 @@ a-scene audio {
   height: 200px;
   background-size: contain;
   background-color: white;
+  color: black;
   font-family: sans-serif, monospace;
   font-size: 20px;
   border-radius: 3px;
@@ -354,6 +355,7 @@ a-scene audio {
 }
 
 .a-dialog-button {
+  color: black;
   cursor: pointer;
   align-self: center;
   opacity: 0.9;


### PR DESCRIPTION
**Description:**

With color-scheme normal or light, you get
<img width="480" height="270" alt="Capture d’écran du 2026-04-16 14-02-10" src="https://github.com/user-attachments/assets/5648d6cf-f751-4f16-9273-d5fa9df37fcc" />
but the black text is from the browser default style.
When you switch to color-scheme: dark for example with
```html
<style>
:root {
  color-scheme: dark;
}
</style>
```

you get white on white
<img width="480" height="270" alt="Capture d’écran du 2026-04-16 14-02-37" src="https://github.com/user-attachments/assets/1959f9b6-4ecb-4b92-acb3-f0322bde8ab2" />

and with inspector open you get
<img width="480" height="270" alt="Capture d’écran du 2026-04-16 14-02-43" src="https://github.com/user-attachments/assets/2431f5eb-a650-4fa0-ae91-968ae6d8a7e0" />
because color come from the body.aframe-inspector-opened rule.

**Changes proposed:**
- Define text color explicitly for a-dialog and a-button so we have the first image with color-scheme dark.
