### PR TITLE
[docs] Update examples to use aframe-extras 7.7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ objects straight from HTML:
   <head>
     <script src="https://aframe.io/releases/1.8.0/aframe.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.7.x/dist/aframe-extras.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@fern-solutions/aframe-sky-background/dist/sky-background.umd.min.js"></script>
   </head>
   <body>

--- a/docs/introduction/entity-component-system.md
+++ b/docs/introduction/entity-component-system.md
@@ -482,7 +482,7 @@ Registry and using the JSDELIVR CDN.  This example can also be viewed in the [A-
     <script src="https://aframe.io/releases/1.8.0/aframe.min.js"></script>
     <script src="https://unpkg.com/@c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/aframe-simple-sun-sky@^1.2.2/simple-sun-sky.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.7.x/dist/aframe-extras.min.js"></script>
   </head>
   <body>
     <a-scene>

--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -412,7 +412,7 @@ Make sure the three and A-Frame versions are compatible. See browser console (or
         "aframe": "https://aframe.io/releases/1.8.0/aframe.module.min.js",
         "three": "https://cdn.jsdelivr.net/npm/super-three@0.184.0/build/three.module.min.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/super-three@0.184.0/examples/jsm/",
-        "aframe-extras/controls": "https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.x/dist/aframe-extras.controls.min.js"
+        "aframe-extras/controls": "https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.7.x/dist/aframe-extras.controls.min.js"
       }
     }
   </script>

--- a/examples/boilerplate/importmap/index.html
+++ b/examples/boilerplate/importmap/index.html
@@ -10,7 +10,7 @@
           "aframe": "../../../dist/aframe-master.module.min.js",
           "three": "../../../super-three-package/build/three.module.min.js",
           "three/addons/": "../../../super-three-package/examples/jsm/",
-          "aframe-extras/controls": "https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.x/dist/aframe-extras.controls.min.js"
+          "aframe-extras/controls": "https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.7.x/dist/aframe-extras.controls.min.js"
         }
       }
     </script>

--- a/examples/docs/community-components/index.html
+++ b/examples/docs/community-components/index.html
@@ -8,7 +8,7 @@
     -->
     <script src="../../../dist/aframe-master.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-particle-system-component@1.2.x/dist/aframe-particle-system-component.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.5.0/dist/aframe-extras.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.7.x/dist/aframe-extras.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@fern-solutions/aframe-sky-background/dist/sky-background.umd.min.js"></script>
   </head>
   <body>


### PR DESCRIPTION
So that users looking at the examples use the latest version, this includes embed mode support for nipple-controls, VR room-scale support for nav-mesh contraint.