### PR TITLE
Update link to meshopt_decoder.cjs to 1.1.1

### DIFF
--- a/docs/components/gltf-model.md
+++ b/docs/components/gltf-model.md
@@ -179,7 +179,7 @@ These files are available from the three.js repository in [`/examples/jsm/libs/b
 You can use a CDN like this: `basisTranscoderPath:https://cdn.jsdelivr.net/npm/three@0.154.0/examples/jsm/libs/basis/;`
 
 
-`meshoptDecoderPath` path should be the complete file path (including filename) for a Meshopt decoder, typically named `meshopt_decoder.cjs`. Meshopt requires WebAssembly support. A CDN-hosted, versioned decoder is available at `https://unpkg.com/meshoptimizer@1.0.1/meshopt_decoder.cjs` (check the latest version number on [npm](https://www.npmjs.com/package/meshoptimizer)), or you may download copies from the [meshoptimizer GitHub repository][meshopt-decoder].
+`meshoptDecoderPath` path should be the complete file path (including filename) for a Meshopt decoder, typically named `meshopt_decoder.cjs`. Meshopt requires WebAssembly support. A CDN-hosted, versioned decoder is available at `https://unpkg.com/meshoptimizer@1.1.1/meshopt_decoder.cjs` (check the latest version number on [npm](https://www.npmjs.com/package/meshoptimizer)), or you may download copies from the [meshoptimizer GitHub repository][meshopt-decoder].
 
 ## More Resources
 


### PR DESCRIPTION
**Description:**
For info, see https://github.com/mrdoob/three.js/pull/33393

**Changes proposed:**
- Update link to meshopt_decoder.cjs to 1.1.1 in documentation