### PR TITLE
Force premultipliedAlpha for subtractive blending too

### DIFF
--- a/docs/components/material.md
+++ b/docs/components/material.md
@@ -64,7 +64,7 @@ depending on the material type applied.
 | flatShading  | Use `THREE.FlatShading` rather than `THREE.StandardShading`.                                                                                      | false         |
 | offset       | Texture offset to be used.                                                                                                                        | {x: 0, y: 0}  |
 | opacity      | Extent of transparency. If the `transparent` property is not `true`, then the material will remain opaque and `opacity` will only affect color.   | 1.0           |
-| premultipliedAlpha | Whether the material's RGB channels are premultiplied by its alpha channel. Automatically forced to `true` when `blending` is `multiply`.   | false         |
+| premultipliedAlpha | Whether the material's RGB channels are premultiplied by its alpha channel. Automatically forced to `true` when `blending` is `multiply` or `subtractive`.   | false         |
 | repeat       | Texture repeat to be used.                                                                                                                        | {x: 1, y: 1}  |
 | magFilter    | Which magnifying filter to use when sampling textures. Can be one of `linear` or `nearest`.                                                       | `linear`      |
 | minFilter    | Which minifying filter to use when sampling textures. Can be one of `linear`, `linear-mipmap-nearest`, `linear-mipmap-linear`, `nearest`, `nearest-mipmap-nearest` or `nearest-mipmap-linear`. | `linear-mipmap-linear` |

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -140,9 +140,11 @@ export var Component = registerComponent('material', {
     material.vertexColors = data.vertexColorsEnabled;
     material.visible = data.visible;
     material.blending = parseBlending(data.blending);
-    // three.js r178+ requires premultipliedAlpha for MultiplyBlending,
-    // so force it on regardless of the user-supplied value.
-    material.premultipliedAlpha = data.blending === 'multiply' ? true : data.premultipliedAlpha;
+    // three.js r178+ requires premultipliedAlpha for MultiplyBlending and
+    // SubtractiveBlending, so force it on regardless of the user-supplied value.
+    material.premultipliedAlpha = (data.blending === 'multiply' || data.blending === 'subtractive')
+      ? true
+      : data.premultipliedAlpha;
     material.dithering = data.dithering;
 
     // Check if material needs update.

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -405,6 +405,16 @@ suite('material', function () {
       assert.strictEqual(el.components.material.material.premultipliedAlpha, true);
     });
 
+    test('forces premultipliedAlpha when blending is subtractive', function () {
+      el.setAttribute('material', 'blending: subtractive; transparent: true');
+      assert.strictEqual(el.components.material.material.premultipliedAlpha, true);
+    });
+
+    test('forces premultipliedAlpha even if user sets it to false with subtractive', function () {
+      el.setAttribute('material', 'blending: subtractive; transparent: true; premultipliedAlpha: false');
+      assert.strictEqual(el.components.material.material.premultipliedAlpha, true);
+    });
+
     test('premultipliedAlpha defaults to false for other blending modes', function () {
       el.setAttribute('material', 'blending: additive; transparent: true');
       assert.strictEqual(el.components.material.material.premultipliedAlpha, false);


### PR DESCRIPTION
three.js's WebGLState requires material.premultipliedAlpha = true for both SubtractiveBlending and MultiplyBlending. The previous fix (#5810) only handled multiply, so subtractive blending (e.g. in the showcase/ui example) still emitted "THREE.WebGLState: SubtractiveBlending requires material.premultipliedAlpha = true". Extend the force to subtractive.

I got the infinite error log on the https://localhost:8080/showcase/ui/ example. (`npm run start:https` in the repo)