### PR TITLE
Add stopOn and pauseOn event properties to sound component

### DIFF
--- a/docs/components/sound.md
+++ b/docs/components/sound.md
@@ -35,6 +35,8 @@ component is positional and is thus affected by the
 | loop          | Whether to loop the sound once the sound finishes playing.                                                     | false         |
 | maxDistance   | Maximum distance between the audio source and the listener, after which the volume is not reduced any further. | 10000         |
 | on            | An event for the entity to listen to before playing sound.                                                     | null          |
+| stopOn        | An event for the entity to listen to before stopping sound.                                                    | null          |
+| pauseOn       | An event for the entity to listen to before pausing sound.                                                     | null          |
 | poolSize      | Numbers of simultaneous instances of this sound that can be playing at the same time                           | 1             |
 | positional    | Whether or not the audio is positional (movable).                                                               | true          |
 | refDistance   | Reference distance for reducing volume as the audio source moves further from the listener.                    | 1             |
@@ -68,6 +70,24 @@ example, we might have a laughing sound play every time we click a monster:
 
 <a-entity id="elmo" geometry="primitive: box" material="src: elmo.png"
           sound="src: url(ticklelaugh.mp3); on: click"></a-entity>
+```
+
+## Stopping on an Event
+
+The `sound` component can also listen to an event before stopping the sound,
+using the `stopOn` property. For example, we might play music when the user
+enters a zone and stop it when they leave:
+
+```html
+<a-entity sound="src: url(music.mp3); on: zone-enter; stopOn: zone-leave"></a-entity>
+```
+
+Similarly, the `pauseOn` property pauses the sound on an event. Unlike `stopOn`,
+a sound paused this way resumes from where it left off the next time it is
+played:
+
+```html
+<a-entity sound="src: url(music.mp3); on: zone-enter; pauseOn: menu-open"></a-entity>
 ```
 
 ## Preloading a Sound Asset

--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -16,6 +16,8 @@ export var Component = registerComponent('sound', {
     loopEnd: {default: 0},
     maxDistance: {default: 10000},
     on: {default: ''},
+    stopOn: {default: ''},
+    pauseOn: {default: ''},
     poolSize: {default: 1},
     positional: {default: true},
     refDistance: {default: 1},
@@ -37,6 +39,8 @@ export var Component = registerComponent('sound', {
 
     // Don't pass evt because playSound takes a function as parameter.
     this.playSoundBound = function () { self.playSound(); };
+    this.stopSoundBound = function () { self.stopSound(); };
+    this.pauseSoundBound = function () { self.pauseSound(); };
   },
 
   update: function (oldData) {
@@ -73,8 +77,8 @@ export var Component = registerComponent('sound', {
       sound.isPaused = false;
     }
 
-    if (data.on !== oldData.on) {
-      this.updateEventListener(oldData.on);
+    if (data.on !== oldData.on || data.stopOn !== oldData.stopOn || data.pauseOn !== oldData.pauseOn) {
+      this.updateEventListener(oldData);
     }
 
     // All sound values set. Load in `src`.
@@ -131,14 +135,23 @@ export var Component = registerComponent('sound', {
   /**
   *  Update listener attached to the user defined on event.
   */
-  updateEventListener: function (oldEvt) {
+  updateEventListener: function (oldData) {
     var el = this.el;
-    if (oldEvt) { el.removeEventListener(oldEvt, this.playSoundBound); }
-    el.addEventListener(this.data.on, this.playSoundBound);
+    var oldOnEvt = oldData && oldData.on;
+    var oldStopOnEvt = oldData && oldData.stopOn;
+    var oldPauseOnEvt = oldData && oldData.pauseOn;
+    if (oldOnEvt) { el.removeEventListener(oldOnEvt, this.playSoundBound); }
+    if (oldStopOnEvt) { el.removeEventListener(oldStopOnEvt, this.stopSoundBound); }
+    if (oldPauseOnEvt) { el.removeEventListener(oldPauseOnEvt, this.pauseSoundBound); }
+    if (this.data.on) { el.addEventListener(this.data.on, this.playSoundBound); }
+    if (this.data.stopOn) { el.addEventListener(this.data.stopOn, this.stopSoundBound); }
+    if (this.data.pauseOn) { el.addEventListener(this.data.pauseOn, this.pauseSoundBound); }
   },
 
   removeEventListener: function () {
-    this.el.removeEventListener(this.data.on, this.playSoundBound);
+    if (this.data.on) { this.el.removeEventListener(this.data.on, this.playSoundBound); }
+    if (this.data.stopOn) { this.el.removeEventListener(this.data.stopOn, this.stopSoundBound); }
+    if (this.data.pauseOn) { this.el.removeEventListener(this.data.pauseOn, this.pauseSoundBound); }
   },
 
   /**

--- a/tests/components/sound.test.js
+++ b/tests/components/sound.test.js
@@ -204,7 +204,9 @@ suite('sound', function () {
       el.setAttribute('sound', 'src', 'url(base/tests/assets/test.ogg)');
       el.components.sound.isPlaying = true;
     });
+  });
 
+  suite('on', function () {
     test('plays sound on event', function (done) {
       const el = this.el;
       el.setAttribute('sound', 'on', 'foo');
@@ -214,6 +216,81 @@ suite('sound', function () {
         assert.ok(playSoundStub.called);
         done();
       });
+    });
+
+    test('does not listen to old on event after change', function (done) {
+      const el = this.el;
+      el.setAttribute('sound', 'on', 'foo');
+      el.setAttribute('sound', 'on', 'bar');
+      const playSoundStub = el.components.sound.playSound = sinon.stub();
+      el.emit('foo');
+      el.emit('bar');
+      setTimeout(() => {
+        assert.ok(playSoundStub.calledOnce);
+        done();
+      });
+    });
+  });
+
+  suite('stopOn', function () {
+    test('stops sound on event', function (done) {
+      const el = this.el;
+      el.setAttribute('sound', 'stopOn', 'zone-leave');
+      const stopSoundStub = el.components.sound.stopSound = sinon.stub();
+      el.emit('zone-leave');
+      setTimeout(() => {
+        assert.ok(stopSoundStub.called);
+        done();
+      });
+    });
+
+    test('does not listen to old stopOn event after change', function (done) {
+      const el = this.el;
+      el.setAttribute('sound', 'stopOn', 'zone-leave');
+      el.setAttribute('sound', 'stopOn', 'experience-end');
+      const stopSoundStub = el.components.sound.stopSound = sinon.stub();
+      el.emit('zone-leave');
+      el.emit('experience-end');
+      setTimeout(() => {
+        assert.ok(stopSoundStub.calledOnce);
+        done();
+      });
+    });
+  });
+
+  suite('pauseOn', function () {
+    test('pauses sound on event', function (done) {
+      const el = this.el;
+      el.setAttribute('sound', 'pauseOn', 'menu-open');
+      const pauseSoundStub = el.components.sound.pauseSound = sinon.stub();
+      el.emit('menu-open');
+      setTimeout(() => {
+        assert.ok(pauseSoundStub.called);
+        done();
+      });
+    });
+
+    test('does not listen to old pauseOn event after change', function (done) {
+      const el = this.el;
+      el.setAttribute('sound', 'pauseOn', 'menu-open');
+      el.setAttribute('sound', 'pauseOn', 'app-blur');
+      const pauseSoundStub = el.components.sound.pauseSound = sinon.stub();
+      el.emit('menu-open');
+      el.emit('app-blur');
+      setTimeout(() => {
+        assert.ok(pauseSoundStub.calledOnce);
+        done();
+      });
+    });
+  });
+
+  suite('updateEventListener', function () {
+    test('does not register a listener for empty event names', function () {
+      var el = this.el;
+      // on, stopOn and pauseOn all default to empty string.
+      var addEventListenerSpy = sinon.spy(el, 'addEventListener');
+      el.components.sound.updateEventListener();
+      assert.notOk(addEventListenerSpy.calledWith(''));
     });
   });
 


### PR DESCRIPTION
Add `stopOn` and `pauseOn` properties to the sound component to stop or pause the sound on a user-defined event, mirroring the existing `on` property. Listeners are now only registered when the event name is non-empty, fixing the previous behavior where an empty-string listener was registered for `on`.