### PR TITLE
Reposition CodeSandbox button in gh-pages examples

### DIFF
--- a/scripts/preghpages.js
+++ b/scripts/preghpages.js
@@ -29,14 +29,35 @@ shell.cp('-r', [
   '*.md'
 ], 'gh-pages');
 
+// Track which HTML files had at least one link replaced, so the CodeSandbox
+// style below is only injected into the examples we actually modified.
+const modifiedFiles = new Set();
+
 function htmlReplace (before, after) {
-  replaceInFileSync({
+  const results = replaceInFileSync({
     from: before,
     to: after,
     files: 'gh-pages/**/*.html'
   });
+  results.filter(result => result.hasChanged).forEach(result => modifiedFiles.add(result.file));
 }
 
 htmlReplace('../../../dist/aframe-master.module.min.js', `https://aframe.io/releases/${aframeVersion}/aframe.module.min.js`);
 htmlReplace('../../../dist/aframe-master.js', `https://aframe.io/releases/${aframeVersion}/aframe.min.js`);
 htmlReplace(/\.\.\/\.\.\/\.\.\/super-three-package/g, `https://cdn.jsdelivr.net/npm/super-three@${threeVersion}`);
+
+// Move the CodeSandbox "Open Sandbox" button to the top so it does not overlap
+// the VR/AR enter buttons, but only in the examples where a link was replaced.
+if (modifiedFiles.size > 0) {
+  replaceInFileSync({
+    from: '</head>',
+    to: `  <style>
+      iframe[id^="sb__open-sandbox"] {
+        top: 16px !important;
+        bottom: auto !important;
+      }
+    </style>
+  </head>`,
+    files: Array.from(modifiedFiles)
+  });
+}

--- a/scripts/preghpages.js
+++ b/scripts/preghpages.js
@@ -53,8 +53,7 @@ if (modifiedFiles.size > 0) {
     from: '</head>',
     to: `  <style>
       iframe[id^="sb__open-sandbox"] {
-        top: 16px !important;
-        bottom: auto !important;
+        inset: 16px auto auto 16px;
       }
     </style>
   </head>`,


### PR DESCRIPTION
## Description

When generating the gh-pages examples, inject a small `<style>` block that moves the CodeSandbox "Open Sandbox" button to the top of the page so it no longer overlaps the VR/AR enter buttons.

The style is only injected into the example HTML pages where a CDN link was actually replaced (tracked via the `hasChanged` result from `replace-in-file`), so untouched pages are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)