### PR TITLE
Fix cdn build to use super-three 0.184.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "load-bmfont": "^1.2.3",
         "stats-gl": "^3.6.0",
         "super-animejs": "^3.1.0",
-        "three": "npm:super-three@0.181.0",
+        "three": "npm:super-three@0.184.0",
         "three-bmfont-text": "dmarcos/three-bmfont-text#c3eec235b9188aa0d8ed949101236e6d5fccf071"
       },
       "devDependencies": {
@@ -13429,9 +13429,9 @@
     },
     "node_modules/three": {
       "name": "super-three",
-      "version": "0.181.0",
-      "resolved": "https://registry.npmjs.org/super-three/-/super-three-0.181.0.tgz",
-      "integrity": "sha512-ffemt+MKDPVVkQwG1nzW/5SXHROVqcXCCj/sR6V8nlt7X9qy8vEngoVyeHmsuXjwuSWBBihlVIm+8QUZ1MJDfg==",
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/super-three/-/super-three-0.184.0.tgz",
+      "integrity": "sha512-9NSv1Ow/k/hevFC/VLeFoejnZSw72iz4e8Nt5LuDiSrkVinh7+r7lfb7Fxsl3aE+2yBP0tPRk1zLqX/aq6EYnQ==",
       "license": "MIT"
     },
     "node_modules/three-bmfont-text": {


### PR DESCRIPTION
The a-frobot built the cdn build still with 0.181.0, we also got the error downloading super-three 0.184.0 in the tests https://github.com/aframevr/aframe/commit/ec6f6a8dd956a23dd930c073aab4617bebf4f3cb#commitcomment-188253469
Also the package-lock.json wasn't pushed with the correct super-three version so here it is, it should triggers a correct new build.

Separate note, we should switch to Github CI for the build #5813