### PR TITLE
[docs] Use minified versions of three in importmap

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -407,7 +407,7 @@ Make sure the three and A-Frame versions are compatible. See browser console (or
     {
       "imports": {
         "aframe": "https://aframe.io/releases/1.8.0/aframe.module.min.js",
-        "three": "https://cdn.jsdelivr.net/npm/super-three@0.184.0/build/three.module.js",
+        "three": "https://cdn.jsdelivr.net/npm/super-three@0.184.0/build/three.module.min.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/super-three@0.184.0/examples/jsm/",
         "aframe-extras/controls": "https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.x/dist/aframe-extras.controls.min.js"
       }

--- a/examples/boilerplate/importmap/index.html
+++ b/examples/boilerplate/importmap/index.html
@@ -8,7 +8,7 @@
       {
         "imports": {
           "aframe": "../../../dist/aframe-master.module.min.js",
-          "three": "../../../super-three-package/build/three.module.js",
+          "three": "../../../super-three-package/build/three.module.min.js",
           "three/addons/": "../../../super-three-package/examples/jsm/",
           "aframe-extras/controls": "https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.x/dist/aframe-extras.controls.min.js"
         }

--- a/examples/showcase/post-processing/index.html
+++ b/examples/showcase/post-processing/index.html
@@ -8,7 +8,7 @@
       {
         "imports": {
           "aframe": "../../../dist/aframe-master.module.min.js",
-          "three": "../../../super-three-package/build/three.module.js",
+          "three": "../../../super-three-package/build/three.module.min.js",
           "three/addons/": "../../../super-three-package/examples/jsm/"
         }
       }

--- a/examples/showcase/webgpu/index.html
+++ b/examples/showcase/webgpu/index.html
@@ -8,9 +8,9 @@
       {
         "imports": {
           "aframe": "../../../dist/aframe-master.module.min.js",
-          "three": "../../../super-three-package/build/three.webgpu.js",
-          "three/webgpu": "../../../super-three-package/build/three.webgpu.js",
-          "three/tsl": "../../../super-three-package/build/three.tsl.js",
+          "three": "../../../super-three-package/build/three.webgpu.min.js",
+          "three/webgpu": "../../../super-three-package/build/three.webgpu.min.js",
+          "three/tsl": "../../../super-three-package/build/three.tsl.min.js",
           "three/addons/": "../../../super-three-package/examples/jsm/"
         }
       }


### PR DESCRIPTION
This reduces transferred js from 857kB to 466kB.