### PR TITLE
[docs] Fix code snippet for AFRAME_ASYNC, need to call emitReady(), not ready()

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -393,7 +393,7 @@ await import('aframe');
 
 // Asynchronously register components/systems
 
-window.AFRAME.ready();
+window.AFRAME.emitReady();
 ```
 
 Since version 1.7.1, A-Frame ships an ES module bundle without the three dependency.


### PR DESCRIPTION
And error slipped through #5481 `ready()` doesn't exist, it's `emitReady()`
The paragraph above the code snippet was correct, it's just the code snippet that was wrong.