### PR TITLE
Fix a-sky losing material.side 'back' because of previous object recycling

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -830,7 +830,16 @@ function mergeComponentData (attrValue, extraData) {
 
   // Merge multi-property data.
   if (extraData.constructor === Object) {
-    return utils.extend(extraData, utils.styleParser.parse(attrValue || {}));
+    var parsedAttrValue = utils.styleParser.parse(attrValue || {});
+    // Only merge in defined properties. `attrValue` may be a component's pooled `attrValue`
+    // object that still carries stale keys from a previous use (recycled objects keep their
+    // keys with `undefined` values), and those must not clobber the extra/default data
+    // (e.g. an a-sky primitive's `material.side: back`).
+    for (var key in parsedAttrValue) {
+      if (parsedAttrValue[key] === undefined) { continue; }
+      extraData[key] = parsedAttrValue[key];
+    }
+    return extraData;
   }
 
   // Return data, precedence to the defined value.

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -672,8 +672,8 @@ export function registerComponent (name, definition) {
   NewComponent.prototype.play = wrapPlay(NewComponent.prototype.play);
   NewComponent.prototype.pause = wrapPause(NewComponent.prototype.pause);
 
-  schema = utils.extend(processSchema(NewComponent.prototype.schema,
-                                      NewComponent.prototype.name));
+  schema = processSchema(NewComponent.prototype.schema,
+                         NewComponent.prototype.name);
   NewComponent.prototype.isSingleProperty = schemaIsSingleProp = isSingleProp(NewComponent.prototype.schema);
   NewComponent.prototype.isObjectBased = !schemaIsSingleProp ||
               (schemaIsSingleProp && (isObject(schema.default) || isObject(parseProperty(undefined, schema))));

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -145,7 +145,7 @@ export function registerSystem (name, definition) {
   NewSystem.prototype = Object.create(System.prototype, proto);
   NewSystem.prototype.name = name;
   NewSystem.prototype.constructor = NewSystem;
-  NewSystem.prototype.schema = utils.extend(processSchema(NewSystem.prototype.schema));
+  NewSystem.prototype.schema = processSchema(NewSystem.prototype.schema);
   systems[name] = NewSystem;
 
   // Initialize systems for existing scenes

--- a/src/utils/styleParser.js
+++ b/src/utils/styleParser.js
@@ -8,9 +8,10 @@ var DASH_REGEX = /-([a-z])/g;
 /**
  * Deserialize style-like string into an object of properties.
  *
- * @param {string} value - HTML attribute value.
+ * @param {string|object} value - HTML attribute value.
  * @param {object} [obj] - Reused object for object pooling.
- * @returns {object} Property data.
+ * @returns {object|string} Parsed property data, or `value` unchanged when it is not a
+ *   parseable style string (e.g. already an object, or a plain string with no properties).
  */
 export function parse (value, obj) {
   var parsedData;

--- a/tests/extras/primitives/primitives/a-sky.test.js
+++ b/tests/extras/primitives/primitives/a-sky.test.js
@@ -29,3 +29,67 @@ suite('a-sky', function () {
     });
   });
 });
