### PR TITLE
Fix screenshot component keyboard shortcuts

### DIFF
--- a/src/components/scene/screenshot.js
+++ b/src/components/scene/screenshot.js
@@ -52,6 +52,10 @@ export var Component = registerComponent('screenshot', {
 
   sceneOnly: true,
 
+  init: function () {
+    this.onKeyDown = this.onKeyDown.bind(this);
+  },
+
   setup: function () {
     var el = this.el;
     if (this.canvas) { return; }
@@ -73,7 +77,6 @@ export var Component = registerComponent('screenshot', {
     this.canvas = document.createElement('canvas');
     this.ctx = this.canvas.getContext('2d');
     el.object3D.add(this.quad);
-    this.onKeyDown = this.onKeyDown.bind(this);
   },
 
   getRenderTarget: function (width, height) {


### PR DESCRIPTION
**Description:**
The keyboard shortcuts for making screenshots weren't properly working since #5442. The deferred setup takes place _after_ `play` is called which causes the `onKeyDown` event handler to be used before it's bound to the current this.

**Changes proposed:**
- Re-introduce a `init` method for binding `onKeyDown`.