+
+suite('a-sky material default components', function () {
+  test('keeps material defaults when setting src via createElement and setAttribute', function (done) {
+    helpers.elFactory().then(function (entityEl) {
+      var skyEl = document.createElement('a-sky');
+      skyEl.setAttribute('material', {src: 'sky.webp'});
+      skyEl.addEventListener('loaded', function () {
+        var material = skyEl.getAttribute('material');
+        assert.equal(material.side, 'back');
+        assert.equal(material.shader, 'flat');
+        assert.equal(material.minFilter, 'linear');
+        assert.equal(material.src, 'sky.webp');
+        done();
+      });
+      entityEl.sceneEl.appendChild(skyEl);
+    });
+  });
+
+  test('keeps material defaults after recycled sky materials dirty the pool', function (done) {
+    // Two entities carry a sky-shaped material
+    // (color/shader/side/minFilter), then removeAttribute('material') recycles both
+    // attrValue objects into objectPools['material']. A subsequent a-sky created via
+    // createElement + setAttribute pulls a recycled attrValue (keys present, valued
+    // undefined) and used to lose its primitive defaults (side: back -> front).
+    // Two recycled materials are required: the first recycled attrValue is consumed
+    // before the a-sky's attrValue is allocated.
+    var skyMaterial = 'color: #FFF; shader: flat; side: back; minFilter: linear';
+    helpers.elFactory().then(function (entityEl) {
+      var sceneEl = entityEl.sceneEl;
+      var leftEye = document.createElement('a-entity');
+      leftEye.setAttribute('geometry', 'primitive: sphere; radius: 198');
+      leftEye.setAttribute('material', skyMaterial);
+      var rightEye = document.createElement('a-entity');
+      rightEye.setAttribute('geometry', 'primitive: sphere; radius: 198');
+      rightEye.setAttribute('material', skyMaterial);
+
+      var loaded = 0;
+      function onEyeLoaded () {
+        if (++loaded < 2) { return; }
+        // Recycle both {color, shader, side, minFilter} attrValues into the pool.
+        leftEye.removeAttribute('material');
+        rightEye.removeAttribute('material');
+        // a-sky's material attrValue is now pulled from the dirtied pool.
+        var skyEl = document.createElement('a-sky');
+        skyEl.setAttribute('material', 'src: sky.webp');
+        skyEl.addEventListener('loaded', function () {
+          try {
+            var material = skyEl.getAttribute('material');
+            assert.equal(material.src, 'sky.webp');
+            assert.equal(material.side, 'back');
+            assert.equal(material.shader, 'flat');
+            assert.equal(material.minFilter, 'linear');
+            done();
+          } catch (e) { done(e); }
+        });
+        sceneEl.appendChild(skyEl);
+      }
+      leftEye.addEventListener('loaded', onEyeLoaded);
+      rightEye.addEventListener('loaded', onEyeLoaded);
+      sceneEl.appendChild(leftEye);
+      sceneEl.appendChild(rightEye);
+    });
+  });
+});

--- a/tests/extras/primitives/primitives/a-sky.test.js
+++ b/tests/extras/primitives/primitives/a-sky.test.js
@@ -92,4 +92,35 @@ suite('a-sky material default components', function () {
       sceneEl.appendChild(rightEye);
     });
   });
+
+  test('keeps material defaults when the component attrValue carries recycled undefined keys', function (done) {
+    // Simple version of the previous test with explicit undefined values.
+    // A material component's attrValue is a
+    // pooled object that keeps its keys (valued undefined) when recycled, so a reused
+    // attrValue can look like {color:undefined, side:undefined, ..., src}. At load,
+    // getDOMAttribute returns that object and mergeComponentData used to copy the undefined
+    // values over the primitive defaults (side:back -> undefined -> schema default 'front').
+    // We reproduce the recycled-object shape deterministically by seeding the (deferred)
+    // component's attrValue with undefined-valued keys before the entity loads.
+    helpers.elFactory().then(function (entityEl) {
+      var skyEl = document.createElement('a-sky');
+      // Object set allocates attrValue from the pool; component init is deferred (not loaded).
+      skyEl.setAttribute('material', {src: 'sky.webp'});
+      // Simulate stale keys left on a recycled pooled attrValue object.
+      var attrValue = skyEl.components.material.attrValue;
+      attrValue.color = undefined;
+      attrValue.side = undefined;
+      attrValue.shader = undefined;
+      attrValue.minFilter = undefined;
+      skyEl.addEventListener('loaded', function () {
+        var material = skyEl.getAttribute('material');
+        assert.equal(material.src, 'sky.webp');
+        assert.equal(material.side, 'back');
+        assert.equal(material.shader, 'flat');
+        assert.equal(material.minFilter, 'linear');
+        done();
+      });
+      entityEl.sceneEl.appendChild(skyEl);
+    });
+  });
 });


### PR DESCRIPTION
This fixes the issue I had with the environment component https://github.com/supermedium/aframe-environment-component/pull/89

Fix primitive default components clobbered by recycled component attrValue mergeComponentData merged the entity-defined value into a primitive's default/extra component data with `utils.extend` (`Object.assign`), which copies undefined-valued keys. A component's `attrValue` is a pooled object that keeps its keys (valued undefined) when recycled, so a reused `attrValue` like `{side: undefined, ..., src: 'sky.webp'}` would clobber the primitive defaults (e.g. a-sky's material side: back -> undefined -> material schema default 'front'). This made `<a-sky material="src: ...">` created via createElement + setAttribute intermittently lose side/shader/minFilter depending on object-pool state.

Only merge in defined properties so stale recycled keys no longer overwrite the extra/default data.